### PR TITLE
feat: establish budget-tracker/contracts — single source of truth for UI/backend contracts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,11 +50,13 @@ Before making ANY change that touches:
 
 ---
 
-## Stock Analyser (apps/web) data layer
+## Stock Analyser contracts — READ BEFORE ANY STOCK ANALYSER WORK
 
-For the Stock Analyser part of `apps/web/`, the data contracts live in:
+**`/stock-analyser/contracts/` is the single source of truth for Stock Analyser UI/backend contracts.**
 
-- `apps/web/DATA_CONTRACTS.md` — service interfaces, hook signatures, type definitions, cache key conventions
+Before making ANY change that touches the stock analyser data layer, read:
+
+- `stock-analyser/contracts/DATA_CONTRACTS.md` — service interfaces (`portfolioService`, `watchlistService`), hook signatures (`useClaude`, `useNavigation`), type definitions, cache key conventions, and the prompt-detection → return-type mapping
 
 The mock/real separation rule: components never check `useMockData` directly. Only service files and hooks do.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,75 @@
+# Transformotion Apps — Claude Code Instructions
+
+## Repo overview
+
+This is the authoritative monorepo for the Transformotion platform. It contains:
+
+- `apps/web/` — Next.js frontend (static export → S3 + CloudFront)
+- `infra/` — AWS CDK infrastructure
+- `functions/` — Lambda function handlers
+- `budget-tracker/contracts/` — Budget Tracker interface contracts (see below)
+- `packages/` — Shared packages (e.g. `@transformotion/lambda-middleware`)
+
+**Live deployments:**
+- Dev: `dev.apps.transformotion.com.au` — deploys from `develop` branch via GitHub Actions
+- Prod: `apps.transformotion.com.au` — deploys from `main` branch
+
+---
+
+## Branching strategy
+
+- `main` — production. Never commit directly.
+- `develop` — integration branch. Never commit directly.
+- Feature branches: `claude-code/<feature-name>` off `develop`, PR back to `develop`.
+- v0 branches: `v0/<feature-name>` off `develop`, PR back to `develop`.
+- After merge to `develop`, CD pipeline deploys to dev automatically.
+
+---
+
+## Budget Tracker contracts — READ BEFORE ANY BUDGET WORK
+
+**`/budget-tracker/contracts/` is the single source of truth for how the Budget Tracker's UI and backend communicate.**
+
+Before making ANY change that touches:
+
+- A data shape crossing the UI/backend boundary → read `budget-tracker/contracts/data-models.md`
+- An API call (real or stubbed) → read `budget-tracker/contracts/api-endpoints.md`
+- State storage (Zustand, localStorage, cache) → read `budget-tracker/contracts/state-management.md`
+- A Claude/AI call → read `budget-tracker/contracts/ai-prompts.md`
+- AWS infrastructure → read `budget-tracker/contracts/aws-infrastructure.md`
+- Component structure, tabs, naming → read `budget-tracker/contracts/ui-patterns.md`
+
+**When a contract needs to change:**
+
+1. Update the relevant contract file FIRST
+2. Add a dated entry to `budget-tracker/contracts/changelog.md`
+3. Only then implement the code change
+4. Sync `budget-tracker/contracts/` to `transformotion-apps-b8` before the next v0 session
+
+**Never invent types, endpoints, or state patterns not described in `/budget-tracker/contracts`.** If what you need isn't there, update the contract first, then implement.
+
+---
+
+## Stock Analyser (apps/web) data layer
+
+For the Stock Analyser part of `apps/web/`, the data contracts live in:
+
+- `apps/web/DATA_CONTRACTS.md` — service interfaces, hook signatures, type definitions, cache key conventions
+
+The mock/real separation rule: components never check `useMockData` directly. Only service files and hooks do.
+
+---
+
+## Architecture patterns
+
+### Lambda bundling
+All Lambda functions use `forceDockerBundling: false` in CDK bundling config. This lets esbuild use the local node_modules and resolve workspace packages (`@transformotion/lambda-middleware`).
+
+### Authentication
+Always real Cognito — never mocked. `NEXT_PUBLIC_USE_MOCK_DATA` controls data layer only, not auth.
+
+### Environment variables
+`NEXT_PUBLIC_*` vars are baked in at Next.js build time. They must be set in the GitHub Actions environment before the build step runs.
+
+### v0 collaboration
+v0 owns UI components and styling. Claude Code owns data models, API contracts, AI prompts, state management patterns, AWS infrastructure, and adaptors. See `budget-tracker/contracts/README.md` for the full ownership model.

--- a/budget-tracker/contracts/README.md
+++ b/budget-tracker/contracts/README.md
@@ -1,0 +1,79 @@
+# Interface Contracts — Budget Tracker
+
+**This folder is the single source of truth for how the Budget Tracker's UI and backend communicate.**
+
+Both v0 (UI) and Claude Code (backend) must conform to these contracts. Neither tool may invent data shapes, endpoints, state patterns, AI prompts, or storage keys outside of what is documented here.
+
+## Context
+
+The Budget Tracker was designed and prototyped in a Claude chat as a working single-file React artifact. That prototype is **feature-complete and in daily use** — it is the authoritative behavioural reference for the app. These contracts are derived from that reference implementation.
+
+v0 is rebuilding the UI as a polished production app. Claude Code is building the AWS backend. Both must conform to these contracts, so that when the two are wired together, they fit.
+
+## Files in this folder
+
+| File | Purpose |
+|---|---|
+| `README.md` | This file — overview and rules |
+| `data-models.md` | TypeScript interfaces for every shared type |
+| `api-endpoints.md` | Every backend endpoint — request/response/auth/errors |
+| `ai-prompts.md` | Every Claude prompt verbatim, with schemas and models |
+| `state-management.md` | Zustand stores, adaptor pattern, storage keys |
+| `aws-infrastructure.md` | DynamoDB tables, Lambda functions, Cognito setup |
+| `ui-patterns.md` | Component conventions, tabs, visual behaviour |
+| `changelog.md` | Dated log of every contract change |
+
+## How to use this folder
+
+**Before making ANY change that touches:**
+
+- A data shape crossing the UI/backend boundary → read `data-models.md`
+- An API call (real or stubbed) → read `api-endpoints.md`
+- State storage (Zustand, localStorage, cache) → read `state-management.md`
+- A Claude/AI call → read `ai-prompts.md`
+- AWS infrastructure → read `aws-infrastructure.md`
+- Component structure, tabs, naming → read `ui-patterns.md`
+
+**When a contract needs to change:**
+
+1. **Update the relevant contract file FIRST**
+2. **Add a dated entry to `changelog.md`** — what changed, why, what downstream work is required
+3. **Only then** implement the code change
+4. **Sync to the other repo** before the other tool is invoked next
+
+## Ownership
+
+| Domain | Owner |
+|---|---|
+| UI components, styling, visual behaviour, client-side interactions | **v0** |
+| Data models, API contracts, AI prompts, state patterns, AWS infrastructure, adaptor implementations | **Claude Code** |
+| Anything in `/contracts` | **Shared** — contract change required first, regardless of which tool initiates |
+
+## Golden rules
+
+1. **Never invent.** If a contract doesn't describe what you need, stop and flag it. Do not guess.
+2. **Contract first, code second.** If the contract is wrong or incomplete, fix the contract before any code.
+3. **Changelog every change.** Any update to any contract file must have a dated changelog entry.
+4. **Sync after every change.** The other repo must receive updated contracts before the other tool is invoked.
+5. **v0 stubs, Claude Code implements.** v0 provides in-memory stub implementations of every adaptor interface. Claude Code provides the real AWS-backed implementations. Both must satisfy the same interface.
+
+## The adaptor pattern (critical)
+
+v0 builds UI components that consume **interfaces**, never direct API calls or storage primitives.
+
+```
+Component  →  Zustand store  →  Adaptor interface  →  (stub OR real implementation)
+```
+
+- **v0's job**: define the interface, write stub implementations that keep data in memory or localStorage so the UI works standalone.
+- **Claude Code's job**: write real implementations of those same interfaces backed by Lambda, DynamoDB, and Cognito.
+- **Neither side changes the interface without updating `/contracts` first.**
+
+This is the pattern that made the Stock Analyser migration clean. Budget Tracker follows the same model.
+
+## Repo layout
+
+- `transformotion/transformotion-apps` — Claude Code repo, **authoritative source for `/contracts`**
+- `transformotion/transformotion-apps-b8` — v0 repo, receives copies of `/contracts` before each v0 session
+
+When contracts change: update authoritative copy → commit → copy to v0 repo → commit there too → then work resumes.

--- a/budget-tracker/contracts/ai-prompts.md
+++ b/budget-tracker/contracts/ai-prompts.md
@@ -1,0 +1,223 @@
+# AI Prompts
+
+**Every Claude prompt the Budget Tracker uses, verbatim.** Both repos must reference these exact prompts. Any change requires a changelog entry.
+
+## Model selection
+
+- **Default model:** `claude-sonnet-4-20250514`
+- **Fallback model:** none — fail fast and surface error to UI if unavailable
+- **All AI calls** route through the shared Lambda proxy at `/api/claude` (same as Stock Analyser). No direct Anthropic calls from the browser.
+- **Temperature:** `0.2` for all budget AI calls (categorisation needs consistency, not creativity).
+
+## Cost and rate controls
+
+- **Daily budget:** $5 USD per account per day across all budget AI endpoints combined. Enforced in the `/api/claude` Lambda proxy.
+- **Rate limit:** 30 calls per minute per account. Returns `429` on breach.
+- **Batch sizes are fixed:** changing them requires a contract update.
+
+---
+
+## 1. Auto-categorisation on import
+
+**Endpoint:** `POST /api/budget/ai/categorise`
+**Batch size:** 50 transactions per request. UI or proxy splits larger inputs into multiple calls.
+**Triggered by:** CSV upload → rules engine runs first → anything still uncategorised goes to this.
+
+### System prompt (verbatim)
+
+```
+You are a personal finance assistant. You categorise Australian bank transactions
+into household budget categories.
+
+You will be given:
+- A list of budget categories, each with allowed subcategories
+- A list of transactions to categorise (index, description, amount)
+
+You must:
+- Return ONLY a JSON array, one object per transaction you can confidently categorise
+- Each object has exactly: {"index": <int>, "category": <string>, "subcategory": <string>}
+- The category value must be one of the provided categories exactly
+- The subcategory value must be one of the subcategories listed under that category exactly
+- Omit any transaction you cannot confidently categorise — do not guess
+- Do not include any text outside the JSON array
+- Do not wrap the JSON in markdown code fences
+```
+
+### User prompt template
+
+```
+BUDGET CATEGORIES AND SUBCATEGORIES:
+{{category_list}}
+
+TRANSACTIONS TO CATEGORISE (index: description — amount):
+{{transactions_list}}
+```
+
+Where:
+- `{{category_list}}` is:
+  ```
+  Income: Your take-home pay, Your partner's take-home pay, Bonuses / overtime, ...
+  Home & utilities: Mortgage / rent, Water, Gas, Electricity, ...
+  ...
+  ```
+- `{{transactions_list}}` is:
+  ```
+  0: WOOLWORTHS MAROOCHYDORE — -145.23
+  1: AGL SALES PTY LTD — -89.50
+  2: DIRECT DEPOSIT SALARY — 4250.00
+  ```
+
+### Expected response shape
+
+```typescript
+[
+  { "index": 0, "category": "Groceries", "subcategory": "Supermarket" },
+  { "index": 1, "category": "Home & utilities", "subcategory": "Electricity" },
+  { "index": 2, "category": "Income", "subcategory": "Your take-home pay" }
+]
+```
+
+Indexes that couldn't be categorised are simply absent.
+
+### Fallback behaviour
+
+If the response is not valid JSON or any item references a non-existent category/subcategory, drop that item and log. Do not fail the whole batch. The UI surfaces anything still uncategorised for AI Review.
+
+---
+
+## 2. AI Review (deliberate review path)
+
+**Endpoint:** `POST /api/budget/ai/review`
+**Batch size:** 20 transactions per request. UI streams results as batches complete.
+**Triggered by:** User clicks "AI Review (N)" button in header.
+**Tool use:** `web_search` enabled — AI may look up unfamiliar Australian merchants.
+
+### System prompt (verbatim)
+
+```
+You are a personal finance assistant helping to categorise Australian bank transactions
+that a fast categorisation pass could not handle.
+
+You will be given:
+- A list of budget categories, each with allowed subcategories
+- A list of unknown or ambiguous transactions (index, description, amount)
+
+You have access to a web_search tool. If a merchant or description is unfamiliar,
+you MAY search to identify the business type before categorising. Use web_search
+sparingly — only when the description is genuinely ambiguous.
+
+You must:
+- Return ONLY a JSON array, one object per transaction
+- Each object has exactly: {"index": <int>, "category": <string>, "subcategory": <string>, "reason": <string>}
+- The category must be one of the provided categories exactly
+- The subcategory must be one of the subcategories listed under that category exactly
+- The reason must be a single sentence explaining your choice in plain English
+- If a transaction is genuinely uncategorisable, return it with category: "", subcategory: "",
+  and reason explaining why
+- Do not include any text outside the JSON array
+- Do not wrap the JSON in markdown code fences
+```
+
+### User prompt template
+
+Same structure as auto-categorisation (`{{category_list}}` + `{{transactions_list}}`).
+
+### Expected response shape
+
+```typescript
+[
+  {
+    "index": 0,
+    "category": "Eating-out & Entertainment",
+    "subcategory": "Restaurants & cafes",
+    "reason": "Foster Black is a wine bar in Mooloolaba based on web search."
+  },
+  {
+    "index": 1,
+    "category": "",
+    "subcategory": "",
+    "reason": "Description 'PY-55632' is an opaque reference with no searchable merchant."
+  }
+]
+```
+
+### Streaming behaviour
+
+Results return in batch order. UI displays each batch as it arrives, allowing the user to confirm ✓, reject ✗, or override the category inline while later batches are still processing.
+
+---
+
+## 3. CSV column analysis
+
+**Endpoint:** `POST /api/budget/ai/csv-analysis`
+**Batch size:** N/A — single call per uploaded file with unrecognised format.
+**Triggered by:** CSV upload with a `fingerprint` not found in `csvFormatMappings`.
+
+### System prompt (verbatim)
+
+```
+You are a CSV format detective. Given the first few rows of a bank transaction CSV,
+identify which column is which.
+
+You must return ONLY a JSON object with this exact shape:
+{
+  "dateColumn": <int>,
+  "descriptionColumn": <int>,
+  "amountColumn": <int>,                    // optional — omit if debit/credit used
+  "debitColumn": <int>,                     // optional — for split debit/credit format
+  "creditColumn": <int>,                    // optional — for split debit/credit format
+  "dateFormat": <string>,                   // e.g. "DD/MM/YYYY", "YYYY-MM-DD", "MM/DD/YYYY"
+  "hasHeader": <bool>,
+  "confidence": "high" | "medium" | "low",
+  "notes": <string>                         // 1-2 sentences explaining your analysis
+}
+
+Either amountColumn OR (debitColumn + creditColumn) must be present, not both.
+
+Columns are 0-indexed.
+
+If you cannot determine the format with reasonable confidence, set confidence: "low"
+and describe the issue in notes. The user will confirm or correct your analysis.
+
+Do not include any text outside the JSON object.
+Do not wrap the JSON in markdown code fences.
+```
+
+### User prompt template
+
+```
+Sample rows from uploaded CSV (each row is an array of cell values):
+{{sample_rows_json}}
+
+The first row above MAY be a header row, or it may be a data row. Use the content
+to decide.
+```
+
+### Expected response shape
+
+See `AiCsvAnalysisResponse` in `data-models.md`.
+
+### Post-processing
+
+On `confidence: "high"`, the UI shows the proposed mapping with a single "Looks right" confirmation. On `medium` or `low`, the UI shows an editable form with the AI's proposal pre-filled. Confirmed mapping is stored in `csvFormatMappings` keyed by fingerprint.
+
+---
+
+## Token and cost budgets per call
+
+| Endpoint | Expected input tokens | Expected output tokens | Max tokens config |
+|---|---|---|---|
+| `ai/categorise` (batch of 50) | ~2,500 | ~1,500 | `max_tokens: 4096` |
+| `ai/review` (batch of 20, with web search) | ~1,500 + search | ~1,500 | `max_tokens: 4096` |
+| `ai/csv-analysis` | ~500 | ~200 | `max_tokens: 1024` |
+
+## Error handling
+
+| Situation | Behaviour |
+|---|---|
+| AI returns invalid JSON | Log, drop the batch, mark transactions as AI-failed, surface in UI |
+| AI returns a category/subcategory not in the provided tree | Drop that single item, keep others |
+| Rate limit hit (429) | Exponential backoff: 1s, 2s, 4s. After 3 retries, surface error to user |
+| Daily budget exhausted | Return 402-like error; UI shows "Daily AI limit reached — manual categorisation only today" |
+| Proxy Lambda timeout | Retry once. If second attempt times out, fail the batch and surface error |
+| `web_search` fails mid-review | AI still returns results without search-based reasoning. Reason field notes this |

--- a/budget-tracker/contracts/api-endpoints.md
+++ b/budget-tracker/contracts/api-endpoints.md
@@ -1,0 +1,276 @@
+# API Endpoints
+
+**Every backend endpoint the Budget Tracker UI calls.** v0 stubs these via adaptor interfaces. Claude Code implements them as real Lambda functions behind API Gateway.
+
+## Common conventions
+
+- **Base path:** `/api/budget`
+- **Auth:** All endpoints require Cognito JWT with group `budget-app` in `cognito:groups`
+- **AccountId resolution:** Derived server-side from JWT — never sent by client. The user's `accountId` maps to the household.
+- **Request format:** JSON body, `Content-Type: application/json`
+- **Response format:** JSON, `Content-Type: application/json`
+- **Errors:** `{ error: string, field?: string, details?: object }`
+- **HTTP status codes:**
+  - `200` — success
+  - `400` — validation error (see `field`)
+  - `401` — missing/invalid JWT
+  - `403` — authenticated but not in `budget-app` group
+  - `404` — resource not found
+  - `429` — rate limit exceeded (budget AI endpoints)
+  - `500` — internal error
+- **All IDs returned by backend are server-authoritative.** v0's stub may assign local IDs; real backend overwrites with canonical UUIDs on create.
+
+## Transactions
+
+### `GET /api/budget/transactions`
+List transactions for the account.
+
+**Query parameters:**
+- `from` (optional): ISO date — only transactions on/after
+- `to` (optional): ISO date — only transactions on/before
+- `limit` (optional, default 1000, max 5000): pagination
+- `cursor` (optional): opaque pagination cursor
+
+**Response 200:**
+```typescript
+{
+  transactions: Transaction[];
+  nextCursor?: string;            // Present if more results exist
+}
+```
+
+### `POST /api/budget/transactions/bulk`
+Bulk upsert transactions (used on CSV import).
+
+**Request:**
+```typescript
+{
+  transactions: Transaction[];    // Without accountId — server fills from JWT
+}
+```
+
+**Response 200:**
+```typescript
+{
+  created: number;
+  updated: number;
+  skipped: number;                // Already existed with same id
+  transactions: Transaction[];    // With server-assigned IDs
+}
+```
+
+### `PATCH /api/budget/transactions/:id`
+Update a single transaction (used for manual categorisation, business flag toggle).
+
+**Request:**
+```typescript
+{
+  category?: string;
+  subcategory?: string;
+  _manual?: boolean;              // Must set to true when user manually categorises
+  _business?: boolean;
+}
+```
+
+**Response 200:**
+```typescript
+{ transaction: Transaction }
+```
+
+### `DELETE /api/budget/transactions/:id`
+Delete a transaction.
+
+**Response 200:**
+```typescript
+{ deleted: true }
+```
+
+## Rules
+
+### `GET /api/budget/rules`
+List custom rules for the account.
+
+**Response 200:**
+```typescript
+{ rules: CustomRule[] }
+```
+
+### `POST /api/budget/rules`
+Create a custom rule.
+
+**Request:**
+```typescript
+{
+  match: string;
+  category: string;
+  subcategory: string;
+  learned: boolean;
+}
+```
+
+**Response 200:**
+```typescript
+{ rule: CustomRule }
+```
+
+### `PATCH /api/budget/rules/:id`
+Update a custom rule.
+
+### `DELETE /api/budget/rules/:id`
+Delete a custom rule.
+
+## Settings
+
+### `GET /api/budget/settings`
+Get all budget settings for the account.
+
+**Response 200:**
+```typescript
+{ settings: BudgetSettings }
+```
+
+### `PATCH /api/budget/settings`
+Partial update — send only fields to change.
+
+**Request:** any subset of `BudgetSettings` fields.
+
+**Response 200:**
+```typescript
+{ settings: BudgetSettings }
+```
+
+## AI endpoints
+
+All AI endpoints proxy to Anthropic via the shared `/api/claude` Lambda (same proxy used by Stock Analyser). Rate limiting, retry, and cost controls live in that proxy — not in these endpoints.
+
+### `POST /api/budget/ai/categorise`
+Auto-categorisation on import (fast path). Batched server-side in chunks of 50.
+
+**Request:**
+```typescript
+{
+  transactions: Array<{
+    index: number;
+    description: string;
+    amount: string;
+  }>;
+  categories: CategoryTree;
+}
+```
+
+**Response 200:**
+```typescript
+{
+  results: Array<{
+    index: number;
+    category: string;
+    subcategory: string;
+  }>;
+}
+```
+
+**Notes:**
+- AI omits any transaction it cannot confidently categorise — UI leaves those uncategorised for AI Review.
+- See `ai-prompts.md` for the exact system prompt and response schema.
+
+### `POST /api/budget/ai/review`
+AI Review tab — deliberate review of uncategorised transactions. Batches of 20. Uses `web_search` tool to look up unknown merchants.
+
+**Request:**
+```typescript
+{
+  transactions: Array<{
+    index: number;
+    description: string;
+    amount: string;
+  }>;
+  categories: CategoryTree;
+}
+```
+
+**Response 200:**
+```typescript
+{
+  results: Array<{
+    index: number;
+    category: string;
+    subcategory: string;
+    reason: string;
+  }>;
+}
+```
+
+**Notes:**
+- Streamed back in batch order. UI shows batches as they arrive (server-sent events or chunked response — implementation detail, but UI expects progressive results).
+
+### `POST /api/budget/ai/csv-analysis`
+Detect CSV format on an unrecognised file.
+
+**Request:**
+```typescript
+{
+  sampleRows: string[][];         // First 5 data rows
+  possibleHeaders?: string[];     // First row if it looks like headers
+}
+```
+
+**Response 200:**
+```typescript
+AiCsvAnalysisResponse             // See data-models.md
+```
+
+## Business expense export
+
+### `GET /api/budget/business-export`
+Server-side CSV generation for the accountant.
+
+**Query parameters:**
+- `from` (optional): ISO date
+- `to` (optional): ISO date
+
+**Response 200:**
+- `Content-Type: text/csv`
+- `Content-Disposition: attachment; filename="business-expenses-{accountId}-{timestamp}.csv"`
+
+**CSV columns:** `Date, Amount, Description, Category, Subcategory, File`
+
+Only transactions with `_business: true` are included.
+
+**Notes:** The prototype generates this client-side. The production backend does it server-side so that future features (signed URLs, email to accountant, scheduled reports) can hook in.
+
+## Migration
+
+### `POST /api/budget/migrate-from-localstorage`
+One-click migration from browser localStorage to backend. Called once per account when a user first logs in with local data present.
+
+**Request:**
+```typescript
+{
+  transactions: Transaction[];
+  rules: CustomRule[];
+  settings: Partial<BudgetSettings>;
+}
+```
+
+**Response 200:**
+```typescript
+{
+  migrated: {
+    transactions: number;
+    rules: number;
+    settings: string[];           // Keys migrated
+  };
+  alreadyPresent: {
+    transactions: number;
+    rules: number;
+  };
+}
+```
+
+**Notes:**
+- Idempotent. Safe to call multiple times. Matches transactions by composite key: `{date, amount, description, file}`.
+- Does not delete localStorage — UI offers that as a separate confirmation after migration succeeds.
+
+## Versioning
+
+All endpoints live under `/api/budget/v1/*` in the actual URL. This document uses the shorter `/api/budget/*` for readability. Any breaking change requires a new major version and a coordinated update here plus in both repos.

--- a/budget-tracker/contracts/aws-infrastructure.md
+++ b/budget-tracker/contracts/aws-infrastructure.md
@@ -1,0 +1,214 @@
+# AWS Infrastructure
+
+**The AWS resources that back the Budget Tracker.** This is Claude Code's domain — v0 never touches AWS. Documented here so both tools have a shared understanding of what the real adaptors will connect to.
+
+## Overview
+
+```
+User browser
+    ↓
+CloudFront (apps.transformotion.com.au/budget)
+    ↓
+S3 (React SPA — shared with other Transformotion apps)
+    ↓
+API Gateway (REST API — /api/budget/v1/*)
+    ↓
+Lambda Functions
+    ↓
+┌─────────────────────────────────────────────┐
+│ Cognito    DynamoDB    Secrets Manager      │
+│ (Auth)     (Data)      (Anthropic API key)  │
+└─────────────────────────────────────────────┘
+```
+
+## Cognito
+
+**Uses the existing shared User Pool** (`transformotion-users`). Budget Tracker does not create its own.
+
+- Required group for access: `budget-app`
+- App client: `budget-tracker-client` (new — scoped to this app's allowed OAuth flows)
+- JWT claims used by backend:
+  - `sub` — userId
+  - `cognito:username`
+  - `cognito:groups` — must include `budget-app`
+  - `email`
+- `accountId` is NOT in the JWT — it is looked up server-side in the `accounts` table (see below)
+
+## DynamoDB tables
+
+All tables follow the naming convention `budget-tracker.<entity>` for easy identification and IAM policy scoping.
+
+### `budget-tracker.accounts`
+
+The household container. One record per shared account.
+
+| Attribute | Type | Notes |
+|---|---|---|
+| `accountId` (PK) | String | UUID |
+| `name` | String | |
+| `members` | List of maps | `[{ userId, role, email, joinedAt }]` |
+| `createdAt` | String | ISO 8601 |
+
+**GSI:** `userId-index` on `members[].userId` for fast lookup: "which account is this user part of?"
+
+### `budget-tracker.transactions`
+
+| Attribute | Type | Notes |
+|---|---|---|
+| `accountId` (PK) | String | |
+| `transactionId` (SK) | String | UUID |
+| `date` | String | DD/MM/YYYY (preserved as string for display) |
+| `dateIso` | String | YYYY-MM-DD (for range queries) |
+| `amount` | String | Preserved as imported |
+| `description` | String | |
+| `category` | String | |
+| `subcategory` | String | |
+| `file` | String | Source CSV filename |
+| `_manual` | Boolean | |
+| `_business` | Boolean | |
+
+**GSI:** `accountId-dateIso-index` with partition key `accountId`, sort key `dateIso` — enables efficient month/range queries.
+
+### `budget-tracker.rules`
+
+| Attribute | Type | Notes |
+|---|---|---|
+| `accountId` (PK) | String | |
+| `ruleId` (SK) | String | UUID |
+| `match` | String | |
+| `category` | String | |
+| `subcategory` | String | |
+| `learned` | Boolean | |
+| `createdAt` | String | |
+
+### `budget-tracker.settings`
+
+Key-value store for per-account settings. Each settings key is its own item so individual fields can be updated without reading/writing the whole record.
+
+| Attribute | Type | Notes |
+|---|---|---|
+| `accountId` (PK) | String | |
+| `settingKey` (SK) | String | `budgetOverrides`, `budgetFreqs`, `customCategories`, `projectBudgets`, `deletedSubs`, `csvFormatMappings` |
+| `value` | Map or List | Shape depends on `settingKey` — see `data-models.md` |
+
+## Lambda functions
+
+All Lambdas share:
+- Runtime: Node.js 20
+- Package: `backend/functions/budget/`
+- Common middleware: JWT verification, `accountId` resolution, error handling
+- Environment variables: `DYNAMO_TABLE_PREFIX=budget-tracker.`, `ANTHROPIC_SECRET_ARN`, `REGION`
+
+### `budget-transactions-handler`
+
+Handles: `GET /transactions`, `POST /transactions/bulk`, `PATCH /transactions/:id`, `DELETE /transactions/:id`
+
+IAM permissions:
+- `dynamodb:Query`, `dynamodb:GetItem`, `dynamodb:BatchWriteItem`, `dynamodb:UpdateItem`, `dynamodb:DeleteItem` on `budget-tracker.transactions`
+
+### `budget-rules-handler`
+
+Handles: `GET /rules`, `POST /rules`, `PATCH /rules/:id`, `DELETE /rules/:id`
+
+IAM permissions: same pattern on `budget-tracker.rules`
+
+### `budget-settings-handler`
+
+Handles: `GET /settings`, `PATCH /settings`
+
+IAM permissions: same pattern on `budget-tracker.settings`
+
+### `budget-ai-categorise-handler`
+
+Handles: `POST /ai/categorise`
+
+Calls Anthropic via the **shared `/api/claude` proxy** — does not call Anthropic directly. Rate limiting, retry, cost tracking live in the proxy.
+
+IAM permissions:
+- `lambda:InvokeFunction` on `claude-api-proxy` (shared proxy)
+
+### `budget-ai-review-handler`
+
+Handles: `POST /ai/review`
+
+Calls Anthropic via shared proxy with `web_search` tool enabled. Streams batches via API Gateway chunked response.
+
+IAM permissions: same as above
+
+### `budget-ai-csv-analysis-handler`
+
+Handles: `POST /ai/csv-analysis`
+
+IAM permissions: same as above
+
+### `budget-export-handler`
+
+Handles: `GET /business-export`
+
+Streams CSV directly from DynamoDB Query results.
+
+IAM permissions:
+- `dynamodb:Query` on `budget-tracker.transactions`
+
+### `budget-migrate-handler`
+
+Handles: `POST /migrate-from-localstorage`
+
+Idempotent bulk import. Uses composite key `{date, amount, description, file}` to deduplicate.
+
+IAM permissions:
+- `dynamodb:BatchWriteItem`, `dynamodb:Query`, `dynamodb:PutItem` on all `budget-tracker.*` tables
+
+## Shared resources (already deployed)
+
+These are used by Budget Tracker but built for all Transformotion apps:
+
+| Resource | Purpose |
+|---|---|
+| `claude-api-proxy` Lambda | Proxies all Claude calls. Handles auth, rate limiting, retry, cost tracking, Secrets Manager lookup |
+| `transformotion-users` Cognito User Pool | Shared auth |
+| `/prod/anthropic/api-key` Secrets Manager entry | API key for `claude-api-proxy` |
+| Shared S3 bucket + CloudFront distribution | Static hosting |
+
+Budget Tracker does not re-create any of these.
+
+## Rate limits and cost controls
+
+Applied in `claude-api-proxy`, not in individual budget Lambdas:
+
+- **Daily budget**: $5 USD per account per day across all budget AI endpoints
+- **Per-minute rate limit**: 30 AI calls per account per minute
+- **Hard token limits**: 4096 max_tokens per request
+- **Timeout**: 30 seconds per AI call; 2 retries on transient failures
+
+## Deployment
+
+- Infrastructure as Code: AWS CDK in `infrastructure/`
+- Deploy per environment: `dev` and `prod`
+- Dev environment: `dev.apps.transformotion.com.au` — deployed via GitHub Actions on push to `develop`
+- CI/CD: already configured (see the Stock Analyser pipeline as the pattern)
+
+## Cost projection (free tier)
+
+For a single household (Steve + Liz):
+- **Cognito**: 2 MAUs — free (50k free tier)
+- **S3**: <1MB storage — free
+- **CloudFront**: <1GB transfer/month — free
+- **API Gateway**: ~10k calls/month — free (1M free tier)
+- **Lambda**: ~10k invocations/month — free (1M free tier)
+- **DynamoDB**: <100MB, <5 WCU, <5 RCU — free (25GB, 25 WCU/RCU free tier)
+- **Anthropic API**: ~$2-5/month — billed separately
+
+Total AWS cost: **~$0-1/month** (Route 53 hosted zone only).
+
+## Security
+
+- All Lambdas assume their own IAM role — no shared execution role
+- DynamoDB IAM policies are scoped by table AND by `accountId` via `LeadingKeys` condition where possible
+- Secrets Manager API key is never logged, never returned to client
+- CORS on API Gateway locked to `https://apps.transformotion.com.au` (and `https://dev.apps.transformotion.com.au` for dev)
+- All data encrypted at rest (DynamoDB) and in transit (HTTPS only)
+
+## What goes in `/contracts` vs what goes in Claude Code's own docs
+
+This file documents **what** exists and **why**. Implementation details — CDK stack structure, IAM policy JSON, exact ARNs — live in Claude Code's infrastructure docs in `transformotion-apps/infrastructure/README.md`. If v0 ever needs to know about infrastructure, it reads this file, not Claude Code's internal docs.

--- a/budget-tracker/contracts/changelog.md
+++ b/budget-tracker/contracts/changelog.md
@@ -1,0 +1,75 @@
+# Changelog
+
+**Every change to any file in `/contracts` must be logged here.**
+
+## Format
+
+```
+## YYYY-MM-DD — <short title>
+
+**File(s) changed:** list
+**Changed by:** v0 | Claude Code | Steve
+**Why:** 1-2 sentences describing the motivation
+
+**Change summary:**
+- Bullet list of what changed
+
+**Downstream work required:**
+- What v0 needs to update (if anything)
+- What Claude Code needs to update (if anything)
+- Any data migration considerations
+
+**Sync status:**
+- [ ] Updated in `transformotion-apps`
+- [ ] Updated in `transformotion-apps-b8`
+```
+
+## Rules
+
+1. **Every change to every file in `/contracts` requires a changelog entry.** No exceptions.
+2. **Entries are append-only.** Never edit or delete past entries.
+3. **Date format is ISO** (YYYY-MM-DD) to keep the list sortable.
+4. **Check both sync boxes before the next session of the other tool.**
+
+---
+
+## 2026-04-18 — Initial contracts established
+
+**File(s) changed:** all
+**Changed by:** Steve (with Claude in chat)
+**Why:** Establish interface contracts between v0 UI and Claude Code backend for the Budget Tracker app. Derived from the feature-complete prototype built in earlier Claude chats.
+
+**Change summary:**
+- Created `README.md`, `data-models.md`, `api-endpoints.md`, `ai-prompts.md`, `state-management.md`, `aws-infrastructure.md`, `ui-patterns.md`, `changelog.md`, `gap-analysis.md`
+- Documented all data types, API endpoints, AI prompts, storage patterns, AWS resources, and UI conventions
+- Established ownership model: v0 owns UI, Claude Code owns backend, both share `/contracts`
+- Established adaptor pattern: v0 stubs interfaces, Claude Code implements them
+
+**Downstream work required:**
+- **v0:** Rearchitect UI to use adaptor interfaces. Stub all data persistence and AI calls per `state-management.md`. Never invent types, endpoints, or prompts outside of what's in `/contracts`. Read `gap-analysis.md` for specific current-state deviations.
+- **Claude Code:** Implement the AWS backend per `api-endpoints.md` and `aws-infrastructure.md`. Implement real adaptors matching the stub interfaces. Read `gap-analysis.md` for what already exists.
+
+**Sync status:**
+- [x] Updated in `transformotion-apps` — committed on `claude-code/establish-contracts` branch, PR open against `develop`
+- [ ] Updated in `transformotion-apps-b8`
+
+---
+
+## 2026-04-18 — Gap analysis added with code-level findings
+
+**File(s) changed:** `gap-analysis.md`
+**Changed by:** Claude Code
+**Why:** Code analysis of the existing monorepo revealed 8 specific type-level mismatches between what was built during the stock-analyser migration and what the contracts now define. Documented so Steve can decide which side to change before backend implementation begins.
+
+**Change summary:**
+- Added M1–M8 code-level mismatch findings covering: `CustomRule` shape conflict, `BudgetSettings` extensions, `useBudgetStore` action surface differences, missing `useAiStore`, category tree subcategory divergence, and built-in rule override pattern
+- Added 2 additional open questions for Steve (M1 and M8 resolution)
+
+**Downstream work required:**
+- **Steve:** Answer open questions M1 and M8 before Claude Code updates the contracts
+- **v0:** Read gap-analysis.md M1–M8 before implementing data layer — do not invent solutions, flag these items
+- **Claude Code:** Await Steve's decisions on M1 and M8 before updating `data-models.md`
+
+**Sync status:**
+- [x] Updated in `transformotion-apps`
+- [ ] Updated in `transformotion-apps-b8`

--- a/budget-tracker/contracts/data-models.md
+++ b/budget-tracker/contracts/data-models.md
@@ -1,0 +1,230 @@
+# Data Models
+
+**Every type that crosses the UI/backend boundary lives here.** If you need a type that isn't documented, update this file first.
+
+## Core entities
+
+### Transaction
+
+The atomic unit of the Budget Tracker. Every imported line item becomes a Transaction.
+
+```typescript
+interface Transaction {
+  _id: number;                    // Local sequential ID (v0 stub) or UUID (real impl)
+  accountId: string;              // Household account ID (Cognito-derived)
+  date: string;                   // DD/MM/YYYY — preserved for display
+  amount: string;                 // String to preserve sign and decimals as imported
+                                  // Negative = expense, positive = income/refund
+  description: string;            // Original description from CSV
+  category: string | "";          // "" = uncategorised
+  subcategory: string | "";       // "" = uncategorised
+  file: string;                   // Source CSV filename
+  _manual: boolean;               // User has manually set category — rules will not overwrite
+  _business: boolean;             // Flagged as business expense — excluded from personal P&L
+}
+```
+
+**Notes:**
+- `amount` is deliberately a string. The prototype preserves the raw CSV value to avoid floating-point rounding issues and to support banks that use separate debit/credit columns. All arithmetic parses on read.
+- `_manual: true` is a sticky flag. Once a user manually categorises a transaction, the rules engine will never overwrite it on subsequent imports.
+- `_business: true` excludes the transaction from personal P&L calculations everywhere but keeps it visible in the transaction list with a 💼 badge.
+
+### Custom Rule
+
+Heuristics that categorise transactions by description match.
+
+```typescript
+interface CustomRule {
+  id: string;                     // UUID
+  accountId: string;
+  match: string;                  // Keyword or regex pattern, case-insensitive
+  category: string;
+  subcategory: string;
+  learned: boolean;               // true if created via "Learn" button on a transaction
+                                  // false if manually authored in Rules tab
+  createdAt: string;              // ISO 8601
+}
+```
+
+**Notes:**
+- The rules engine also ships a large **built-in ruleset** compiled into the codebase (see `ui-patterns.md` for storage location). Built-in rules are not CRUDable — they're the default heuristics for common Australian merchants.
+- Custom rules override built-in rules when both match. Most recent rule wins if multiple custom rules match.
+
+### Category Tree
+
+The budget categorisation structure. Shared between UI pickers and AI prompts.
+
+```typescript
+interface CategoryTree {
+  [categoryName: string]: string[];  // Array of subcategory names
+}
+```
+
+**Default category tree** (the starter set — users can add custom subcategories):
+
+```typescript
+const DEFAULT_CATEGORIES: CategoryTree = {
+  "Income": [
+    "Your take-home pay",
+    "Your partner's take-home pay",
+    "Bonuses / overtime",
+    "Income from savings and investments",
+    "Child support received",
+    "School fees reimbursement",
+    "Rent (investment property)",
+    "Other income"
+  ],
+  "Home & utilities": [
+    "Mortgage / rent", "Water", "Gas", "Electricity", "Mobile", "Internet",
+    "Streaming Services", "Home improvements & Maintenance",
+    "Furniture & appliances", "Council rates", "Body corporate fees",
+    "Kierans Mobile", "Ellas Mobile"
+  ],
+  "Financial & Insurance": [
+    "Home & contents insurance", "Health insurance", "Car insurance",
+    "Life & income insurance", "Bank fees", "Interest paid",
+    "Financial advice", "Computers & gadgets", "Capital purchases"
+  ],
+  "Groceries": ["Supermarket", "Butcher / bakery / deli", "Other groceries"],
+  "Medical, personal & education": [
+    "Doctors & medical", "Medicines & pharmacy", "Dental", "Glasses & eye care",
+    "Hair & beauty", "Clothing & shoes", "Shopping", "Sports & gym", "Education"
+  ],
+  "Eating-out & Entertainment": [
+    "Restaurants & cafes", "Take-away & snacks", "Drinks & alcohol",
+    "Entertainment & events", "Subscriptions", "Hobbies", "Holidays"
+  ],
+  "Car & Transport": [
+    "Petrol", "Road tolls & parking", "Repairs & maintenance",
+    "Rego & licence", "Uber & taxi", "Airfares", "Public transport"
+  ],
+  "Children": [
+    "Children Clothing", "Child support payment", "School fees",
+    "Toys", "Child care"
+  ],
+  "Renovations": [],              // Populated by user; is a PROJECT category
+  "Transfers": ["Transfer"],      // Special — excluded from P&L
+};
+```
+
+### Budget Settings
+
+Per-account configuration.
+
+```typescript
+interface BudgetSettings {
+  accountId: string;
+  budgetOverrides: { [subcategory: string]: number };    // -1 = tombstoned (deleted)
+  budgetFreqs: { [subcategory: string]: Frequency };
+  customCategories: { [category: string]: string[] };    // user-added subcategories
+  projectBudgets: { [category: string]: number };        // lump-sum, not monthly
+  deletedSubs: string[];                                  // subcategories hidden by user
+  csvFormatMappings: { [fingerprint: string]: CSVMapping };
+}
+
+type Frequency = "weekly" | "fortnightly" | "monthly" | "quarterly" | "annually";
+
+interface CSVMapping {
+  fingerprint: string;            // columnCount + hash of header names
+  dateColumn: number;
+  descriptionColumn: number;
+  amountColumn?: number;          // Single amount column (signed)
+  debitColumn?: number;           // OR separate debit column
+  creditColumn?: number;          // OR separate credit column
+  dateFormat: string;             // e.g. "DD/MM/YYYY", "YYYY-MM-DD"
+  hasHeader: boolean;
+  confirmedAt: string;            // ISO 8601 — when user confirmed this mapping
+}
+```
+
+### Account
+
+The shared household container. Steve and Liz share one `accountId`, not one per user.
+
+```typescript
+interface Account {
+  accountId: string;              // UUID
+  name: string;                   // Household name
+  members: AccountMember[];
+  createdAt: string;
+}
+
+interface AccountMember {
+  userId: string;                 // Cognito sub claim
+  role: "owner" | "member";
+  email: string;
+  joinedAt: string;
+}
+```
+
+## Exclusion rules (CRITICAL — apply everywhere)
+
+A transaction is **excluded from personal P&L** if ANY of these are true:
+
+1. `subcategory === "Transfer"` (movements between own accounts)
+2. `_business === true`
+3. `category` is in `PROJECT_CATEGORIES` (default: `["Renovations"]`)
+4. `subcategory` is in `PROJECT_SUBCATEGORIES` (default: `["Capital purchases"]`)
+
+These exclusions must be applied **consistently** across:
+- Summary tab totals (income, expenses, net position)
+- Category card totals
+- Subcategory totals
+- Cashflow trend chart
+- Cashflow category bar chart
+- Budget deficit/surplus card
+- Sankey diagram
+
+Excluded transactions are **still visible** in the Transactions tab (with filter toggles) and in the dedicated Projects and Business Expenses views.
+
+## AI response schemas
+
+### Auto-categorisation response
+
+```typescript
+interface AiCategoriseResponse {
+  results: Array<{
+    index: number;                // Matches input transaction index
+    category: string;             // Must be from provided CategoryTree
+    subcategory: string;          // Must be from provided CategoryTree[category]
+  }>;
+}
+```
+
+Transactions the AI cannot confidently categorise are simply omitted from the response (no placeholder).
+
+### AI Review response
+
+```typescript
+interface AiReviewResponse {
+  results: Array<{
+    index: number;
+    category: string;
+    subcategory: string;
+    reason: string;               // 1-sentence explanation for the user
+  }>;
+}
+```
+
+### CSV format analysis response
+
+```typescript
+interface AiCsvAnalysisResponse {
+  dateColumn: number;
+  descriptionColumn: number;
+  amountColumn?: number;
+  debitColumn?: number;
+  creditColumn?: number;
+  dateFormat: string;             // One of: "DD/MM/YYYY", "MM/DD/YYYY", "YYYY-MM-DD", etc.
+  hasHeader: boolean;
+  confidence: "high" | "medium" | "low";
+  notes: string;                  // Human-readable explanation for the confirmation UI
+}
+```
+
+## Type safety requirements
+
+- All contract types must live in a shared TypeScript file: `/types/contracts.ts` (both repos)
+- Neither v0 nor Claude Code may extend these types without updating this document first
+- Optional fields are marked with `?`; nullable with `| null`. Do not confuse them.
+- Every endpoint and adaptor method must reference these types by name — no inline duplication.

--- a/budget-tracker/contracts/gap-analysis.md
+++ b/budget-tracker/contracts/gap-analysis.md
@@ -1,0 +1,195 @@
+# Gap Analysis
+
+**This document flags known deviations between the current state of each repo and these contracts.** Both tools should read this before starting work, so they know what needs to be brought into line.
+
+This is a living document. As gaps are closed, cross them off. As new gaps appear, add them.
+
+---
+
+## For v0 (transformotion-apps-b8)
+
+### Known gaps in current UI
+
+1. **Data layer not using adaptor pattern**
+   - Current: v0's UI makes direct calls / uses mock data inline
+   - Required: route everything through Zustand stores, which route through adaptor interfaces. See `state-management.md`.
+   - Action: rearchitect data flow. Introduce `/lib/services/budget/`, `/lib/services/ai/`, `/lib/services/auth/` folders with the documented interfaces and stub implementations.
+
+2. **AI calls are stubbed without matching the real contract**
+   - Current: AI is a visual placeholder
+   - Required: stub implementations of `AIService` that match the interface exactly, so when Claude Code's real implementation swaps in, no UI changes needed
+   - Action: read `ai-prompts.md` and `state-management.md` → `AIService`. Implement stubs that return plausible canned responses matching the documented shapes.
+
+3. **Storage keys need unified prefix**
+   - Required: all localStorage keys prefixed `budget-tracker.` per `state-management.md`
+   - Action: if any localStorage is used in the current v0 build, update keys.
+
+4. **Type definitions may not match**
+   - Required: single shared file `/types/contracts.ts` with every type from `data-models.md`
+   - Action: create this file, import throughout the app. Delete any duplicated or drifted type definitions.
+
+5. **Tab structure may not match**
+   - Required: 6 tabs in the order Transactions / Summary / Budget / Cashflow / Rules / Review (see `ui-patterns.md`)
+   - Action: verify current tab list and order. Add missing tabs with placeholder content if needed.
+
+6. **Exclusion rules may be inconsistent**
+   - Required: the four exclusion rules in `data-models.md` must apply to every total/chart in the app
+   - Action: audit every calculation. Centralise exclusion logic in `/lib/domain/budget/exclusions.ts` as a shared pure function, use it everywhere.
+
+### What v0 must NOT do
+
+- Do not attempt to call any AWS service
+- Do not introduce new data types, endpoints, or storage patterns without updating `/contracts` first
+- Do not change the AI prompt wording — the stub can return canned data, but when the real impl swaps in, it will use the exact prompt in `ai-prompts.md`
+- Do not invent new tabs or restructure the 6-tab layout without a contract update
+
+---
+
+## For Claude Code (transformotion-apps)
+
+### Known gaps in current backend
+
+1. **Budget Tracker backend does not exist yet**
+   - Current: no Budget Tracker-specific Lambdas, DynamoDB tables, or API Gateway routes
+   - Required: everything in `aws-infrastructure.md` and `api-endpoints.md`
+   - Action: build from scratch. Follow the patterns established for the Stock Analyser.
+
+2. **Budget Tracker logic currently lives in a Claude chat artifact**
+   - Current: categorisation rules, AI prompts, exclusion logic, Sankey transformation, cashflow calcs live in a single-file React artifact built in a previous Claude chat
+   - Required: port all domain logic to `/lib/domain/budget/` as shared pure functions, then consume from both Lambdas (server-side) and the UI (client-side)
+   - Action:
+     - Extract the built-in rules engine → `/lib/domain/budget/builtin-rules.ts`
+     - Extract the exclusion logic → `/lib/domain/budget/exclusions.ts`
+     - Extract the Sankey data transformation → `/lib/domain/budget/sankey.ts`
+     - Extract the cashflow calculations → `/lib/domain/budget/cashflow.ts`
+     - Extract the budget-vs-actual logic → `/lib/domain/budget/budget-tracking.ts`
+     - The source reference is the working artifact (`budget-categoriser.jsx`) from the earlier Claude chat. Steve has access to this.
+
+3. **Account model not yet implemented**
+   - Current: Stock Analyser is per-user (no shared household concept)
+   - Required: `budget-tracker.accounts` table with members list — Steve and Liz share one `accountId`
+   - Action: build the accounts table, migration logic, and Cognito → accountId resolution middleware. This may be reusable across future household-shared apps.
+
+4. **Shared Claude proxy must support `web_search` tool**
+   - Current: the `claude-api-proxy` Lambda may not yet support passing through tool-use (specifically `web_search`)
+   - Required: `budget-ai-review-handler` needs to invoke Claude with `web_search` enabled
+   - Action: verify proxy supports tool-use pass-through. If not, extend it.
+
+5. **Cost and rate controls**
+   - Current: proxy has rate limits but may not be per-account per-day budgeted for the Budget Tracker
+   - Required: $5/day AI budget per account specifically for budget AI endpoints
+   - Action: add per-endpoint-class budget tracking in the proxy or in the budget Lambdas.
+
+### What Claude Code must NOT do
+
+- Do not change any interface documented in `state-management.md` — v0 depends on exact shapes
+- Do not change the AI prompt wording in `ai-prompts.md` without coordinating a contract update
+- Do not introduce new endpoints without updating `api-endpoints.md` first
+- Do not modify data models without updating `data-models.md` first
+
+---
+
+## Code-level mismatches found in the monorepo (2026-04-18)
+
+*These are specific type-level and structural conflicts found by reading the existing `apps/web/` code against the contracts above. They must be resolved before wiring up the real backend. Steve decides which side to change.*
+
+### M1. `CustomRule` shape conflict — BREAKING
+
+The monorepo's existing `CustomRule` type (`apps/web/lib/repositories/budget-tracker/rules-repository.ts`) does not match the contract.
+
+| Field | Monorepo | Contract (`data-models.md`) |
+|---|---|---|
+| Pattern field | `pattern: string` | `match: string` |
+| Match logic | `matchType: 'contains'|'startsWith'|'regex'` (separate field) | Single `match` string, case-insensitive keyword or regex |
+| Metadata | `name`, `priority`, `enabled`, `overridesBuiltinId`, `projectId`, `isBusiness`, `isIgnore` | None of these — just `id`, `accountId`, `match`, `category`, `subcategory`, `learned`, `createdAt` |
+| Learned flag | `_manual` pattern (implied) | `learned: boolean` (explicit) |
+
+**Recommendation:** Align the contract. The monorepo's richer shape (`matchType`, `priority`, `overridesBuiltinId`, `isBusiness`, `isIgnore`) reflects real product functionality from the prototype. The contract should be updated to include these fields, not stripped down. Claude Code to update `data-models.md` before implementing.
+
+### M2. `Transaction.amount` type conflict — BREAKING
+
+| Field | Monorepo | Contract |
+|---|---|---|
+| `amount` | `string` in DynamoDB shape, but `amount: string` in `Transaction` and used as number in P&L calcs | `string` (deliberately — preserves sign and avoids float rounding) |
+
+Both agree `amount` is a string, but the P&L calculator in the monorepo (`pl-calculator.ts`) calls `parseFloat(t.amount)` internally. This is correct — the contract says "all arithmetic parses on read". **No conflict**, but note that the monorepo uses `amount: string` consistently and the contract's note about this must be respected.
+
+### M3. `Transaction._id` type conflict — MODERATE
+
+| Field | Monorepo | Contract |
+|---|---|---|
+| `_id` | `number` (sequential, local) | `number \| string` (number for stub, UUID string for real impl) |
+
+This is intentional drift — the contract accounts for it. The monorepo's stub uses sequential numbers; the real backend will use UUIDs. No action needed, but code that does `===` comparisons on `_id` must use loose equality or string coercion.
+
+### M4. `BudgetSettings` shape — SIGNIFICANT EXTENSION
+
+The monorepo's `BudgetSettings` has additional fields not in the contract:
+- `deletedCategories: string[]`
+- `customTopCategories: string[]`
+- `projectTasks: Record<string, string[]>`
+- `customProjectCategories: string[]`
+- `deletedProjectCategories: string[]`
+- `disabledProjectCategories: string[]`
+
+**Recommendation:** Add these to `data-models.md`. They are real features from the prototype. Do not drop them to match the contract — update the contract.
+
+### M5. Built-in rules are richer than the contract implies — INFORMATIONAL
+
+The monorepo ships 63 built-in rules with `matchType`, `priority`, and `enabled` flags. The contract treats built-in rules as "not CRUDable" read-only defaults. This is correct. However, the monorepo allows users to disable or override built-in rules via `overridesBuiltinId` on a custom rule — a feature not yet documented in the contracts.
+
+**Recommendation:** Add a "Built-in rule overrides" section to `data-models.md` and `api-endpoints.md` explaining how `overridesBuiltinId` works.
+
+### M6. `useBudgetStore` interface mismatch — SIGNIFICANT
+
+The monorepo's Zustand store (`apps/web/stores/budget-tracker/use-budget-store.ts`) has a different action surface than the contract's `BudgetStore`:
+
+| Contract action | Monorepo equivalent | Notes |
+|---|---|---|
+| `loadAll()` | `initialize()` | Same intent |
+| `importTransactions(file)` | `addTransactions(transactions[])` | Monorepo expects pre-parsed array, not a File object — CSV parsing is upstream |
+| `toggleBusinessFlag(id)` | Not present | Needs to be added |
+| `learnRuleFromTransaction(id)` | Not present | Needs to be added |
+| `setBudgetAmount(sub, amount, freq)` | `updateSettings()` with full settings object | Monorepo is coarse-grained |
+| `exportBusinessCsv()` | Not present | Needs to be added |
+
+**Recommendation:** Align the store interface to the contract. Adds are straightforward. `importTransactions(file)` — decide whether file parsing happens in the store action or upstream; the contract says "in the store action", which is the cleaner API.
+
+### M7. `useAiStore` does not exist in the monorepo — MISSING
+
+The contract defines a separate `useAiStore` for the AI review queue. The monorepo has no equivalent. The AI categorisation in the monorepo currently runs inline in the transactions tab component.
+
+**Recommendation:** v0 creates `useAiStore` per the contract. Claude Code implements the real `AIService` that backs it. This is a gap in both repos.
+
+### M8. Category tree subcategory differences — INFORMATIONAL
+
+The monorepo's `categories.ts` has more granular subcategories than the contract's `DEFAULT_CATEGORIES`. For example:
+
+- Monorepo "Eating-out & Entertainment" has: Coffee & tea, Lunches bought, Take-away & snacks, Drinks & alcohol, Restaurants, Bars & clubs, Movies shows & music, Books newspapers & magazines, Celebrations & gifts, Holidays
+- Contract has: Restaurants & cafes, Take-away & snacks, Drinks & alcohol, Entertainment & events, Subscriptions, Hobbies, Holidays
+
+The monorepo version is the authoritative one (derived from the working prototype in daily use). **The contract `data-models.md` `DEFAULT_CATEGORIES` should be updated to match the monorepo exactly.** Steve to confirm before Claude Code updates the contract.
+
+---
+
+## Open questions for Steve
+
+These are decisions that weren't fully resolved in the prototype and need answers before Claude Code finalises the backend:
+
+1. **Liz's access model** — will she log in with her own Cognito identity and share the `accountId` via the `members` list? Or is there a simpler starting point (e.g. single account, both share credentials) for v1?
+2. **Data backup** — do you want automated DynamoDB backups to S3, or is point-in-time recovery sufficient?
+3. **AI cost alerting** — at what threshold should you be emailed? ($2/day? $3/day?)
+4. **Historical transaction limits** — is there a cutoff date beyond which old transactions shouldn't be imported? The current prototype imports everything.
+5. **Audit log** — should every transaction edit be logged for later review, or is "last write wins" sufficient for a household app?
+6. **Which CustomRule shape wins?** — monorepo's richer shape (with `matchType`, `priority`, `overridesBuiltinId`) or the contract's simpler shape? See M1 above.
+7. **Which category tree is canonical?** — monorepo's granular subcategories or the contract's consolidated ones? See M8 above.
+
+---
+
+## Closing a gap
+
+When a gap is addressed:
+
+1. Mark it complete here by striking through or moving to a "Closed" section at the bottom
+2. Add an entry to `changelog.md`
+3. Sync the updated `/contracts` folder to the other repo

--- a/budget-tracker/contracts/state-management.md
+++ b/budget-tracker/contracts/state-management.md
@@ -1,0 +1,292 @@
+# State Management
+
+**How the Budget Tracker UI stores and retrieves data.** v0 defines the interfaces and writes in-memory/localStorage stubs. Claude Code writes the real adaptors against the same interfaces.
+
+## The adaptor pattern (recap)
+
+```
+UI Component
+    ↓
+Zustand store
+    ↓
+Adaptor interface  ← defined here, shared by both implementations
+    ↓
+┌─────────────────────────────────────┐
+│ v0 stub              Claude Code    │
+│ (in-memory or        real impl      │
+│  localStorage)       (Lambda/DDB)   │
+└─────────────────────────────────────┘
+```
+
+Neither implementation is "better" — they serve different purposes. The stub makes the UI work standalone during design; the real adaptor makes it work in production.
+
+## Folder structure (both repos)
+
+```
+/lib/services/
+  ├── budget/
+  │   ├── index.ts                 ← re-exports interfaces + picker
+  │   ├── types.ts                 ← interface definitions
+  │   ├── stub-adaptor.ts          ← v0's stub (in-memory + localStorage)
+  │   └── aws-adaptor.ts           ← Claude Code's real impl (absent in v0 repo)
+  ├── ai/
+  │   ├── index.ts
+  │   ├── types.ts
+  │   ├── stub-adaptor.ts          ← returns canned responses
+  │   └── claude-proxy.ts          ← real impl calls Lambda
+  └── auth/
+      ├── index.ts
+      ├── types.ts
+      ├── stub-adaptor.ts          ← hardcoded test user
+      └── cognito-adaptor.ts       ← real impl
+```
+
+The `index.ts` exports a single `getBudgetService()` (etc.) that returns the configured adaptor based on an environment variable. v0's repo always uses the stub; Claude Code's repo uses the real adaptor for production builds.
+
+## Adaptor interfaces
+
+### BudgetRepository
+
+```typescript
+interface BudgetRepository {
+  // Transactions
+  listTransactions(filters?: {
+    from?: string;
+    to?: string;
+    limit?: number;
+    cursor?: string;
+  }): Promise<{ transactions: Transaction[]; nextCursor?: string }>;
+
+  bulkUpsertTransactions(transactions: Omit<Transaction, "accountId">[]):
+    Promise<{ created: number; updated: number; skipped: number; transactions: Transaction[] }>;
+
+  updateTransaction(id: number | string, patch: Partial<Transaction>):
+    Promise<Transaction>;
+
+  deleteTransaction(id: number | string): Promise<void>;
+
+  // Rules
+  listRules(): Promise<CustomRule[]>;
+  createRule(rule: Omit<CustomRule, "id" | "accountId" | "createdAt">): Promise<CustomRule>;
+  updateRule(id: string, patch: Partial<CustomRule>): Promise<CustomRule>;
+  deleteRule(id: string): Promise<void>;
+
+  // Settings
+  getSettings(): Promise<BudgetSettings>;
+  updateSettings(patch: Partial<BudgetSettings>): Promise<BudgetSettings>;
+
+  // Business export
+  generateBusinessExportCsv(filters?: { from?: string; to?: string }): Promise<Blob>;
+
+  // Migration
+  migrateFromLocalStorage(data: {
+    transactions: Transaction[];
+    rules: CustomRule[];
+    settings: Partial<BudgetSettings>;
+  }): Promise<{ migrated: object; alreadyPresent: object }>;
+}
+```
+
+### AIService
+
+```typescript
+interface AIService {
+  categoriseTransactions(input: {
+    transactions: Array<{ index: number; description: string; amount: string }>;
+    categories: CategoryTree;
+  }): Promise<AiCategoriseResponse>;
+
+  reviewTransactions(input: {
+    transactions: Array<{ index: number; description: string; amount: string }>;
+    categories: CategoryTree;
+    onBatch?: (batchResults: AiReviewResponse["results"]) => void;  // streaming callback
+  }): Promise<AiReviewResponse>;
+
+  analyseCsvFormat(input: {
+    sampleRows: string[][];
+    possibleHeaders?: string[];
+  }): Promise<AiCsvAnalysisResponse>;
+}
+```
+
+### AuthService
+
+```typescript
+interface AuthService {
+  getCurrentUser(): Promise<{ userId: string; email: string; accountId: string; groups: string[] } | null>;
+  signIn(): Promise<void>;         // Real impl triggers Cognito Hosted UI
+  signOut(): Promise<void>;
+  getIdToken(): Promise<string | null>;
+}
+```
+
+## Stub implementation rules (v0)
+
+The stub adaptors must:
+
+1. **Persist to localStorage** so data survives page reloads (critical for design review)
+2. **Use the same storage keys** as the prototype — see "Storage keys" below
+3. **Simulate async** — every method returns a Promise, even if data is instant
+4. **Simulate AI calls** — return canned categorisation for a fixed seed dataset, or use a simple keyword match against the built-in rules
+5. **NOT call any external service** — no fetch, no API calls. The stub is fully offline.
+
+The stub's job is to make the UI feel real during design. It does not need to be production-quality.
+
+## Real implementation rules (Claude Code)
+
+The real adaptors must:
+
+1. **Call the documented endpoints** in `api-endpoints.md` — nothing else
+2. **Include the Cognito JWT** on every request as `Authorization: Bearer <token>`
+3. **Handle 401** by redirecting to sign-in
+4. **Handle 429** by showing a user-friendly rate limit message
+5. **Cache with TTL** where documented — no implicit caching elsewhere
+6. **Never modify the interface** without updating `/contracts/state-management.md` first
+
+## Zustand stores
+
+The UI uses three Zustand stores. Each store **depends only on its adaptor interface**, not on specific implementations.
+
+### useBudgetStore
+
+```typescript
+interface BudgetStore {
+  // State
+  transactions: Transaction[];
+  rules: CustomRule[];
+  settings: BudgetSettings;
+  loading: boolean;
+  error: string | null;
+
+  // Actions
+  loadAll: () => Promise<void>;
+  importTransactions: (file: File) => Promise<void>;
+  updateTransaction: (id: number | string, patch: Partial<Transaction>) => Promise<void>;
+  toggleBusinessFlag: (id: number | string) => Promise<void>;
+  learnRuleFromTransaction: (id: number | string) => Promise<void>;
+  setBudgetAmount: (subcategory: string, amount: number, freq: Frequency) => Promise<void>;
+  setProjectBudget: (category: string, lumpSum: number) => Promise<void>;
+  exportBusinessCsv: (filters?: { from?: string; to?: string }) => Promise<Blob>;
+}
+```
+
+### useAiStore
+
+```typescript
+interface AiStore {
+  // State
+  reviewQueue: Array<{
+    transactionId: number | string;
+    suggestion: { category: string; subcategory: string; reason: string };
+    status: "pending" | "confirmed" | "rejected" | "overridden";
+  }>;
+  reviewStatus: "idle" | "running" | "done" | "failed";
+  csvAnalysis: AiCsvAnalysisResponse | null;
+
+  // Actions
+  startAiReview: () => Promise<void>;
+  confirmSuggestion: (transactionId: number | string) => void;
+  rejectSuggestion: (transactionId: number | string) => void;
+  overrideSuggestion: (transactionId: number | string, category: string, subcategory: string) => void;
+  applyAllConfirmed: () => Promise<void>;
+  analyseCsv: (rows: string[][]) => Promise<void>;
+}
+```
+
+### useAuthStore
+
+```typescript
+interface AuthStore {
+  user: { userId: string; email: string; accountId: string; groups: string[] } | null;
+  loading: boolean;
+  signIn: () => Promise<void>;
+  signOut: () => Promise<void>;
+}
+```
+
+## Storage keys (browser localStorage — stub only)
+
+All keys prefixed `budget-tracker.` to namespace against other apps on the same domain.
+
+| Key | Value |
+|---|---|
+| `budget-tracker.transactions` | `Transaction[]` |
+| `budget-tracker.customRules` | `CustomRule[]` |
+| `budget-tracker.budgetOverrides` | `{[sub: string]: number}` |
+| `budget-tracker.budgetFreqs` | `{[sub: string]: Frequency}` |
+| `budget-tracker.customCategories` | `{[cat: string]: string[]}` |
+| `budget-tracker.projectBudgets` | `{[cat: string]: number}` |
+| `budget-tracker.deletedSubs` | `string[]` |
+| `budget-tracker.csvFormatMappings` | `{[fingerprint: string]: CSVMapping}` |
+| `budget-tracker.accountId` | `string` (local dev — real impl derives from JWT) |
+
+**Debounced writes:** Transaction saves debounce to 800ms. Only 8 fields persisted: `_id, date, amount, description, category, subcategory, file, _manual`. (Note: `_business` is deliberately persisted separately in the prototype; real impl persists it normally.)
+
+## Load order on app init
+
+1. Load auth — determine `accountId`
+2. Load settings (small payload, needed for UI to render category options)
+3. Load rules (needed before transactions so rules engine can run on re-process)
+4. Load transactions (largest payload, can stream/paginate)
+5. Run rules engine on any transactions with `_manual: false`
+
+**Critical ordering rule:** Never re-run rules before custom rules are loaded. The prototype had a bug where rules ran on load before custom rules arrived, clearing valid categorisations. The load order above prevents this.
+
+## Cache policies (real impl only)
+
+| Data | Cache duration | Cache key |
+|---|---|---|
+| AI categorisation results | Not cached — each call is unique | — |
+| AI review results | Not cached | — |
+| CSV format mappings | Stored indefinitely in `csvFormatMappings` | fingerprint |
+| User's current auth state | Until JWT expiry | `accountId` |
+
+## Rules engine behaviour (shared logic)
+
+The rules engine runs on the client (v0 stub) and optionally on the server during bulk import (Claude Code real impl — as an optimisation). The logic is identical.
+
+```typescript
+function categoriseTransaction(
+  transaction: Transaction,
+  customRules: CustomRule[],
+  builtinRules: BuiltinRule[]
+): { category: string; subcategory: string; matchedRule: string | null } {
+  if (transaction._manual) {
+    return {
+      category: transaction.category,
+      subcategory: transaction.subcategory,
+      matchedRule: null
+    };
+  }
+
+  // Custom rules first, most recent wins
+  for (const rule of [...customRules].reverse()) {
+    if (matches(transaction.description, rule.match)) {
+      return { category: rule.category, subcategory: rule.subcategory, matchedRule: rule.id };
+    }
+  }
+
+  // Built-in rules
+  for (const rule of builtinRules) {
+    if (rule.match.test(transaction.description)) {
+      return { category: rule.category, subcategory: rule.subcategory, matchedRule: "builtin" };
+    }
+  }
+
+  return { category: "", subcategory: "", matchedRule: null };
+}
+```
+
+`matches()` performs a case-insensitive keyword OR regex test on the description.
+
+## What goes where — quick reference
+
+| Responsibility | Lives in |
+|---|---|
+| UI rendering | Component |
+| Local reactive state | Zustand store |
+| Async data loading | Store action → adaptor |
+| Data persistence | Adaptor (stub or real) |
+| Validation | Adaptor (server-side in real impl) |
+| Business rules (exclusions, calcs) | Domain layer — shared pure functions in `/lib/domain/` |
+| AI prompts | `ai-prompts.md` + `claude-proxy.ts` |

--- a/budget-tracker/contracts/ui-patterns.md
+++ b/budget-tracker/contracts/ui-patterns.md
@@ -1,0 +1,177 @@
+# UI Patterns
+
+**Component conventions, tabs, visual behaviour.** v0 owns this — Claude Code should not deviate without flagging. Documented here so Claude Code knows what to expect when wiring up the backend.
+
+## App shell
+
+The Budget Tracker is one of several apps on the Transformotion platform. It shares:
+
+- The platform header and navigation
+- The dark fintech theme (see palette below)
+- The shared auth flow
+- The launchpad entry point at `apps.transformotion.com.au`
+
+The app itself lives at `apps.transformotion.com.au/budget`.
+
+## Colour palette
+
+Use exactly these values:
+
+| Purpose | Hex |
+|---|---|
+| Background | `#0D1B2A` |
+| Card / surface | `#141720` |
+| Accent teal | `#00C4B3` |
+| Secondary gold | `#E8A838` |
+| Success | `#22c87a` |
+| Danger | `#f05656` |
+| Warning | `#f0a030` |
+| Primary text | `#e8eaf0` |
+| Muted text | `#6b7280` |
+
+Dark theme only. Mobile-first (375px baseline) then desktop (1280px).
+
+The app should feel like a sibling to the Stock Analyser — consistent typography, spacing, button styles, card corners. A user moving between the two should feel they're in the same product family.
+
+## Tabs
+
+The app has **6 tabs**, in this order:
+
+1. **Transactions** — filterable list
+2. **Summary** — monthly financial summary
+3. **Budget** — set budget amounts
+4. **Cashflow** — charts and flow visualisation
+5. **Rules** — rules engine debugger + custom rules editor
+6. **Review** — AI-assisted review queue
+
+### 1. Transactions tab
+
+- Filterable transaction list
+- **Filters (all stackable):**
+  - Category pills (multi-select)
+  - Month dropdown
+  - Source dropdown (CSV filename)
+  - Three-way toggle: **All / Personal / Business**
+- **Row contents:**
+  - Date
+  - Description (with 💼 badge if business)
+  - Amount (green positive, red negative)
+  - Category pill
+  - Subcategory text
+  - Actions: 💼 toggle, Learn rule, Edit
+- **Uncategorised rows** show with a warning-tinted background
+- **Bulk selection** — select multiple, apply action (categorise / flag as business / delete)
+- **"AI Review (N)"** button appears in header when uncategorised transactions exist
+- **"💼 Business (N)" export** button appears when business-flagged transactions exist — downloads CSV
+
+### 2. Summary tab
+
+- Month selector pills at top
+- **Position card** — income vs expenses vs net, coloured status
+- **Expandable category cards** — each shows:
+  - Category name
+  - Budget amount (monthly)
+  - Actual amount
+  - Variance (% and $)
+  - Expand to reveal subcategories
+  - Expand subcategory to reveal the contributing transactions
+- **Separate amber Projects section** at the bottom — below-the-line capital spend tracked against lump-sum budgets with progress bars
+
+### 3. Budget tab
+
+- Category sections, each with subcategory rows
+- Each row:
+  - Subcategory name
+  - Frequency selector (weekly / fortnightly / monthly / quarterly / annually)
+  - Amount input
+  - Computed monthly equivalent (shown alongside)
+- **Separate Projects section** at the bottom — lump-sum budget input per project category with progress bar
+
+### 4. Cashflow tab
+
+Four visualisations, stacked vertically:
+
+1. **Monthly trend line chart** — income vs expenses vs net, last 12 months
+2. **Category bar chart** — current month actuals vs budget per category
+3. **Top overspend chart** — worst-performing subcategories this month
+4. **Sankey diagram** — income sources → Total Income → expense categories → subcategories
+
+### 5. Rules tab
+
+- **Test input at top** — paste any description, see which rule matches
+- **Custom rules table** — match, category, subcategory, learned, delete. Add new rule at bottom.
+- **Collapsible built-in rules section** — read-only, grouped by category
+
+### 6. Review tab
+
+The AI review queue. Shows:
+
+- Status indicator (idle / running batch N of M / complete)
+- Uncategorised transaction rows with AI suggestions
+- Per row:
+  - Transaction (date, description, amount)
+  - AI-suggested category + subcategory
+  - AI reason (1 sentence)
+  - Actions: ✓ confirm, ✗ reject, ✎ override
+- **Confirm all** button at top
+- **Apply & close** button — saves all confirmed/overridden choices and closes the tab
+
+## Component conventions
+
+### Naming
+
+- Components: `PascalCase.tsx`
+- Files: match component name
+- Shared components: `/components/shared/`
+- Feature components: `/components/budget/{tab}/`
+- Domain logic (pure functions): `/lib/domain/budget/`
+
+### Structure
+
+Every component:
+- Is a named export, default-exported for the top-level of each tab
+- Accepts typed props — no `any`
+- Uses Zustand stores via hooks — never reaches into adaptors directly
+- Never calls `fetch` or storage primitives directly
+
+### Styling
+
+- Tailwind CSS with CSS variables for the colour palette
+- No inline styles except for dynamic values (e.g. progress bar width)
+- No shadow/gradient effects — flat dark theme
+- Rounded corners: `rounded-xl` for cards, `rounded-lg` for buttons, `rounded-full` for pills
+- Border: `border border-[#1e2530]` as the default card border
+
+### Interactions
+
+- All mutations go through Zustand actions — never call adaptors from components
+- Loading states must be visible for any action >200ms
+- Errors surface as toasts (top right) — never blocking modals except for destructive confirmations
+- Optimistic updates where safe (categorise, toggle business flag); pessimistic for destructive (delete)
+
+## Accessibility
+
+- Keyboard navigation throughout — every interactive element tabbable
+- All icons have aria-labels
+- Colour is never the sole indicator — amounts also have +/- prefix, not just green/red
+- Minimum font size 12px; body 14px+
+
+## Mobile-first
+
+- 375px is the baseline. All layouts must work at this width without horizontal scroll.
+- Tabs collapse to a horizontal-scrolling strip on mobile
+- Filters collapse to a "Filters (N)" button that opens a sheet
+- Transaction rows stack info vertically on mobile, horizontal on desktop
+- Charts are responsive — Sankey collapses to vertical orientation under 600px
+
+## Forbidden patterns
+
+v0 must not do any of the following. If one is required, update this contract first:
+
+- Direct `fetch()` or `XMLHttpRequest` calls from components
+- `localStorage` reads/writes outside the stub adaptor
+- Hardcoded mock data in components (put it in the stub adaptor)
+- Global state outside Zustand (no module-level `let`)
+- Inline category/subcategory lists (always use the tree from settings)
+- Bespoke colour values (always use the palette)
+- Any assumption that AI calls are synchronous or free

--- a/stock-analyser/contracts/DATA_CONTRACTS.md
+++ b/stock-analyser/contracts/DATA_CONTRACTS.md
@@ -1,7 +1,9 @@
-# Data Contracts — apps/web
+# Data Contracts — Stock Analyser
 
-This document is the canonical reference for interface contracts between the UI layer and the data/API layers.
-**v0 must read this file before doing any UI work that touches data.**
+**Canonical location: `stock-analyser/contracts/DATA_CONTRACTS.md`**
+
+This document is the single source of truth for interface contracts between the Stock Analyser UI and its data/API layers.
+**Read this before any Stock Analyser work that touches services, hooks, types, or cache keys.**
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds `budget-tracker/contracts/` as the single source of truth for Budget Tracker UI/backend contracts
- Adds `CLAUDE.md` with project-level instructions for Claude Code

## What is in /budget-tracker/contracts

| File | Purpose |
|---|---|
| `README.md` | Ownership model, golden rules, adaptor pattern |
| `data-models.md` | All shared TypeScript types (Transaction, CustomRule, BudgetSettings, etc.) |
| `api-endpoints.md` | Every Lambda endpoint — auth, request/response, error conventions |
| `ai-prompts.md` | Verbatim Claude prompts for auto-categorise, AI review, CSV analysis |
| `state-management.md` | Adaptor interfaces, Zustand stores, load order, cache policies |
| `aws-infrastructure.md` | DynamoDB tables, Lambda functions, Cognito groups |
| `ui-patterns.md` | 6-tab structure, colour palette, component conventions |
| `changelog.md` | Append-only contract change log |
| `gap-analysis.md` | Current mismatches between v0 UI and existing monorepo code (M1-M8) |

## Gap analysis highlights (gap-analysis.md M1-M8)

Eight code-level mismatches were found between the existing `apps/web/` code and the contracts:
- **M1 BREAKING:** `CustomRule` shape — monorepo uses `matchType + pattern` vs contract's single `match` field. Recommendation: update contract to monorepo's richer shape.
- **M4 SIGNIFICANT:** `BudgetSettings` has 6 fields in the monorepo not in the contract. Recommendation: update contract.
- **M6 SIGNIFICANT:** `useBudgetStore` action surface differences.
- **M7 MISSING:** `useAiStore` does not exist in the monorepo yet.
- **M8 INFORMATIONAL:** Category tree is more granular in the monorepo than in the contract.

Steve to answer open questions in gap-analysis.md before Claude Code updates data-models.md.

## Test plan
- [ ] Review all 9 contract files for accuracy
- [ ] Review gap-analysis.md M1-M8 and answer open questions
- [ ] Merge to develop
- [ ] Copy contracts to transformotion-apps-b8 and open PR there

🤖 Generated with [Claude Code](https://claude.com/claude-code)