### PR TITLE
feat(budget-tracker): land contracts and migration artifacts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,3 +30,5 @@ Before modifying shared code or platform infrastructure, consider the impact on 
 | Shared packages | `packages/` |
 | Platform Lambda handlers | `functions/` |
 | AWS CDK infrastructure | `infrastructure/` |
+| App contracts (data models, API, state) | `contracts/<app>/` |
+| Migration data artifacts | `migration-artifacts/<app>/` |

--- a/contracts/budget-tracker/README.md
+++ b/contracts/budget-tracker/README.md
@@ -1,0 +1,79 @@
+# Interface Contracts — Budget Tracker
+
+**This folder is the single source of truth for how the Budget Tracker's UI and backend communicate.**
+
+Both v0 (UI) and Claude Code (backend) must conform to these contracts. Neither tool may invent data shapes, endpoints, state patterns, AI prompts, or storage keys outside of what is documented here.
+
+## Context
+
+The Budget Tracker was designed and prototyped in a Claude chat as a working single-file React artifact. That prototype is **feature-complete and in daily use** — it is the authoritative behavioural reference for the app. These contracts are derived from that reference implementation.
+
+v0 is rebuilding the UI as a polished production app. Claude Code is building the AWS backend. Both must conform to these contracts, so that when the two are wired together, they fit.
+
+## Files in this folder
+
+| File | Purpose |
+|---|---|
+| `README.md` | This file — overview and rules |
+| `data-models.md` | TypeScript interfaces for every shared type |
+| `api-endpoints.md` | Every backend endpoint — request/response/auth/errors |
+| `ai-prompts.md` | Every Claude prompt verbatim, with schemas and models |
+| `state-management.md` | Zustand stores, adaptor pattern, storage keys |
+| `aws-infrastructure.md` | DynamoDB tables, Lambda functions, Cognito setup |
+| `ui-patterns.md` | Component conventions, tabs, visual behaviour |
+| `changelog.md` | Dated log of every contract change |
+
+## How to use this folder
+
+**Before making ANY change that touches:**
+
+- A data shape crossing the UI/backend boundary → read `data-models.md`
+- An API call (real or stubbed) → read `api-endpoints.md`
+- State storage (Zustand, localStorage, cache) → read `state-management.md`
+- A Claude/AI call → read `ai-prompts.md`
+- AWS infrastructure → read `aws-infrastructure.md`
+- Component structure, tabs, naming → read `ui-patterns.md`
+
+**When a contract needs to change:**
+
+1. **Update the relevant contract file FIRST**
+2. **Add a dated entry to `changelog.md`** — what changed, why, what downstream work is required
+3. **Only then** implement the code change
+4. **Sync to the other repo** before the other tool is invoked next
+
+## Ownership
+
+| Domain | Owner |
+|---|---|
+| UI components, styling, visual behaviour, client-side interactions | **v0** |
+| Data models, API contracts, AI prompts, state patterns, AWS infrastructure, adaptor implementations | **Claude Code** |
+| Anything in `/contracts` | **Shared** — contract change required first, regardless of which tool initiates |
+
+## Golden rules
+
+1. **Never invent.** If a contract doesn't describe what you need, stop and flag it. Do not guess.
+2. **Contract first, code second.** If the contract is wrong or incomplete, fix the contract before any code.
+3. **Changelog every change.** Any update to any contract file must have a dated changelog entry.
+4. **Sync after every change.** The other repo must receive updated contracts before the other tool is invoked.
+5. **v0 stubs, Claude Code implements.** v0 provides in-memory stub implementations of every adaptor interface. Claude Code provides the real AWS-backed implementations. Both must satisfy the same interface.
+
+## The adaptor pattern (critical)
+
+v0 builds UI components that consume **interfaces**, never direct API calls or storage primitives.
+
+```
+Component  →  Zustand store  →  Adaptor interface  →  (stub OR real implementation)
+```
+
+- **v0's job**: define the interface, write stub implementations that keep data in memory or localStorage so the UI works standalone.
+- **Claude Code's job**: write real implementations of those same interfaces backed by Lambda, DynamoDB, and Cognito.
+- **Neither side changes the interface without updating `/contracts` first.**
+
+This is the pattern that made the Stock Analyser migration clean. Budget Tracker follows the same model.
+
+## Repo layout
+
+- `transformotion/transformotion-apps` — Claude Code repo, **authoritative source for `/contracts`**
+- `transformotion/transformotion-apps-b8` — v0 repo, receives copies of `/contracts` before each v0 session
+
+When contracts change: update authoritative copy → commit → copy to v0 repo → commit there too → then work resumes.

--- a/contracts/budget-tracker/ai-prompts.md
+++ b/contracts/budget-tracker/ai-prompts.md
@@ -1,0 +1,223 @@
+# AI Prompts
+
+**Every Claude prompt the Budget Tracker uses, verbatim.** Both repos must reference these exact prompts. Any change requires a changelog entry.
+
+## Model selection
+
+- **Default model:** `claude-sonnet-4-20250514`
+- **Fallback model:** none — fail fast and surface error to UI if unavailable
+- **All AI calls** route through the shared Lambda proxy at `/api/claude` (same as Stock Analyser). No direct Anthropic calls from the browser.
+- **Temperature:** `0.2` for all budget AI calls (categorisation needs consistency, not creativity).
+
+## Cost and rate controls
+
+- **Daily budget:** $5 USD per account per day across all budget AI endpoints combined. Enforced in the `/api/claude` Lambda proxy.
+- **Rate limit:** 30 calls per minute per account. Returns `429` on breach.
+- **Batch sizes are fixed:** changing them requires a contract update.
+
+---
+
+## 1. Auto-categorisation on import
+
+**Endpoint:** `POST /api/budget/ai/categorise`
+**Batch size:** 50 transactions per request. UI or proxy splits larger inputs into multiple calls.
+**Triggered by:** CSV upload → rules engine runs first → anything still uncategorised goes to this.
+
+### System prompt (verbatim)
+
+```
+You are a personal finance assistant. You categorise Australian bank transactions
+into household budget categories.
+
+You will be given:
+- A list of budget categories, each with allowed subcategories
+- A list of transactions to categorise (index, description, amount)
+
+You must:
+- Return ONLY a JSON array, one object per transaction you can confidently categorise
+- Each object has exactly: {"index": <int>, "category": <string>, "subcategory": <string>}
+- The category value must be one of the provided categories exactly
+- The subcategory value must be one of the subcategories listed under that category exactly
+- Omit any transaction you cannot confidently categorise — do not guess
+- Do not include any text outside the JSON array
+- Do not wrap the JSON in markdown code fences
+```
+
+### User prompt template
+
+```
+BUDGET CATEGORIES AND SUBCATEGORIES:
+{{category_list}}
+
+TRANSACTIONS TO CATEGORISE (index: description — amount):
+{{transactions_list}}
+```
+
+Where:
+- `{{category_list}}` is:
+  ```
+  Income: Your take-home pay, Your partner's take-home pay, Bonuses / overtime, ...
+  Home & utilities: Mortgage / rent, Water, Gas, Electricity, ...
+  ...
+  ```
+- `{{transactions_list}}` is:
+  ```
+  0: WOOLWORTHS MAROOCHYDORE — -145.23
+  1: AGL SALES PTY LTD — -89.50
+  2: DIRECT DEPOSIT SALARY — 4250.00
+  ```
+
+### Expected response shape
+
+```typescript
+[
+  { "index": 0, "category": "Groceries", "subcategory": "Supermarket" },
+  { "index": 1, "category": "Home & utilities", "subcategory": "Electricity" },
+  { "index": 2, "category": "Income", "subcategory": "Your take-home pay" }
+]
+```
+
+Indexes that couldn't be categorised are simply absent.
+
+### Fallback behaviour
+
+If the response is not valid JSON or any item references a non-existent category/subcategory, drop that item and log. Do not fail the whole batch. The UI surfaces anything still uncategorised for AI Review.
+
+---
+
+## 2. AI Review (deliberate review path)
+
+**Endpoint:** `POST /api/budget/ai/review`
+**Batch size:** 20 transactions per request. UI streams results as batches complete.
+**Triggered by:** User clicks "AI Review (N)" button in header.
+**Tool use:** `web_search` enabled — AI may look up unfamiliar Australian merchants.
+
+### System prompt (verbatim)
+
+```
+You are a personal finance assistant helping to categorise Australian bank transactions
+that a fast categorisation pass could not handle.
+
+You will be given:
+- A list of budget categories, each with allowed subcategories
+- A list of unknown or ambiguous transactions (index, description, amount)
+
+You have access to a web_search tool. If a merchant or description is unfamiliar,
+you MAY search to identify the business type before categorising. Use web_search
+sparingly — only when the description is genuinely ambiguous.
+
+You must:
+- Return ONLY a JSON array, one object per transaction
+- Each object has exactly: {"index": <int>, "category": <string>, "subcategory": <string>, "reason": <string>}
+- The category must be one of the provided categories exactly
+- The subcategory must be one of the subcategories listed under that category exactly
+- The reason must be a single sentence explaining your choice in plain English
+- If a transaction is genuinely uncategorisable, return it with category: "", subcategory: "",
+  and reason explaining why
+- Do not include any text outside the JSON array
+- Do not wrap the JSON in markdown code fences
+```
+
+### User prompt template
+
+Same structure as auto-categorisation (`{{category_list}}` + `{{transactions_list}}`).
+
+### Expected response shape
+
+```typescript
+[
+  {
+    "index": 0,
+    "category": "Eating-out & Entertainment",
+    "subcategory": "Restaurants & cafes",
+    "reason": "Foster Black is a wine bar in Mooloolaba based on web search."
+  },
+  {
+    "index": 1,
+    "category": "",
+    "subcategory": "",
+    "reason": "Description 'PY-55632' is an opaque reference with no searchable merchant."
+  }
+]
+```
+
+### Streaming behaviour
+
+Results return in batch order. UI displays each batch as it arrives, allowing the user to confirm ✓, reject ✗, or override the category inline while later batches are still processing.
+
+---
+
+## 3. CSV column analysis
+
+**Endpoint:** `POST /api/budget/ai/csv-analysis`
+**Batch size:** N/A — single call per uploaded file with unrecognised format.
+**Triggered by:** CSV upload with a `fingerprint` not found in `csvFormatMappings`.
+
+### System prompt (verbatim)
+
+```
+You are a CSV format detective. Given the first few rows of a bank transaction CSV,
+identify which column is which.
+
+You must return ONLY a JSON object with this exact shape:
+{
+  "dateColumn": <int>,
+  "descriptionColumn": <int>,
+  "amountColumn": <int>,                    // optional — omit if debit/credit used
+  "debitColumn": <int>,                     // optional — for split debit/credit format
+  "creditColumn": <int>,                    // optional — for split debit/credit format
+  "dateFormat": <string>,                   // e.g. "DD/MM/YYYY", "YYYY-MM-DD", "MM/DD/YYYY"
+  "hasHeader": <bool>,
+  "confidence": "high" | "medium" | "low",
+  "notes": <string>                         // 1-2 sentences explaining your analysis
+}
+
+Either amountColumn OR (debitColumn + creditColumn) must be present, not both.
+
+Columns are 0-indexed.
+
+If you cannot determine the format with reasonable confidence, set confidence: "low"
+and describe the issue in notes. The user will confirm or correct your analysis.
+
+Do not include any text outside the JSON object.
+Do not wrap the JSON in markdown code fences.
+```
+
+### User prompt template
+
+```
+Sample rows from uploaded CSV (each row is an array of cell values):
+{{sample_rows_json}}
+
+The first row above MAY be a header row, or it may be a data row. Use the content
+to decide.
+```
+
+### Expected response shape
+
+See `AiCsvAnalysisResponse` in `data-models.md`.
+
+### Post-processing
+
+On `confidence: "high"`, the UI shows the proposed mapping with a single "Looks right" confirmation. On `medium` or `low`, the UI shows an editable form with the AI's proposal pre-filled. Confirmed mapping is stored in `csvFormatMappings` keyed by fingerprint.
+
+---
+
+## Token and cost budgets per call
+
+| Endpoint | Expected input tokens | Expected output tokens | Max tokens config |
+|---|---|---|---|
+| `ai/categorise` (batch of 50) | ~2,500 | ~1,500 | `max_tokens: 4096` |
+| `ai/review` (batch of 20, with web search) | ~1,500 + search | ~1,500 | `max_tokens: 4096` |
+| `ai/csv-analysis` | ~500 | ~200 | `max_tokens: 1024` |
+
+## Error handling
+
+| Situation | Behaviour |
+|---|---|
+| AI returns invalid JSON | Log, drop the batch, mark transactions as AI-failed, surface in UI |
+| AI returns a category/subcategory not in the provided tree | Drop that single item, keep others |
+| Rate limit hit (429) | Exponential backoff: 1s, 2s, 4s. After 3 retries, surface error to user |
+| Daily budget exhausted | Return 402-like error; UI shows "Daily AI limit reached — manual categorisation only today" |
+| Proxy Lambda timeout | Retry once. If second attempt times out, fail the batch and surface error |
+| `web_search` fails mid-review | AI still returns results without search-based reasoning. Reason field notes this |

--- a/contracts/budget-tracker/api-endpoints.md
+++ b/contracts/budget-tracker/api-endpoints.md
@@ -1,0 +1,276 @@
+# API Endpoints
+
+**Every backend endpoint the Budget Tracker UI calls.** v0 stubs these via adaptor interfaces. Claude Code implements them as real Lambda functions behind API Gateway.
+
+## Common conventions
+
+- **Base path:** `/api/budget`
+- **Auth:** All endpoints require Cognito JWT with group `budget-app` in `cognito:groups`
+- **AccountId resolution:** Derived server-side from JWT — never sent by client. The user's `accountId` maps to the household.
+- **Request format:** JSON body, `Content-Type: application/json`
+- **Response format:** JSON, `Content-Type: application/json`
+- **Errors:** `{ error: string, field?: string, details?: object }`
+- **HTTP status codes:**
+  - `200` — success
+  - `400` — validation error (see `field`)
+  - `401` — missing/invalid JWT
+  - `403` — authenticated but not in `budget-app` group
+  - `404` — resource not found
+  - `429` — rate limit exceeded (budget AI endpoints)
+  - `500` — internal error
+- **All IDs returned by backend are server-authoritative.** v0's stub may assign local IDs; real backend overwrites with canonical UUIDs on create.
+
+## Transactions
+
+### `GET /api/budget/transactions`
+List transactions for the account.
+
+**Query parameters:**
+- `from` (optional): ISO date — only transactions on/after
+- `to` (optional): ISO date — only transactions on/before
+- `limit` (optional, default 1000, max 5000): pagination
+- `cursor` (optional): opaque pagination cursor
+
+**Response 200:**
+```typescript
+{
+  transactions: Transaction[];
+  nextCursor?: string;            // Present if more results exist
+}
+```
+
+### `POST /api/budget/transactions/bulk`
+Bulk upsert transactions (used on CSV import).
+
+**Request:**
+```typescript
+{
+  transactions: Transaction[];    // Without accountId — server fills from JWT
+}
+```
+
+**Response 200:**
+```typescript
+{
+  created: number;
+  updated: number;
+  skipped: number;                // Already existed with same id
+  transactions: Transaction[];    // With server-assigned IDs
+}
+```
+
+### `PATCH /api/budget/transactions/:id`
+Update a single transaction (used for manual categorisation, business flag toggle).
+
+**Request:**
+```typescript
+{
+  category?: string;
+  subcategory?: string;
+  _manual?: boolean;              // Must set to true when user manually categorises
+  _business?: boolean;
+}
+```
+
+**Response 200:**
+```typescript
+{ transaction: Transaction }
+```
+
+### `DELETE /api/budget/transactions/:id`
+Delete a transaction.
+
+**Response 200:**
+```typescript
+{ deleted: true }
+```
+
+## Rules
+
+### `GET /api/budget/rules`
+List custom rules for the account.
+
+**Response 200:**
+```typescript
+{ rules: CustomRule[] }
+```
+
+### `POST /api/budget/rules`
+Create a custom rule.
+
+**Request:**
+```typescript
+{
+  match: string;
+  category: string;
+  subcategory: string;
+  learned: boolean;
+}
+```
+
+**Response 200:**
+```typescript
+{ rule: CustomRule }
+```
+
+### `PATCH /api/budget/rules/:id`
+Update a custom rule.
+
+### `DELETE /api/budget/rules/:id`
+Delete a custom rule.
+
+## Settings
+
+### `GET /api/budget/settings`
+Get all budget settings for the account.
+
+**Response 200:**
+```typescript
+{ settings: BudgetSettings }
+```
+
+### `PATCH /api/budget/settings`
+Partial update — send only fields to change.
+
+**Request:** any subset of `BudgetSettings` fields.
+
+**Response 200:**
+```typescript
+{ settings: BudgetSettings }
+```
+
+## AI endpoints
+
+All AI endpoints proxy to Anthropic via the shared `/api/claude` Lambda (same proxy used by Stock Analyser). Rate limiting, retry, and cost controls live in that proxy — not in these endpoints.
+
+### `POST /api/budget/ai/categorise`
+Auto-categorisation on import (fast path). Batched server-side in chunks of 50.
+
+**Request:**
+```typescript
+{
+  transactions: Array<{
+    index: number;
+    description: string;
+    amount: string;
+  }>;
+  categories: CategoryTree;
+}
+```
+
+**Response 200:**
+```typescript
+{
+  results: Array<{
+    index: number;
+    category: string;
+    subcategory: string;
+  }>;
+}
+```
+
+**Notes:**
+- AI omits any transaction it cannot confidently categorise — UI leaves those uncategorised for AI Review.
+- See `ai-prompts.md` for the exact system prompt and response schema.
+
+### `POST /api/budget/ai/review`
+AI Review tab — deliberate review of uncategorised transactions. Batches of 20. Uses `web_search` tool to look up unknown merchants.
+
+**Request:**
+```typescript
+{
+  transactions: Array<{
+    index: number;
+    description: string;
+    amount: string;
+  }>;
+  categories: CategoryTree;
+}
+```
+
+**Response 200:**
+```typescript
+{
+  results: Array<{
+    index: number;
+    category: string;
+    subcategory: string;
+    reason: string;
+  }>;
+}
+```
+
+**Notes:**
+- Streamed back in batch order. UI shows batches as they arrive (server-sent events or chunked response — implementation detail, but UI expects progressive results).
+
+### `POST /api/budget/ai/csv-analysis`
+Detect CSV format on an unrecognised file.
+
+**Request:**
+```typescript
+{
+  sampleRows: string[][];         // First 5 data rows
+  possibleHeaders?: string[];     // First row if it looks like headers
+}
+```
+
+**Response 200:**
+```typescript
+AiCsvAnalysisResponse             // See data-models.md
+```
+
+## Business expense export
+
+### `GET /api/budget/business-export`
+Server-side CSV generation for the accountant.
+
+**Query parameters:**
+- `from` (optional): ISO date
+- `to` (optional): ISO date
+
+**Response 200:**
+- `Content-Type: text/csv`
+- `Content-Disposition: attachment; filename="business-expenses-{accountId}-{timestamp}.csv"`
+
+**CSV columns:** `Date, Amount, Description, Category, Subcategory, File`
+
+Only transactions with `_business: true` are included.
+
+**Notes:** The prototype generates this client-side. The production backend does it server-side so that future features (signed URLs, email to accountant, scheduled reports) can hook in.
+
+## Migration
+
+### `POST /api/budget/migrate-from-localstorage`
+One-click migration from browser localStorage to backend. Called once per account when a user first logs in with local data present.
+
+**Request:**
+```typescript
+{
+  transactions: Transaction[];
+  rules: CustomRule[];
+  settings: Partial<BudgetSettings>;
+}
+```
+
+**Response 200:**
+```typescript
+{
+  migrated: {
+    transactions: number;
+    rules: number;
+    settings: string[];           // Keys migrated
+  };
+  alreadyPresent: {
+    transactions: number;
+    rules: number;
+  };
+}
+```
+
+**Notes:**
+- Idempotent. Safe to call multiple times. Matches transactions by composite key: `{date, amount, description, file}`.
+- Does not delete localStorage — UI offers that as a separate confirmation after migration succeeds.
+
+## Versioning
+
+All endpoints live under `/api/budget/v1/*` in the actual URL. This document uses the shorter `/api/budget/*` for readability. Any breaking change requires a new major version and a coordinated update here plus in both repos.

--- a/contracts/budget-tracker/aws-infrastructure.md
+++ b/contracts/budget-tracker/aws-infrastructure.md
@@ -1,0 +1,214 @@
+# AWS Infrastructure
+
+**The AWS resources that back the Budget Tracker.** This is Claude Code's domain — v0 never touches AWS. Documented here so both tools have a shared understanding of what the real adaptors will connect to.
+
+## Overview
+
+```
+User browser
+    ↓
+CloudFront (apps.transformotion.com.au/budget)
+    ↓
+S3 (React SPA — shared with other Transformotion apps)
+    ↓
+API Gateway (REST API — /api/budget/v1/*)
+    ↓
+Lambda Functions
+    ↓
+┌─────────────────────────────────────────────┐
+│ Cognito    DynamoDB    Secrets Manager      │
+│ (Auth)     (Data)      (Anthropic API key)  │
+└─────────────────────────────────────────────┘
+```
+
+## Cognito
+
+**Uses the existing shared User Pool** (`transformotion-users`). Budget Tracker does not create its own.
+
+- Required group for access: `budget-app`
+- App client: `budget-tracker-client` (new — scoped to this app's allowed OAuth flows)
+- JWT claims used by backend:
+  - `sub` — userId
+  - `cognito:username`
+  - `cognito:groups` — must include `budget-app`
+  - `email`
+- `accountId` is NOT in the JWT — it is looked up server-side in the `accounts` table (see below)
+
+## DynamoDB tables
+
+All tables follow the naming convention `budget-tracker.<entity>` for easy identification and IAM policy scoping.
+
+### `budget-tracker.accounts`
+
+The household container. One record per shared account.
+
+| Attribute | Type | Notes |
+|---|---|---|
+| `accountId` (PK) | String | UUID |
+| `name` | String | |
+| `members` | List of maps | `[{ userId, role, email, joinedAt }]` |
+| `createdAt` | String | ISO 8601 |
+
+**GSI:** `userId-index` on `members[].userId` for fast lookup: "which account is this user part of?"
+
+### `budget-tracker.transactions`
+
+| Attribute | Type | Notes |
+|---|---|---|
+| `accountId` (PK) | String | |
+| `transactionId` (SK) | String | UUID |
+| `date` | String | DD/MM/YYYY (preserved as string for display) |
+| `dateIso` | String | YYYY-MM-DD (for range queries) |
+| `amount` | String | Preserved as imported |
+| `description` | String | |
+| `category` | String | |
+| `subcategory` | String | |
+| `file` | String | Source CSV filename |
+| `_manual` | Boolean | |
+| `_business` | Boolean | |
+
+**GSI:** `accountId-dateIso-index` with partition key `accountId`, sort key `dateIso` — enables efficient month/range queries.
+
+### `budget-tracker.rules`
+
+| Attribute | Type | Notes |
+|---|---|---|
+| `accountId` (PK) | String | |
+| `ruleId` (SK) | String | UUID |
+| `match` | String | |
+| `category` | String | |
+| `subcategory` | String | |
+| `learned` | Boolean | |
+| `createdAt` | String | |
+
+### `budget-tracker.settings`
+
+Key-value store for per-account settings. Each settings key is its own item so individual fields can be updated without reading/writing the whole record.
+
+| Attribute | Type | Notes |
+|---|---|---|
+| `accountId` (PK) | String | |
+| `settingKey` (SK) | String | `budgetOverrides`, `budgetFreqs`, `customCategories`, `projectBudgets`, `deletedSubs`, `csvFormatMappings` |
+| `value` | Map or List | Shape depends on `settingKey` — see `data-models.md` |
+
+## Lambda functions
+
+All Lambdas share:
+- Runtime: Node.js 20
+- Package: `backend/functions/budget/`
+- Common middleware: JWT verification, `accountId` resolution, error handling
+- Environment variables: `DYNAMO_TABLE_PREFIX=budget-tracker.`, `ANTHROPIC_SECRET_ARN`, `REGION`
+
+### `budget-transactions-handler`
+
+Handles: `GET /transactions`, `POST /transactions/bulk`, `PATCH /transactions/:id`, `DELETE /transactions/:id`
+
+IAM permissions:
+- `dynamodb:Query`, `dynamodb:GetItem`, `dynamodb:BatchWriteItem`, `dynamodb:UpdateItem`, `dynamodb:DeleteItem` on `budget-tracker.transactions`
+
+### `budget-rules-handler`
+
+Handles: `GET /rules`, `POST /rules`, `PATCH /rules/:id`, `DELETE /rules/:id`
+
+IAM permissions: same pattern on `budget-tracker.rules`
+
+### `budget-settings-handler`
+
+Handles: `GET /settings`, `PATCH /settings`
+
+IAM permissions: same pattern on `budget-tracker.settings`
+
+### `budget-ai-categorise-handler`
+
+Handles: `POST /ai/categorise`
+
+Calls Anthropic via the **shared `/api/claude` proxy** — does not call Anthropic directly. Rate limiting, retry, cost tracking live in the proxy.
+
+IAM permissions:
+- `lambda:InvokeFunction` on `claude-api-proxy` (shared proxy)
+
+### `budget-ai-review-handler`
+
+Handles: `POST /ai/review`
+
+Calls Anthropic via shared proxy with `web_search` tool enabled. Streams batches via API Gateway chunked response.
+
+IAM permissions: same as above
+
+### `budget-ai-csv-analysis-handler`
+
+Handles: `POST /ai/csv-analysis`
+
+IAM permissions: same as above
+
+### `budget-export-handler`
+
+Handles: `GET /business-export`
+
+Streams CSV directly from DynamoDB Query results.
+
+IAM permissions:
+- `dynamodb:Query` on `budget-tracker.transactions`
+
+### `budget-migrate-handler`
+
+Handles: `POST /migrate-from-localstorage`
+
+Idempotent bulk import. Uses composite key `{date, amount, description, file}` to deduplicate.
+
+IAM permissions:
+- `dynamodb:BatchWriteItem`, `dynamodb:Query`, `dynamodb:PutItem` on all `budget-tracker.*` tables
+
+## Shared resources (already deployed)
+
+These are used by Budget Tracker but built for all Transformotion apps:
+
+| Resource | Purpose |
+|---|---|
+| `claude-api-proxy` Lambda | Proxies all Claude calls. Handles auth, rate limiting, retry, cost tracking, Secrets Manager lookup |
+| `transformotion-users` Cognito User Pool | Shared auth |
+| `/prod/anthropic/api-key` Secrets Manager entry | API key for `claude-api-proxy` |
+| Shared S3 bucket + CloudFront distribution | Static hosting |
+
+Budget Tracker does not re-create any of these.
+
+## Rate limits and cost controls
+
+Applied in `claude-api-proxy`, not in individual budget Lambdas:
+
+- **Daily budget**: $5 USD per account per day across all budget AI endpoints
+- **Per-minute rate limit**: 30 AI calls per account per minute
+- **Hard token limits**: 4096 max_tokens per request
+- **Timeout**: 30 seconds per AI call; 2 retries on transient failures
+
+## Deployment
+
+- Infrastructure as Code: AWS CDK in `infrastructure/`
+- Deploy per environment: `dev` and `prod`
+- Dev environment: `dev.apps.transformotion.com.au` — deployed via GitHub Actions on push to `develop`
+- CI/CD: already configured (see the Stock Analyser pipeline as the pattern)
+
+## Cost projection (free tier)
+
+For a single household (Steve + Liz):
+- **Cognito**: 2 MAUs — free (50k free tier)
+- **S3**: <1MB storage — free
+- **CloudFront**: <1GB transfer/month — free
+- **API Gateway**: ~10k calls/month — free (1M free tier)
+- **Lambda**: ~10k invocations/month — free (1M free tier)
+- **DynamoDB**: <100MB, <5 WCU, <5 RCU — free (25GB, 25 WCU/RCU free tier)
+- **Anthropic API**: ~$2-5/month — billed separately
+
+Total AWS cost: **~$0-1/month** (Route 53 hosted zone only).
+
+## Security
+
+- All Lambdas assume their own IAM role — no shared execution role
+- DynamoDB IAM policies are scoped by table AND by `accountId` via `LeadingKeys` condition where possible
+- Secrets Manager API key is never logged, never returned to client
+- CORS on API Gateway locked to `https://apps.transformotion.com.au` (and `https://dev.apps.transformotion.com.au` for dev)
+- All data encrypted at rest (DynamoDB) and in transit (HTTPS only)
+
+## What goes in `/contracts` vs what goes in Claude Code's own docs
+
+This file documents **what** exists and **why**. Implementation details — CDK stack structure, IAM policy JSON, exact ARNs — live in Claude Code's infrastructure docs in `transformotion-apps/infrastructure/README.md`. If v0 ever needs to know about infrastructure, it reads this file, not Claude Code's internal docs.

--- a/contracts/budget-tracker/changelog.md
+++ b/contracts/budget-tracker/changelog.md
@@ -1,0 +1,54 @@
+# Changelog
+
+**Every change to any file in `/contracts` must be logged here.**
+
+## Format
+
+```
+## YYYY-MM-DD — <short title>
+
+**File(s) changed:** list
+**Changed by:** v0 | Claude Code | Steve
+**Why:** 1-2 sentences describing the motivation
+
+**Change summary:**
+- Bullet list of what changed
+
+**Downstream work required:**
+- What v0 needs to update (if anything)
+- What Claude Code needs to update (if anything)
+- Any data migration considerations
+
+**Sync status:**
+- [ ] Updated in `transformotion-apps`
+- [ ] Updated in `transformotion-apps-b8`
+```
+
+## Rules
+
+1. **Every change to every file in `/contracts` requires a changelog entry.** No exceptions.
+2. **Entries are append-only.** Never edit or delete past entries.
+3. **Date format is ISO** (YYYY-MM-DD) to keep the list sortable.
+4. **Check both sync boxes before the next session of the other tool.**
+
+---
+
+## 2026-04-18 — Initial contracts established
+
+**File(s) changed:** all
+**Changed by:** Steve (with Claude in chat)
+**Why:** Establish interface contracts between v0 UI and Claude Code backend for the Budget Tracker app. Derived from the feature-complete prototype built in earlier Claude chats.
+
+**Change summary:**
+- Created `README.md`, `data-models.md`, `api-endpoints.md`, `ai-prompts.md`, `state-management.md`, `aws-infrastructure.md`, `ui-patterns.md`, `changelog.md`, `gap-analysis.md`
+- Documented all data types, API endpoints, AI prompts, storage patterns, AWS resources, and UI conventions
+- Established ownership model: v0 owns UI, Claude Code owns backend, both share `/contracts`
+- Established adaptor pattern: v0 stubs interfaces, Claude Code implements them
+
+**Downstream work required:**
+- **v0:** Rearchitect UI to use adaptor interfaces. Stub all data persistence and AI calls per `state-management.md`. Never invent types, endpoints, or prompts outside of what's in `/contracts`. Read `gap-analysis.md` for specific current-state deviations.
+- **Claude Code:** Implement the AWS backend per `api-endpoints.md` and `aws-infrastructure.md`. Implement real adaptors matching the stub interfaces. Read `gap-analysis.md` for what already exists.
+
+**Sync status:**
+- [ ] Updated in `transformotion-apps`
+- [ ] Updated in `transformotion-apps-b8`

--- a/contracts/budget-tracker/data-models.md
+++ b/contracts/budget-tracker/data-models.md
@@ -1,0 +1,230 @@
+# Data Models
+
+**Every type that crosses the UI/backend boundary lives here.** If you need a type that isn't documented, update this file first.
+
+## Core entities
+
+### Transaction
+
+The atomic unit of the Budget Tracker. Every imported line item becomes a Transaction.
+
+```typescript
+interface Transaction {
+  _id: number;                    // Local sequential ID (v0 stub) or UUID (real impl)
+  accountId: string;              // Household account ID (Cognito-derived)
+  date: string;                   // DD/MM/YYYY — preserved for display
+  amount: string;                 // String to preserve sign and decimals as imported
+                                  // Negative = expense, positive = income/refund
+  description: string;            // Original description from CSV
+  category: string | "";          // "" = uncategorised
+  subcategory: string | "";       // "" = uncategorised
+  file: string;                   // Source CSV filename
+  _manual: boolean;               // User has manually set category — rules will not overwrite
+  _business: boolean;             // Flagged as business expense — excluded from personal P&L
+}
+```
+
+**Notes:**
+- `amount` is deliberately a string. The prototype preserves the raw CSV value to avoid floating-point rounding issues and to support banks that use separate debit/credit columns. All arithmetic parses on read.
+- `_manual: true` is a sticky flag. Once a user manually categorises a transaction, the rules engine will never overwrite it on subsequent imports.
+- `_business: true` excludes the transaction from personal P&L calculations everywhere but keeps it visible in the transaction list with a 💼 badge.
+
+### Custom Rule
+
+Heuristics that categorise transactions by description match.
+
+```typescript
+interface CustomRule {
+  id: string;                     // UUID
+  accountId: string;
+  match: string;                  // Keyword or regex pattern, case-insensitive
+  category: string;
+  subcategory: string;
+  learned: boolean;               // true if created via "Learn" button on a transaction
+                                  // false if manually authored in Rules tab
+  createdAt: string;              // ISO 8601
+}
+```
+
+**Notes:**
+- The rules engine also ships a large **built-in ruleset** compiled into the codebase (see `ui-patterns.md` for storage location). Built-in rules are not CRUDable — they're the default heuristics for common Australian merchants.
+- Custom rules override built-in rules when both match. Most recent rule wins if multiple custom rules match.
+
+### Category Tree
+
+The budget categorisation structure. Shared between UI pickers and AI prompts.
+
+```typescript
+interface CategoryTree {
+  [categoryName: string]: string[];  // Array of subcategory names
+}
+```
+
+**Default category tree** (the starter set — users can add custom subcategories):
+
+```typescript
+const DEFAULT_CATEGORIES: CategoryTree = {
+  "Income": [
+    "Your take-home pay",
+    "Your partner's take-home pay",
+    "Bonuses / overtime",
+    "Income from savings and investments",
+    "Child support received",
+    "School fees reimbursement",
+    "Rent (investment property)",
+    "Other income"
+  ],
+  "Home & utilities": [
+    "Mortgage / rent", "Water", "Gas", "Electricity", "Mobile", "Internet",
+    "Streaming Services", "Home improvements & Maintenance",
+    "Furniture & appliances", "Council rates", "Body corporate fees",
+    "Kierans Mobile", "Ellas Mobile"
+  ],
+  "Financial & Insurance": [
+    "Home & contents insurance", "Health insurance", "Car insurance",
+    "Life & income insurance", "Bank fees", "Interest paid",
+    "Financial advice", "Computers & gadgets", "Capital purchases"
+  ],
+  "Groceries": ["Supermarket", "Butcher / bakery / deli", "Other groceries"],
+  "Medical, personal & education": [
+    "Doctors & medical", "Medicines & pharmacy", "Dental", "Glasses & eye care",
+    "Hair & beauty", "Clothing & shoes", "Shopping", "Sports & gym", "Education"
+  ],
+  "Eating-out & Entertainment": [
+    "Restaurants & cafes", "Take-away & snacks", "Drinks & alcohol",
+    "Entertainment & events", "Subscriptions", "Hobbies", "Holidays"
+  ],
+  "Car & Transport": [
+    "Petrol", "Road tolls & parking", "Repairs & maintenance",
+    "Rego & licence", "Uber & taxi", "Airfares", "Public transport"
+  ],
+  "Children": [
+    "Children Clothing", "Child support payment", "School fees",
+    "Toys", "Child care"
+  ],
+  "Renovations": [],              // Populated by user; is a PROJECT category
+  "Transfers": ["Transfer"],      // Special — excluded from P&L
+};
+```
+
+### Budget Settings
+
+Per-account configuration.
+
+```typescript
+interface BudgetSettings {
+  accountId: string;
+  budgetOverrides: { [subcategory: string]: number };    // -1 = tombstoned (deleted)
+  budgetFreqs: { [subcategory: string]: Frequency };
+  customCategories: { [category: string]: string[] };    // user-added subcategories
+  projectBudgets: { [category: string]: number };        // lump-sum, not monthly
+  deletedSubs: string[];                                  // subcategories hidden by user
+  csvFormatMappings: { [fingerprint: string]: CSVMapping };
+}
+
+type Frequency = "weekly" | "fortnightly" | "monthly" | "quarterly" | "annually";
+
+interface CSVMapping {
+  fingerprint: string;            // columnCount + hash of header names
+  dateColumn: number;
+  descriptionColumn: number;
+  amountColumn?: number;          // Single amount column (signed)
+  debitColumn?: number;           // OR separate debit column
+  creditColumn?: number;          // OR separate credit column
+  dateFormat: string;             // e.g. "DD/MM/YYYY", "YYYY-MM-DD"
+  hasHeader: boolean;
+  confirmedAt: string;            // ISO 8601 — when user confirmed this mapping
+}
+```
+
+### Account
+
+The shared household container. Steve and Liz share one `accountId`, not one per user.
+
+```typescript
+interface Account {
+  accountId: string;              // UUID
+  name: string;                   // Household name
+  members: AccountMember[];
+  createdAt: string;
+}
+
+interface AccountMember {
+  userId: string;                 // Cognito sub claim
+  role: "owner" | "member";
+  email: string;
+  joinedAt: string;
+}
+```
+
+## Exclusion rules (CRITICAL — apply everywhere)
+
+A transaction is **excluded from personal P&L** if ANY of these are true:
+
+1. `subcategory === "Transfer"` (movements between own accounts)
+2. `_business === true`
+3. `category` is in `PROJECT_CATEGORIES` (default: `["Renovations"]`)
+4. `subcategory` is in `PROJECT_SUBCATEGORIES` (default: `["Capital purchases"]`)
+
+These exclusions must be applied **consistently** across:
+- Summary tab totals (income, expenses, net position)
+- Category card totals
+- Subcategory totals
+- Cashflow trend chart
+- Cashflow category bar chart
+- Budget deficit/surplus card
+- Sankey diagram
+
+Excluded transactions are **still visible** in the Transactions tab (with filter toggles) and in the dedicated Projects and Business Expenses views.
+
+## AI response schemas
+
+### Auto-categorisation response
+
+```typescript
+interface AiCategoriseResponse {
+  results: Array<{
+    index: number;                // Matches input transaction index
+    category: string;             // Must be from provided CategoryTree
+    subcategory: string;          // Must be from provided CategoryTree[category]
+  }>;
+}
+```
+
+Transactions the AI cannot confidently categorise are simply omitted from the response (no placeholder).
+
+### AI Review response
+
+```typescript
+interface AiReviewResponse {
+  results: Array<{
+    index: number;
+    category: string;
+    subcategory: string;
+    reason: string;               // 1-sentence explanation for the user
+  }>;
+}
+```
+
+### CSV format analysis response
+
+```typescript
+interface AiCsvAnalysisResponse {
+  dateColumn: number;
+  descriptionColumn: number;
+  amountColumn?: number;
+  debitColumn?: number;
+  creditColumn?: number;
+  dateFormat: string;             // One of: "DD/MM/YYYY", "MM/DD/YYYY", "YYYY-MM-DD", etc.
+  hasHeader: boolean;
+  confidence: "high" | "medium" | "low";
+  notes: string;                  // Human-readable explanation for the confirmation UI
+}
+```
+
+## Type safety requirements
+
+- All contract types must live in a shared TypeScript file: `/types/contracts.ts` (both repos)
+- Neither v0 nor Claude Code may extend these types without updating this document first
+- Optional fields are marked with `?`; nullable with `| null`. Do not confuse them.
+- Every endpoint and adaptor method must reference these types by name — no inline duplication.

--- a/contracts/budget-tracker/gap-analysis.md
+++ b/contracts/budget-tracker/gap-analysis.md
@@ -1,0 +1,110 @@
+# Gap Analysis
+
+**This document flags known deviations between the current state of each repo and these contracts.** Both tools should read this before starting work, so they know what needs to be brought into line.
+
+This is a living document. As gaps are closed, cross them off. As new gaps appear, add them.
+
+---
+
+## For v0 (transformotion-apps-b8)
+
+### Known gaps in current UI
+
+1. **Data layer not using adaptor pattern**
+   - Current: v0's UI makes direct calls / uses mock data inline
+   - Required: route everything through Zustand stores, which route through adaptor interfaces. See `state-management.md`.
+   - Action: rearchitect data flow. Introduce `/lib/services/budget/`, `/lib/services/ai/`, `/lib/services/auth/` folders with the documented interfaces and stub implementations.
+
+2. **AI calls are stubbed without matching the real contract**
+   - Current: AI is a visual placeholder
+   - Required: stub implementations of `AIService` that match the interface exactly, so when Claude Code's real implementation swaps in, no UI changes needed
+   - Action: read `ai-prompts.md` and `state-management.md` → `AIService`. Implement stubs that return plausible canned responses matching the documented shapes.
+
+3. **Storage keys need unified prefix**
+   - Required: all localStorage keys prefixed `budget-tracker.` per `state-management.md`
+   - Action: if any localStorage is used in the current v0 build, update keys.
+
+4. **Type definitions may not match**
+   - Required: single shared file `/types/contracts.ts` with every type from `data-models.md`
+   - Action: create this file, import throughout the app. Delete any duplicated or drifted type definitions.
+
+5. **Tab structure may not match**
+   - Required: 6 tabs in the order Transactions / Summary / Budget / Cashflow / Rules / Review (see `ui-patterns.md`)
+   - Action: verify current tab list and order. Add missing tabs with placeholder content if needed.
+
+6. **Exclusion rules may be inconsistent**
+   - Required: the four exclusion rules in `data-models.md` must apply to every total/chart in the app
+   - Action: audit every calculation. Centralise exclusion logic in `/lib/domain/budget/exclusions.ts` as a shared pure function, use it everywhere.
+
+### What v0 must NOT do
+
+- Do not attempt to call any AWS service
+- Do not introduce new data types, endpoints, or storage patterns without updating `/contracts` first
+- Do not change the AI prompt wording — the stub can return canned data, but when the real impl swaps in, it will use the exact prompt in `ai-prompts.md`
+- Do not invent new tabs or restructure the 6-tab layout without a contract update
+
+---
+
+## For Claude Code (transformotion-apps)
+
+### Known gaps in current backend
+
+1. **Budget Tracker backend does not exist yet**
+   - Current: no Budget Tracker-specific Lambdas, DynamoDB tables, or API Gateway routes
+   - Required: everything in `aws-infrastructure.md` and `api-endpoints.md`
+   - Action: build from scratch. Follow the patterns established for the Stock Analyser.
+
+2. **Budget Tracker logic currently lives in a Claude chat artifact**
+   - Current: categorisation rules, AI prompts, exclusion logic, Sankey transformation, cashflow calcs live in a single-file React artifact built in a previous Claude chat
+   - Required: port all domain logic to `/lib/domain/budget/` as shared pure functions, then consume from both Lambdas (server-side) and the UI (client-side)
+   - Action:
+     - Extract the built-in rules engine → `/lib/domain/budget/builtin-rules.ts`
+     - Extract the exclusion logic → `/lib/domain/budget/exclusions.ts`
+     - Extract the Sankey data transformation → `/lib/domain/budget/sankey.ts`
+     - Extract the cashflow calculations → `/lib/domain/budget/cashflow.ts`
+     - Extract the budget-vs-actual logic → `/lib/domain/budget/budget-tracking.ts`
+     - The source reference is the working artifact (`budget-categoriser.jsx`) from the earlier Claude chat. Steve has access to this.
+
+3. **Account model not yet implemented**
+   - Current: Stock Analyser is per-user (no shared household concept)
+   - Required: `budget-tracker.accounts` table with members list — Steve and Liz share one `accountId`
+   - Action: build the accounts table, migration logic, and Cognito → accountId resolution middleware. This may be reusable across future household-shared apps.
+
+4. **Shared Claude proxy must support `web_search` tool**
+   - Current: the `claude-api-proxy` Lambda may not yet support passing through tool-use (specifically `web_search`)
+   - Required: `budget-ai-review-handler` needs to invoke Claude with `web_search` enabled
+   - Action: verify proxy supports tool-use pass-through. If not, extend it.
+
+5. **Cost and rate controls**
+   - Current: proxy has rate limits but may not be per-account per-day budgeted for the Budget Tracker
+   - Required: $5/day AI budget per account specifically for budget AI endpoints
+   - Action: add per-endpoint-class budget tracking in the proxy or in the budget Lambdas.
+
+### What Claude Code must NOT do
+
+- Do not change any interface documented in `state-management.md` — v0 depends on exact shapes
+- Do not change the AI prompt wording in `ai-prompts.md` without coordinating a contract update
+- Do not introduce new endpoints without updating `api-endpoints.md` first
+- Do not modify data models without updating `data-models.md` first
+
+---
+
+## Open questions for Steve
+
+These are decisions that weren't fully resolved in the prototype and need answers before Claude Code finalises the backend:
+
+1. **Liz's access model** — will she log in with her own Cognito identity and share the `accountId` via the `members` list? Or is there a simpler starting point (e.g. single account, both share credentials) for v1?
+2. **Data backup** — do you want automated DynamoDB backups to S3, or is point-in-time recovery sufficient?
+3. **AI cost alerting** — at what threshold should you be emailed? ($2/day? $3/day?)
+4. **Historical transaction limits** — is there a cutoff date beyond which old transactions shouldn't be imported? The current prototype imports everything.
+5. **Audit log** — should every transaction edit be logged for later review, or is "last write wins" sufficient for a household app?
+
+---
+
+## Closing a gap
+
+When a gap is addressed:
+
+1. Mark it complete here by striking through or moving to a "Closed" section at the bottom
+2. Add an entry to `changelog.md`
+3. Sync the updated `/contracts` folder to the other repo

--- a/contracts/budget-tracker/state-management.md
+++ b/contracts/budget-tracker/state-management.md
@@ -1,0 +1,292 @@
+# State Management
+
+**How the Budget Tracker UI stores and retrieves data.** v0 defines the interfaces and writes in-memory/localStorage stubs. Claude Code writes the real adaptors against the same interfaces.
+
+## The adaptor pattern (recap)
+
+```
+UI Component
+    ↓
+Zustand store
+    ↓
+Adaptor interface  ← defined here, shared by both implementations
+    ↓
+┌─────────────────────────────────────┐
+│ v0 stub              Claude Code    │
+│ (in-memory or        real impl      │
+│  localStorage)       (Lambda/DDB)   │
+└─────────────────────────────────────┘
+```
+
+Neither implementation is "better" — they serve different purposes. The stub makes the UI work standalone during design; the real adaptor makes it work in production.
+
+## Folder structure (both repos)
+
+```
+/lib/services/
+  ├── budget/
+  │   ├── index.ts                 ← re-exports interfaces + picker
+  │   ├── types.ts                 ← interface definitions
+  │   ├── stub-adaptor.ts          ← v0's stub (in-memory + localStorage)
+  │   └── aws-adaptor.ts           ← Claude Code's real impl (absent in v0 repo)
+  ├── ai/
+  │   ├── index.ts
+  │   ├── types.ts
+  │   ├── stub-adaptor.ts          ← returns canned responses
+  │   └── claude-proxy.ts          ← real impl calls Lambda
+  └── auth/
+      ├── index.ts
+      ├── types.ts
+      ├── stub-adaptor.ts          ← hardcoded test user
+      └── cognito-adaptor.ts       ← real impl
+```
+
+The `index.ts` exports a single `getBudgetService()` (etc.) that returns the configured adaptor based on an environment variable. v0's repo always uses the stub; Claude Code's repo uses the real adaptor for production builds.
+
+## Adaptor interfaces
+
+### BudgetRepository
+
+```typescript
+interface BudgetRepository {
+  // Transactions
+  listTransactions(filters?: {
+    from?: string;
+    to?: string;
+    limit?: number;
+    cursor?: string;
+  }): Promise<{ transactions: Transaction[]; nextCursor?: string }>;
+
+  bulkUpsertTransactions(transactions: Omit<Transaction, "accountId">[]):
+    Promise<{ created: number; updated: number; skipped: number; transactions: Transaction[] }>;
+
+  updateTransaction(id: number | string, patch: Partial<Transaction>):
+    Promise<Transaction>;
+
+  deleteTransaction(id: number | string): Promise<void>;
+
+  // Rules
+  listRules(): Promise<CustomRule[]>;
+  createRule(rule: Omit<CustomRule, "id" | "accountId" | "createdAt">): Promise<CustomRule>;
+  updateRule(id: string, patch: Partial<CustomRule>): Promise<CustomRule>;
+  deleteRule(id: string): Promise<void>;
+
+  // Settings
+  getSettings(): Promise<BudgetSettings>;
+  updateSettings(patch: Partial<BudgetSettings>): Promise<BudgetSettings>;
+
+  // Business export
+  generateBusinessExportCsv(filters?: { from?: string; to?: string }): Promise<Blob>;
+
+  // Migration
+  migrateFromLocalStorage(data: {
+    transactions: Transaction[];
+    rules: CustomRule[];
+    settings: Partial<BudgetSettings>;
+  }): Promise<{ migrated: object; alreadyPresent: object }>;
+}
+```
+
+### AIService
+
+```typescript
+interface AIService {
+  categoriseTransactions(input: {
+    transactions: Array<{ index: number; description: string; amount: string }>;
+    categories: CategoryTree;
+  }): Promise<AiCategoriseResponse>;
+
+  reviewTransactions(input: {
+    transactions: Array<{ index: number; description: string; amount: string }>;
+    categories: CategoryTree;
+    onBatch?: (batchResults: AiReviewResponse["results"]) => void;  // streaming callback
+  }): Promise<AiReviewResponse>;
+
+  analyseCsvFormat(input: {
+    sampleRows: string[][];
+    possibleHeaders?: string[];
+  }): Promise<AiCsvAnalysisResponse>;
+}
+```
+
+### AuthService
+
+```typescript
+interface AuthService {
+  getCurrentUser(): Promise<{ userId: string; email: string; accountId: string; groups: string[] } | null>;
+  signIn(): Promise<void>;         // Real impl triggers Cognito Hosted UI
+  signOut(): Promise<void>;
+  getIdToken(): Promise<string | null>;
+}
+```
+
+## Stub implementation rules (v0)
+
+The stub adaptors must:
+
+1. **Persist to localStorage** so data survives page reloads (critical for design review)
+2. **Use the same storage keys** as the prototype — see "Storage keys" below
+3. **Simulate async** — every method returns a Promise, even if data is instant
+4. **Simulate AI calls** — return canned categorisation for a fixed seed dataset, or use a simple keyword match against the built-in rules
+5. **NOT call any external service** — no fetch, no API calls. The stub is fully offline.
+
+The stub's job is to make the UI feel real during design. It does not need to be production-quality.
+
+## Real implementation rules (Claude Code)
+
+The real adaptors must:
+
+1. **Call the documented endpoints** in `api-endpoints.md` — nothing else
+2. **Include the Cognito JWT** on every request as `Authorization: Bearer <token>`
+3. **Handle 401** by redirecting to sign-in
+4. **Handle 429** by showing a user-friendly rate limit message
+5. **Cache with TTL** where documented — no implicit caching elsewhere
+6. **Never modify the interface** without updating `/contracts/state-management.md` first
+
+## Zustand stores
+
+The UI uses three Zustand stores. Each store **depends only on its adaptor interface**, not on specific implementations.
+
+### useBudgetStore
+
+```typescript
+interface BudgetStore {
+  // State
+  transactions: Transaction[];
+  rules: CustomRule[];
+  settings: BudgetSettings;
+  loading: boolean;
+  error: string | null;
+
+  // Actions
+  loadAll: () => Promise<void>;
+  importTransactions: (file: File) => Promise<void>;
+  updateTransaction: (id: number | string, patch: Partial<Transaction>) => Promise<void>;
+  toggleBusinessFlag: (id: number | string) => Promise<void>;
+  learnRuleFromTransaction: (id: number | string) => Promise<void>;
+  setBudgetAmount: (subcategory: string, amount: number, freq: Frequency) => Promise<void>;
+  setProjectBudget: (category: string, lumpSum: number) => Promise<void>;
+  exportBusinessCsv: (filters?: { from?: string; to?: string }) => Promise<Blob>;
+}
+```
+
+### useAiStore
+
+```typescript
+interface AiStore {
+  // State
+  reviewQueue: Array<{
+    transactionId: number | string;
+    suggestion: { category: string; subcategory: string; reason: string };
+    status: "pending" | "confirmed" | "rejected" | "overridden";
+  }>;
+  reviewStatus: "idle" | "running" | "done" | "failed";
+  csvAnalysis: AiCsvAnalysisResponse | null;
+
+  // Actions
+  startAiReview: () => Promise<void>;
+  confirmSuggestion: (transactionId: number | string) => void;
+  rejectSuggestion: (transactionId: number | string) => void;
+  overrideSuggestion: (transactionId: number | string, category: string, subcategory: string) => void;
+  applyAllConfirmed: () => Promise<void>;
+  analyseCsv: (rows: string[][]) => Promise<void>;
+}
+```
+
+### useAuthStore
+
+```typescript
+interface AuthStore {
+  user: { userId: string; email: string; accountId: string; groups: string[] } | null;
+  loading: boolean;
+  signIn: () => Promise<void>;
+  signOut: () => Promise<void>;
+}
+```
+
+## Storage keys (browser localStorage — stub only)
+
+All keys prefixed `budget-tracker.` to namespace against other apps on the same domain.
+
+| Key | Value |
+|---|---|
+| `budget-tracker.transactions` | `Transaction[]` |
+| `budget-tracker.customRules` | `CustomRule[]` |
+| `budget-tracker.budgetOverrides` | `{[sub: string]: number}` |
+| `budget-tracker.budgetFreqs` | `{[sub: string]: Frequency}` |
+| `budget-tracker.customCategories` | `{[cat: string]: string[]}` |
+| `budget-tracker.projectBudgets` | `{[cat: string]: number}` |
+| `budget-tracker.deletedSubs` | `string[]` |
+| `budget-tracker.csvFormatMappings` | `{[fingerprint: string]: CSVMapping}` |
+| `budget-tracker.accountId` | `string` (local dev — real impl derives from JWT) |
+
+**Debounced writes:** Transaction saves debounce to 800ms. Only 8 fields persisted: `_id, date, amount, description, category, subcategory, file, _manual`. (Note: `_business` is deliberately persisted separately in the prototype; real impl persists it normally.)
+
+## Load order on app init
+
+1. Load auth — determine `accountId`
+2. Load settings (small payload, needed for UI to render category options)
+3. Load rules (needed before transactions so rules engine can run on re-process)
+4. Load transactions (largest payload, can stream/paginate)
+5. Run rules engine on any transactions with `_manual: false`
+
+**Critical ordering rule:** Never re-run rules before custom rules are loaded. The prototype had a bug where rules ran on load before custom rules arrived, clearing valid categorisations. The load order above prevents this.
+
+## Cache policies (real impl only)
+
+| Data | Cache duration | Cache key |
+|---|---|---|
+| AI categorisation results | Not cached — each call is unique | — |
+| AI review results | Not cached | — |
+| CSV format mappings | Stored indefinitely in `csvFormatMappings` | fingerprint |
+| User's current auth state | Until JWT expiry | `accountId` |
+
+## Rules engine behaviour (shared logic)
+
+The rules engine runs on the client (v0 stub) and optionally on the server during bulk import (Claude Code real impl — as an optimisation). The logic is identical.
+
+```typescript
+function categoriseTransaction(
+  transaction: Transaction,
+  customRules: CustomRule[],
+  builtinRules: BuiltinRule[]
+): { category: string; subcategory: string; matchedRule: string | null } {
+  if (transaction._manual) {
+    return {
+      category: transaction.category,
+      subcategory: transaction.subcategory,
+      matchedRule: null
+    };
+  }
+
+  // Custom rules first, most recent wins
+  for (const rule of [...customRules].reverse()) {
+    if (matches(transaction.description, rule.match)) {
+      return { category: rule.category, subcategory: rule.subcategory, matchedRule: rule.id };
+    }
+  }
+
+  // Built-in rules
+  for (const rule of builtinRules) {
+    if (rule.match.test(transaction.description)) {
+      return { category: rule.category, subcategory: rule.subcategory, matchedRule: "builtin" };
+    }
+  }
+
+  return { category: "", subcategory: "", matchedRule: null };
+}
+```
+
+`matches()` performs a case-insensitive keyword OR regex test on the description.
+
+## What goes where — quick reference
+
+| Responsibility | Lives in |
+|---|---|
+| UI rendering | Component |
+| Local reactive state | Zustand store |
+| Async data loading | Store action → adaptor |
+| Data persistence | Adaptor (stub or real) |
+| Validation | Adaptor (server-side in real impl) |
+| Business rules (exclusions, calcs) | Domain layer — shared pure functions in `/lib/domain/` |
+| AI prompts | `ai-prompts.md` + `claude-proxy.ts` |

--- a/contracts/budget-tracker/ui-patterns.md
+++ b/contracts/budget-tracker/ui-patterns.md
@@ -1,0 +1,177 @@
+# UI Patterns
+
+**Component conventions, tabs, visual behaviour.** v0 owns this — Claude Code should not deviate without flagging. Documented here so Claude Code knows what to expect when wiring up the backend.
+
+## App shell
+
+The Budget Tracker is one of several apps on the Transformotion platform. It shares:
+
+- The platform header and navigation
+- The dark fintech theme (see palette below)
+- The shared auth flow
+- The launchpad entry point at `apps.transformotion.com.au`
+
+The app itself lives at `apps.transformotion.com.au/budget`.
+
+## Colour palette
+
+Use exactly these values:
+
+| Purpose | Hex |
+|---|---|
+| Background | `#0D1B2A` |
+| Card / surface | `#141720` |
+| Accent teal | `#00C4B3` |
+| Secondary gold | `#E8A838` |
+| Success | `#22c87a` |
+| Danger | `#f05656` |
+| Warning | `#f0a030` |
+| Primary text | `#e8eaf0` |
+| Muted text | `#6b7280` |
+
+Dark theme only. Mobile-first (375px baseline) then desktop (1280px).
+
+The app should feel like a sibling to the Stock Analyser — consistent typography, spacing, button styles, card corners. A user moving between the two should feel they're in the same product family.
+
+## Tabs
+
+The app has **6 tabs**, in this order:
+
+1. **Transactions** — filterable list
+2. **Summary** — monthly financial summary
+3. **Budget** — set budget amounts
+4. **Cashflow** — charts and flow visualisation
+5. **Rules** — rules engine debugger + custom rules editor
+6. **Review** — AI-assisted review queue
+
+### 1. Transactions tab
+
+- Filterable transaction list
+- **Filters (all stackable):**
+  - Category pills (multi-select)
+  - Month dropdown
+  - Source dropdown (CSV filename)
+  - Three-way toggle: **All / Personal / Business**
+- **Row contents:**
+  - Date
+  - Description (with 💼 badge if business)
+  - Amount (green positive, red negative)
+  - Category pill
+  - Subcategory text
+  - Actions: 💼 toggle, Learn rule, Edit
+- **Uncategorised rows** show with a warning-tinted background
+- **Bulk selection** — select multiple, apply action (categorise / flag as business / delete)
+- **"AI Review (N)"** button appears in header when uncategorised transactions exist
+- **"💼 Business (N)" export** button appears when business-flagged transactions exist — downloads CSV
+
+### 2. Summary tab
+
+- Month selector pills at top
+- **Position card** — income vs expenses vs net, coloured status
+- **Expandable category cards** — each shows:
+  - Category name
+  - Budget amount (monthly)
+  - Actual amount
+  - Variance (% and $)
+  - Expand to reveal subcategories
+  - Expand subcategory to reveal the contributing transactions
+- **Separate amber Projects section** at the bottom — below-the-line capital spend tracked against lump-sum budgets with progress bars
+
+### 3. Budget tab
+
+- Category sections, each with subcategory rows
+- Each row:
+  - Subcategory name
+  - Frequency selector (weekly / fortnightly / monthly / quarterly / annually)
+  - Amount input
+  - Computed monthly equivalent (shown alongside)
+- **Separate Projects section** at the bottom — lump-sum budget input per project category with progress bar
+
+### 4. Cashflow tab
+
+Four visualisations, stacked vertically:
+
+1. **Monthly trend line chart** — income vs expenses vs net, last 12 months
+2. **Category bar chart** — current month actuals vs budget per category
+3. **Top overspend chart** — worst-performing subcategories this month
+4. **Sankey diagram** — income sources → Total Income → expense categories → subcategories
+
+### 5. Rules tab
+
+- **Test input at top** — paste any description, see which rule matches
+- **Custom rules table** — match, category, subcategory, learned, delete. Add new rule at bottom.
+- **Collapsible built-in rules section** — read-only, grouped by category
+
+### 6. Review tab
+
+The AI review queue. Shows:
+
+- Status indicator (idle / running batch N of M / complete)
+- Uncategorised transaction rows with AI suggestions
+- Per row:
+  - Transaction (date, description, amount)
+  - AI-suggested category + subcategory
+  - AI reason (1 sentence)
+  - Actions: ✓ confirm, ✗ reject, ✎ override
+- **Confirm all** button at top
+- **Apply & close** button — saves all confirmed/overridden choices and closes the tab
+
+## Component conventions
+
+### Naming
+
+- Components: `PascalCase.tsx`
+- Files: match component name
+- Shared components: `/components/shared/`
+- Feature components: `/components/budget/{tab}/`
+- Domain logic (pure functions): `/lib/domain/budget/`
+
+### Structure
+
+Every component:
+- Is a named export, default-exported for the top-level of each tab
+- Accepts typed props — no `any`
+- Uses Zustand stores via hooks — never reaches into adaptors directly
+- Never calls `fetch` or storage primitives directly
+
+### Styling
+
+- Tailwind CSS with CSS variables for the colour palette
+- No inline styles except for dynamic values (e.g. progress bar width)
+- No shadow/gradient effects — flat dark theme
+- Rounded corners: `rounded-xl` for cards, `rounded-lg` for buttons, `rounded-full` for pills
+- Border: `border border-[#1e2530]` as the default card border
+
+### Interactions
+
+- All mutations go through Zustand actions — never call adaptors from components
+- Loading states must be visible for any action >200ms
+- Errors surface as toasts (top right) — never blocking modals except for destructive confirmations
+- Optimistic updates where safe (categorise, toggle business flag); pessimistic for destructive (delete)
+
+## Accessibility
+
+- Keyboard navigation throughout — every interactive element tabbable
+- All icons have aria-labels
+- Colour is never the sole indicator — amounts also have +/- prefix, not just green/red
+- Minimum font size 12px; body 14px+
+
+## Mobile-first
+
+- 375px is the baseline. All layouts must work at this width without horizontal scroll.
+- Tabs collapse to a horizontal-scrolling strip on mobile
+- Filters collapse to a "Filters (N)" button that opens a sheet
+- Transaction rows stack info vertically on mobile, horizontal on desktop
+- Charts are responsive — Sankey collapses to vertical orientation under 600px
+
+## Forbidden patterns
+
+v0 must not do any of the following. If one is required, update this contract first:
+
+- Direct `fetch()` or `XMLHttpRequest` calls from components
+- `localStorage` reads/writes outside the stub adaptor
+- Hardcoded mock data in components (put it in the stub adaptor)
+- Global state outside Zustand (no module-level `let`)
+- Inline category/subcategory lists (always use the tree from settings)
+- Bespoke colour values (always use the palette)
+- Any assumption that AI calls are synchronous or free

--- a/migration-artifacts/budget-tracker/budget-tracker-export-2026-04-18.json
+++ b/migration-artifacts/budget-tracker/budget-tracker-export-2026-04-18.json
@@ -1,0 +1,7937 @@
+{
+  "exportedAt": "2026-04-18T06:12:53.523Z",
+  "sourceApp": "budget-categoriser.jsx",
+  "sourceChat": "2eafe99b-cff6-40fe-afaf-0587686d0830",
+  "transactions": [
+    {
+      "_id": 0,
+      "date": "30/01/2026",
+      "amount": "-8050.94",
+      "description": "PAYMENT TO MOODIE STEVEN JAMES",
+      "category": "Financial & Insurance",
+      "subcategory": "Home loan",
+      "file": "ANZ Joint Offset 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 1,
+      "date": "28/01/2026",
+      "amount": "3500.00",
+      "description": "PAYMENT FROM Hawkins E A",
+      "category": "_ignore",
+      "subcategory": "",
+      "file": "ANZ Joint Offset 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 2,
+      "date": "15/01/2026",
+      "amount": "-9775.00",
+      "description": "ANZ M-BANKING FUNDS TFER TRANSFER 279885  TO 4564X",
+      "category": "Financial & Insurance",
+      "subcategory": "Transfer",
+      "file": "ANZ Joint Offset 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 3,
+      "date": "14/01/2026",
+      "amount": "6000.00",
+      "description": "PAYMENT FROM Hawkins E A",
+      "category": "_ignore",
+      "subcategory": "",
+      "file": "ANZ Joint Offset 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 4,
+      "date": "09/01/2026",
+      "amount": "-10.00",
+      "description": "ACCOUNT SERVICING FEE",
+      "category": "Financial & Insurance",
+      "subcategory": "Bank fees",
+      "file": "ANZ Joint Offset 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 5,
+      "date": "07/01/2026",
+      "amount": "43.90",
+      "description": "EFTPOS MEDICARE BENEFIT",
+      "category": "Income",
+      "subcategory": "Health insurance reimbursement",
+      "file": "ANZ Joint Offset 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 6,
+      "date": "25/02/2026",
+      "amount": "3300.00",
+      "description": "PAYMENT FROM Hawkins E A",
+      "category": "_ignore",
+      "subcategory": "",
+      "file": "ANZ Joint Offset 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 7,
+      "date": "11/02/2026",
+      "amount": "-10.00",
+      "description": "ACCOUNT SERVICING FEE",
+      "category": "Financial & Insurance",
+      "subcategory": "Bank fees",
+      "file": "ANZ Joint Offset 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 8,
+      "date": "11/02/2026",
+      "amount": "4000.00",
+      "description": "PAYMENT FROM Hawkins E A",
+      "category": "_ignore",
+      "subcategory": "",
+      "file": "ANZ Joint Offset 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 9,
+      "date": "29/01/2026",
+      "amount": "-150.00",
+      "description": "ANZ INTERNET BANKING PAYMENT 858073 TO ELLA MOODIE",
+      "category": "Children",
+      "subcategory": "Child support payment",
+      "file": "ANZ Offset 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 10,
+      "date": "29/01/2026",
+      "amount": "6350.03",
+      "description": "PAY/SALARY FROM TALENT INTERNATI 500011896",
+      "category": "Income",
+      "subcategory": "Your take-home pay",
+      "file": "ANZ Offset 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 11,
+      "date": "22/01/2026",
+      "amount": "-150.00",
+      "description": "ANZ INTERNET BANKING PAYMENT 687595 TO ELLA MOODIE",
+      "category": "Children",
+      "subcategory": "Child support payment",
+      "file": "ANZ Offset 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 12,
+      "date": "22/01/2026",
+      "amount": "-26.00",
+      "description": "ANZ MOBILE BANKING PAYMENT 844618 TO ELLA MOODIE",
+      "category": "Children",
+      "subcategory": "Child support payment",
+      "file": "ANZ Offset 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 13,
+      "date": "20/01/2026",
+      "amount": "-100.00",
+      "description": "ANZ MOBILE BANKING PAYMENT 501243 TO ELLA MOODIE",
+      "category": "Children",
+      "subcategory": "Child support payment",
+      "file": "ANZ Offset 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 14,
+      "date": "15/01/2026",
+      "amount": "-150.00",
+      "description": "ANZ INTERNET BANKING PAYMENT 272737 TO ELLA MOODIE",
+      "category": "Children",
+      "subcategory": "Child support payment",
+      "file": "ANZ Offset 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 15,
+      "date": "15/01/2026",
+      "amount": "3944.24",
+      "description": "PAY/SALARY FROM TALENT INTERNATI 500011896",
+      "category": "Income",
+      "subcategory": "Your take-home pay",
+      "file": "ANZ Offset 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 16,
+      "date": "13/01/2026",
+      "amount": "-402.04",
+      "description": "PAYMENT TO BUPA AUSTRALIA   661368390000187000",
+      "category": "Financial & Insurance",
+      "subcategory": "Health insurance",
+      "file": "ANZ Offset 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 17,
+      "date": "08/01/2026",
+      "amount": "-150.00",
+      "description": "ANZ INTERNET BANKING PAYMENT 975600 TO ELLA MOODIE",
+      "category": "Children",
+      "subcategory": "Child support payment",
+      "file": "ANZ Offset 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 18,
+      "date": "02/01/2026",
+      "amount": "-150.00",
+      "description": "ANZ INTERNET BANKING PAYMENT 795103 TO ELLA MOODIE",
+      "category": "Children",
+      "subcategory": "Child support payment",
+      "file": "ANZ Offset 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 19,
+      "date": "26/02/2026",
+      "amount": "-421.30",
+      "description": "ANZ INTERNET BANKING BPAY TMR REG RENEW 4817      ",
+      "category": "Car & Transport",
+      "subcategory": "Rego & licence",
+      "file": "ANZ Offset 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 20,
+      "date": "26/02/2026",
+      "amount": "-150.00",
+      "description": "ANZ INTERNET BANKING PAYMENT 258399 TO ELLA MOODIE",
+      "category": "Children",
+      "subcategory": "Child support payment",
+      "file": "ANZ Offset 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 21,
+      "date": "26/02/2026",
+      "amount": "6350.03",
+      "description": "PAY/SALARY FROM TALENT INTERNATI 500011896",
+      "category": "Income",
+      "subcategory": "Your take-home pay",
+      "file": "ANZ Offset 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 22,
+      "date": "19/02/2026",
+      "amount": "-150.00",
+      "description": "ANZ INTERNET BANKING PAYMENT 735869 TO ELLA MOODIE",
+      "category": "Children",
+      "subcategory": "Child support payment",
+      "file": "ANZ Offset 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 23,
+      "date": "16/02/2026",
+      "amount": "-8400.00",
+      "description": "ANZ M-BANKING FUNDS TFER TRANSFER 681977  TO 4564X",
+      "category": "Financial & Insurance",
+      "subcategory": "Transfer",
+      "file": "ANZ Offset 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 24,
+      "date": "12/02/2026",
+      "amount": "-402.04",
+      "description": "PAYMENT TO BUPA AUSTRALIA   661368390000188000",
+      "category": "Financial & Insurance",
+      "subcategory": "Health insurance",
+      "file": "ANZ Offset 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 25,
+      "date": "12/02/2026",
+      "amount": "-150.00",
+      "description": "ANZ INTERNET BANKING PAYMENT 211935 TO ELLA MOODIE",
+      "category": "Children",
+      "subcategory": "Child support payment",
+      "file": "ANZ Offset 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 26,
+      "date": "12/02/2026",
+      "amount": "6350.03",
+      "description": "PAY/SALARY FROM TALENT INTERNATI 500011896",
+      "category": "Income",
+      "subcategory": "Your take-home pay",
+      "file": "ANZ Offset 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 27,
+      "date": "05/02/2026",
+      "amount": "-150.00",
+      "description": "ANZ INTERNET BANKING PAYMENT 701230 TO ELLA MOODIE",
+      "category": "Children",
+      "subcategory": "Child support payment",
+      "file": "ANZ Offset 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 28,
+      "date": "03/02/2026",
+      "amount": "-9700.00",
+      "description": "ANZ M-BANKING FUNDS TFER TRANSFER 508136  TO 4564X",
+      "category": "Financial & Insurance",
+      "subcategory": "Transfer",
+      "file": "ANZ Offset 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 29,
+      "date": "30/01/2026",
+      "amount": "-203.87",
+      "description": "GLOW UP                   YANDINA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Restaurants",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 30,
+      "date": "30/01/2026",
+      "amount": "-16.09",
+      "description": "SQ *AN NAM VIETNAMESE KIT Sippy Downs",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Lunches bought",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 31,
+      "date": "30/01/2026",
+      "amount": "-171.81",
+      "description": "SUNCORP INSURANCE         BRISBANE CITY",
+      "category": "Financial & Insurance",
+      "subcategory": "Home & contents insurance",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 32,
+      "date": "30/01/2026",
+      "amount": "-45.45",
+      "description": "SECURE PARKING PTY LTD    NORTH SYDNEY",
+      "category": "Car & Transport",
+      "subcategory": "Road tolls & parking",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 33,
+      "date": "30/01/2026",
+      "amount": "-100.03",
+      "description": "AMRITYU PTY LTD           BOKARINA",
+      "category": "Car & Transport",
+      "subcategory": "Petrol",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 34,
+      "date": "30/01/2026",
+      "amount": "-18.9",
+      "description": "POINT PARKING             KAWANA",
+      "category": "Car & Transport",
+      "subcategory": "Road tolls & parking",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 35,
+      "date": "30/01/2026",
+      "amount": "-16.6",
+      "description": "POINTPARKING NAMBOUR      NAMBOUR",
+      "category": "Car & Transport",
+      "subcategory": "Road tolls & parking",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 36,
+      "date": "29/01/2026",
+      "amount": "-40.2",
+      "description": "THE BOATSHED              COTTON TREE",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Restaurants",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 37,
+      "date": "29/01/2026",
+      "amount": "-64",
+      "description": "SP BANDIFY AUSTRALIA      AIRPORT WEST",
+      "category": "Medical, personal & education",
+      "subcategory": "Computers & gadgets",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 38,
+      "date": "29/01/2026",
+      "amount": "-23.75",
+      "description": "MCDONALDS SIPPY DOWN      SIPPY DOWNS",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Take-away & snacks",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 39,
+      "date": "29/01/2026",
+      "amount": "-57",
+      "description": "CHANCE PARK CHM PHARM     SIPPY DOWNS",
+      "category": "Medical, personal & education",
+      "subcategory": "Medicines & pharmacy",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 40,
+      "date": "29/01/2026",
+      "amount": "-13.5",
+      "description": "THEPICKLEB* EVT SOCIAL    NAMBOUR",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 41,
+      "date": "29/01/2026",
+      "amount": "-13.5",
+      "description": "THEPICKLEB* EVT SOCIAL    NAMBOUR",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 42,
+      "date": "28/01/2026",
+      "amount": "-800",
+      "description": "Coles Group Limited -     Hawthorn East",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Celebrations & gifts",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 43,
+      "date": "28/01/2026",
+      "amount": "-64",
+      "description": "FITSTOP SIPPY DO          SUNSHINE COAS",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 44,
+      "date": "28/01/2026",
+      "amount": "-64",
+      "description": "FITSTOP SIPPY DO          SUNSHINE COAS",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 45,
+      "date": "28/01/2026",
+      "amount": "-4.05",
+      "description": "MEGA FRESH FOOD MARKET    MOUNTAIN CREE",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 46,
+      "date": "28/01/2026",
+      "amount": "-50.36",
+      "description": "BUNNINGS 490000           MAROOCHYDORE",
+      "category": "Home & utilities",
+      "subcategory": "Home improvements & Maintenance",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 47,
+      "date": "27/01/2026",
+      "amount": "-170",
+      "description": "BWS/163 KARAWATHA ST - SH BUDERIM",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Drinks & alcohol",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 48,
+      "date": "27/01/2026",
+      "amount": "-181.77",
+      "description": "COLES 4647                SIPPY DOWNS",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 49,
+      "date": "27/01/2026",
+      "amount": "-54.15",
+      "description": "WOOLWORTHS/KARAWATHA DR & MOUNTAIN CRK",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 50,
+      "date": "27/01/2026",
+      "amount": "-90.45",
+      "description": "SQ *AN NAM VIETNAMESE KIT Sippy Downs",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Lunches bought",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 51,
+      "date": "27/01/2026",
+      "amount": "-25.46",
+      "description": "COLES 4647                SIPPY DOWNS",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 52,
+      "date": "27/01/2026",
+      "amount": "-45.45",
+      "description": "ZLR*Somewhere On Buderi   Buderim",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Restaurants",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 53,
+      "date": "27/01/2026",
+      "amount": "-5.31",
+      "description": "SFS THE CONTAINER BY      BIRTINYA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 54,
+      "date": "27/01/2026",
+      "amount": "-82.32",
+      "description": "THE FOREST BLEND CAFE     FOREST GLEN",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 55,
+      "date": "27/01/2026",
+      "amount": "-7.2",
+      "description": "WOOLWORTHS/KARAWATHA DR & MOUNTAIN CRK",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 56,
+      "date": "27/01/2026",
+      "amount": "-20.99",
+      "description": "Netflix.com               Melbourne",
+      "category": "Home & utilities",
+      "subcategory": "Streaming Services",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 57,
+      "date": "27/01/2026",
+      "amount": "-18",
+      "description": "THEPICKLEB* EVT SOCIAL    NAMBOUR",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 58,
+      "date": "27/01/2026",
+      "amount": "-18",
+      "description": "THEPICKLEB* EVT SOCIAL    NAMBOUR",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 59,
+      "date": "27/01/2026",
+      "amount": "-18",
+      "description": "THEPICKLEB* EVT SOCIAL    NAMBOUR",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 60,
+      "date": "27/01/2026",
+      "amount": "-53.4",
+      "description": "WOOLWORTHS/KARAWATHA DR & MOUNTAIN CRK",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 61,
+      "date": "27/01/2026",
+      "amount": "-80.85",
+      "description": "COLES 7835                BUDERIM",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 62,
+      "date": "27/01/2026",
+      "amount": "-33.47",
+      "description": "DBS*Goodlife Queen Str    Brisbane",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 63,
+      "date": "27/01/2026",
+      "amount": "-50.35",
+      "description": "LINKT BRISBANE            BRISBANE",
+      "category": "Car & Transport",
+      "subcategory": "Road tolls & parking",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 64,
+      "date": "27/01/2026",
+      "amount": "-18",
+      "description": "THEPICKLEB* EVT SOCIAL    NAMBOUR",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 65,
+      "date": "27/01/2026",
+      "amount": "-13.4",
+      "description": "MCDONALDS SOUTHBANK       SOUTH BRISBAN",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Take-away & snacks",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 66,
+      "date": "27/01/2026",
+      "amount": "-5.59",
+      "description": "SMP*Jamoke Espresso Ba    Nambour",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 67,
+      "date": "27/01/2026",
+      "amount": "-96.75",
+      "description": "AMPOL SIPPY DOW 10262F    SIPPY DOWNS",
+      "category": "Car & Transport",
+      "subcategory": "Petrol",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 68,
+      "date": "23/01/2026",
+      "amount": "-9.99",
+      "description": "AMZNPRIMEA* AMZNPRIMEA    SYDNEY SOUTH",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Movies, shows & music",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 69,
+      "date": "23/01/2026",
+      "amount": "-20",
+      "description": "SOUTHBANK CARPARK         SOUTH BANK",
+      "category": "Car & Transport",
+      "subcategory": "Road tolls & parking",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 70,
+      "date": "23/01/2026",
+      "amount": "-13.2",
+      "description": "ROSE & CROWN              South Brisban",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 71,
+      "date": "23/01/2026",
+      "amount": "-13.72",
+      "description": "Mebami                    South Brisban",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Lunches bought",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 72,
+      "date": "23/01/2026",
+      "amount": "-6.12",
+      "description": "SQ *BLACK FOX             Mooloolaba",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 73,
+      "date": "23/01/2026",
+      "amount": "-480",
+      "description": "COASTAL AESTHETIC INJE    MAROOCHYDORE",
+      "category": "Medical, personal & education",
+      "subcategory": "Hair & beauty",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 74,
+      "date": "22/01/2026",
+      "amount": "129.95",
+      "description": "MYER  MAROOCHYDORE        MAROOCHYDORE",
+      "category": "Medical, personal & education",
+      "subcategory": "Shopping",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 75,
+      "date": "22/01/2026",
+      "amount": "-47.45",
+      "description": "COLES 4523                MAROOCHYDORE",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 76,
+      "date": "22/01/2026",
+      "amount": "-30",
+      "description": "TARGET 5038               MAROOCHYDORE",
+      "category": "Medical, personal & education",
+      "subcategory": "Shopping",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 77,
+      "date": "22/01/2026",
+      "amount": "-24",
+      "description": "KMART 1060                MAROOCHYDORE",
+      "category": "Medical, personal & education",
+      "subcategory": "Shopping",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 78,
+      "date": "22/01/2026",
+      "amount": "-253.94",
+      "description": "MYER  MAROOCHYDORE        MAROOCHYDORE",
+      "category": "Medical, personal & education",
+      "subcategory": "Shopping",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 79,
+      "date": "22/01/2026",
+      "amount": "-341",
+      "description": "NDC SERVICE CO PTY LIM    MAROOCHYDORE",
+      "category": "Medical, personal & education",
+      "subcategory": "Dental",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 80,
+      "date": "22/01/2026",
+      "amount": "-163.27",
+      "description": "AGL SALES 0308            MELBOURNE",
+      "category": "Home & utilities",
+      "subcategory": "Electricity",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 81,
+      "date": "22/01/2026",
+      "amount": "-58.44",
+      "description": "DECJUBA PTY LTD           MAROOCHYDORE",
+      "category": "Medical, personal & education",
+      "subcategory": "Clothing & shoes",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 82,
+      "date": "22/01/2026",
+      "amount": "-287.3",
+      "description": "QTIX TICKETING            SOUTH BRISBAN",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Movies, shows & music",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 83,
+      "date": "22/01/2026",
+      "amount": "-13.5",
+      "description": "THEPICKLEB* EVT SOCIAL    NAMBOUR",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 84,
+      "date": "22/01/2026",
+      "amount": "-40.5",
+      "description": "THEPICKLEB* EVT SOCIAL    NAMBOUR",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 85,
+      "date": "21/01/2026",
+      "amount": "-122.2",
+      "description": "ALH VENUES/81 BURNETT ST  BUDERIM",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 86,
+      "date": "21/01/2026",
+      "amount": "-132.98",
+      "description": "THE GREEN AT TANAWHA      TANAWHA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Restaurants",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 87,
+      "date": "21/01/2026",
+      "amount": "-115.36",
+      "description": "Bli Bli Watersports Compl Bli Bli",
+      "category": "Medical, personal & education",
+      "subcategory": "Hobbies",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 88,
+      "date": "21/01/2026",
+      "amount": "-64",
+      "description": "FITSTOP SIPPY DO          SUNSHINE COAS",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 89,
+      "date": "21/01/2026",
+      "amount": "-64",
+      "description": "FITSTOP SIPPY DO          SUNSHINE COAS",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 90,
+      "date": "21/01/2026",
+      "amount": "-14.1",
+      "description": "WELLINGTON BAKERY PART    MAROOCHYDORE",
+      "category": "Groceries",
+      "subcategory": "Deli & bakery",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 91,
+      "date": "20/01/2026",
+      "amount": "-9.3",
+      "description": "Boost Sunshine Plaza      Maroochydore",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Take-away & snacks",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 92,
+      "date": "20/01/2026",
+      "amount": "-308.14",
+      "description": "WOOLWORTHS/SUNSHINE PLZ S MAROOCHYDORE",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 93,
+      "date": "20/01/2026",
+      "amount": "-20",
+      "description": "BWS/50 PARK PLAZA         MAROOCHYDORE",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Drinks & alcohol",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 94,
+      "date": "20/01/2026",
+      "amount": "-68.07",
+      "description": "SQ *WALTER'S DINER        Maroochydore",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Restaurants",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 95,
+      "date": "20/01/2026",
+      "amount": "-1.02",
+      "description": "SQ *WALTER'S DINER        Maroochydore",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Restaurants",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 96,
+      "date": "20/01/2026",
+      "amount": "-120",
+      "description": "TARGET 5038               MAROOCHYDORE",
+      "category": "Medical, personal & education",
+      "subcategory": "Shopping",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 97,
+      "date": "20/01/2026",
+      "amount": "-16.45",
+      "description": "Audible Limited AU        MELBOURNE",
+      "category": "Home & utilities",
+      "subcategory": "Streaming Services",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 98,
+      "date": "20/01/2026",
+      "amount": "-35.95",
+      "description": "Microsoft*14 Day Trial Re msbill.info",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Movies, shows & music",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 99,
+      "date": "20/01/2026",
+      "amount": "-253.91",
+      "description": "MYER  MAROOCHYDORE        MAROOCHYDORE",
+      "category": "Medical, personal & education",
+      "subcategory": "Shopping",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 100,
+      "date": "20/01/2026",
+      "amount": "-28.99",
+      "description": "Bonds Sunshine Plaza      Maroochydore",
+      "category": "Medical, personal & education",
+      "subcategory": "Clothing & shoes",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 101,
+      "date": "20/01/2026",
+      "amount": "-112.46",
+      "description": "DECJUBA PTY LTD           MAROOCHYDORE",
+      "category": "Medical, personal & education",
+      "subcategory": "Clothing & shoes",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 102,
+      "date": "20/01/2026",
+      "amount": "-66.7",
+      "description": "Sunshine Krua Thai        Buderim",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Restaurants",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 103,
+      "date": "20/01/2026",
+      "amount": "-107.9",
+      "description": "SMP*Orchid Massage in03   Sippy Downs",
+      "category": "Medical, personal & education",
+      "subcategory": "Hair & beauty",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 104,
+      "date": "20/01/2026",
+      "amount": "-130",
+      "description": "SMP*Orchid Massage in03   Sippy Downs",
+      "category": "Medical, personal & education",
+      "subcategory": "Hair & beauty",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 105,
+      "date": "19/01/2026",
+      "amount": "-85",
+      "description": "L/LAND QLD    2266        SIPPY DOWNS",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Drinks & alcohol",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 106,
+      "date": "19/01/2026",
+      "amount": "-54.43",
+      "description": "SQ *AN NAM VIETNAMESE KIT Sippy Downs",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Lunches bought",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 107,
+      "date": "19/01/2026",
+      "amount": "-24.36",
+      "description": "Aussie World              Palmview",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 108,
+      "date": "19/01/2026",
+      "amount": "-24.36",
+      "description": "Aussie World              Palmview",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 109,
+      "date": "19/01/2026",
+      "amount": "-24.36",
+      "description": "Aussie World              Palmview",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 110,
+      "date": "19/01/2026",
+      "amount": "-75.11",
+      "description": "Aussie World              Palmview",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 111,
+      "date": "19/01/2026",
+      "amount": "-34.51",
+      "description": "Aussie World              Palmview",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 112,
+      "date": "19/01/2026",
+      "amount": "-165.85",
+      "description": "SPER QLD TREASURY         BRISBANE",
+      "category": "Car & Transport",
+      "subcategory": "Road tolls & parking",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 113,
+      "date": "19/01/2026",
+      "amount": "-65.64",
+      "description": "SPINTEL PTY LTD           SURRY HILLS",
+      "category": "Home & utilities",
+      "subcategory": "Internet",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 114,
+      "date": "19/01/2026",
+      "amount": "-87.41",
+      "description": "YOUI - PREMIUM            SIPPY DOWNS",
+      "category": "Financial & Insurance",
+      "subcategory": "Car insurance",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 115,
+      "date": "19/01/2026",
+      "amount": "-44.96",
+      "description": "DAVID JONES PTY LTD -     MAROOCHYDORE",
+      "category": "Medical, personal & education",
+      "subcategory": "Shopping",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 116,
+      "date": "19/01/2026",
+      "amount": "-16",
+      "description": "KMART 1060                MAROOCHYDORE",
+      "category": "Medical, personal & education",
+      "subcategory": "Shopping",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 117,
+      "date": "19/01/2026",
+      "amount": "-79.94",
+      "description": "Forever New Clothing      Richmond",
+      "category": "Medical, personal & education",
+      "subcategory": "Clothing & shoes",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 118,
+      "date": "19/01/2026",
+      "amount": "-24.36",
+      "description": "Aussie World              Palmview",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 119,
+      "date": "19/01/2026",
+      "amount": "-51",
+      "description": "Mecca Brands Pty Ltd      Richmond",
+      "category": "Medical, personal & education",
+      "subcategory": "Hair & beauty",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 120,
+      "date": "19/01/2026",
+      "amount": "-4",
+      "description": "POINTPARKING SUNSHINE     MAROOCHYDORE",
+      "category": "Car & Transport",
+      "subcategory": "Road tolls & parking",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 121,
+      "date": "19/01/2026",
+      "amount": "-56.99",
+      "description": "COTTON ON BODY 4839       MAROOCHYDORE",
+      "category": "Medical, personal & education",
+      "subcategory": "Clothing & shoes",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 122,
+      "date": "19/01/2026",
+      "amount": "-83",
+      "description": "Sunshine Coast Regiona... Sunshine C...",
+      "category": "Home & utilities",
+      "subcategory": "Council rates",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 123,
+      "date": "19/01/2026",
+      "amount": "-51.99",
+      "description": "AMPOL SIPPY DOW 10262F    SIPPY DOWNS",
+      "category": "Car & Transport",
+      "subcategory": "Petrol",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 124,
+      "date": "19/01/2026",
+      "amount": "-36.03",
+      "description": "CHANCELLOR TAVERN APP     Sippy Downs",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 125,
+      "date": "19/01/2026",
+      "amount": "-14.85",
+      "description": "MCDONALDS MEADOWBROO      MEADOWBROOK",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Take-away & snacks",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 126,
+      "date": "19/01/2026",
+      "amount": "-13.4",
+      "description": "MCDONALDS SOUTHBANK       SOUTH BRISBAN",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Take-away & snacks",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 127,
+      "date": "19/01/2026",
+      "amount": "-18.3",
+      "description": "SMP*Mrs Luus Southpoin    Southbank",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Lunches bought",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 128,
+      "date": "19/01/2026",
+      "amount": "-4.05",
+      "description": "SFS THE CONTAINER BY      BIRTINYA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 129,
+      "date": "19/01/2026",
+      "amount": "-201.87",
+      "description": "YOUI - PREMIUM            SIPPY DOWNS",
+      "category": "Financial & Insurance",
+      "subcategory": "Car insurance",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 130,
+      "date": "19/01/2026",
+      "amount": "-27.99",
+      "description": "SPOTIFY                   SYDNEY",
+      "category": "Home & utilities",
+      "subcategory": "Streaming Services",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 131,
+      "date": "16/01/2026",
+      "amount": "-20",
+      "description": "SOUTHBANK CARPARK         SOUTH BANK",
+      "category": "Car & Transport",
+      "subcategory": "Road tolls & parking",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 132,
+      "date": "16/01/2026",
+      "amount": "-4.3",
+      "description": "WOOLWORTHS/217 GREY STREE STH BRISBANE",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 133,
+      "date": "16/01/2026",
+      "amount": "-38",
+      "description": "BWS/163 KARAWATHA ST - SH BUDERIM",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Drinks & alcohol",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 134,
+      "date": "16/01/2026",
+      "amount": "-9.09",
+      "description": "SECURE PARKING PTY LTD    NORTH SYDNEY",
+      "category": "Car & Transport",
+      "subcategory": "Road tolls & parking",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 135,
+      "date": "16/01/2026",
+      "amount": "-40",
+      "description": "HUBBL - KAYO SPORTS       131999",
+      "category": "Home & utilities",
+      "subcategory": "Streaming Services",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 136,
+      "date": "16/01/2026",
+      "amount": "-140",
+      "description": "TELSTRA SERVICES          MELBOURNE",
+      "category": "Home & utilities",
+      "subcategory": "Mobile",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 137,
+      "date": "15/01/2026",
+      "amount": "9775",
+      "description": "PAYMENT THANKYOU 279885",
+      "category": "Financial & Insurance",
+      "subcategory": "Transfer",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 138,
+      "date": "15/01/2026",
+      "amount": "-33",
+      "description": "BWS/163 KARAWATHA ST - SH BUDERIM",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Drinks & alcohol",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 139,
+      "date": "15/01/2026",
+      "amount": "-12.5",
+      "description": "WOOLWORTHS/KARAWATHA DR & MOUNTAIN CRK",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 140,
+      "date": "15/01/2026",
+      "amount": "-725",
+      "description": "EZI*Dietitians Austral    DEAKIN",
+      "category": "Medical, personal & education",
+      "subcategory": "Education & Professional Memberships",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 141,
+      "date": "15/01/2026",
+      "amount": "-160",
+      "description": "IPY*COBBCO NINE MILE      Tandur",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Holidays",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 142,
+      "date": "15/01/2026",
+      "amount": "-51.99",
+      "description": "AMPOL SIPPY DOW 10262F    SIPPY DOWNS",
+      "category": "Car & Transport",
+      "subcategory": "Petrol",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 143,
+      "date": "14/01/2026",
+      "amount": "-8.3",
+      "description": "COLES 4647                SIPPY DOWNS",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 144,
+      "date": "14/01/2026",
+      "amount": "-16.09",
+      "description": "SQ *AN NAM VIETNAMESE KIT Sippy Downs",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Lunches bought",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 145,
+      "date": "14/01/2026",
+      "amount": "-39.18",
+      "description": "WOOLWORTHS/KARAWATHA DR & MOUNTAIN CRK",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 146,
+      "date": "14/01/2026",
+      "amount": "-151.2",
+      "description": "Amino Z                   Caringbah",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 147,
+      "date": "14/01/2026",
+      "amount": "-64",
+      "description": "FITSTOP SIPPY DO          SUNSHINE COAS",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 148,
+      "date": "14/01/2026",
+      "amount": "-64",
+      "description": "FITSTOP SIPPY DO          SUNSHINE COAS",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 149,
+      "date": "14/01/2026",
+      "amount": "-69.18",
+      "description": "TERRY WHITE CHEMAR        MINYAMA",
+      "category": "Medical, personal & education",
+      "subcategory": "Medicines & pharmacy",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 150,
+      "date": "14/01/2026",
+      "amount": "-7.7",
+      "description": "EVENT CINEMAS KAWANA      BUDDINA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Movies, shows & music",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 151,
+      "date": "13/01/2026",
+      "amount": "-650",
+      "description": "THEKINKINWOOD260314NB     KIN KIN",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Holidays",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 152,
+      "date": "13/01/2026",
+      "amount": "-105.93",
+      "description": "Liberty Tanawha           Tanawha",
+      "category": "Car & Transport",
+      "subcategory": "Petrol",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 153,
+      "date": "13/01/2026",
+      "amount": "-23.8",
+      "description": "ALH VENUES/2/46 DAVID LOW DIDDILLIBAH",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 154,
+      "date": "13/01/2026",
+      "amount": "-25",
+      "description": "BWS/163 KARAWATHA ST - SH BUDERIM",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Drinks & alcohol",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 155,
+      "date": "13/01/2026",
+      "amount": "-134.38",
+      "description": "COLES 4647                SIPPY DOWNS",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 156,
+      "date": "13/01/2026",
+      "amount": "-23.8",
+      "description": "ALH VENUES/2/46 DAVID LOW DIDDILLIBAH",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 157,
+      "date": "13/01/2026",
+      "amount": "-83.6",
+      "description": "SPRINGBOK FOODS PTY LT    FOREST GLEN",
+      "category": "Groceries",
+      "subcategory": "Deli & bakery",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 158,
+      "date": "13/01/2026",
+      "amount": "-141.3",
+      "description": "EVENT KAWANA              BUDDINA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Celebrations & gifts",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 159,
+      "date": "12/01/2026",
+      "amount": "-146.45",
+      "description": "POMONA DISTILLING CO      POMONA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Restaurants",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 160,
+      "date": "12/01/2026",
+      "amount": "-104.07",
+      "description": "COLES 4647                SIPPY DOWNS",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 161,
+      "date": "12/01/2026",
+      "amount": "-113.38",
+      "description": "Liberty Tanawha           Tanawha",
+      "category": "Car & Transport",
+      "subcategory": "Petrol",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 162,
+      "date": "12/01/2026",
+      "amount": "-37.61",
+      "description": "Pomona Distilling Co      Pomona",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Restaurants",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 163,
+      "date": "12/01/2026",
+      "amount": "-19.95",
+      "description": "POMONA TRUE VALUE HA      POMONA",
+      "category": "Home & utilities",
+      "subcategory": "Home improvements & Maintenance",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 164,
+      "date": "12/01/2026",
+      "amount": "-69.54",
+      "description": "ZLR*Bombay Bliss - Maro   Maroochydore",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Restaurants",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 165,
+      "date": "12/01/2026",
+      "amount": "-4.05",
+      "description": "SFS THE CONTAINER BY      BIRTINYA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 166,
+      "date": "12/01/2026",
+      "amount": "-8.7",
+      "description": "COLES 4647                SIPPY DOWNS",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 167,
+      "date": "12/01/2026",
+      "amount": "-23.1",
+      "description": "Maroochy RSL              Maroochydore",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 168,
+      "date": "12/01/2026",
+      "amount": "-32.18",
+      "description": "SQ *AN NAM VIETNAMESE KIT Sippy Downs",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Lunches bought",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 169,
+      "date": "12/01/2026",
+      "amount": "-32",
+      "description": "Dominos Estore Buderim    dominos.com.a",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Take-away & snacks",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 170,
+      "date": "12/01/2026",
+      "amount": "-4.9",
+      "description": "AMPOL SIPPY DOW 10262F    SIPPY DOWNS",
+      "category": "Car & Transport",
+      "subcategory": "Petrol",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 171,
+      "date": "12/01/2026",
+      "amount": "-190",
+      "description": "MAMMOTH FOREST GLEN       FOREST GLEN",
+      "category": "Home & utilities",
+      "subcategory": "Furniture & appliances",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 172,
+      "date": "12/01/2026",
+      "amount": "-18",
+      "description": "THEPICKLEB* EVT SOCIAL    NAMBOUR",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 173,
+      "date": "12/01/2026",
+      "amount": "-18",
+      "description": "THEPICKLEB* EVT SOCIAL    NAMBOUR",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 174,
+      "date": "12/01/2026",
+      "amount": "-194.88",
+      "description": "Pavilion Mooloolaba       Mooloolaba",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Restaurants",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 175,
+      "date": "12/01/2026",
+      "amount": "-25",
+      "description": "MCDONALDS SIPPY DOWN      SIPPY DOWNS",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Take-away & snacks",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 176,
+      "date": "12/01/2026",
+      "amount": "-16.25",
+      "description": "SUBWAY SIPPYDOWNS         SIPPY DOWNS",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Take-away & snacks",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 177,
+      "date": "12/01/2026",
+      "amount": "-5.31",
+      "description": "SFS THE CONTAINER BY      BIRTINYA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 178,
+      "date": "12/01/2026",
+      "amount": "-154",
+      "description": "SpaghettiHouse            South Brisban",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Restaurants",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 179,
+      "date": "12/01/2026",
+      "amount": "-10.7",
+      "description": "MCDONALDS SOUTHBANK       SOUTH BRISBAN",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Take-away & snacks",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 180,
+      "date": "12/01/2026",
+      "amount": "-33.47",
+      "description": "DBS*Goodlife Queen Str    Brisbane",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 181,
+      "date": "12/01/2026",
+      "amount": "-4.75",
+      "description": "ROBINSON'S VENDING PTY LT NARANGBA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Take-away & snacks",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 182,
+      "date": "9/01/2026",
+      "amount": "-20",
+      "description": "SOUTHBANK CARPARK         SOUTH BANK",
+      "category": "Car & Transport",
+      "subcategory": "Road tolls & parking",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 183,
+      "date": "9/01/2026",
+      "amount": "-95.95",
+      "description": "Suncoast Health Cntre     Forest Glen",
+      "category": "Medical, personal & education",
+      "subcategory": "Doctors & medical",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 184,
+      "date": "9/01/2026",
+      "amount": "-5.3",
+      "description": "LS Micasa Cafe Soutban    South Brisban",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 185,
+      "date": "9/01/2026",
+      "amount": "-5.3",
+      "description": "LS Micasa Cafe Soutban    South Brisban",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 186,
+      "date": "9/01/2026",
+      "amount": "-72.72",
+      "description": "SECURE PARKING PTY LTD    NORTH SYDNEY",
+      "category": "Car & Transport",
+      "subcategory": "Road tolls & parking",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 187,
+      "date": "9/01/2026",
+      "amount": "-24.2",
+      "description": "GUZMAN Y GOMEZ            SURRY HILLS",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Take-away & snacks",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 188,
+      "date": "8/01/2026",
+      "amount": "-9.99",
+      "description": "DD *DOORDASHDASHPASS      MELBOURNE",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Take-away & snacks",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 189,
+      "date": "8/01/2026",
+      "amount": "-46.34",
+      "description": "WW METRO/67 BURNETT STREE BUDERIM",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 190,
+      "date": "8/01/2026",
+      "amount": "-31.99",
+      "description": "Adobe                     Sydney",
+      "category": "Medical, personal & education",
+      "subcategory": "Computers & gadgets",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 191,
+      "date": "8/01/2026",
+      "amount": "-5.31",
+      "description": "SFS THE CONTAINER BY      BIRTINYA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 192,
+      "date": "8/01/2026",
+      "amount": "-4.49",
+      "description": "APPLE.COM/BILL            SYDNEY",
+      "category": "Medical, personal & education",
+      "subcategory": "Computers & gadgets",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 193,
+      "date": "8/01/2026",
+      "amount": "-27",
+      "description": "THEPICKLEB* EVT SOCIAL    NAMBOUR",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 194,
+      "date": "8/01/2026",
+      "amount": "-13.5",
+      "description": "THEPICKLEB* EVT SOCIAL    NAMBOUR",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 195,
+      "date": "7/01/2026",
+      "amount": "-53.34",
+      "description": "VODAFONE AUSTRALIA        NORTH SYDNEY",
+      "category": "Home & utilities",
+      "subcategory": "Ellas Mobile",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 196,
+      "date": "7/01/2026",
+      "amount": "-9.95",
+      "description": "BANJOS SIPPY DOWNS        SIPPY DOWNS",
+      "category": "Groceries",
+      "subcategory": "Deli & bakery",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 197,
+      "date": "7/01/2026",
+      "amount": "-64",
+      "description": "FITSTOP SIPPY DO          SUNSHINE COAS",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 198,
+      "date": "7/01/2026",
+      "amount": "-64",
+      "description": "FITSTOP SIPPY DO          SUNSHINE COAS",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 199,
+      "date": "7/01/2026",
+      "amount": "-10",
+      "description": "FOSTER & BLACK P/L        UPPER MOUNT G",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 200,
+      "date": "7/01/2026",
+      "amount": "-58.49",
+      "description": "UNITED BETHANIA           BETHANIA",
+      "category": "Car & Transport",
+      "subcategory": "Petrol",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 201,
+      "date": "7/01/2026",
+      "amount": "-31.31",
+      "description": "BURLEIGH HDS RUGBY        MERMAID BEACH",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 202,
+      "date": "7/01/2026",
+      "amount": "-21.21",
+      "description": "BURLEIGH HDS RUGBY        MERMAID BEACH",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 203,
+      "date": "6/01/2026",
+      "amount": "-418.81",
+      "description": "COLES 4647                SIPPY DOWNS",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 204,
+      "date": "6/01/2026",
+      "amount": "-15.68",
+      "description": "SQ *AN NAM VIETNAMESE KIT Sippy Downs",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Lunches bought",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 205,
+      "date": "6/01/2026",
+      "amount": "-133",
+      "description": "LIQUORLAND 6476           SIPPY DOWNS",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Drinks & alcohol",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 206,
+      "date": "6/01/2026",
+      "amount": "-54.65",
+      "description": "Kiosk                     Alexandra Hea",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Restaurants",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 207,
+      "date": "6/01/2026",
+      "amount": "-11.99",
+      "description": "help.hbomax.com           St. Leonards",
+      "category": "Home & utilities",
+      "subcategory": "Streaming Services",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 208,
+      "date": "6/01/2026",
+      "amount": "-83.59",
+      "description": "AMPOL SIPPY DOW 10262F    SIPPY DOWNS",
+      "category": "Car & Transport",
+      "subcategory": "Petrol",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 209,
+      "date": "5/01/2026",
+      "amount": "-46.26",
+      "description": "COLES 4647                SIPPY DOWNS",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 210,
+      "date": "5/01/2026",
+      "amount": "-14.9",
+      "description": "Nandos GARDEN CITY        Mt Gravatt",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Take-away & snacks",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 211,
+      "date": "5/01/2026",
+      "amount": "-84.25",
+      "description": "Nandos GARDEN CITY        Mt Gravatt",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Take-away & snacks",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 212,
+      "date": "5/01/2026",
+      "amount": "-43.48",
+      "description": "SQ *MOUSTACHE             Mermaid Beach",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Restaurants",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 213,
+      "date": "5/01/2026",
+      "amount": "-11.18",
+      "description": "SQ *THE HOLLIDAY COFFEE   Mermaid Beach",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 214,
+      "date": "5/01/2026",
+      "amount": "-10",
+      "description": "BYRON SHIRE COUNCIL       MULLUMBIMBY",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 215,
+      "date": "5/01/2026",
+      "amount": "-23.3",
+      "description": "BRUNSWICK HOTEL OPCO P    BRUNSWICK HEA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 216,
+      "date": "5/01/2026",
+      "amount": "-23.54",
+      "description": "BRUNSWICK HOTEL OPCO P    BRUNSWICK HEA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 217,
+      "date": "5/01/2026",
+      "amount": "-7",
+      "description": "AMPOL EAGLEBY 10266F      EAGLEBY",
+      "category": "Car & Transport",
+      "subcategory": "Petrol",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 218,
+      "date": "5/01/2026",
+      "amount": "-22.22",
+      "description": "BRUNSWICK HOTEL OPCO P    BRUNSWICK HEA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 219,
+      "date": "5/01/2026",
+      "amount": "-56.67",
+      "description": "BRUNSWICK HOTEL OPCO P    BRUNSWICK HEA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 220,
+      "date": "5/01/2026",
+      "amount": "-102.31",
+      "description": "SQ *MORE THAI RESTAURANT  Mermaid Beach",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Restaurants",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 221,
+      "date": "5/01/2026",
+      "amount": "-30",
+      "description": "BWS/2223 GOLD COAST HWY-S MERMAID BCH",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Drinks & alcohol",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 222,
+      "date": "5/01/2026",
+      "amount": "-545.5",
+      "description": "QTIX TICKETING            SOUTH BRISBAN",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Movies, shows & music",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 223,
+      "date": "5/01/2026",
+      "amount": "-15",
+      "description": "SQ *MOOLOOLABA SURF LIFE  Mooloolaba",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 224,
+      "date": "5/01/2026",
+      "amount": "-15.99",
+      "description": "Disney Plus               1800-965160",
+      "category": "Home & utilities",
+      "subcategory": "Streaming Services",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 225,
+      "date": "5/01/2026",
+      "amount": "-41.5",
+      "description": "BWS/163 KARAWATHA ST - SH BUDERIM",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Drinks & alcohol",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 226,
+      "date": "5/01/2026",
+      "amount": "-31.99",
+      "description": "BUNNINGS 490000           MAROOCHYDORE",
+      "category": "Home & utilities",
+      "subcategory": "Home improvements & Maintenance",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 227,
+      "date": "2/01/2026",
+      "amount": "-29.6",
+      "description": "ALH VENUES/NICKLIN WAY    BUDDINA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 228,
+      "date": "2/01/2026",
+      "amount": "-124",
+      "description": "LIQUORLAND 6476           SIPPY DOWNS",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Drinks & alcohol",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 229,
+      "date": "2/01/2026",
+      "amount": "-189",
+      "description": "Booking.com Hotel         Sydney",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Holidays",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 230,
+      "date": "2/01/2026",
+      "amount": "-5.9",
+      "description": "SFS SCUH MERLOT           BIRTINYA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 231,
+      "date": "2/01/2026",
+      "amount": "-10.82",
+      "description": "SQ *BLACK FOX             Mooloolaba",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 232,
+      "date": "2/01/2026",
+      "amount": "-847.83",
+      "description": "TRANSPORTMAINRDS          BRISBANE",
+      "category": "Car & Transport",
+      "subcategory": "Rego & licence",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 233,
+      "date": "2/01/2026",
+      "amount": "-119.98",
+      "description": "COLES 4647                SIPPY DOWNS",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 234,
+      "date": "2/01/2026",
+      "amount": "-42",
+      "description": "LIQUORLAND 6476           SIPPY DOWNS",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Drinks & alcohol",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 235,
+      "date": "2/01/2026",
+      "amount": "-5.57",
+      "description": "SQ *ROCK HOP ESPRESSO     Coolum",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 236,
+      "date": "2/01/2026",
+      "amount": "-41.96",
+      "description": "LS Delifish Buderim       Buderim",
+      "category": "Groceries",
+      "subcategory": "Deli & bakery",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 237,
+      "date": "2/01/2026",
+      "amount": "-59.48",
+      "description": "LIVELIFE PHARMACY CV      COOLUM BEACH",
+      "category": "Medical, personal & education",
+      "subcategory": "Medicines & pharmacy",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 238,
+      "date": "2/01/2026",
+      "amount": "-171.81",
+      "description": "SUNCORP INSURANCE         BRISBANE CITY",
+      "category": "Financial & Insurance",
+      "subcategory": "Home & contents insurance",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 239,
+      "date": "2/01/2026",
+      "amount": "13.12",
+      "description": "YOUI - PREMIUM            SIPPY DOWNS",
+      "category": "Financial & Insurance",
+      "subcategory": "Car insurance",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 240,
+      "date": "2/01/2026",
+      "amount": "-25.47",
+      "description": "ALDI STORES               BIRTINYA",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 241,
+      "date": "27/02/2026",
+      "amount": "-59.30",
+      "description": "WOOLWORTHS/OCEAN ST & HOR MAROOCHYDORE",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 242,
+      "date": "27/02/2026",
+      "amount": "-48.95",
+      "description": "WOOLWORTHS/KARAWATHA DR & MOUNTAIN CRK",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 243,
+      "date": "27/02/2026",
+      "amount": "-16.45",
+      "description": "KFC Sippy Downs           Sippy Downs",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Take-away & snacks",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 244,
+      "date": "27/02/2026",
+      "amount": "-1355.20",
+      "description": "Sunshine Coast Regiona... Sunshine C...",
+      "category": "Home & utilities",
+      "subcategory": "Council rates",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 245,
+      "date": "27/02/2026",
+      "amount": "-75.73",
+      "description": "Playa                     Bokarina",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Restaurants",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 246,
+      "date": "27/02/2026",
+      "amount": "-88.86",
+      "description": "AMRITYU PTY LTD           BOKARINA",
+      "category": "Car & Transport",
+      "subcategory": "Petrol",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 247,
+      "date": "26/02/2026",
+      "amount": "-20.00",
+      "description": "SOUTHBANK CARPARK         SOUTH BANK",
+      "category": "Car & Transport",
+      "subcategory": "Road tolls & parking",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 248,
+      "date": "26/02/2026",
+      "amount": "-13.72",
+      "description": "Mebami                    South Brisban",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Lunches bought",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 249,
+      "date": "26/02/2026",
+      "amount": "-5.30",
+      "description": "LS Micasa Cafe Soutban    South Brisban",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 250,
+      "date": "26/02/2026",
+      "amount": "-45.45",
+      "description": "SECURE PARKING PTY LTD    NORTH SYDNEY",
+      "category": "Car & Transport",
+      "subcategory": "Road tolls & parking",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 251,
+      "date": "25/02/2026",
+      "amount": "-64.00",
+      "description": "FITSTOP SIPPY DO          SUNSHINE COAS",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 252,
+      "date": "25/02/2026",
+      "amount": "-64.00",
+      "description": "FITSTOP SIPPY DO          SUNSHINE COAS",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 253,
+      "date": "25/02/2026",
+      "amount": "-48.95",
+      "description": "WOOLWORTHS/KARAWATHA DR & MOUNTAIN CRK",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 254,
+      "date": "25/02/2026",
+      "amount": "-20.99",
+      "description": "Netflix.com               Melbourne",
+      "category": "Home & utilities",
+      "subcategory": "Streaming Services",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 255,
+      "date": "25/02/2026",
+      "amount": "-36.00",
+      "description": "THEPICKLEB* EVT SOCIAL    NAMBOUR",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 256,
+      "date": "25/02/2026",
+      "amount": "-62.10",
+      "description": "MCDONALDS SIPPY DOWN      SIPPY DOWNS",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Take-away & snacks",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 257,
+      "date": "24/02/2026",
+      "amount": "-15.80",
+      "description": "ALH VENUES/2/46 DAVID LOW DIDDILLIBAH",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 258,
+      "date": "24/02/2026",
+      "amount": "-139.12",
+      "description": "COLES 7835                BUDERIM",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 259,
+      "date": "24/02/2026",
+      "amount": "-99.34",
+      "description": "Liberty Tanawha           Tanawha",
+      "category": "Car & Transport",
+      "subcategory": "Petrol",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 260,
+      "date": "24/02/2026",
+      "amount": "-99.98",
+      "description": "SQ *DEPOT NOOSA           Noosaville",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Restaurants",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 261,
+      "date": "23/02/2026",
+      "amount": "-36.00",
+      "description": "BWS/23 VENNING STREET     MOOLOOLABA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Drinks & alcohol",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 262,
+      "date": "23/02/2026",
+      "amount": "-41.00",
+      "description": "ALH VENUES/23 VENNING ST  MOOLOOLABA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 263,
+      "date": "23/02/2026",
+      "amount": "-96.00",
+      "description": "ALH VENUES/23 VENNING ST  MOOLOOLABA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 264,
+      "date": "23/02/2026",
+      "amount": "-24.40",
+      "description": "WOOLWORTHS/KARAWATHA DR & MOUNTAIN CRK",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 265,
+      "date": "23/02/2026",
+      "amount": "-22.80",
+      "description": "ALH VENUES/23 VENNING ST  MOOLOOLABA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 266,
+      "date": "23/02/2026",
+      "amount": "-5.04",
+      "description": "ZLR*Brumby's Mountain C   Mountain Cree",
+      "category": "Groceries",
+      "subcategory": "Deli & bakery",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 267,
+      "date": "23/02/2026",
+      "amount": "-9.99",
+      "description": "AMZNPRIMEA* AMZNPRIMEA    SYDNEY SOUTH",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Movies, shows & music",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 268,
+      "date": "23/02/2026",
+      "amount": "-23.58",
+      "description": "UBER *TRIP HELP.UBER.COM  Sydney",
+      "category": "Car & Transport",
+      "subcategory": "Uber & taxi",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 269,
+      "date": "23/02/2026",
+      "amount": "-141.30",
+      "description": "BWS/163 KARAWATHA ST - SH BUDERIM",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Drinks & alcohol",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 270,
+      "date": "23/02/2026",
+      "amount": "-263.55",
+      "description": "AGL SALES 0308            MELBOURNE",
+      "category": "Home & utilities",
+      "subcategory": "Electricity",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 271,
+      "date": "23/02/2026",
+      "amount": "-4.90",
+      "description": "AMPOL SIPPY DOW 10262F    SIPPY DOWNS",
+      "category": "Car & Transport",
+      "subcategory": "Petrol",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 272,
+      "date": "23/02/2026",
+      "amount": "-48.95",
+      "description": "WOOLWORTHS/KARAWATHA DR & MOUNTAIN CRK",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 273,
+      "date": "23/02/2026",
+      "amount": "-123.58",
+      "description": "COLES 4647                SIPPY DOWNS",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 274,
+      "date": "23/02/2026",
+      "amount": "-4.05",
+      "description": "SFS SCUH ALICE & GEO      BIRTINYA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 275,
+      "date": "23/02/2026",
+      "amount": "-14.00",
+      "description": "WOOLWORTHS/KARAWATHA DR & MOUNTAIN CRK",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 276,
+      "date": "23/02/2026",
+      "amount": "-19.50",
+      "description": "MAROOCHYDORE STATE HIG    MAROOCHYDORE",
+      "category": "Children",
+      "subcategory": "School uniforms",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 277,
+      "date": "23/02/2026",
+      "amount": "-35.95",
+      "description": "Microsoft*14 Day Trial Re msbill.info",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Movies, shows & music",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 278,
+      "date": "23/02/2026",
+      "amount": "-33.47",
+      "description": "DBS*Goodlife Queen Str    Brisbane",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 279,
+      "date": "23/02/2026",
+      "amount": "-12.20",
+      "description": "SMP*Jamoke Espresso Ba    Nambour",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 280,
+      "date": "23/02/2026",
+      "amount": "-179.40",
+      "description": "DNH*GODADDY#4019909627    130-035-1076",
+      "category": "Medical, personal & education",
+      "subcategory": "Computers & gadgets",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 281,
+      "date": "23/02/2026",
+      "amount": "-22.22",
+      "description": "SG BAKERY BUDERIM         BUDERIM",
+      "category": "Groceries",
+      "subcategory": "Deli & bakery",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 282,
+      "date": "23/02/2026",
+      "amount": "-10.41",
+      "description": "BACKSTREET CAFE           MOOLOOLABA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 283,
+      "date": "23/02/2026",
+      "amount": "-16.60",
+      "description": "POINTPARKING NAMBOUR      NAMBOUR",
+      "category": "Car & Transport",
+      "subcategory": "Road tolls & parking",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 284,
+      "date": "20/02/2026",
+      "amount": "-16.45",
+      "description": "Audible Limited AU        MELBOURNE",
+      "category": "Home & utilities",
+      "subcategory": "Streaming Services",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 285,
+      "date": "20/02/2026",
+      "amount": "-22.50",
+      "description": "ZLR*Wishlist Coffee Hou   Nambour",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 286,
+      "date": "20/02/2026",
+      "amount": "-118.67",
+      "description": "YOUI - PREMIUM            SIPPY DOWNS",
+      "category": "Financial & Insurance",
+      "subcategory": "Car insurance",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 287,
+      "date": "20/02/2026",
+      "amount": "-80.67",
+      "description": "SPINTEL PTY LTD           SURRY HILLS",
+      "category": "Home & utilities",
+      "subcategory": "Internet",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 288,
+      "date": "20/02/2026",
+      "amount": "-47.50",
+      "description": "AMPOL SIPPY DOW 10262F    SIPPY DOWNS",
+      "category": "Car & Transport",
+      "subcategory": "Petrol",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 289,
+      "date": "19/02/2026",
+      "amount": "-132.90",
+      "description": "ALH VENUES/NICKLIN WAY    BUDDINA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 290,
+      "date": "19/02/2026",
+      "amount": "-35.00",
+      "description": "BWS/163 KARAWATHA ST - SH BUDERIM",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Drinks & alcohol",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 291,
+      "date": "19/02/2026",
+      "amount": "-201.91",
+      "description": "YOUI - PREMIUM            SIPPY DOWNS",
+      "category": "Financial & Insurance",
+      "subcategory": "Car insurance",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 292,
+      "date": "19/02/2026",
+      "amount": "-87.41",
+      "description": "YOUI - PREMIUM            SIPPY DOWNS",
+      "category": "Financial & Insurance",
+      "subcategory": "Car insurance",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 293,
+      "date": "18/02/2026",
+      "amount": "-64.00",
+      "description": "FITSTOP SIPPY DO          SUNSHINE COAS",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 294,
+      "date": "18/02/2026",
+      "amount": "-64.00",
+      "description": "FITSTOP SIPPY DO          SUNSHINE COAS",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 295,
+      "date": "18/02/2026",
+      "amount": "-151.20",
+      "description": "Amino Z                   Caringbah",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 296,
+      "date": "18/02/2026",
+      "amount": "-5.31",
+      "description": "SFS SCUH ALICE & GEO      BIRTINYA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 297,
+      "date": "18/02/2026",
+      "amount": "-9.95",
+      "description": "BANJOS SIPPY DOWNS        SIPPY DOWNS",
+      "category": "Groceries",
+      "subcategory": "Deli & bakery",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 298,
+      "date": "18/02/2026",
+      "amount": "-9.80",
+      "description": "SUSHI HUB SUNSHINE P      MAROOCHYDORE",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 299,
+      "date": "17/02/2026",
+      "amount": "-297.73",
+      "description": "COLES 4647                SIPPY DOWNS",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 300,
+      "date": "17/02/2026",
+      "amount": "-60.85",
+      "description": "Somewhere Over Coffee     Rainbow Beach",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 301,
+      "date": "17/02/2026",
+      "amount": "-27.99",
+      "description": "SPOTIFY                   0012345678",
+      "category": "Home & utilities",
+      "subcategory": "Streaming Services",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 302,
+      "date": "17/02/2026",
+      "amount": "-92.92",
+      "description": "THE DECK SEA SALT         RAINBOW BEACH",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 303,
+      "date": "17/02/2026",
+      "amount": "-46.46",
+      "description": "THE DECK SEA SALT         RAINBOW BEACH",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 304,
+      "date": "16/02/2026",
+      "amount": "8400.00",
+      "description": "PAYMENT THANKYOU 681977",
+      "category": "Financial & Insurance",
+      "subcategory": "Transfer",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 305,
+      "date": "16/02/2026",
+      "amount": "-16.59",
+      "description": "Rainbow Beach Bakery      Rainbow Beach",
+      "category": "Groceries",
+      "subcategory": "Deli & bakery",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 306,
+      "date": "16/02/2026",
+      "amount": "-29.00",
+      "description": "BWS/14 RAINBOW BEACH PARA RAINBOW BEACH",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Drinks & alcohol",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 307,
+      "date": "16/02/2026",
+      "amount": "-50.75",
+      "description": "LITTLE PARLIAMENT         Rainbow Beach",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Restaurants",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 308,
+      "date": "16/02/2026",
+      "amount": "-45.99",
+      "description": "HUBBL - KAYO SPORTS       131999",
+      "category": "Home & utilities",
+      "subcategory": "Streaming Services",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 309,
+      "date": "16/02/2026",
+      "amount": "-19.00",
+      "description": "SP THE BODY SHOP          CHADSTONE",
+      "category": "Medical, personal & education",
+      "subcategory": "Hair & beauty",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 310,
+      "date": "16/02/2026",
+      "amount": "-24.00",
+      "description": "RAINBOW BEACH SURF LI     Rainbow Beach",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 311,
+      "date": "16/02/2026",
+      "amount": "-66.04",
+      "description": "Galaxy Nails  sunshin     Maroochydore",
+      "category": "Medical, personal & education",
+      "subcategory": "Hair & beauty",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 312,
+      "date": "16/02/2026",
+      "amount": "-7.40",
+      "description": "COLES 4647                SIPPY DOWNS",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 313,
+      "date": "16/02/2026",
+      "amount": "-120.55",
+      "description": "COLES 4647                SIPPY DOWNS",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 314,
+      "date": "16/02/2026",
+      "amount": "-9.90",
+      "description": "Noosa Chocolate Factory   Noosa Heads",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Take-away & snacks",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 315,
+      "date": "16/02/2026",
+      "amount": "-84.00",
+      "description": "MYER  MAROOCHYDORE        MAROOCHYDORE",
+      "category": "Medical, personal & education",
+      "subcategory": "Shopping",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 316,
+      "date": "16/02/2026",
+      "amount": "-24.00",
+      "description": "RAINBOW BEACH SURF LI     Rainbow Beach",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 317,
+      "date": "16/02/2026",
+      "amount": "-24.00",
+      "description": "RAINBOW BEACH SURF LI     Rainbow Beach",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 318,
+      "date": "16/02/2026",
+      "amount": "-38.67",
+      "description": "Liberty Tanawha           Tanawha",
+      "category": "Car & Transport",
+      "subcategory": "Petrol",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 319,
+      "date": "16/02/2026",
+      "amount": "-20.00",
+      "description": "BWS/14 RAINBOW BEACH PARA RAINBOW BEACH",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Drinks & alcohol",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 320,
+      "date": "16/02/2026",
+      "amount": "-29.00",
+      "description": "RAINBOW BEACH SURF LI     Rainbow Beach",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 321,
+      "date": "16/02/2026",
+      "amount": "-140.00",
+      "description": "TELSTRA SERVICES          MELBOURNE",
+      "category": "Home & utilities",
+      "subcategory": "Mobile",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 322,
+      "date": "16/02/2026",
+      "amount": "-48.84",
+      "description": "snshn-kr-th-bdrm          Buderim",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Restaurants",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 323,
+      "date": "16/02/2026",
+      "amount": "-18.12",
+      "description": "SUNNY SLOTHS PTY LTD      BIRTINYA",
+      "category": "Children",
+      "subcategory": "Toys",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 324,
+      "date": "16/02/2026",
+      "amount": "-48.00",
+      "description": "BWS/163 KARAWATHA ST - SH BUDERIM",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Drinks & alcohol",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 325,
+      "date": "16/02/2026",
+      "amount": "-16.09",
+      "description": "SQ *AN NAM VIETNAMESE KIT Sippy Downs",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Lunches bought",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 326,
+      "date": "16/02/2026",
+      "amount": "-101.05",
+      "description": "Liberty Tanawha           Tanawha",
+      "category": "Car & Transport",
+      "subcategory": "Petrol",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 327,
+      "date": "16/02/2026",
+      "amount": "-19.70",
+      "description": "MTN CREEK CHEM PHARM      MOUNTAIN CREE",
+      "category": "Medical, personal & education",
+      "subcategory": "Medicines & pharmacy",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 328,
+      "date": "16/02/2026",
+      "amount": "-10.41",
+      "description": "BACKSTREET CAFE           MOOLOOLABA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 329,
+      "date": "16/02/2026",
+      "amount": "-36.00",
+      "description": "THEPICKLEB* EVT SOCIAL    NAMBOUR",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 330,
+      "date": "13/02/2026",
+      "amount": "-113.80",
+      "description": "McAfee.com mcafee.com/aut Mahon  Cork",
+      "category": "Medical, personal & education",
+      "subcategory": "Computers & gadgets",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 331,
+      "date": "13/02/2026",
+      "amount": "-75.60",
+      "description": "ALH VENUES/NICKLIN WAY    BUDDINA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 332,
+      "date": "13/02/2026",
+      "amount": "-50.99",
+      "description": "WOOLWORTHS/KARAWATHA DR & MOUNTAIN CRK",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 333,
+      "date": "13/02/2026",
+      "amount": "-5.00",
+      "description": "WOOLWORTHS/KARAWATHA DR & MOUNTAIN CRK",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 334,
+      "date": "13/02/2026",
+      "amount": "-36.00",
+      "description": "ALH VENUES/NICKLIN WAY    BUDDINA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 335,
+      "date": "13/02/2026",
+      "amount": "-24.20",
+      "description": "ALH VENUES/NICKLIN WAY    BUDDINA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 336,
+      "date": "13/02/2026",
+      "amount": "-389.00",
+      "description": "Booking.com Hotel         Sydney",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Holidays",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 337,
+      "date": "13/02/2026",
+      "amount": "-63.63",
+      "description": "SECURE PARKING PTY LTD    NORTH SYDNEY",
+      "category": "Car & Transport",
+      "subcategory": "Road tolls & parking",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 338,
+      "date": "13/02/2026",
+      "amount": "-5.31",
+      "description": "SFS THE CONTAINER BY      BIRTINYA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 339,
+      "date": "13/02/2026",
+      "amount": "-51.99",
+      "description": "AMPOL SIPPY DOW 10262F    SIPPY DOWNS",
+      "category": "Car & Transport",
+      "subcategory": "Petrol",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 340,
+      "date": "12/02/2026",
+      "amount": "-31.00",
+      "description": "BWS/163 KARAWATHA ST - SH BUDERIM",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Drinks & alcohol",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 341,
+      "date": "12/02/2026",
+      "amount": "-7.43",
+      "description": "SFS THE CONTAINER BY      BIRTINYA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 342,
+      "date": "12/02/2026",
+      "amount": "-76.42",
+      "description": "AMPOL HAMILTON 11781F     HAMILTON",
+      "category": "Car & Transport",
+      "subcategory": "Petrol",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 343,
+      "date": "11/02/2026",
+      "amount": "-64.00",
+      "description": "FITSTOP SIPPY DO          SUNSHINE COAS",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 344,
+      "date": "11/02/2026",
+      "amount": "-64.00",
+      "description": "FITSTOP SIPPY DO          SUNSHINE COAS",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 345,
+      "date": "11/02/2026",
+      "amount": "-50.37",
+      "description": "LINKT BRISBANE            BRISBANE",
+      "category": "Car & Transport",
+      "subcategory": "Road tolls & parking",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 346,
+      "date": "11/02/2026",
+      "amount": "-9.80",
+      "description": "SUSHI HUB SUNSHINE P      MAROOCHYDORE",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 347,
+      "date": "11/02/2026",
+      "amount": "-9.42",
+      "description": "ALDI STORES               BIRTINYA",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 348,
+      "date": "11/02/2026",
+      "amount": "-5.70",
+      "description": "BAKERS DELIGHT BIRTI      BIRTINYA",
+      "category": "Groceries",
+      "subcategory": "Deli & bakery",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 349,
+      "date": "11/02/2026",
+      "amount": "-305.00",
+      "description": "SPECSAVERS MAROOCHYDOR    MAROOCHYDORE",
+      "category": "Medical, personal & education",
+      "subcategory": "Glasses & eye care",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 350,
+      "date": "11/02/2026",
+      "amount": "-75.48",
+      "description": "THE BOATSHED              COTTON TREE",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Restaurants",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 351,
+      "date": "11/02/2026",
+      "amount": "-36.00",
+      "description": "THEPICKLEB* EVT SOCIAL    NAMBOUR",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 352,
+      "date": "10/02/2026",
+      "amount": "-70.40",
+      "description": "OZT*HAYLEY MARY - QUIT    WOOLLOONGABBA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Movies, shows & music",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 353,
+      "date": "10/02/2026",
+      "amount": "-139.59",
+      "description": "COLES 7835                BUDERIM",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 354,
+      "date": "10/02/2026",
+      "amount": "-20.00",
+      "description": "L/LAND QLD 6526           BUDERIM",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Drinks & alcohol",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 355,
+      "date": "10/02/2026",
+      "amount": "-23.80",
+      "description": "ALH VENUES/2/46 DAVID LOW DIDDILLIBAH",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 356,
+      "date": "10/02/2026",
+      "amount": "-71.03",
+      "description": "SQ *AN NAM VIETNAMESE KIT Sippy Downs",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Lunches bought",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 357,
+      "date": "09/02/2026",
+      "amount": "-120.00",
+      "description": "SP LSKD.CO                YATALA",
+      "category": "Medical, personal & education",
+      "subcategory": "Clothing & shoes",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 358,
+      "date": "09/02/2026",
+      "amount": "-39.53",
+      "description": "The Pocket Espresso       Moffat Beach",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 359,
+      "date": "09/02/2026",
+      "amount": "-34.19",
+      "description": "The Pocket Espresso       Moffat Beach",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 360,
+      "date": "09/02/2026",
+      "amount": "-61.00",
+      "description": "KMART 1060                MAROOCHYDORE",
+      "category": "Medical, personal & education",
+      "subcategory": "Shopping",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 361,
+      "date": "09/02/2026",
+      "amount": "-72.65",
+      "description": "COLES 7836                BIRTINYA",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 362,
+      "date": "09/02/2026",
+      "amount": "-16.03",
+      "description": "The Pocket Espresso       Moffat Beach",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 363,
+      "date": "09/02/2026",
+      "amount": "-21.80",
+      "description": "Gun Cotton Coffee         INDOOROOPILLY",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Restaurants",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 364,
+      "date": "09/02/2026",
+      "amount": "-121.60",
+      "description": "Gun Cotton Coffee         INDOOROOPILLY",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Restaurants",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 365,
+      "date": "09/02/2026",
+      "amount": "-31.95",
+      "description": "A&E JONES PTY LTD         MAROOCHYDORE",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Restaurants",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 366,
+      "date": "09/02/2026",
+      "amount": "-29.85",
+      "description": "Cotton Tree Ice Creame    Cotton Tree",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Take-away & snacks",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 367,
+      "date": "09/02/2026",
+      "amount": "-6.00",
+      "description": "MAROOCHYDORE STATE HIG    MAROOCHYDORE",
+      "category": "Children",
+      "subcategory": "School uniforms",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 368,
+      "date": "09/02/2026",
+      "amount": "-7.50",
+      "description": "MAROOCHYDORE STATE HIG    MAROOCHYDORE",
+      "category": "Children",
+      "subcategory": "School uniforms",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 369,
+      "date": "09/02/2026",
+      "amount": "-50.18",
+      "description": "GLOW UP                   YANDINA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Restaurants",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 370,
+      "date": "09/02/2026",
+      "amount": "-9.99",
+      "description": "DD *DOORDASHDASHPASS      MELBOURNE",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Take-away & snacks",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 371,
+      "date": "09/02/2026",
+      "amount": "-8.00",
+      "description": "WOOLWORTHS/OCEAN ST & HOR MAROOCHYDORE",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 372,
+      "date": "09/02/2026",
+      "amount": "-40.00",
+      "description": "BWS/BIG TOP S/C HORTON PD MAROOCHYDORE",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Drinks & alcohol",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 373,
+      "date": "09/02/2026",
+      "amount": "-36.00",
+      "description": "THEPICKLEB* EVT PAIRED    NAMBOUR",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 374,
+      "date": "09/02/2026",
+      "amount": "-31.99",
+      "description": "Adobe                     Sydney",
+      "category": "Medical, personal & education",
+      "subcategory": "Computers & gadgets",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 375,
+      "date": "09/02/2026",
+      "amount": "-13.70",
+      "description": "KFC Caboolture BP Nort    Caboolture BP",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Take-away & snacks",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 376,
+      "date": "09/02/2026",
+      "amount": "-18.30",
+      "description": "SMP*Mrs Luus Southpoin    Southbank",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Lunches bought",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 377,
+      "date": "09/02/2026",
+      "amount": "-5.31",
+      "description": "SFS THE CONTAINER BY      BIRTINYA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 378,
+      "date": "09/02/2026",
+      "amount": "-4.95",
+      "description": "CALTEX CALOUNDRA          CALOUNDRA",
+      "category": "Car & Transport",
+      "subcategory": "Petrol",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 379,
+      "date": "09/02/2026",
+      "amount": "-36.36",
+      "description": "SECURE PARKING PTY LTD    NORTH SYDNEY",
+      "category": "Car & Transport",
+      "subcategory": "Road tolls & parking",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 380,
+      "date": "09/02/2026",
+      "amount": "-4.49",
+      "description": "APPLE.COM/BILL            SYDNEY",
+      "category": "Medical, personal & education",
+      "subcategory": "Computers & gadgets",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 381,
+      "date": "09/02/2026",
+      "amount": "-20.00",
+      "description": "SOUTHBANK CARPARK         SOUTH BANK",
+      "category": "Car & Transport",
+      "subcategory": "Road tolls & parking",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 382,
+      "date": "09/02/2026",
+      "amount": "-23.48",
+      "description": "KINGS BEACH HOTEL APP     Caloundra",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 383,
+      "date": "09/02/2026",
+      "amount": "-23.28",
+      "description": "KINGS BEACH HOTEL APP     Caloundra",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 384,
+      "date": "09/02/2026",
+      "amount": "-23.48",
+      "description": "KINGS BEACH HOTEL APP     Caloundra",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 385,
+      "date": "09/02/2026",
+      "amount": "-23.48",
+      "description": "KINGS BEACH HOTEL APP     Caloundra",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 386,
+      "date": "09/02/2026",
+      "amount": "-5.30",
+      "description": "LS Micasa Cafe Soutban    South Brisban",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 387,
+      "date": "09/02/2026",
+      "amount": "-33.47",
+      "description": "DBS*Goodlife Queen Str    Brisbane",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 388,
+      "date": "09/02/2026",
+      "amount": "-5.56",
+      "description": "BACKSTREET CAFE           MOOLOOLABA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 389,
+      "date": "09/02/2026",
+      "amount": "-20.14",
+      "description": "SUNNY SLOTHS PTY LTD      BIRTINYA",
+      "category": "Children",
+      "subcategory": "Toys",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 390,
+      "date": "06/02/2026",
+      "amount": "-32.18",
+      "description": "SQ *AN NAM VIETNAMESE KIT Sippy Downs",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Lunches bought",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 391,
+      "date": "06/02/2026",
+      "amount": "-5.31",
+      "description": "SFS SCUH ALICE & GEO      BIRTINYA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 392,
+      "date": "06/02/2026",
+      "amount": "-11.99",
+      "description": "help.hbomax.com           St. Leonards",
+      "category": "Home & utilities",
+      "subcategory": "Streaming Services",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 393,
+      "date": "06/02/2026",
+      "amount": "-5.31",
+      "description": "SFS THE CONTAINER BY      BIRTINYA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 394,
+      "date": "05/02/2026",
+      "amount": "-262.46",
+      "description": "QANTAS AIR                MASCOT",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Holidays",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 395,
+      "date": "05/02/2026",
+      "amount": "-1093.73",
+      "description": "Cars on Booking           London",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Holidays",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 396,
+      "date": "05/02/2026",
+      "amount": "-100.02",
+      "description": "Liberty Tanawha           Tanawha",
+      "category": "Car & Transport",
+      "subcategory": "Petrol",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 397,
+      "date": "05/02/2026",
+      "amount": "-53.34",
+      "description": "VODAFONE AUSTRALIA        NORTH SYDNEY",
+      "category": "Home & utilities",
+      "subcategory": "Ellas Mobile",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 398,
+      "date": "04/02/2026",
+      "amount": "-64.00",
+      "description": "FITSTOP SIPPY DO          SUNSHINE COAS",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 399,
+      "date": "04/02/2026",
+      "amount": "-64.00",
+      "description": "FITSTOP SIPPY DO          SUNSHINE COAS",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 400,
+      "date": "04/02/2026",
+      "amount": "-43.32",
+      "description": "COLES 4647                SIPPY DOWNS",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 401,
+      "date": "04/02/2026",
+      "amount": "-14.00",
+      "description": "LIQUORLAND 6476           SIPPY DOWNS",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Drinks & alcohol",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 402,
+      "date": "04/02/2026",
+      "amount": "-83.97",
+      "description": "HARRIS SCARFE MRHYDR      MAROOCHYDORE",
+      "category": "Home & utilities",
+      "subcategory": "Furniture & appliances",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 403,
+      "date": "04/02/2026",
+      "amount": "-110.00",
+      "description": "SPOTLIGHT                 MAROOCHYDORE",
+      "category": "Home & utilities",
+      "subcategory": "Home improvements & Maintenance",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 404,
+      "date": "04/02/2026",
+      "amount": "-144.54",
+      "description": "BUNNINGS 490000           MAROOCHYDORE",
+      "category": "Home & utilities",
+      "subcategory": "Home improvements & Maintenance",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 405,
+      "date": "04/02/2026",
+      "amount": "-36.00",
+      "description": "THEPICKLEB* EVT SOCIAL    NAMBOUR",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 406,
+      "date": "03/02/2026",
+      "amount": "9700.00",
+      "description": "PAYMENT THANKYOU 508136",
+      "category": "Financial & Insurance",
+      "subcategory": "Transfer",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 407,
+      "date": "03/02/2026",
+      "amount": "-1997.26",
+      "description": "JETSTAR AIR KK2YQV        WWW.JETSTAR.C",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Holidays",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 408,
+      "date": "03/02/2026",
+      "amount": "-569.50",
+      "description": "GORGE VIEW KATHERINE      KATHERINE",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Holidays",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 409,
+      "date": "03/02/2026",
+      "amount": "-323.67",
+      "description": "COLES 4647                SIPPY DOWNS",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 410,
+      "date": "03/02/2026",
+      "amount": "-15.99",
+      "description": "Disney Plus               1800-965160",
+      "category": "Home & utilities",
+      "subcategory": "Streaming Services",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 411,
+      "date": "03/02/2026",
+      "amount": "-370.17",
+      "description": "Hotel at Booking.com      Sydney",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Holidays",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 412,
+      "date": "03/02/2026",
+      "amount": "-65.50",
+      "description": "Riba Kai                  Maroochydore",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Restaurants",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 413,
+      "date": "02/02/2026",
+      "amount": "-26.43",
+      "description": "Dock Mooloolaba           Mooloolaba",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 414,
+      "date": "02/02/2026",
+      "amount": "-27.38",
+      "description": "ZLR*The Beach Bar & Gri   Mooloolaba",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Restaurants",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 415,
+      "date": "02/02/2026",
+      "amount": "-82.15",
+      "description": "ZLR*The Beach Bar & Gri   Mooloolaba",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Restaurants",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 416,
+      "date": "02/02/2026",
+      "amount": "-26.37",
+      "description": "ZLR*The Beach Bar & Gri   Mooloolaba",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Restaurants",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 417,
+      "date": "02/02/2026",
+      "amount": "-26.00",
+      "description": "BWS/RIVER ESP & PARKLYN P MOOLOOLABA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Drinks & alcohol",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 418,
+      "date": "02/02/2026",
+      "amount": "-486.40",
+      "description": "GARRY CRICKS NAMBOUR      MAROOCHYDORE",
+      "category": "Car & Transport",
+      "subcategory": "Repairs & maintenance",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 419,
+      "date": "02/02/2026",
+      "amount": "18.00",
+      "description": "THEPICKLEB* EVT SOCIAL    NAMBOUR",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 420,
+      "date": "02/02/2026",
+      "amount": "18.00",
+      "description": "THEPICKLEB* EVT SOCIAL    NAMBOUR",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 421,
+      "date": "02/02/2026",
+      "amount": "-35.75",
+      "description": "UBER *EATS HELP.UBER.COM  Sydney",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Take-away & snacks",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 422,
+      "date": "02/02/2026",
+      "amount": "-63.80",
+      "description": "Nandos MAROOCHYDORE       Maroochydore",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Take-away & snacks",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 423,
+      "date": "02/02/2026",
+      "amount": "-5.59",
+      "description": "SMP*Jamoke Espresso Ba    Nambour",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 424,
+      "date": "02/02/2026",
+      "amount": "-16.60",
+      "description": "POINTPARKING NAMBOUR      NAMBOUR",
+      "category": "Car & Transport",
+      "subcategory": "Road tolls & parking",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 425,
+      "date": "02/02/2026",
+      "amount": "-78.80",
+      "description": "WOOLWORTHS/KARAWATHA DR & MOUNTAIN CRK",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 426,
+      "date": "02/02/2026",
+      "amount": "-5.56",
+      "description": "BACKSTREET CAFE           MOOLOOLABA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 427,
+      "date": "31/01/2026",
+      "amount": "3.47",
+      "description": "Payment",
+      "category": "",
+      "subcategory": "",
+      "file": "Macquarie Pay 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 428,
+      "date": "30/01/2026",
+      "amount": "328.68",
+      "description": "From E552212Txn420196 - 552212*RP 18/02/20",
+      "category": "Income",
+      "subcategory": "Other income",
+      "file": "Macquarie Pay 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 429,
+      "date": "28/01/2026",
+      "amount": "-3500",
+      "description": "To Elizabeth Hawkins  - Funds transfer",
+      "category": "Financial & Insurance",
+      "subcategory": "Transfer",
+      "file": "Macquarie Pay 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 430,
+      "date": "28/01/2026",
+      "amount": "3112.39",
+      "description": "Salary from QLD DEPARTMENT O - SALARY 00428738",
+      "category": "Income",
+      "subcategory": "Your partner's take-home pay",
+      "file": "Macquarie Pay 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 431,
+      "date": "16/01/2026",
+      "amount": "328.68",
+      "description": "From E552212Txn419100 - 552212*RP 18/02/20",
+      "category": "Income",
+      "subcategory": "Other income",
+      "file": "Macquarie Pay 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 432,
+      "date": "16/01/2026",
+      "amount": "0.02",
+      "description": "From closed account xx5111",
+      "category": "",
+      "subcategory": "",
+      "file": "Macquarie Pay 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 433,
+      "date": "16/01/2026",
+      "amount": "0.07",
+      "description": "From closed account xx5695",
+      "category": "",
+      "subcategory": "",
+      "file": "Macquarie Pay 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 434,
+      "date": "14/01/2026",
+      "amount": "-6000",
+      "description": "To Elizabeth Hawkins  - Funds transfer",
+      "category": "Financial & Insurance",
+      "subcategory": "Transfer",
+      "file": "Macquarie Pay 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 435,
+      "date": "14/01/2026",
+      "amount": "-600",
+      "description": "To linked account xx2193 - Internal transfer",
+      "category": "Financial & Insurance",
+      "subcategory": "Transfer",
+      "file": "Macquarie Pay 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 436,
+      "date": "14/01/2026",
+      "amount": "3075.86",
+      "description": "Salary from QLD DEPARTMENT O - SALARY 00428738",
+      "category": "Income",
+      "subcategory": "Your partner's take-home pay",
+      "file": "Macquarie Pay 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 437,
+      "date": "02/01/2026",
+      "amount": "328.68",
+      "description": "From E552212Txn418095 - 552212*RP 18/02/20",
+      "category": "Income",
+      "subcategory": "Other income",
+      "file": "Macquarie Pay 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 438,
+      "date": "28/02/2026",
+      "amount": "0.59",
+      "description": "Payment",
+      "category": "",
+      "subcategory": "",
+      "file": "Macquarie Spending 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 439,
+      "date": "25/02/2026",
+      "amount": "-90.11",
+      "description": "Transfer To Elizabeth Hawkins - Kids expenses",
+      "category": "Financial & Insurance",
+      "subcategory": "Transfer",
+      "file": "Macquarie Spending 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 440,
+      "date": "25/02/2026",
+      "amount": "-12.89",
+      "description": "Transfer To Elizabeth Hawkins - Spotifyhealthmobil",
+      "category": "Home & utilities",
+      "subcategory": "Streaming Services",
+      "file": "Macquarie Spending 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 441,
+      "date": "22/02/2026",
+      "amount": "-10",
+      "description": "Transfer To Bailen Rouse-Upjohn - Family love",
+      "category": "Children",
+      "subcategory": "Child support payment",
+      "file": "Macquarie Spending 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 442,
+      "date": "22/02/2026",
+      "amount": "-10",
+      "description": "Transfer To Jasper Rouse-upjohn - Family love",
+      "category": "Children",
+      "subcategory": "Child support payment",
+      "file": "Macquarie Spending 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 443,
+      "date": "18/02/2026",
+      "amount": "-90.11",
+      "description": "Transfer To Elizabeth Hawkins - Kids expenses",
+      "category": "Financial & Insurance",
+      "subcategory": "Transfer",
+      "file": "Macquarie Spending 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 444,
+      "date": "18/02/2026",
+      "amount": "-12.89",
+      "description": "Transfer To Elizabeth Hawkins - Spotifyhealthmobil",
+      "category": "Home & utilities",
+      "subcategory": "Streaming Services",
+      "file": "Macquarie Spending 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 445,
+      "date": "16/02/2026",
+      "amount": "150",
+      "description": "From AUSTRALIAN UNITY - AU HEALTH 31246163",
+      "category": "Income",
+      "subcategory": "Health insurance reimbursement",
+      "file": "Macquarie Spending 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 446,
+      "date": "15/02/2026",
+      "amount": "-10",
+      "description": "Transfer To Bailen Rouse-Upjohn - Family love",
+      "category": "Children",
+      "subcategory": "Child support payment",
+      "file": "Macquarie Spending 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 447,
+      "date": "15/02/2026",
+      "amount": "-10",
+      "description": "Transfer To Jasper Rouse-upjohn - Family love",
+      "category": "Children",
+      "subcategory": "Child support payment",
+      "file": "Macquarie Spending 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 448,
+      "date": "11/02/2026",
+      "amount": "350",
+      "description": "From linked account xx4650 - Internal transfer",
+      "category": "Financial & Insurance",
+      "subcategory": "Transfer",
+      "file": "Macquarie Spending 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 449,
+      "date": "11/02/2026",
+      "amount": "-155",
+      "description": "To Jasper Rouse-Upjohn - Gift card exchange",
+      "category": "Children",
+      "subcategory": "Child support payment",
+      "file": "Macquarie Spending 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 450,
+      "date": "11/02/2026",
+      "amount": "-95",
+      "description": "To Bailen Rouse-Upjohn - Cash exchange",
+      "category": "Children",
+      "subcategory": "Child support payment",
+      "file": "Macquarie Spending 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 451,
+      "date": "11/02/2026",
+      "amount": "-90.11",
+      "description": "Transfer To Elizabeth Hawkins - Kids expenses",
+      "category": "Financial & Insurance",
+      "subcategory": "Transfer",
+      "file": "Macquarie Spending 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 452,
+      "date": "11/02/2026",
+      "amount": "-12.89",
+      "description": "Transfer To Elizabeth Hawkins - Spotifyhealthmobil",
+      "category": "Home & utilities",
+      "subcategory": "Streaming Services",
+      "file": "Macquarie Spending 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 453,
+      "date": "08/02/2026",
+      "amount": "-10",
+      "description": "Transfer To Bailen Rouse-Upjohn - Family love",
+      "category": "Children",
+      "subcategory": "Child support payment",
+      "file": "Macquarie Spending 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 454,
+      "date": "08/02/2026",
+      "amount": "-10",
+      "description": "Transfer To Jasper Rouse-upjohn - Family love",
+      "category": "Children",
+      "subcategory": "Child support payment",
+      "file": "Macquarie Spending 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 455,
+      "date": "06/02/2026",
+      "amount": "-20.34",
+      "description": "To Jasper Rouse-Upjohn - Yummy ribs",
+      "category": "Children",
+      "subcategory": "Child support payment",
+      "file": "Macquarie Spending 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 456,
+      "date": "05/02/2026",
+      "amount": "149",
+      "description": "From AUSTRALIAN UNITY - AU HEALTH 31246163",
+      "category": "Income",
+      "subcategory": "Health insurance reimbursement",
+      "file": "Macquarie Spending 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 457,
+      "date": "04/02/2026",
+      "amount": "-90.11",
+      "description": "Transfer To Elizabeth Hawkins - Kids expenses",
+      "category": "Financial & Insurance",
+      "subcategory": "Transfer",
+      "file": "Macquarie Spending 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 458,
+      "date": "04/02/2026",
+      "amount": "-12.89",
+      "description": "Transfer To Elizabeth Hawkins - Spotifyhealthmobil",
+      "category": "Home & utilities",
+      "subcategory": "Streaming Services",
+      "file": "Macquarie Spending 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 459,
+      "date": "02/02/2026",
+      "amount": "27",
+      "description": "From Elizabeth Hawkins - Pickleball",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "Macquarie Spending 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 460,
+      "date": "01/02/2026",
+      "amount": "-10",
+      "description": "Transfer To Bailen Rouse-Upjohn - Family love",
+      "category": "Children",
+      "subcategory": "Child support payment",
+      "file": "Macquarie Spending 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 461,
+      "date": "01/02/2026",
+      "amount": "-10",
+      "description": "Transfer To Jasper Rouse-upjohn - Family love",
+      "category": "Children",
+      "subcategory": "Child support payment",
+      "file": "Macquarie Spending 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 462,
+      "date": "28/02/2026",
+      "amount": "0.88",
+      "description": "Payment",
+      "category": "",
+      "subcategory": "",
+      "file": "Macquarie Pay 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 463,
+      "date": "25/02/2026",
+      "amount": "-3300",
+      "description": "To Elizabeth Hawkins  - Funds transfer",
+      "category": "Financial & Insurance",
+      "subcategory": "Transfer",
+      "file": "Macquarie Pay 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 464,
+      "date": "25/02/2026",
+      "amount": "3075",
+      "description": "Salary from QLD DEPARTMENT O - SALARY 00428738",
+      "category": "Income",
+      "subcategory": "Your partner's take-home pay",
+      "file": "Macquarie Pay 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 465,
+      "date": "13/02/2026",
+      "amount": "328.68",
+      "description": "From E552212Txn421241 - 552212*RP 18/02/20",
+      "category": "Income",
+      "subcategory": "Other income",
+      "file": "Macquarie Pay 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 466,
+      "date": "11/02/2026",
+      "amount": "-4000",
+      "description": "To Elizabeth Hawkins  - Funds transfer",
+      "category": "Financial & Insurance",
+      "subcategory": "Transfer",
+      "file": "Macquarie Pay 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 467,
+      "date": "11/02/2026",
+      "amount": "3867.35",
+      "description": "Salary from QLD DEPARTMENT O - SALARY 00428738",
+      "category": "Income",
+      "subcategory": "Your partner's take-home pay",
+      "file": "Macquarie Pay 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 468,
+      "date": "11/02/2026",
+      "amount": "-350",
+      "description": "To linked account xx2193 - Internal transfer",
+      "category": "Financial & Insurance",
+      "subcategory": "Transfer",
+      "file": "Macquarie Pay 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 469,
+      "date": "31/03/2026",
+      "amount": "-62.14",
+      "description": "COLES 7835                BUDERIM",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 470,
+      "date": "31/03/2026",
+      "amount": "-17.5",
+      "description": "BWS/163 KARAWATHA ST - SH BUDERIM",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Drinks & alcohol",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 471,
+      "date": "31/03/2026",
+      "amount": "-48.24",
+      "description": "UBER *TRIP HELP.UBER.COM  Sydney",
+      "category": "Car & Transport",
+      "subcategory": "Uber & taxi",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 472,
+      "date": "31/03/2026",
+      "amount": "-60.35",
+      "description": "SPRINGBOK FOODS PTY LT    FOREST GLEN",
+      "category": "Groceries",
+      "subcategory": "Deli & bakery",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 473,
+      "date": "31/03/2026",
+      "amount": "-9.95",
+      "description": "BANJOS SIPPY DOWNS        SIPPY DOWNS",
+      "category": "Groceries",
+      "subcategory": "Deli & bakery",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 474,
+      "date": "30/03/2026",
+      "amount": "-143.32",
+      "description": "COLES 4647                SIPPY DOWNS",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 475,
+      "date": "30/03/2026",
+      "amount": "-25.5",
+      "description": "SQ *COOROIBAH GREENS - KA Bokarina",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 476,
+      "date": "30/03/2026",
+      "amount": "-110",
+      "description": "LIQUORLAND 6476           SIPPY DOWNS",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Drinks & alcohol",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 477,
+      "date": "30/03/2026",
+      "amount": "-12.24",
+      "description": "SQ *MYSTICA BURGERS       Noosa",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 478,
+      "date": "30/03/2026",
+      "amount": "-3.15",
+      "description": "SFS THE CONTAINER BY      BIRTINYA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 479,
+      "date": "30/03/2026",
+      "amount": "-462.47",
+      "description": "UNITYWATER - CABOOLTUR    CABOOLTURE",
+      "category": "Home & utilities",
+      "subcategory": "Water",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 480,
+      "date": "30/03/2026",
+      "amount": "-164.2",
+      "description": "AMPOL SIPPY DOW 10262F    SIPPY DOWNS",
+      "category": "Car & Transport",
+      "subcategory": "Petrol",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 481,
+      "date": "30/03/2026",
+      "amount": "-31",
+      "description": "BWS/163 KARAWATHA ST - SH BUDERIM",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Drinks & alcohol",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 482,
+      "date": "30/03/2026",
+      "amount": "-16.09",
+      "description": "SQ *AN NAM VIETNAMESE KIT Sippy Downs",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Lunches bought",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 483,
+      "date": "30/03/2026",
+      "amount": "-20",
+      "description": "SQ *THE OLD AMBULANCE STA Nambour",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 484,
+      "date": "30/03/2026",
+      "amount": "-16",
+      "description": "SQ *THE OLD AMBULANCE STA Nambour",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 485,
+      "date": "30/03/2026",
+      "amount": "-171.81",
+      "description": "SUNCORP INSURANCE         BRISBANE CITY",
+      "category": "Financial & Insurance",
+      "subcategory": "Home & contents insurance",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 486,
+      "date": "30/03/2026",
+      "amount": "-44",
+      "description": "COUNTRY CARE GROUP        MILDURA",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 487,
+      "date": "30/03/2026",
+      "amount": "-10",
+      "description": "MERTHYR BOWLS CLUB        NEW FARM",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 488,
+      "date": "30/03/2026",
+      "amount": "-10",
+      "description": "MERTHYR BOWLS CLUB        NEW FARM",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 489,
+      "date": "30/03/2026",
+      "amount": "-28.65",
+      "description": "MERTHYR BOWLS CLUB        NEW FARM",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 490,
+      "date": "30/03/2026",
+      "amount": "-29",
+      "description": "MERTHYR BOWLS CLUB        NEW FARM",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 491,
+      "date": "30/03/2026",
+      "amount": "-18.3",
+      "description": "SMP*Mrs Luus Southpoin    Southbank",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Lunches bought",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 492,
+      "date": "30/03/2026",
+      "amount": "-5.59",
+      "description": "SMP*Jamoke Espresso Ba    Nambour",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 493,
+      "date": "30/03/2026",
+      "amount": "-59.14",
+      "description": "BACKSTREET CAFE           MOOLOOLABA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 494,
+      "date": "30/03/2026",
+      "amount": "-16.6",
+      "description": "POINTPARKING NAMBOUR      NAMBOUR",
+      "category": "Car & Transport",
+      "subcategory": "Road tolls & parking",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 495,
+      "date": "30/03/2026",
+      "amount": "-36",
+      "description": "THEPICKLEB* EVT PAIRED    NAMBOUR",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 496,
+      "date": "27/03/2026",
+      "amount": "-35",
+      "description": "LIQUORLAND 6687           BUDERIM",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Drinks & alcohol",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 497,
+      "date": "27/03/2026",
+      "amount": "-11.2",
+      "description": "LS Micasa Cafe Soutban    South Brisban",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 498,
+      "date": "27/03/2026",
+      "amount": "-16.99",
+      "description": "SOUTHBANK PHARMACY        SOUTH BRISBAN",
+      "category": "Medical, personal & education",
+      "subcategory": "Medicines & pharmacy",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 499,
+      "date": "27/03/2026",
+      "amount": "-203.87",
+      "description": "GLOW UP                   YANDINA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Restaurants",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 500,
+      "date": "27/03/2026",
+      "amount": "-115.2",
+      "description": "TICKETEK WEB              SYDNEY",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Celebrations & gifts",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 501,
+      "date": "26/03/2026",
+      "amount": "-99.99",
+      "description": "SECURE PARKING PTY LTD    NORTH SYDNEY",
+      "category": "Car & Transport",
+      "subcategory": "Road tolls & parking",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 502,
+      "date": "26/03/2026",
+      "amount": "-27",
+      "description": "THEPICKLEB* EVT SOCIAL    NAMBOUR",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 503,
+      "date": "25/03/2026",
+      "amount": "-64",
+      "description": "FITSTOP SIPPY DO          SUNSHINE COAS",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 504,
+      "date": "25/03/2026",
+      "amount": "-64",
+      "description": "FITSTOP SIPPY DO          SUNSHINE COAS",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 505,
+      "date": "25/03/2026",
+      "amount": "-151.2",
+      "description": "Amino Z                   Caringbah",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 506,
+      "date": "25/03/2026",
+      "amount": "-60.42",
+      "description": "BLI BLI HOTEL             BLI BLI",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 507,
+      "date": "25/03/2026",
+      "amount": "-10.4",
+      "description": "BLI BLI HOTEL             BLI BLI",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 508,
+      "date": "25/03/2026",
+      "amount": "-26.72",
+      "description": "BLI BLI HOTEL             BLI BLI",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 509,
+      "date": "25/03/2026",
+      "amount": "-87.91",
+      "description": "CALTEX BLI BLI            BLI BLI",
+      "category": "Car & Transport",
+      "subcategory": "Petrol",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 510,
+      "date": "25/03/2026",
+      "amount": "-20.99",
+      "description": "Netflix.com               Melbourne",
+      "category": "Home & utilities",
+      "subcategory": "Streaming Services",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 511,
+      "date": "25/03/2026",
+      "amount": "-4.65",
+      "description": "BALLINA BWLNGNREC LD      BALLINA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 512,
+      "date": "25/03/2026",
+      "amount": "-81.81",
+      "description": "BALLINA BWLNGNREC LD      BALLINA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 513,
+      "date": "25/03/2026",
+      "amount": "-38.95",
+      "description": "MCDONALDS SIPPY DOWN      SIPPY DOWNS",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Take-away & snacks",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 514,
+      "date": "24/03/2026",
+      "amount": "-150.09",
+      "description": "COLES 4647                SIPPY DOWNS",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 515,
+      "date": "24/03/2026",
+      "amount": "-22.36",
+      "description": "LS Buderim Distillery     Maroochydore",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 516,
+      "date": "24/03/2026",
+      "amount": "-22.36",
+      "description": "LS Buderim Distillery     Maroochydore",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 517,
+      "date": "24/03/2026",
+      "amount": "-148.16",
+      "description": "AMPOL CHINDERAH 22163F    CHINDERAH",
+      "category": "Car & Transport",
+      "subcategory": "Petrol",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 518,
+      "date": "23/03/2026",
+      "amount": "-118.46",
+      "description": "SQ *ZABB BY MEOW          Buderim",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 519,
+      "date": "23/03/2026",
+      "amount": "-10.16",
+      "description": "SQ *MFC                   Kuluin",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 520,
+      "date": "23/03/2026",
+      "amount": "-9.99",
+      "description": "AMZNPRIMEA* AMZNPRIMEA    SYDNEY SOUTH",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Movies, shows & music",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 521,
+      "date": "23/03/2026",
+      "amount": "-23.97",
+      "description": "UBER *TRIP HELP.UBER.COM  Sydney",
+      "category": "Car & Transport",
+      "subcategory": "Uber & taxi",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 522,
+      "date": "23/03/2026",
+      "amount": "-5.76",
+      "description": "SFS THE CONTAINER BY      BIRTINYA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 523,
+      "date": "23/03/2026",
+      "amount": "-10",
+      "description": "MISTERZIMI* MISTER ZIM    PORT MELBOURN",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 524,
+      "date": "23/03/2026",
+      "amount": "-17",
+      "description": "STAN.COM.AU               WWW.STAN.COM.",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 525,
+      "date": "23/03/2026",
+      "amount": "-20",
+      "description": "STAN.COM.AU               WWW.STAN.COM.",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 526,
+      "date": "23/03/2026",
+      "amount": "-32",
+      "description": "BWS/163 KARAWATHA ST - SH BUDERIM",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Drinks & alcohol",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 527,
+      "date": "23/03/2026",
+      "amount": "-172.81",
+      "description": "AGL SALES 0308            MELBOURNE",
+      "category": "Home & utilities",
+      "subcategory": "Electricity",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 528,
+      "date": "23/03/2026",
+      "amount": "-35",
+      "description": "EG GROUP/KARAWATHA DR & G MOUNTAIN CRK",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 529,
+      "date": "23/03/2026",
+      "amount": "-55.35",
+      "description": "SQ *AN NAM VIETNAMESE KIT Sippy Downs",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Lunches bought",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 530,
+      "date": "23/03/2026",
+      "amount": "-56",
+      "description": "COLES 4647                SIPPY DOWNS",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 531,
+      "date": "23/03/2026",
+      "amount": "-15",
+      "description": "BWS/163 KARAWATHA ST - SH BUDERIM",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Drinks & alcohol",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 532,
+      "date": "23/03/2026",
+      "amount": "-76",
+      "description": "A1 MART                   WEST END",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 533,
+      "date": "23/03/2026",
+      "amount": "-35.95",
+      "description": "Microsoft*14 Day Trial Re msbill.info",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Movies, shows & music",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 534,
+      "date": "23/03/2026",
+      "amount": "-18.3",
+      "description": "SMP*Mrs Luus Southpoin    Southbank",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Lunches bought",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 535,
+      "date": "23/03/2026",
+      "amount": "-33.47",
+      "description": "DBS*Goodlife Queen Str    Brisbane",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 536,
+      "date": "20/03/2026",
+      "amount": "-150.08",
+      "description": "REMENTO                   REMENTO.CO",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 537,
+      "date": "20/03/2026",
+      "amount": "-20",
+      "description": "SOUTHBANK CARPARK         SOUTH BANK",
+      "category": "Car & Transport",
+      "subcategory": "Road tolls & parking",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 538,
+      "date": "20/03/2026",
+      "amount": "-60.3",
+      "description": "LS PTC PHONE ACCESSOR     MAROOCHYDORE",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 539,
+      "date": "20/03/2026",
+      "amount": "-69.83",
+      "description": "King IT Maroochydore      Maroochydore",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 540,
+      "date": "20/03/2026",
+      "amount": "-35",
+      "description": "CASE KING                 Maroochydore",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 541,
+      "date": "20/03/2026",
+      "amount": "-197",
+      "description": "COLES 4523                MAROOCHYDORE",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 542,
+      "date": "20/03/2026",
+      "amount": "-78",
+      "description": "KMART 1060                MAROOCHYDORE",
+      "category": "Medical, personal & education",
+      "subcategory": "Shopping",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 543,
+      "date": "20/03/2026",
+      "amount": "-16.45",
+      "description": "Audible Limited AU        MELBOURNE",
+      "category": "Home & utilities",
+      "subcategory": "Streaming Services",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 544,
+      "date": "20/03/2026",
+      "amount": "-10.3",
+      "description": "LS Micasa Cafe Soutban    South Brisban",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 545,
+      "date": "20/03/2026",
+      "amount": "-11.2",
+      "description": "LS Micasa Cafe Soutban    South Brisban",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 546,
+      "date": "20/03/2026",
+      "amount": "-72.76",
+      "description": "TICKETS*FUNNY COAS        0272026035",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 547,
+      "date": "19/03/2026",
+      "amount": "-133.3",
+      "description": "SP MISTER ZIMI            MALVERN",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 548,
+      "date": "19/03/2026",
+      "amount": "-82",
+      "description": "ALH VENUES/NICKLIN WAY    BUDDINA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 549,
+      "date": "19/03/2026",
+      "amount": "-10.8",
+      "description": "ALH VENUES/NICKLIN WAY    BUDDINA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 550,
+      "date": "19/03/2026",
+      "amount": "-121.63",
+      "description": "EG GROUP/KARAWATHA DR & G MOUNTAIN CRK",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 551,
+      "date": "19/03/2026",
+      "amount": "-16.49",
+      "description": "FAMDDS PTY LTD            MAROOCHYDORE",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 552,
+      "date": "19/03/2026",
+      "amount": "-323.4",
+      "description": "DNH*GODADDY#4039396544    130-035-1076",
+      "category": "Medical, personal & education",
+      "subcategory": "Computers & gadgets",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false,
+      "_business": true
+    },
+    {
+      "_id": 553,
+      "date": "19/03/2026",
+      "amount": "-5.31",
+      "description": "SFS THE CONTAINER BY      BIRTINYA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 554,
+      "date": "19/03/2026",
+      "amount": "-118.67",
+      "description": "YOUI - PREMIUM            SIPPY DOWNS",
+      "category": "Financial & Insurance",
+      "subcategory": "Car insurance",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 555,
+      "date": "19/03/2026",
+      "amount": "-201.91",
+      "description": "YOUI - PREMIUM            SIPPY DOWNS",
+      "category": "Financial & Insurance",
+      "subcategory": "Car insurance",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 556,
+      "date": "19/03/2026",
+      "amount": "-87.41",
+      "description": "YOUI - PREMIUM            SIPPY DOWNS",
+      "category": "Financial & Insurance",
+      "subcategory": "Car insurance",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 557,
+      "date": "19/03/2026",
+      "amount": "-9.95",
+      "description": "BANJOS SIPPY DOWNS        SIPPY DOWNS",
+      "category": "Groceries",
+      "subcategory": "Deli & bakery",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 558,
+      "date": "19/03/2026",
+      "amount": "-40.5",
+      "description": "THEPICKLEB* EVT SOCIAL    NAMBOUR",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 559,
+      "date": "18/03/2026",
+      "amount": "-64",
+      "description": "FITSTOP SIPPY DO          SUNSHINE COAS",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 560,
+      "date": "18/03/2026",
+      "amount": "-64",
+      "description": "FITSTOP SIPPY DO          SUNSHINE COAS",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 561,
+      "date": "18/03/2026",
+      "amount": "-1601.06",
+      "description": "Partners on Booking BV    Sydney",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 562,
+      "date": "18/03/2026",
+      "amount": "-88",
+      "description": "COUNTY CARE BIRTINYA      BIRTINYA",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 563,
+      "date": "17/03/2026",
+      "amount": "-28.35",
+      "description": "THE DOONAN                WWW.THEDOONAN",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 564,
+      "date": "17/03/2026",
+      "amount": "-37.62",
+      "description": "THE DOONAN                WWW.THEDOONAN",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 565,
+      "date": "17/03/2026",
+      "amount": "-172",
+      "description": "COLES 4647                SIPPY DOWNS",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 566,
+      "date": "17/03/2026",
+      "amount": "-373.77",
+      "description": "Kin Kin Hotel             Kin Kin",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 567,
+      "date": "17/03/2026",
+      "amount": "-50.5",
+      "description": "THE DOONAN PUB            DOONAN",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 568,
+      "date": "17/03/2026",
+      "amount": "-25.05",
+      "description": "THE DOONAN PUB            DOONAN",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 569,
+      "date": "17/03/2026",
+      "amount": "-27.99",
+      "description": "SPOTIFY                   0012345678",
+      "category": "Home & utilities",
+      "subcategory": "Streaming Services",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 570,
+      "date": "16/03/2026",
+      "amount": "10000",
+      "description": "PAYMENT THANKYOU 740802",
+      "category": "Financial & Insurance",
+      "subcategory": "Transfer",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 571,
+      "date": "16/03/2026",
+      "amount": "-21.26",
+      "description": "Matso'sSunshineCoast      Eumundi",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 572,
+      "date": "16/03/2026",
+      "amount": "-21.26",
+      "description": "Matso'sSunshineCoast      Eumundi",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 573,
+      "date": "16/03/2026",
+      "amount": "-49.83",
+      "description": "MATSOS - SUNSHINE COAS    EUMUNDI",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 574,
+      "date": "16/03/2026",
+      "amount": "-45.99",
+      "description": "HUBBL - KAYO SPORTS       131999",
+      "category": "Home & utilities",
+      "subcategory": "Streaming Services",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 575,
+      "date": "16/03/2026",
+      "amount": "-100.21",
+      "description": "SPINTEL PTY LTD           ST PETERS",
+      "category": "Home & utilities",
+      "subcategory": "Internet",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 576,
+      "date": "16/03/2026",
+      "amount": "-20.14",
+      "description": "KOMEKHUN PTY LTD          BIRTINYA",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 577,
+      "date": "16/03/2026",
+      "amount": "-33.4",
+      "description": "ALH VENUES/81 BURNETT ST  BUDERIM",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 578,
+      "date": "16/03/2026",
+      "amount": "-3.5",
+      "description": "WW METRO/67 BURNETT STREE BUDERIM",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 579,
+      "date": "16/03/2026",
+      "amount": "-36",
+      "description": "BWS/163 KARAWATHA ST - SH BUDERIM",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Drinks & alcohol",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 580,
+      "date": "16/03/2026",
+      "amount": "-5.63",
+      "description": "WOOLWORTHS/KARAWATHA DR & MOUNTAIN CRK",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 581,
+      "date": "16/03/2026",
+      "amount": "-140",
+      "description": "TELSTRA SERVICES          MELBOURNE",
+      "category": "Home & utilities",
+      "subcategory": "Mobile",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 582,
+      "date": "16/03/2026",
+      "amount": "-181.93",
+      "description": "BUSINESS ARCHITECTURE GUI 831-464-5344  125.00  USD 6.15 AUD",
+      "category": "Renovations",
+      "subcategory": "Planning & design",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 583,
+      "date": "16/03/2026",
+      "amount": "-28.35",
+      "description": "MCDONALDS SIPPY DOWN      SIPPY DOWNS",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Take-away & snacks",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 584,
+      "date": "16/03/2026",
+      "amount": "-5.56",
+      "description": "BACKSTREET CAFE           MOOLOOLABA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 585,
+      "date": "16/03/2026",
+      "amount": "-50.36",
+      "description": "LINKT BRISBANE            BRISBANE",
+      "category": "Car & Transport",
+      "subcategory": "Road tolls & parking",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 586,
+      "date": "16/03/2026",
+      "amount": "-18",
+      "description": "THEPICKLEB* EVT SOCIAL    NAMBOUR",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 587,
+      "date": "16/03/2026",
+      "amount": "-18",
+      "description": "THEPICKLEB* EVT SOCIAL    NAMBOUR",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 588,
+      "date": "13/03/2026",
+      "amount": "-50",
+      "description": "COLES 4647                SIPPY DOWNS",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 589,
+      "date": "13/03/2026",
+      "amount": "-170",
+      "description": "QUT FINANCE OPS           KELVIN GROVE",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 590,
+      "date": "13/03/2026",
+      "amount": "-18",
+      "description": "THEPICKLEB* EVT SOCIAL    NAMBOUR",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 591,
+      "date": "13/03/2026",
+      "amount": "-18",
+      "description": "THEPICKLEB* EVT SOCIAL    NAMBOUR",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 592,
+      "date": "12/03/2026",
+      "amount": "-319.91",
+      "description": "CLAUDE.AI SUBSCRIPTION    ANTHROPIC.COM",
+      "category": "Medical, personal & education",
+      "subcategory": "Computers & gadgets",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 593,
+      "date": "12/03/2026",
+      "amount": "-78.53",
+      "description": "WOOLWORTHS/OCEAN ST & HOR MAROOCHYDORE",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 594,
+      "date": "12/03/2026",
+      "amount": "-55.99",
+      "description": "SQ *SUMAK MED EAST CUISIN Kelvin Grove",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 595,
+      "date": "12/03/2026",
+      "amount": "-5.3",
+      "description": "LS Micasa Cafe Soutban    South Brisban",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 596,
+      "date": "12/03/2026",
+      "amount": "-63.63",
+      "description": "SECURE PARKING PTY LTD    NORTH SYDNEY",
+      "category": "Car & Transport",
+      "subcategory": "Road tolls & parking",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 597,
+      "date": "12/03/2026",
+      "amount": "-140.15",
+      "description": "AMRITYU PTY LTD           BOKARINA",
+      "category": "Car & Transport",
+      "subcategory": "Petrol",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 598,
+      "date": "12/03/2026",
+      "amount": "-22.3",
+      "description": "GUZMAN Y GOMEZ            SURRY HILLS",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Take-away & snacks",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 599,
+      "date": "12/03/2026",
+      "amount": "-16.99",
+      "description": "SOUTHBANK PHARMACY        SOUTH BRISBAN",
+      "category": "Medical, personal & education",
+      "subcategory": "Medicines & pharmacy",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 600,
+      "date": "12/03/2026",
+      "amount": "-130.25",
+      "description": "AMPOL MAROOCHYDORE 111    MAROOCHYDORE",
+      "category": "Car & Transport",
+      "subcategory": "Petrol",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 601,
+      "date": "11/03/2026",
+      "amount": "-190",
+      "description": "MAMMOTH FOREST GLEN       FOREST GLEN",
+      "category": "Home & utilities",
+      "subcategory": "Furniture & appliances",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 602,
+      "date": "11/03/2026",
+      "amount": "-64",
+      "description": "FITSTOP SIPPY DO          SUNSHINE COAS",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 603,
+      "date": "11/03/2026",
+      "amount": "-64",
+      "description": "FITSTOP SIPPY DO          SUNSHINE COAS",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 604,
+      "date": "11/03/2026",
+      "amount": "-10",
+      "description": "BWS/163 KARAWATHA ST - SH BUDERIM",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Drinks & alcohol",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 605,
+      "date": "11/03/2026",
+      "amount": "-25.18",
+      "description": "BLI BLI HOTEL             BLI BLI",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 606,
+      "date": "11/03/2026",
+      "amount": "-25.18",
+      "description": "BLI BLI HOTEL             BLI BLI",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 607,
+      "date": "11/03/2026",
+      "amount": "-30.6",
+      "description": "BLI BLI HOTEL             BLI BLI",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 608,
+      "date": "11/03/2026",
+      "amount": "-44.48",
+      "description": "THE CHARMING SQUIRE       SOUTH BRISBAN",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 609,
+      "date": "11/03/2026",
+      "amount": "-91",
+      "description": "QPAC                      SOUTH BRISBAN",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 610,
+      "date": "11/03/2026",
+      "amount": "-30",
+      "description": "QPAC                      SOUTH BRISBAN",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 611,
+      "date": "11/03/2026",
+      "amount": "-4.5",
+      "description": "CocaColaEPP               South Brisban",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 612,
+      "date": "10/03/2026",
+      "amount": "-63.95",
+      "description": "SQ *AN NAM VIETNAMESE KIT Sippy Downs",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Lunches bought",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 613,
+      "date": "10/03/2026",
+      "amount": "-250.29",
+      "description": "COLES 4523                MAROOCHYDORE",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 614,
+      "date": "10/03/2026",
+      "amount": "-28",
+      "description": "SQ *SCOOP HOUSE           Buderim",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 615,
+      "date": "10/03/2026",
+      "amount": "-18.01",
+      "description": "SQ *AN NAM VIETNAMESE KIT Sippy Downs",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Lunches bought",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 616,
+      "date": "10/03/2026",
+      "amount": "-180",
+      "description": "Mecca Brands Pty Ltd      Richmond",
+      "category": "Medical, personal & education",
+      "subcategory": "Hair & beauty",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 617,
+      "date": "10/03/2026",
+      "amount": "-10.02",
+      "description": "UBER *TRIP HELP.UBER.COM  Sydney",
+      "category": "Car & Transport",
+      "subcategory": "Uber & taxi",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 618,
+      "date": "09/03/2026",
+      "amount": "-245.87",
+      "description": "SQ *LEMAK KITCHEN AND BAR Woolloongabba",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 619,
+      "date": "09/03/2026",
+      "amount": "-11.6",
+      "description": "UBER *TRIP HELP.UBER.COM  Sydney",
+      "category": "Car & Transport",
+      "subcategory": "Uber & taxi",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 620,
+      "date": "09/03/2026",
+      "amount": "60",
+      "description": "OZT*HAYLEY MARY - QUIT    WOOLLOONGABBA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Movies, shows & music",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 621,
+      "date": "09/03/2026",
+      "amount": "-8.7",
+      "description": "WW METRO/67 BURNETT STREE BUDERIM",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 622,
+      "date": "09/03/2026",
+      "amount": "-20",
+      "description": "Guzman y Gomez            Maroochydore",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Take-away & snacks",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 623,
+      "date": "09/03/2026",
+      "amount": "-20",
+      "description": "Guzman y Gomez            Maroochydore",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Take-away & snacks",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 624,
+      "date": "09/03/2026",
+      "amount": "-91.35",
+      "description": "PARADISE ARCADE COTTO     Maroochydore",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 625,
+      "date": "09/03/2026",
+      "amount": "-53.6",
+      "description": "GUZMAN Y GOMEZ            SURRY HILLS",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Take-away & snacks",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 626,
+      "date": "09/03/2026",
+      "amount": "-9.99",
+      "description": "DD *DOORDASHDASHPASS      MELBOURNE",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Take-away & snacks",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 627,
+      "date": "09/03/2026",
+      "amount": "-31.99",
+      "description": "Adobe                     Sydney",
+      "category": "Medical, personal & education",
+      "subcategory": "Computers & gadgets",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 628,
+      "date": "09/03/2026",
+      "amount": "-4.05",
+      "description": "SFS THE CONTAINER BY      BIRTINYA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 629,
+      "date": "09/03/2026",
+      "amount": "-4.49",
+      "description": "APPLE.COM/BILL            SYDNEY",
+      "category": "Medical, personal & education",
+      "subcategory": "Computers & gadgets",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 630,
+      "date": "09/03/2026",
+      "amount": "-33.47",
+      "description": "DBS*Goodlife Queen Str    Brisbane",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 631,
+      "date": "09/03/2026",
+      "amount": "-16.5",
+      "description": "MAROOCHYDORE STATE HIG    MAROOCHYDORE",
+      "category": "Children",
+      "subcategory": "School uniforms",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 632,
+      "date": "09/03/2026",
+      "amount": "-53.58",
+      "description": "BACKSTREET CAFE           MOOLOOLABA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 633,
+      "date": "09/03/2026",
+      "amount": "-5.56",
+      "description": "BACKSTREET CAFE           MOOLOOLABA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 634,
+      "date": "06/03/2026",
+      "amount": "-32.18",
+      "description": "SQ *AN NAM VIETNAMESE KIT Sippy Downs",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Lunches bought",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 635,
+      "date": "06/03/2026",
+      "amount": "-39",
+      "description": "BWS/163 KARAWATHA ST - SH BUDERIM",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Drinks & alcohol",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 636,
+      "date": "06/03/2026",
+      "amount": "-36.91",
+      "description": "Print Locker              Alphington",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 637,
+      "date": "06/03/2026",
+      "amount": "-8.7",
+      "description": "MCDONALDS SOUTHBANK       SOUTH BRISBAN",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Take-away & snacks",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 638,
+      "date": "06/03/2026",
+      "amount": "-11.99",
+      "description": "help.hbomax.com           St. Leonards",
+      "category": "Home & utilities",
+      "subcategory": "Streaming Services",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 639,
+      "date": "06/03/2026",
+      "amount": "-18.3",
+      "description": "SMP*SIAM SOUTH BANK   0   SOUTH BRISBAN",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 640,
+      "date": "06/03/2026",
+      "amount": "-53.34",
+      "description": "VODAFONE AUSTRALIA        NORTH SYDNEY",
+      "category": "Home & utilities",
+      "subcategory": "Ellas Mobile",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 641,
+      "date": "06/03/2026",
+      "amount": "-10.8",
+      "description": "SFS THE CONTAINER BY      BIRTINYA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 642,
+      "date": "06/03/2026",
+      "amount": "-45.45",
+      "description": "SECURE PARKING PTY LTD    NORTH SYDNEY",
+      "category": "Car & Transport",
+      "subcategory": "Road tolls & parking",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 643,
+      "date": "05/03/2026",
+      "amount": "-20",
+      "description": "SOUTHBANK CARPARK         SOUTH BANK",
+      "category": "Car & Transport",
+      "subcategory": "Road tolls & parking",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 644,
+      "date": "05/03/2026",
+      "amount": "-59.68",
+      "description": "FRUIT LOVERS/90 WISES ROA MAROOCHYDORE",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 645,
+      "date": "05/03/2026",
+      "amount": "-5.3",
+      "description": "LS Micasa Cafe Soutban    South Brisban",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 646,
+      "date": "05/03/2026",
+      "amount": "-149.14",
+      "description": "CHEMIST WAREHOUSE         BUDERIM",
+      "category": "Medical, personal & education",
+      "subcategory": "Medicines & pharmacy",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 647,
+      "date": "05/03/2026",
+      "amount": "-61.53",
+      "description": "BUNNINGS 490000           MAROOCHYDORE",
+      "category": "Home & utilities",
+      "subcategory": "Home improvements & Maintenance",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 648,
+      "date": "04/03/2026",
+      "amount": "-7.8",
+      "description": "COLES 4647                SIPPY DOWNS",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 649,
+      "date": "04/03/2026",
+      "amount": "-4.95",
+      "description": "Liberty Tanawha           Tanawha",
+      "category": "Car & Transport",
+      "subcategory": "Petrol",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 650,
+      "date": "04/03/2026",
+      "amount": "-62.2",
+      "description": "Liberty Tanawha           Tanawha",
+      "category": "Car & Transport",
+      "subcategory": "Petrol",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 651,
+      "date": "04/03/2026",
+      "amount": "-64",
+      "description": "FITSTOP SIPPY DO          SUNSHINE COAS",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 652,
+      "date": "04/03/2026",
+      "amount": "-64",
+      "description": "FITSTOP SIPPY DO          SUNSHINE COAS",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 653,
+      "date": "04/03/2026",
+      "amount": "-49.89",
+      "description": "MTN CREEK CHEM PHARM      MOUNTAIN CREE",
+      "category": "Medical, personal & education",
+      "subcategory": "Medicines & pharmacy",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 654,
+      "date": "03/03/2026",
+      "amount": "-6.95",
+      "description": "WOOLWORTHS/KARAWATHA DR & MOUNTAIN CRK",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 655,
+      "date": "03/03/2026",
+      "amount": "-66",
+      "description": "OFFICEWORKS  0428         Maroochydore",
+      "category": "Medical, personal & education",
+      "subcategory": "Computers & gadgets",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 656,
+      "date": "03/03/2026",
+      "amount": "-334.27",
+      "description": "COLES 4647                SIPPY DOWNS",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 657,
+      "date": "03/03/2026",
+      "amount": "-48.95",
+      "description": "WOOLWORTHS/KARAWATHA DR & MOUNTAIN CRK",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 658,
+      "date": "03/03/2026",
+      "amount": "-15.99",
+      "description": "Disney Plus               1800-965160",
+      "category": "Home & utilities",
+      "subcategory": "Streaming Services",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 659,
+      "date": "03/03/2026",
+      "amount": "-32",
+      "description": "John Kyle Espresso        Buderim",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 660,
+      "date": "03/03/2026",
+      "amount": "-4.99",
+      "description": "PRIME VIDE* PRIMEVIDEO    SYDNEY",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 661,
+      "date": "03/03/2026",
+      "amount": "-20",
+      "description": "THEPICKLEB* EVT DRILL     NAMBOUR",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 662,
+      "date": "03/03/2026",
+      "amount": "-20",
+      "description": "THEPICKLEB* EVT DRILL     NAMBOUR",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 663,
+      "date": "02/03/2026",
+      "amount": "-31.05",
+      "description": "OPENAI *CHATGPT SUBSCR    OPENAI.COM",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 664,
+      "date": "02/03/2026",
+      "amount": "6000",
+      "description": "PAYMENT THANKYOU 125816",
+      "category": "Financial & Insurance",
+      "subcategory": "Transfer",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 665,
+      "date": "02/03/2026",
+      "amount": "-10.16",
+      "description": "RICK'S GARAGE             Palmwoods",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 666,
+      "date": "02/03/2026",
+      "amount": "-54.86",
+      "description": "RICK'S GARAGE             Palmwoods",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 667,
+      "date": "02/03/2026",
+      "amount": "-32",
+      "description": "WW METRO/67 BURNETT STREE BUDERIM",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 668,
+      "date": "02/03/2026",
+      "amount": "-10.16",
+      "description": "SQ *BE RIGHT BACK BUDERIM Buderim",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 669,
+      "date": "02/03/2026",
+      "amount": "-86",
+      "description": "BWS/81 BURNETT STREET     BUDERIM",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Drinks & alcohol",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 670,
+      "date": "02/03/2026",
+      "amount": "-5000",
+      "description": "PACIFIC MOTOR GROUP PT    MAROOCHYDORE",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 671,
+      "date": "02/03/2026",
+      "amount": "-4.05",
+      "description": "SFS THE CONTAINER BY      BIRTINYA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 672,
+      "date": "02/03/2026",
+      "amount": "-58.87",
+      "description": "SQ *GOODSLICE PIZZA NAPOL Maroochydore",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 673,
+      "date": "02/03/2026",
+      "amount": "-20",
+      "description": "BWS/64 AERODROME STREET   MAROOCHYDORE",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Drinks & alcohol",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 674,
+      "date": "02/03/2026",
+      "amount": "-103.55",
+      "description": "COLES 7836                BIRTINYA",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 675,
+      "date": "02/03/2026",
+      "amount": "-15",
+      "description": "WOOLWORTHS/UNI WAY CHANCE BUDERIM",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 676,
+      "date": "02/03/2026",
+      "amount": "-48.95",
+      "description": "WOOLWORTHS/UNI WAY CHANCE BUDERIM",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 677,
+      "date": "02/03/2026",
+      "amount": "-21.9",
+      "description": "SFS SCUH ALICE & GEO      BIRTINYA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 678,
+      "date": "02/03/2026",
+      "amount": "-171.81",
+      "description": "SUNCORP INSURANCE         BRISBANE CITY",
+      "category": "Financial & Insurance",
+      "subcategory": "Home & contents insurance",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 679,
+      "date": "02/03/2026",
+      "amount": "-20.81",
+      "description": "SOLBAR MAROOCHYDORE       MAROOCHYDORE",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 680,
+      "date": "02/03/2026",
+      "amount": "-83.76",
+      "description": "ZLR*Bombay Bliss - Maro   Maroochydore",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Restaurants",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 681,
+      "date": "02/03/2026",
+      "amount": "-5.56",
+      "description": "BACKSTREET CAFE           MOOLOOLABA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 682,
+      "date": "02/03/2026",
+      "amount": "-51.7",
+      "description": "GRILLD PTY LTD - GARDE    UPPER MT GRAV",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 683,
+      "date": "31/03/2026",
+      "amount": "-6125",
+      "description": "PAYMENT TO MOODIE STEVEN JAMES",
+      "category": "Financial & Insurance",
+      "subcategory": "Home loan",
+      "file": "ANZ Joint Offset 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 684,
+      "date": "25/03/2026",
+      "amount": "3000",
+      "description": "PAYMENT FROM Hawkins E A",
+      "category": "_ignore",
+      "subcategory": "",
+      "file": "ANZ Joint Offset 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 685,
+      "date": "20/03/2026",
+      "amount": "3000",
+      "description": "PAYMENT FROM Hawkins E A",
+      "category": "_ignore",
+      "subcategory": "",
+      "file": "ANZ Joint Offset 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 686,
+      "date": "11/03/2026",
+      "amount": "-10",
+      "description": "ACCOUNT SERVICING FEE",
+      "category": "Financial & Insurance",
+      "subcategory": "Bank fees",
+      "file": "ANZ Joint Offset 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 687,
+      "date": "03/03/2026",
+      "amount": "-8050.94",
+      "description": "PAYMENT TO MOODIE STEVEN JAMES",
+      "category": "Financial & Insurance",
+      "subcategory": "Home loan",
+      "file": "ANZ Joint Offset 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 688,
+      "date": "26/03/2026",
+      "amount": "-150",
+      "description": "ANZ INTERNET BANKING PAYMENT 775908 TO ELLA MOODIE",
+      "category": "Children",
+      "subcategory": "Child support payment",
+      "file": "ANZ Offset 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 689,
+      "date": "26/03/2026",
+      "amount": "6910.48",
+      "description": "PAY/SALARY FROM TALENT INTERNATI 500011896",
+      "category": "Income",
+      "subcategory": "Your take-home pay",
+      "file": "ANZ Offset 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 690,
+      "date": "19/03/2026",
+      "amount": "-150",
+      "description": "ANZ INTERNET BANKING PAYMENT 400378 TO ELLA MOODIE",
+      "category": "Children",
+      "subcategory": "Child support payment",
+      "file": "ANZ Offset 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 691,
+      "date": "17/03/2026",
+      "amount": "41.37",
+      "description": "TRANSFER FROM ATO              ATO001100022265823",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Offset 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 692,
+      "date": "16/03/2026",
+      "amount": "-10000",
+      "description": "ANZ M-BANKING FUNDS TFER TRANSFER 740802  TO 4564XXXXXXXX0557",
+      "category": "Financial & Insurance",
+      "subcategory": "Transfer",
+      "file": "ANZ Offset 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 693,
+      "date": "12/03/2026",
+      "amount": "-402.04",
+      "description": "PAYMENT TO BUPA AUSTRALIA   661368390000189000",
+      "category": "Financial & Insurance",
+      "subcategory": "Health insurance",
+      "file": "ANZ Offset 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 694,
+      "date": "12/03/2026",
+      "amount": "-150",
+      "description": "ANZ INTERNET BANKING PAYMENT 764201 TO ELLA MOODIE",
+      "category": "Children",
+      "subcategory": "Child support payment",
+      "file": "ANZ Offset 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 695,
+      "date": "12/03/2026",
+      "amount": "6910.48",
+      "description": "PAY/SALARY FROM TALENT INTERNATI 500011896",
+      "category": "Income",
+      "subcategory": "Your take-home pay",
+      "file": "ANZ Offset 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 696,
+      "date": "09/03/2026",
+      "amount": "98.69",
+      "description": "PAYMENT FROM MATTHEW HAWKINS",
+      "category": "Financial & Insurance",
+      "subcategory": "Transfer",
+      "file": "ANZ Offset 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 697,
+      "date": "05/03/2026",
+      "amount": "-150",
+      "description": "ANZ INTERNET BANKING PAYMENT 374689 TO ELLA MOODIE",
+      "category": "Children",
+      "subcategory": "Child support payment",
+      "file": "ANZ Offset 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 698,
+      "date": "04/03/2026",
+      "amount": "-10",
+      "description": "ANZ MOBILE BANKING PAYMENT 989779 TO SCOTT ALLINGTON",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Offset 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 699,
+      "date": "02/03/2026",
+      "amount": "-6000",
+      "description": "ANZ M-BANKING FUNDS TFER TRANSFER 125816  TO 4564XXXXXXXX0557",
+      "category": "Financial & Insurance",
+      "subcategory": "Transfer",
+      "file": "ANZ Offset 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 700,
+      "date": "31/03/2026",
+      "amount": "2.27",
+      "description": "Payment",
+      "category": "",
+      "subcategory": "",
+      "file": "Macquarie Pay 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 701,
+      "date": "25/03/2026",
+      "amount": "-3000",
+      "description": "To Elizabeth Hawkins  - Funds transfer",
+      "category": "Financial & Insurance",
+      "subcategory": "Transfer",
+      "file": "Macquarie Pay 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 702,
+      "date": "25/03/2026",
+      "amount": "3112.11",
+      "description": "Salary from QLD DEPARTMENT O - SALARY 00428738",
+      "category": "Income",
+      "subcategory": "Your partner's take-home pay",
+      "file": "Macquarie Pay 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 703,
+      "date": "20/03/2026",
+      "amount": "-300",
+      "description": "To linked account xx2193 - Internal transfer",
+      "category": "Financial & Insurance",
+      "subcategory": "Transfer",
+      "file": "Macquarie Pay 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 704,
+      "date": "20/03/2026",
+      "amount": "-3000",
+      "description": "To Elizabeth Hawkins  - Funds transfer",
+      "category": "Financial & Insurance",
+      "subcategory": "Transfer",
+      "file": "Macquarie Pay 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 705,
+      "date": "11/03/2026",
+      "amount": "3113.53",
+      "description": "Salary from QLD DEPARTMENT O - SALARY 00428738",
+      "category": "Income",
+      "subcategory": "Your partner's take-home pay",
+      "file": "Macquarie Pay 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 782,
+      "date": "31/03/2026",
+      "amount": "0.45",
+      "description": "Payment",
+      "category": "",
+      "subcategory": "",
+      "file": "Macquarie Spending 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 783,
+      "date": "30/03/2026",
+      "amount": "25",
+      "description": "From Elizabeth Hawkins - J bouldering",
+      "category": "Financial & Insurance",
+      "subcategory": "Transfer",
+      "file": "Macquarie Spending 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 784,
+      "date": "30/03/2026",
+      "amount": "-25",
+      "description": "To Jasper Rouse-Upjohn - Bouldering",
+      "category": "Children",
+      "subcategory": "Child support payment",
+      "file": "Macquarie Spending 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 785,
+      "date": "29/03/2026",
+      "amount": "-10",
+      "description": "Transfer To Bailen Rouse-Upjohn - Family love",
+      "category": "Children",
+      "subcategory": "Child support payment",
+      "file": "Macquarie Spending 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 786,
+      "date": "29/03/2026",
+      "amount": "-10",
+      "description": "Transfer To Jasper Rouse-upjohn - Family love",
+      "category": "Children",
+      "subcategory": "Child support payment",
+      "file": "Macquarie Spending 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 787,
+      "date": "25/03/2026",
+      "amount": "-90.11",
+      "description": "Transfer To Elizabeth Hawkins - Kids expenses",
+      "category": "Financial & Insurance",
+      "subcategory": "Transfer",
+      "file": "Macquarie Spending 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 788,
+      "date": "25/03/2026",
+      "amount": "-12.89",
+      "description": "Transfer To Elizabeth Hawkins - Spotifyhealthmobil",
+      "category": "Home & utilities",
+      "subcategory": "Streaming Services",
+      "file": "Macquarie Spending 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 789,
+      "date": "22/03/2026",
+      "amount": "-10",
+      "description": "Transfer To Bailen Rouse-Upjohn - Family love",
+      "category": "Children",
+      "subcategory": "Child support payment",
+      "file": "Macquarie Spending 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 790,
+      "date": "22/03/2026",
+      "amount": "-10",
+      "description": "Transfer To Jasper Rouse-upjohn - Family love",
+      "category": "Children",
+      "subcategory": "Child support payment",
+      "file": "Macquarie Spending 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 791,
+      "date": "20/03/2026",
+      "amount": "-5.5",
+      "description": "To Bailen Rouse-Upjohn - Burrito",
+      "category": "Children",
+      "subcategory": "Child support payment",
+      "file": "Macquarie Spending 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 792,
+      "date": "20/03/2026",
+      "amount": "300",
+      "description": "From linked account xx4650 - Internal transfer",
+      "category": "Financial & Insurance",
+      "subcategory": "Transfer",
+      "file": "Macquarie Spending 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 793,
+      "date": "18/03/2026",
+      "amount": "-90.11",
+      "description": "Transfer To Elizabeth Hawkins - Kids expenses",
+      "category": "Financial & Insurance",
+      "subcategory": "Transfer",
+      "file": "Macquarie Spending 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 794,
+      "date": "18/03/2026",
+      "amount": "-12.89",
+      "description": "Transfer To Elizabeth Hawkins - Spotifyhealthmobil",
+      "category": "Home & utilities",
+      "subcategory": "Streaming Services",
+      "file": "Macquarie Spending 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 795,
+      "date": "17/03/2026",
+      "amount": "80",
+      "description": "From Elizabeth Hawkins - Boys haircuts",
+      "category": "Financial & Insurance",
+      "subcategory": "Transfer",
+      "file": "Macquarie Spending 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 796,
+      "date": "15/03/2026",
+      "amount": "-10",
+      "description": "Transfer To Bailen Rouse-Upjohn - Family love",
+      "category": "Children",
+      "subcategory": "Child support payment",
+      "file": "Macquarie Spending 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 797,
+      "date": "15/03/2026",
+      "amount": "-10",
+      "description": "Transfer To Jasper Rouse-upjohn - Family love",
+      "category": "Children",
+      "subcategory": "Child support payment",
+      "file": "Macquarie Spending 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 798,
+      "date": "11/03/2026",
+      "amount": "-90.11",
+      "description": "Transfer To Elizabeth Hawkins - Kids expenses",
+      "category": "Financial & Insurance",
+      "subcategory": "Transfer",
+      "file": "Macquarie Spending 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 799,
+      "date": "11/03/2026",
+      "amount": "-12.89",
+      "description": "Transfer To Elizabeth Hawkins - Spotifyhealthmobil",
+      "category": "Home & utilities",
+      "subcategory": "Streaming Services",
+      "file": "Macquarie Spending 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 800,
+      "date": "08/03/2026",
+      "amount": "-10",
+      "description": "Transfer To Bailen Rouse-Upjohn - Family love",
+      "category": "Children",
+      "subcategory": "Child support payment",
+      "file": "Macquarie Spending 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 801,
+      "date": "08/03/2026",
+      "amount": "-10",
+      "description": "Transfer To Jasper Rouse-upjohn - Family love",
+      "category": "Children",
+      "subcategory": "Child support payment",
+      "file": "Macquarie Spending 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 802,
+      "date": "07/03/2026",
+      "amount": "80",
+      "description": "From Elizabeth Hawkins - Kids haircuts",
+      "category": "Financial & Insurance",
+      "subcategory": "Transfer",
+      "file": "Macquarie Spending 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 803,
+      "date": "06/03/2026",
+      "amount": "36",
+      "description": "From Elizabeth Hawkins - Boys pickleball",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "Macquarie Spending 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 804,
+      "date": "04/03/2026",
+      "amount": "-90.11",
+      "description": "Transfer To Elizabeth Hawkins - Kids expenses",
+      "category": "Financial & Insurance",
+      "subcategory": "Transfer",
+      "file": "Macquarie Spending 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 805,
+      "date": "04/03/2026",
+      "amount": "-12.89",
+      "description": "Transfer To Elizabeth Hawkins - Spotifyhealthmobil",
+      "category": "Home & utilities",
+      "subcategory": "Streaming Services",
+      "file": "Macquarie Spending 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 806,
+      "date": "01/03/2026",
+      "amount": "-10",
+      "description": "Transfer To Bailen Rouse-Upjohn - Family love",
+      "category": "Children",
+      "subcategory": "Child support payment",
+      "file": "Macquarie Spending 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 807,
+      "date": "01/03/2026",
+      "amount": "-10",
+      "description": "Transfer To Jasper Rouse-upjohn - Family love",
+      "category": "Children",
+      "subcategory": "Child support payment",
+      "file": "Macquarie Spending 2026-03.csv",
+      "_manual": false
+    }
+  ],
+  "customRules": [
+    {
+      "match": "qantas|jetstar",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Holidays",
+      "learned": false
+    },
+    {
+      "match": "VODAFONE AUSTRALIA",
+      "category": "Home & utilities",
+      "subcategory": "Ellas Mobile",
+      "learned": false
+    },
+    {
+      "match": "sfs scuh|sfs the container|sfs scuh alice",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "learned": false
+    },
+    {
+      "match": "mcafee",
+      "category": "Medical, personal & education",
+      "subcategory": "Computers & gadgets",
+      "learned": false
+    },
+    {
+      "match": "Dietitians Austral",
+      "category": "Medical, personal & education",
+      "subcategory": "Education & Professional Memberships",
+      "learned": false
+    },
+    {
+      "match": "COBBCO",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Holidays",
+      "learned": false
+    },
+    {
+      "match": "TRANSPORTMAINRDS",
+      "category": "Car & Transport",
+      "subcategory": "Rego & licence",
+      "learned": false
+    },
+    {
+      "match": "pickleball",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "learned": false
+    },
+    {
+      "match": "brunswick hotel|alh venues|maroochy rsl|rose.*crown|chancellor tavern|Maroochy RSL|deck sea salt|dock mooloolaba|MOOLOOLABA SURF LIFE",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "learned": false
+    },
+    {
+      "match": "bws|liquorland|l/land",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Drinks & alcohol",
+      "learned": false
+    },
+    {
+      "match": "Pavilion Mooloolaba|pomona distilling|boatshed|little parliament|beach bar|green at tanawha",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Restaurants",
+      "learned": false
+    },
+    {
+      "match": "Noosa Chocolate Factory",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Take-away & snacks",
+      "learned": false
+    },
+    {
+      "match": "The Beach Bar & Gri",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Restaurants",
+      "learned": false
+    },
+    {
+      "match": "RAINBOW BEACH SURF LI",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "learned": false
+    },
+    {
+      "match": "OZT*",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Movies, shows & music",
+      "learned": false
+    },
+    {
+      "match": "SFS SCUH ALICE & GEO",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "learned": false
+    },
+    {
+      "match": "Salary from QLD DEPARTMENT",
+      "category": "Income",
+      "subcategory": "Your partner's take-home pay",
+      "learned": false
+    },
+    {
+      "match": "snshn-kr-th-bdrm",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Restaurants",
+      "learned": false
+    },
+    {
+      "match": "From AUSTRALIAN UNITY|MEDICARE BENEFIT",
+      "category": "Income",
+      "subcategory": "Health insurance reimbursement",
+      "learned": false
+    },
+    {
+      "match": "To Jasper Rouse-upjohn",
+      "category": "Children",
+      "subcategory": "Child support payment",
+      "learned": false
+    },
+    {
+      "match": "To Bailen Rouse-Upjohn",
+      "category": "Children",
+      "subcategory": "Child support payment",
+      "learned": false
+    },
+    {
+      "match": "From E552212",
+      "category": "Income",
+      "subcategory": "Other income",
+      "learned": false
+    },
+    {
+      "match": "BYRON SHIRE COUNCIL",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "learned": true
+    },
+    {
+      "match": "snshn-kr-th-bdrm Buderim",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Restaurants",
+      "learned": true
+    },
+    {
+      "match": "FUNDS TFER TRANSFER ",
+      "category": "Financial & Insurance",
+      "subcategory": "Transfer",
+      "learned": false
+    },
+    {
+      "match": "ALH VENUES",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Restaurants",
+      "learned": false
+    },
+    {
+      "match": "SUNCORP INSURANCE",
+      "category": "Financial & Insurance",
+      "subcategory": "Home & contents insurance",
+      "learned": false
+    },
+    {
+      "match": "MAROOCHYDORE STATE HIG",
+      "category": "Children",
+      "subcategory": "School uniforms",
+      "learned": false
+    },
+    {
+      "match": "ELLA MOODIE",
+      "category": "Children",
+      "subcategory": "Child support payment",
+      "learned": false
+    },
+    {
+      "match": "ANZ INTERNET BANKING",
+      "category": "Car & Transport",
+      "subcategory": "Rego & licence",
+      "learned": true
+    },
+    {
+      "match": "ACCOUNT SERVICING FEE",
+      "category": "Financial & Insurance",
+      "subcategory": "Bank fees",
+      "learned": true
+    },
+    {
+      "match": "A&E JONES PTY",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Restaurants",
+      "learned": true
+    },
+    {
+      "match": "DEPOT NOOSA|MOUSTACHE Mermaid",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Restaurants",
+      "learned": true
+    },
+    {
+      "match": "Kiosk Alexandra Hea",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Restaurants",
+      "learned": true
+    },
+    {
+      "match": "PAYMENT TO BUPA",
+      "category": "Financial & Insurance",
+      "subcategory": "Health insurance",
+      "learned": true
+    },
+    {
+      "match": "PAY/SALARY FROM TALENT",
+      "category": "Income",
+      "subcategory": "Your take-home pay",
+      "learned": true
+    },
+    {
+      "match": "PAYMENT FROM Hawkins",
+      "category": "_ignore",
+      "subcategory": "",
+      "learned": true
+    },
+    {
+      "match": "PAYMENT TO MOODIE",
+      "category": "Financial & Insurance",
+      "subcategory": "Home loan",
+      "learned": true
+    },
+    {
+      "match": "SUNCORP INSURANCE BRISBANE",
+      "category": "Financial & Insurance",
+      "subcategory": "Home & contents insurance",
+      "learned": true
+    },
+    {
+      "match": "Cotton Tree Ice",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Take-away & snacks",
+      "learned": true
+    },
+    {
+      "match": "NDC SERVICE CO",
+      "category": "Medical, personal & education",
+      "subcategory": "Dental",
+      "learned": true
+    },
+    {
+      "match": "Aussie World Palmview",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "learned": true
+    },
+    {
+      "match": "The Pocket Espresso",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "learned": true
+    },
+    {
+      "match": "Gun Cotton Coffee",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Restaurants",
+      "learned": true
+    },
+    {
+      "match": "KINGS BEACH HOTEL",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "learned": true
+    },
+    {
+      "match": "Cars on Booking",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Holidays",
+      "learned": true
+    },
+    {
+      "match": "HARRIS SCARFE MRHYDR",
+      "category": "Home & utilities",
+      "subcategory": "Furniture & appliances",
+      "learned": true
+    },
+    {
+      "match": "Disney Plus 1800-965160",
+      "category": "Home & utilities",
+      "subcategory": "Streaming Services",
+      "learned": true
+    },
+    {
+      "match": "QTIX TICKETING",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Movies, shows & music",
+      "learned": true
+    },
+    {
+      "match": "help.hbomax.com St. Leonards",
+      "category": "Home & utilities",
+      "subcategory": "Streaming Services",
+      "learned": true
+    },
+    {
+      "match": "BURLEIGH HDS RUGBY",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "learned": true
+    },
+    {
+      "match": "FOSTER & BLACK",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "learned": true
+    },
+    {
+      "match": "BANJOS SIPPY DOWNS",
+      "category": "Groceries",
+      "subcategory": "Deli & bakery",
+      "learned": true
+    },
+    {
+      "match": "APPLE.COM/BILL SYDNEY",
+      "category": "Medical, personal & education",
+      "subcategory": "Computers & gadgets",
+      "learned": true
+    },
+    {
+      "match": "MAMMOTH FOREST GLEN",
+      "category": "Home & utilities",
+      "subcategory": "Furniture & appliances",
+      "learned": true
+    },
+    {
+      "match": "SPRINGBOK FOODS PTY",
+      "category": "Groceries",
+      "subcategory": "Deli & bakery",
+      "learned": true
+    },
+    {
+      "match": "EVENT CINEMAS",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Movies, shows & music",
+      "learned": true
+    },
+    {
+      "match": "IPY*COBBCO NINE MILE",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Holidays",
+      "learned": true
+    },
+    {
+      "match": "HUBBL - KAYO",
+      "category": "Home & utilities",
+      "subcategory": "Streaming Services",
+      "learned": true
+    },
+    {
+      "match": "SPOTIFY",
+      "category": "Home & utilities",
+      "subcategory": "Streaming Services",
+      "learned": true
+    },
+    {
+      "match": "Mrs Luus",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Lunches bought",
+      "learned": true
+    },
+    {
+      "match": "SPINTEL PTY LTD",
+      "category": "Home & utilities",
+      "subcategory": "Internet",
+      "learned": true
+    },
+    {
+      "match": "Audible Limited AU",
+      "category": "Home & utilities",
+      "subcategory": "Streaming Services",
+      "learned": true
+    },
+    {
+      "match": "Boost Sunshine Plaza",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Take-away & snacks",
+      "learned": true
+    },
+    {
+      "match": "Bli Bli Watersports",
+      "category": "Medical, personal & education",
+      "subcategory": "Hobbies",
+      "learned": true
+    },
+    {
+      "match": "THE GREEN AT",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "learned": true
+    },
+    {
+      "match": "Mebami South Brisban",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Lunches bought",
+      "learned": true
+    },
+    {
+      "match": "THEPICKLEB*",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "learned": true
+    },
+    {
+      "match": "Netflix.com Melbourne",
+      "category": "Home & utilities",
+      "subcategory": "Streaming Services",
+      "learned": true
+    },
+    {
+      "match": "Coles Group Limited",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Celebrations & gifts",
+      "learned": true
+    },
+    {
+      "match": "GLOW UP YANDINA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Restaurants",
+      "learned": true
+    },
+    {
+      "match": "AMRITYU PTY LTD",
+      "category": "Car & Transport",
+      "subcategory": "Petrol",
+      "learned": true
+    },
+    {
+      "match": "AN NAM VIETNAMESE|Mebami",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Lunches bought",
+      "learned": true
+    }
+  ],
+  "budgetOverrides": {
+    "Your take-home pay": 11641,
+    "Your partner's take-home pay": 6391.666666666666,
+    "Gas": 0,
+    "Electricity": 86.66666666666666,
+    "Mobile": 100,
+    "Internet": 100,
+    "Streaming Services": 155,
+    "Home improvements & Maintenance": 100,
+    "Council rates": 451.66666666666663,
+    "Kierans Mobile": 58,
+    "Ellas Mobile": 74,
+    "Savings": 1000,
+    "Investments & super contributions": 0,
+    "Charity donations": 0,
+    "Home loan": 6125,
+    "Home & contents insurance": 350,
+    "Health insurance": 400,
+    "Car insurance": 410,
+    "Personal & life insurance": 0,
+    "Bank fees": 10,
+    "Supermarket": 1650,
+    "Holidays": 1200,
+    "Airfares": 0,
+    "Petrol": 675,
+    "Restaurants": 800,
+    "Bars & clubs": 500,
+    "Lunches bought": 150,
+    "Drinks & alcohol": 200,
+    "Movies, shows & music": 100,
+    "Books, newspapers & magazines": 13,
+    "Coffee & tea": 200,
+    "Rego & licence": 141.66666666666666,
+    "Road tolls & parking": 250,
+    "Public Transport": 52,
+    "Sports & gym": 975,
+    "Fruit & veg market": 0,
+    "Cleaning products": 0,
+    "Toiletries": 0,
+    "Pet food": 0,
+    "Education": 0,
+    "School uniforms": 0,
+    "School fees": 0,
+    "Mortgage / rent": 0,
+    "Hair & beauty": 66.66666666666666,
+    "Cosmetics": 52,
+    "Pet care / vet / pet insurance": 0,
+    "Child support payment": 650,
+    "Children Clothing": 2,
+    "Babysitting": 0,
+    "Excursions": 0,
+    "Other school needs": 0,
+    "Children Sports & activities": 0,
+    "Toys": 0
+  },
+  "budgetFreqs": {
+    "Your partner's take-home pay": "fortnightly",
+    "Electricity": "quarterly",
+    "Council rates": "quarterly",
+    "Your take-home pay": "monthly",
+    "Rego & licence": "annually",
+    "School uniforms": "quarterly",
+    "Hair & beauty": "quarterly",
+    "Child support payment": "weekly"
+  },
+  "customCategories": {
+    "Financial & Insurance": [
+      "Savings",
+      "Investments & super contributions",
+      "Charity donations",
+      "Home loan",
+      "Credit card interest",
+      "Other loans",
+      "Car loan",
+      "Home & contents insurance",
+      "Health insurance",
+      "Car insurance",
+      "Personal & life insurance",
+      "Bank fees"
+    ],
+    "Medical, personal & education": [
+      "Doctors & medical",
+      "Medicines & pharmacy",
+      "Glasses & eye care",
+      "Dental",
+      "Education & Professional Memberships",
+      "Computers & gadgets",
+      "Sports & gym",
+      "Clothing & shoes",
+      "Cosmetics",
+      "Hair & beauty",
+      "Shopping",
+      "Hobbies",
+      "Pet care / vet / pet insurance"
+    ],
+    "Income": [
+      "Your take-home pay",
+      "Your partner's take-home pay",
+      "Bonuses / overtime",
+      "Income from savings and investments",
+      "Child support received",
+      "Health insurance reimbursement",
+      "Rent (investment property)",
+      "Other income"
+    ],
+    "Home & utilities": [
+      "Water",
+      "Gas",
+      "Electricity",
+      "Mobile",
+      "Internet",
+      "Streaming Services",
+      "Home improvements & Maintenance",
+      "Furniture & appliances",
+      "Council rates",
+      "Body corporate fees",
+      "Kierans Mobile",
+      "Ellas Mobile"
+    ]
+  },
+  "projectBudgets": {
+    "Financial & Insurance": 150000,
+    "Renovations": 3500
+  },
+  "deletedSubs": [],
+  "csvFormatMappings": {},
+  "businessExpenseFlags": {
+    "552": true
+  },
+  "summary": {
+    "totalTransactions": 732,
+    "dateRange": {
+      "from": "01/02/2026",
+      "to": "9/01/2026"
+    },
+    "byCategory": {
+      "Financial & Insurance": 55,
+      "_ignore": 6,
+      "Income": 19,
+      "Children": 44,
+      "Car & Transport": 61,
+      "Eating-out & Entertainment": 242,
+      "Medical, personal & education": 112,
+      "Groceries": 73,
+      "Home & utilities": 50,
+      "Uncategorised": 69,
+      "Renovations": 1
+    },
+    "bySourceFile": {
+      "ANZ Joint Offset 2026-01.csv": 6,
+      "ANZ Joint Offset 2026-02.csv": 3,
+      "ANZ Offset 2026-01.csv": 10,
+      "ANZ Offset 2026-02.csv": 10,
+      "ANZ Credit Card 2026-01.csv": 212,
+      "ANZ Credit Card 2026-02.csv": 186,
+      "Macquarie Pay 2026-01.csv": 11,
+      "Macquarie Spending 2026-02.csv": 24,
+      "Macquarie Pay 2026-02.csv": 7,
+      "ANZ Credit Card 2026-03.csv": 214,
+      "ANZ Joint Offset 2026-03.csv": 5,
+      "ANZ Offset 2026-03.csv": 12,
+      "Macquarie Pay 2026-03.csv": 6,
+      "Macquarie Spending 2026-03.csv": 26
+    },
+    "businessFlaggedCount": 1,
+    "manuallyCategoirsedCount": 0,
+    "uncategorisedCount": 69,
+    "customRulesCount": 73
+  }
+}

--- a/migration-artifacts/budget-tracker/budget-tracker-export.csv
+++ b/migration-artifacts/budget-tracker/budget-tracker-export.csv
@@ -1,0 +1,733 @@
+_id,date,amount,description,category,subcategory,file,_manual,_business
+0,30/01/2026,-8050.94,"PAYMENT TO MOODIE STEVEN JAMES",Financial & Insurance,Home loan,ANZ Joint Offset 2026-01.csv,false,false
+1,28/01/2026,3500.00,"PAYMENT FROM Hawkins E A",_ignore,,ANZ Joint Offset 2026-01.csv,false,false
+2,15/01/2026,-9775.00,"ANZ M-BANKING FUNDS TFER TRANSFER 279885  TO 4564X",Financial & Insurance,Transfer,ANZ Joint Offset 2026-01.csv,false,false
+3,14/01/2026,6000.00,"PAYMENT FROM Hawkins E A",_ignore,,ANZ Joint Offset 2026-01.csv,false,false
+4,09/01/2026,-10.00,"ACCOUNT SERVICING FEE",Financial & Insurance,Bank fees,ANZ Joint Offset 2026-01.csv,false,false
+5,07/01/2026,43.90,"EFTPOS MEDICARE BENEFIT",Income,Health insurance reimbursement,ANZ Joint Offset 2026-01.csv,false,false
+6,25/02/2026,3300.00,"PAYMENT FROM Hawkins E A",_ignore,,ANZ Joint Offset 2026-02.csv,false,false
+7,11/02/2026,-10.00,"ACCOUNT SERVICING FEE",Financial & Insurance,Bank fees,ANZ Joint Offset 2026-02.csv,false,false
+8,11/02/2026,4000.00,"PAYMENT FROM Hawkins E A",_ignore,,ANZ Joint Offset 2026-02.csv,false,false
+9,29/01/2026,-150.00,"ANZ INTERNET BANKING PAYMENT 858073 TO ELLA MOODIE",Children,Child support payment,ANZ Offset 2026-01.csv,false,false
+10,29/01/2026,6350.03,"PAY/SALARY FROM TALENT INTERNATI 500011896",Income,Your take-home pay,ANZ Offset 2026-01.csv,false,false
+11,22/01/2026,-150.00,"ANZ INTERNET BANKING PAYMENT 687595 TO ELLA MOODIE",Children,Child support payment,ANZ Offset 2026-01.csv,false,false
+12,22/01/2026,-26.00,"ANZ MOBILE BANKING PAYMENT 844618 TO ELLA MOODIE",Children,Child support payment,ANZ Offset 2026-01.csv,false,false
+13,20/01/2026,-100.00,"ANZ MOBILE BANKING PAYMENT 501243 TO ELLA MOODIE",Children,Child support payment,ANZ Offset 2026-01.csv,false,false
+14,15/01/2026,-150.00,"ANZ INTERNET BANKING PAYMENT 272737 TO ELLA MOODIE",Children,Child support payment,ANZ Offset 2026-01.csv,false,false
+15,15/01/2026,3944.24,"PAY/SALARY FROM TALENT INTERNATI 500011896",Income,Your take-home pay,ANZ Offset 2026-01.csv,false,false
+16,13/01/2026,-402.04,"PAYMENT TO BUPA AUSTRALIA   661368390000187000",Financial & Insurance,Health insurance,ANZ Offset 2026-01.csv,false,false
+17,08/01/2026,-150.00,"ANZ INTERNET BANKING PAYMENT 975600 TO ELLA MOODIE",Children,Child support payment,ANZ Offset 2026-01.csv,false,false
+18,02/01/2026,-150.00,"ANZ INTERNET BANKING PAYMENT 795103 TO ELLA MOODIE",Children,Child support payment,ANZ Offset 2026-01.csv,false,false
+19,26/02/2026,-421.30,"ANZ INTERNET BANKING BPAY TMR REG RENEW 4817      ",Car & Transport,Rego & licence,ANZ Offset 2026-02.csv,false,false
+20,26/02/2026,-150.00,"ANZ INTERNET BANKING PAYMENT 258399 TO ELLA MOODIE",Children,Child support payment,ANZ Offset 2026-02.csv,false,false
+21,26/02/2026,6350.03,"PAY/SALARY FROM TALENT INTERNATI 500011896",Income,Your take-home pay,ANZ Offset 2026-02.csv,false,false
+22,19/02/2026,-150.00,"ANZ INTERNET BANKING PAYMENT 735869 TO ELLA MOODIE",Children,Child support payment,ANZ Offset 2026-02.csv,false,false
+23,16/02/2026,-8400.00,"ANZ M-BANKING FUNDS TFER TRANSFER 681977  TO 4564X",Financial & Insurance,Transfer,ANZ Offset 2026-02.csv,false,false
+24,12/02/2026,-402.04,"PAYMENT TO BUPA AUSTRALIA   661368390000188000",Financial & Insurance,Health insurance,ANZ Offset 2026-02.csv,false,false
+25,12/02/2026,-150.00,"ANZ INTERNET BANKING PAYMENT 211935 TO ELLA MOODIE",Children,Child support payment,ANZ Offset 2026-02.csv,false,false
+26,12/02/2026,6350.03,"PAY/SALARY FROM TALENT INTERNATI 500011896",Income,Your take-home pay,ANZ Offset 2026-02.csv,false,false
+27,05/02/2026,-150.00,"ANZ INTERNET BANKING PAYMENT 701230 TO ELLA MOODIE",Children,Child support payment,ANZ Offset 2026-02.csv,false,false
+28,03/02/2026,-9700.00,"ANZ M-BANKING FUNDS TFER TRANSFER 508136  TO 4564X",Financial & Insurance,Transfer,ANZ Offset 2026-02.csv,false,false
+29,30/01/2026,-203.87,"GLOW UP                   YANDINA",Eating-out & Entertainment,Restaurants,ANZ Credit Card 2026-01.csv,false,false
+30,30/01/2026,-16.09,"SQ *AN NAM VIETNAMESE KIT Sippy Downs",Eating-out & Entertainment,Lunches bought,ANZ Credit Card 2026-01.csv,false,false
+31,30/01/2026,-171.81,"SUNCORP INSURANCE         BRISBANE CITY",Financial & Insurance,Home & contents insurance,ANZ Credit Card 2026-01.csv,false,false
+32,30/01/2026,-45.45,"SECURE PARKING PTY LTD    NORTH SYDNEY",Car & Transport,Road tolls & parking,ANZ Credit Card 2026-01.csv,false,false
+33,30/01/2026,-100.03,"AMRITYU PTY LTD           BOKARINA",Car & Transport,Petrol,ANZ Credit Card 2026-01.csv,false,false
+34,30/01/2026,-18.9,"POINT PARKING             KAWANA",Car & Transport,Road tolls & parking,ANZ Credit Card 2026-01.csv,false,false
+35,30/01/2026,-16.6,"POINTPARKING NAMBOUR      NAMBOUR",Car & Transport,Road tolls & parking,ANZ Credit Card 2026-01.csv,false,false
+36,29/01/2026,-40.2,"THE BOATSHED              COTTON TREE",Eating-out & Entertainment,Restaurants,ANZ Credit Card 2026-01.csv,false,false
+37,29/01/2026,-64,"SP BANDIFY AUSTRALIA      AIRPORT WEST",Medical, personal & education,Computers & gadgets,ANZ Credit Card 2026-01.csv,false,false
+38,29/01/2026,-23.75,"MCDONALDS SIPPY DOWN      SIPPY DOWNS",Eating-out & Entertainment,Take-away & snacks,ANZ Credit Card 2026-01.csv,false,false
+39,29/01/2026,-57,"CHANCE PARK CHM PHARM     SIPPY DOWNS",Medical, personal & education,Medicines & pharmacy,ANZ Credit Card 2026-01.csv,false,false
+40,29/01/2026,-13.5,"THEPICKLEB* EVT SOCIAL    NAMBOUR",Medical, personal & education,Sports & gym,ANZ Credit Card 2026-01.csv,false,false
+41,29/01/2026,-13.5,"THEPICKLEB* EVT SOCIAL    NAMBOUR",Medical, personal & education,Sports & gym,ANZ Credit Card 2026-01.csv,false,false
+42,28/01/2026,-800,"Coles Group Limited -     Hawthorn East",Eating-out & Entertainment,Celebrations & gifts,ANZ Credit Card 2026-01.csv,false,false
+43,28/01/2026,-64,"FITSTOP SIPPY DO          SUNSHINE COAS",Medical, personal & education,Sports & gym,ANZ Credit Card 2026-01.csv,false,false
+44,28/01/2026,-64,"FITSTOP SIPPY DO          SUNSHINE COAS",Medical, personal & education,Sports & gym,ANZ Credit Card 2026-01.csv,false,false
+45,28/01/2026,-4.05,"MEGA FRESH FOOD MARKET    MOUNTAIN CREE",Groceries,Supermarket,ANZ Credit Card 2026-01.csv,false,false
+46,28/01/2026,-50.36,"BUNNINGS 490000           MAROOCHYDORE",Home & utilities,Home improvements & Maintenance,ANZ Credit Card 2026-01.csv,false,false
+47,27/01/2026,-170,"BWS/163 KARAWATHA ST - SH BUDERIM",Eating-out & Entertainment,Drinks & alcohol,ANZ Credit Card 2026-01.csv,false,false
+48,27/01/2026,-181.77,"COLES 4647                SIPPY DOWNS",Groceries,Supermarket,ANZ Credit Card 2026-01.csv,false,false
+49,27/01/2026,-54.15,"WOOLWORTHS/KARAWATHA DR & MOUNTAIN CRK",Groceries,Supermarket,ANZ Credit Card 2026-01.csv,false,false
+50,27/01/2026,-90.45,"SQ *AN NAM VIETNAMESE KIT Sippy Downs",Eating-out & Entertainment,Lunches bought,ANZ Credit Card 2026-01.csv,false,false
+51,27/01/2026,-25.46,"COLES 4647                SIPPY DOWNS",Groceries,Supermarket,ANZ Credit Card 2026-01.csv,false,false
+52,27/01/2026,-45.45,"ZLR*Somewhere On Buderi   Buderim",Eating-out & Entertainment,Restaurants,ANZ Credit Card 2026-01.csv,false,false
+53,27/01/2026,-5.31,"SFS THE CONTAINER BY      BIRTINYA",Eating-out & Entertainment,Coffee & tea,ANZ Credit Card 2026-01.csv,false,false
+54,27/01/2026,-82.32,"THE FOREST BLEND CAFE     FOREST GLEN",Eating-out & Entertainment,Coffee & tea,ANZ Credit Card 2026-01.csv,false,false
+55,27/01/2026,-7.2,"WOOLWORTHS/KARAWATHA DR & MOUNTAIN CRK",Groceries,Supermarket,ANZ Credit Card 2026-01.csv,false,false
+56,27/01/2026,-20.99,"Netflix.com               Melbourne",Home & utilities,Streaming Services,ANZ Credit Card 2026-01.csv,false,false
+57,27/01/2026,-18,"THEPICKLEB* EVT SOCIAL    NAMBOUR",Medical, personal & education,Sports & gym,ANZ Credit Card 2026-01.csv,false,false
+58,27/01/2026,-18,"THEPICKLEB* EVT SOCIAL    NAMBOUR",Medical, personal & education,Sports & gym,ANZ Credit Card 2026-01.csv,false,false
+59,27/01/2026,-18,"THEPICKLEB* EVT SOCIAL    NAMBOUR",Medical, personal & education,Sports & gym,ANZ Credit Card 2026-01.csv,false,false
+60,27/01/2026,-53.4,"WOOLWORTHS/KARAWATHA DR & MOUNTAIN CRK",Groceries,Supermarket,ANZ Credit Card 2026-01.csv,false,false
+61,27/01/2026,-80.85,"COLES 7835                BUDERIM",Groceries,Supermarket,ANZ Credit Card 2026-01.csv,false,false
+62,27/01/2026,-33.47,"DBS*Goodlife Queen Str    Brisbane",Medical, personal & education,Sports & gym,ANZ Credit Card 2026-01.csv,false,false
+63,27/01/2026,-50.35,"LINKT BRISBANE            BRISBANE",Car & Transport,Road tolls & parking,ANZ Credit Card 2026-01.csv,false,false
+64,27/01/2026,-18,"THEPICKLEB* EVT SOCIAL    NAMBOUR",Medical, personal & education,Sports & gym,ANZ Credit Card 2026-01.csv,false,false
+65,27/01/2026,-13.4,"MCDONALDS SOUTHBANK       SOUTH BRISBAN",Eating-out & Entertainment,Take-away & snacks,ANZ Credit Card 2026-01.csv,false,false
+66,27/01/2026,-5.59,"SMP*Jamoke Espresso Ba    Nambour",Eating-out & Entertainment,Coffee & tea,ANZ Credit Card 2026-01.csv,false,false
+67,27/01/2026,-96.75,"AMPOL SIPPY DOW 10262F    SIPPY DOWNS",Car & Transport,Petrol,ANZ Credit Card 2026-01.csv,false,false
+68,23/01/2026,-9.99,"AMZNPRIMEA* AMZNPRIMEA    SYDNEY SOUTH",Eating-out & Entertainment,Movies, shows & music,ANZ Credit Card 2026-01.csv,false,false
+69,23/01/2026,-20,"SOUTHBANK CARPARK         SOUTH BANK",Car & Transport,Road tolls & parking,ANZ Credit Card 2026-01.csv,false,false
+70,23/01/2026,-13.2,"ROSE & CROWN              South Brisban",Eating-out & Entertainment,Bars & clubs,ANZ Credit Card 2026-01.csv,false,false
+71,23/01/2026,-13.72,"Mebami                    South Brisban",Eating-out & Entertainment,Lunches bought,ANZ Credit Card 2026-01.csv,false,false
+72,23/01/2026,-6.12,"SQ *BLACK FOX             Mooloolaba",Eating-out & Entertainment,Coffee & tea,ANZ Credit Card 2026-01.csv,false,false
+73,23/01/2026,-480,"COASTAL AESTHETIC INJE    MAROOCHYDORE",Medical, personal & education,Hair & beauty,ANZ Credit Card 2026-01.csv,false,false
+74,22/01/2026,129.95,"MYER  MAROOCHYDORE        MAROOCHYDORE",Medical, personal & education,Shopping,ANZ Credit Card 2026-01.csv,false,false
+75,22/01/2026,-47.45,"COLES 4523                MAROOCHYDORE",Groceries,Supermarket,ANZ Credit Card 2026-01.csv,false,false
+76,22/01/2026,-30,"TARGET 5038               MAROOCHYDORE",Medical, personal & education,Shopping,ANZ Credit Card 2026-01.csv,false,false
+77,22/01/2026,-24,"KMART 1060                MAROOCHYDORE",Medical, personal & education,Shopping,ANZ Credit Card 2026-01.csv,false,false
+78,22/01/2026,-253.94,"MYER  MAROOCHYDORE        MAROOCHYDORE",Medical, personal & education,Shopping,ANZ Credit Card 2026-01.csv,false,false
+79,22/01/2026,-341,"NDC SERVICE CO PTY LIM    MAROOCHYDORE",Medical, personal & education,Dental,ANZ Credit Card 2026-01.csv,false,false
+80,22/01/2026,-163.27,"AGL SALES 0308            MELBOURNE",Home & utilities,Electricity,ANZ Credit Card 2026-01.csv,false,false
+81,22/01/2026,-58.44,"DECJUBA PTY LTD           MAROOCHYDORE",Medical, personal & education,Clothing & shoes,ANZ Credit Card 2026-01.csv,false,false
+82,22/01/2026,-287.3,"QTIX TICKETING            SOUTH BRISBAN",Eating-out & Entertainment,Movies, shows & music,ANZ Credit Card 2026-01.csv,false,false
+83,22/01/2026,-13.5,"THEPICKLEB* EVT SOCIAL    NAMBOUR",Medical, personal & education,Sports & gym,ANZ Credit Card 2026-01.csv,false,false
+84,22/01/2026,-40.5,"THEPICKLEB* EVT SOCIAL    NAMBOUR",Medical, personal & education,Sports & gym,ANZ Credit Card 2026-01.csv,false,false
+85,21/01/2026,-122.2,"ALH VENUES/81 BURNETT ST  BUDERIM",Eating-out & Entertainment,Bars & clubs,ANZ Credit Card 2026-01.csv,false,false
+86,21/01/2026,-132.98,"THE GREEN AT TANAWHA      TANAWHA",Eating-out & Entertainment,Restaurants,ANZ Credit Card 2026-01.csv,false,false
+87,21/01/2026,-115.36,"Bli Bli Watersports Compl Bli Bli",Medical, personal & education,Hobbies,ANZ Credit Card 2026-01.csv,false,false
+88,21/01/2026,-64,"FITSTOP SIPPY DO          SUNSHINE COAS",Medical, personal & education,Sports & gym,ANZ Credit Card 2026-01.csv,false,false
+89,21/01/2026,-64,"FITSTOP SIPPY DO          SUNSHINE COAS",Medical, personal & education,Sports & gym,ANZ Credit Card 2026-01.csv,false,false
+90,21/01/2026,-14.1,"WELLINGTON BAKERY PART    MAROOCHYDORE",Groceries,Deli & bakery,ANZ Credit Card 2026-01.csv,false,false
+91,20/01/2026,-9.3,"Boost Sunshine Plaza      Maroochydore",Eating-out & Entertainment,Take-away & snacks,ANZ Credit Card 2026-01.csv,false,false
+92,20/01/2026,-308.14,"WOOLWORTHS/SUNSHINE PLZ S MAROOCHYDORE",Groceries,Supermarket,ANZ Credit Card 2026-01.csv,false,false
+93,20/01/2026,-20,"BWS/50 PARK PLAZA         MAROOCHYDORE",Eating-out & Entertainment,Drinks & alcohol,ANZ Credit Card 2026-01.csv,false,false
+94,20/01/2026,-68.07,"SQ *WALTER'S DINER        Maroochydore",Eating-out & Entertainment,Restaurants,ANZ Credit Card 2026-01.csv,false,false
+95,20/01/2026,-1.02,"SQ *WALTER'S DINER        Maroochydore",Eating-out & Entertainment,Restaurants,ANZ Credit Card 2026-01.csv,false,false
+96,20/01/2026,-120,"TARGET 5038               MAROOCHYDORE",Medical, personal & education,Shopping,ANZ Credit Card 2026-01.csv,false,false
+97,20/01/2026,-16.45,"Audible Limited AU        MELBOURNE",Home & utilities,Streaming Services,ANZ Credit Card 2026-01.csv,false,false
+98,20/01/2026,-35.95,"Microsoft*14 Day Trial Re msbill.info",Eating-out & Entertainment,Movies, shows & music,ANZ Credit Card 2026-01.csv,false,false
+99,20/01/2026,-253.91,"MYER  MAROOCHYDORE        MAROOCHYDORE",Medical, personal & education,Shopping,ANZ Credit Card 2026-01.csv,false,false
+100,20/01/2026,-28.99,"Bonds Sunshine Plaza      Maroochydore",Medical, personal & education,Clothing & shoes,ANZ Credit Card 2026-01.csv,false,false
+101,20/01/2026,-112.46,"DECJUBA PTY LTD           MAROOCHYDORE",Medical, personal & education,Clothing & shoes,ANZ Credit Card 2026-01.csv,false,false
+102,20/01/2026,-66.7,"Sunshine Krua Thai        Buderim",Eating-out & Entertainment,Restaurants,ANZ Credit Card 2026-01.csv,false,false
+103,20/01/2026,-107.9,"SMP*Orchid Massage in03   Sippy Downs",Medical, personal & education,Hair & beauty,ANZ Credit Card 2026-01.csv,false,false
+104,20/01/2026,-130,"SMP*Orchid Massage in03   Sippy Downs",Medical, personal & education,Hair & beauty,ANZ Credit Card 2026-01.csv,false,false
+105,19/01/2026,-85,"L/LAND QLD    2266        SIPPY DOWNS",Eating-out & Entertainment,Drinks & alcohol,ANZ Credit Card 2026-01.csv,false,false
+106,19/01/2026,-54.43,"SQ *AN NAM VIETNAMESE KIT Sippy Downs",Eating-out & Entertainment,Lunches bought,ANZ Credit Card 2026-01.csv,false,false
+107,19/01/2026,-24.36,"Aussie World              Palmview",Eating-out & Entertainment,Bars & clubs,ANZ Credit Card 2026-01.csv,false,false
+108,19/01/2026,-24.36,"Aussie World              Palmview",Eating-out & Entertainment,Bars & clubs,ANZ Credit Card 2026-01.csv,false,false
+109,19/01/2026,-24.36,"Aussie World              Palmview",Eating-out & Entertainment,Bars & clubs,ANZ Credit Card 2026-01.csv,false,false
+110,19/01/2026,-75.11,"Aussie World              Palmview",Eating-out & Entertainment,Bars & clubs,ANZ Credit Card 2026-01.csv,false,false
+111,19/01/2026,-34.51,"Aussie World              Palmview",Eating-out & Entertainment,Bars & clubs,ANZ Credit Card 2026-01.csv,false,false
+112,19/01/2026,-165.85,"SPER QLD TREASURY         BRISBANE",Car & Transport,Road tolls & parking,ANZ Credit Card 2026-01.csv,false,false
+113,19/01/2026,-65.64,"SPINTEL PTY LTD           SURRY HILLS",Home & utilities,Internet,ANZ Credit Card 2026-01.csv,false,false
+114,19/01/2026,-87.41,"YOUI - PREMIUM            SIPPY DOWNS",Financial & Insurance,Car insurance,ANZ Credit Card 2026-01.csv,false,false
+115,19/01/2026,-44.96,"DAVID JONES PTY LTD -     MAROOCHYDORE",Medical, personal & education,Shopping,ANZ Credit Card 2026-01.csv,false,false
+116,19/01/2026,-16,"KMART 1060                MAROOCHYDORE",Medical, personal & education,Shopping,ANZ Credit Card 2026-01.csv,false,false
+117,19/01/2026,-79.94,"Forever New Clothing      Richmond",Medical, personal & education,Clothing & shoes,ANZ Credit Card 2026-01.csv,false,false
+118,19/01/2026,-24.36,"Aussie World              Palmview",Eating-out & Entertainment,Bars & clubs,ANZ Credit Card 2026-01.csv,false,false
+119,19/01/2026,-51,"Mecca Brands Pty Ltd      Richmond",Medical, personal & education,Hair & beauty,ANZ Credit Card 2026-01.csv,false,false
+120,19/01/2026,-4,"POINTPARKING SUNSHINE     MAROOCHYDORE",Car & Transport,Road tolls & parking,ANZ Credit Card 2026-01.csv,false,false
+121,19/01/2026,-56.99,"COTTON ON BODY 4839       MAROOCHYDORE",Medical, personal & education,Clothing & shoes,ANZ Credit Card 2026-01.csv,false,false
+122,19/01/2026,-83,"Sunshine Coast Regiona... Sunshine C...",Home & utilities,Council rates,ANZ Credit Card 2026-01.csv,false,false
+123,19/01/2026,-51.99,"AMPOL SIPPY DOW 10262F    SIPPY DOWNS",Car & Transport,Petrol,ANZ Credit Card 2026-01.csv,false,false
+124,19/01/2026,-36.03,"CHANCELLOR TAVERN APP     Sippy Downs",Eating-out & Entertainment,Bars & clubs,ANZ Credit Card 2026-01.csv,false,false
+125,19/01/2026,-14.85,"MCDONALDS MEADOWBROO      MEADOWBROOK",Eating-out & Entertainment,Take-away & snacks,ANZ Credit Card 2026-01.csv,false,false
+126,19/01/2026,-13.4,"MCDONALDS SOUTHBANK       SOUTH BRISBAN",Eating-out & Entertainment,Take-away & snacks,ANZ Credit Card 2026-01.csv,false,false
+127,19/01/2026,-18.3,"SMP*Mrs Luus Southpoin    Southbank",Eating-out & Entertainment,Lunches bought,ANZ Credit Card 2026-01.csv,false,false
+128,19/01/2026,-4.05,"SFS THE CONTAINER BY      BIRTINYA",Eating-out & Entertainment,Coffee & tea,ANZ Credit Card 2026-01.csv,false,false
+129,19/01/2026,-201.87,"YOUI - PREMIUM            SIPPY DOWNS",Financial & Insurance,Car insurance,ANZ Credit Card 2026-01.csv,false,false
+130,19/01/2026,-27.99,"SPOTIFY                   SYDNEY",Home & utilities,Streaming Services,ANZ Credit Card 2026-01.csv,false,false
+131,16/01/2026,-20,"SOUTHBANK CARPARK         SOUTH BANK",Car & Transport,Road tolls & parking,ANZ Credit Card 2026-01.csv,false,false
+132,16/01/2026,-4.3,"WOOLWORTHS/217 GREY STREE STH BRISBANE",Groceries,Supermarket,ANZ Credit Card 2026-01.csv,false,false
+133,16/01/2026,-38,"BWS/163 KARAWATHA ST - SH BUDERIM",Eating-out & Entertainment,Drinks & alcohol,ANZ Credit Card 2026-01.csv,false,false
+134,16/01/2026,-9.09,"SECURE PARKING PTY LTD    NORTH SYDNEY",Car & Transport,Road tolls & parking,ANZ Credit Card 2026-01.csv,false,false
+135,16/01/2026,-40,"HUBBL - KAYO SPORTS       131999",Home & utilities,Streaming Services,ANZ Credit Card 2026-01.csv,false,false
+136,16/01/2026,-140,"TELSTRA SERVICES          MELBOURNE",Home & utilities,Mobile,ANZ Credit Card 2026-01.csv,false,false
+137,15/01/2026,9775,"PAYMENT THANKYOU 279885",Financial & Insurance,Transfer,ANZ Credit Card 2026-01.csv,false,false
+138,15/01/2026,-33,"BWS/163 KARAWATHA ST - SH BUDERIM",Eating-out & Entertainment,Drinks & alcohol,ANZ Credit Card 2026-01.csv,false,false
+139,15/01/2026,-12.5,"WOOLWORTHS/KARAWATHA DR & MOUNTAIN CRK",Groceries,Supermarket,ANZ Credit Card 2026-01.csv,false,false
+140,15/01/2026,-725,"EZI*Dietitians Austral    DEAKIN",Medical, personal & education,Education & Professional Memberships,ANZ Credit Card 2026-01.csv,false,false
+141,15/01/2026,-160,"IPY*COBBCO NINE MILE      Tandur",Eating-out & Entertainment,Holidays,ANZ Credit Card 2026-01.csv,false,false
+142,15/01/2026,-51.99,"AMPOL SIPPY DOW 10262F    SIPPY DOWNS",Car & Transport,Petrol,ANZ Credit Card 2026-01.csv,false,false
+143,14/01/2026,-8.3,"COLES 4647                SIPPY DOWNS",Groceries,Supermarket,ANZ Credit Card 2026-01.csv,false,false
+144,14/01/2026,-16.09,"SQ *AN NAM VIETNAMESE KIT Sippy Downs",Eating-out & Entertainment,Lunches bought,ANZ Credit Card 2026-01.csv,false,false
+145,14/01/2026,-39.18,"WOOLWORTHS/KARAWATHA DR & MOUNTAIN CRK",Groceries,Supermarket,ANZ Credit Card 2026-01.csv,false,false
+146,14/01/2026,-151.2,"Amino Z                   Caringbah",Medical, personal & education,Sports & gym,ANZ Credit Card 2026-01.csv,false,false
+147,14/01/2026,-64,"FITSTOP SIPPY DO          SUNSHINE COAS",Medical, personal & education,Sports & gym,ANZ Credit Card 2026-01.csv,false,false
+148,14/01/2026,-64,"FITSTOP SIPPY DO          SUNSHINE COAS",Medical, personal & education,Sports & gym,ANZ Credit Card 2026-01.csv,false,false
+149,14/01/2026,-69.18,"TERRY WHITE CHEMAR        MINYAMA",Medical, personal & education,Medicines & pharmacy,ANZ Credit Card 2026-01.csv,false,false
+150,14/01/2026,-7.7,"EVENT CINEMAS KAWANA      BUDDINA",Eating-out & Entertainment,Movies, shows & music,ANZ Credit Card 2026-01.csv,false,false
+151,13/01/2026,-650,"THEKINKINWOOD260314NB     KIN KIN",Eating-out & Entertainment,Holidays,ANZ Credit Card 2026-01.csv,false,false
+152,13/01/2026,-105.93,"Liberty Tanawha           Tanawha",Car & Transport,Petrol,ANZ Credit Card 2026-01.csv,false,false
+153,13/01/2026,-23.8,"ALH VENUES/2/46 DAVID LOW DIDDILLIBAH",Eating-out & Entertainment,Bars & clubs,ANZ Credit Card 2026-01.csv,false,false
+154,13/01/2026,-25,"BWS/163 KARAWATHA ST - SH BUDERIM",Eating-out & Entertainment,Drinks & alcohol,ANZ Credit Card 2026-01.csv,false,false
+155,13/01/2026,-134.38,"COLES 4647                SIPPY DOWNS",Groceries,Supermarket,ANZ Credit Card 2026-01.csv,false,false
+156,13/01/2026,-23.8,"ALH VENUES/2/46 DAVID LOW DIDDILLIBAH",Eating-out & Entertainment,Bars & clubs,ANZ Credit Card 2026-01.csv,false,false
+157,13/01/2026,-83.6,"SPRINGBOK FOODS PTY LT    FOREST GLEN",Groceries,Deli & bakery,ANZ Credit Card 2026-01.csv,false,false
+158,13/01/2026,-141.3,"EVENT KAWANA              BUDDINA",Eating-out & Entertainment,Celebrations & gifts,ANZ Credit Card 2026-01.csv,false,false
+159,12/01/2026,-146.45,"POMONA DISTILLING CO      POMONA",Eating-out & Entertainment,Restaurants,ANZ Credit Card 2026-01.csv,false,false
+160,12/01/2026,-104.07,"COLES 4647                SIPPY DOWNS",Groceries,Supermarket,ANZ Credit Card 2026-01.csv,false,false
+161,12/01/2026,-113.38,"Liberty Tanawha           Tanawha",Car & Transport,Petrol,ANZ Credit Card 2026-01.csv,false,false
+162,12/01/2026,-37.61,"Pomona Distilling Co      Pomona",Eating-out & Entertainment,Restaurants,ANZ Credit Card 2026-01.csv,false,false
+163,12/01/2026,-19.95,"POMONA TRUE VALUE HA      POMONA",Home & utilities,Home improvements & Maintenance,ANZ Credit Card 2026-01.csv,false,false
+164,12/01/2026,-69.54,"ZLR*Bombay Bliss - Maro   Maroochydore",Eating-out & Entertainment,Restaurants,ANZ Credit Card 2026-01.csv,false,false
+165,12/01/2026,-4.05,"SFS THE CONTAINER BY      BIRTINYA",Eating-out & Entertainment,Coffee & tea,ANZ Credit Card 2026-01.csv,false,false
+166,12/01/2026,-8.7,"COLES 4647                SIPPY DOWNS",Groceries,Supermarket,ANZ Credit Card 2026-01.csv,false,false
+167,12/01/2026,-23.1,"Maroochy RSL              Maroochydore",Eating-out & Entertainment,Bars & clubs,ANZ Credit Card 2026-01.csv,false,false
+168,12/01/2026,-32.18,"SQ *AN NAM VIETNAMESE KIT Sippy Downs",Eating-out & Entertainment,Lunches bought,ANZ Credit Card 2026-01.csv,false,false
+169,12/01/2026,-32,"Dominos Estore Buderim    dominos.com.a",Eating-out & Entertainment,Take-away & snacks,ANZ Credit Card 2026-01.csv,false,false
+170,12/01/2026,-4.9,"AMPOL SIPPY DOW 10262F    SIPPY DOWNS",Car & Transport,Petrol,ANZ Credit Card 2026-01.csv,false,false
+171,12/01/2026,-190,"MAMMOTH FOREST GLEN       FOREST GLEN",Home & utilities,Furniture & appliances,ANZ Credit Card 2026-01.csv,false,false
+172,12/01/2026,-18,"THEPICKLEB* EVT SOCIAL    NAMBOUR",Medical, personal & education,Sports & gym,ANZ Credit Card 2026-01.csv,false,false
+173,12/01/2026,-18,"THEPICKLEB* EVT SOCIAL    NAMBOUR",Medical, personal & education,Sports & gym,ANZ Credit Card 2026-01.csv,false,false
+174,12/01/2026,-194.88,"Pavilion Mooloolaba       Mooloolaba",Eating-out & Entertainment,Restaurants,ANZ Credit Card 2026-01.csv,false,false
+175,12/01/2026,-25,"MCDONALDS SIPPY DOWN      SIPPY DOWNS",Eating-out & Entertainment,Take-away & snacks,ANZ Credit Card 2026-01.csv,false,false
+176,12/01/2026,-16.25,"SUBWAY SIPPYDOWNS         SIPPY DOWNS",Eating-out & Entertainment,Take-away & snacks,ANZ Credit Card 2026-01.csv,false,false
+177,12/01/2026,-5.31,"SFS THE CONTAINER BY      BIRTINYA",Eating-out & Entertainment,Coffee & tea,ANZ Credit Card 2026-01.csv,false,false
+178,12/01/2026,-154,"SpaghettiHouse            South Brisban",Eating-out & Entertainment,Restaurants,ANZ Credit Card 2026-01.csv,false,false
+179,12/01/2026,-10.7,"MCDONALDS SOUTHBANK       SOUTH BRISBAN",Eating-out & Entertainment,Take-away & snacks,ANZ Credit Card 2026-01.csv,false,false
+180,12/01/2026,-33.47,"DBS*Goodlife Queen Str    Brisbane",Medical, personal & education,Sports & gym,ANZ Credit Card 2026-01.csv,false,false
+181,12/01/2026,-4.75,"ROBINSON'S VENDING PTY LT NARANGBA",Eating-out & Entertainment,Take-away & snacks,ANZ Credit Card 2026-01.csv,false,false
+182,9/01/2026,-20,"SOUTHBANK CARPARK         SOUTH BANK",Car & Transport,Road tolls & parking,ANZ Credit Card 2026-01.csv,false,false
+183,9/01/2026,-95.95,"Suncoast Health Cntre     Forest Glen",Medical, personal & education,Doctors & medical,ANZ Credit Card 2026-01.csv,false,false
+184,9/01/2026,-5.3,"LS Micasa Cafe Soutban    South Brisban",Eating-out & Entertainment,Coffee & tea,ANZ Credit Card 2026-01.csv,false,false
+185,9/01/2026,-5.3,"LS Micasa Cafe Soutban    South Brisban",Eating-out & Entertainment,Coffee & tea,ANZ Credit Card 2026-01.csv,false,false
+186,9/01/2026,-72.72,"SECURE PARKING PTY LTD    NORTH SYDNEY",Car & Transport,Road tolls & parking,ANZ Credit Card 2026-01.csv,false,false
+187,9/01/2026,-24.2,"GUZMAN Y GOMEZ            SURRY HILLS",Eating-out & Entertainment,Take-away & snacks,ANZ Credit Card 2026-01.csv,false,false
+188,8/01/2026,-9.99,"DD *DOORDASHDASHPASS      MELBOURNE",Eating-out & Entertainment,Take-away & snacks,ANZ Credit Card 2026-01.csv,false,false
+189,8/01/2026,-46.34,"WW METRO/67 BURNETT STREE BUDERIM",Groceries,Supermarket,ANZ Credit Card 2026-01.csv,false,false
+190,8/01/2026,-31.99,"Adobe                     Sydney",Medical, personal & education,Computers & gadgets,ANZ Credit Card 2026-01.csv,false,false
+191,8/01/2026,-5.31,"SFS THE CONTAINER BY      BIRTINYA",Eating-out & Entertainment,Coffee & tea,ANZ Credit Card 2026-01.csv,false,false
+192,8/01/2026,-4.49,"APPLE.COM/BILL            SYDNEY",Medical, personal & education,Computers & gadgets,ANZ Credit Card 2026-01.csv,false,false
+193,8/01/2026,-27,"THEPICKLEB* EVT SOCIAL    NAMBOUR",Medical, personal & education,Sports & gym,ANZ Credit Card 2026-01.csv,false,false
+194,8/01/2026,-13.5,"THEPICKLEB* EVT SOCIAL    NAMBOUR",Medical, personal & education,Sports & gym,ANZ Credit Card 2026-01.csv,false,false
+195,7/01/2026,-53.34,"VODAFONE AUSTRALIA        NORTH SYDNEY",Home & utilities,Ellas Mobile,ANZ Credit Card 2026-01.csv,false,false
+196,7/01/2026,-9.95,"BANJOS SIPPY DOWNS        SIPPY DOWNS",Groceries,Deli & bakery,ANZ Credit Card 2026-01.csv,false,false
+197,7/01/2026,-64,"FITSTOP SIPPY DO          SUNSHINE COAS",Medical, personal & education,Sports & gym,ANZ Credit Card 2026-01.csv,false,false
+198,7/01/2026,-64,"FITSTOP SIPPY DO          SUNSHINE COAS",Medical, personal & education,Sports & gym,ANZ Credit Card 2026-01.csv,false,false
+199,7/01/2026,-10,"FOSTER & BLACK P/L        UPPER MOUNT G",Eating-out & Entertainment,Coffee & tea,ANZ Credit Card 2026-01.csv,false,false
+200,7/01/2026,-58.49,"UNITED BETHANIA           BETHANIA",Car & Transport,Petrol,ANZ Credit Card 2026-01.csv,false,false
+201,7/01/2026,-31.31,"BURLEIGH HDS RUGBY        MERMAID BEACH",Eating-out & Entertainment,Bars & clubs,ANZ Credit Card 2026-01.csv,false,false
+202,7/01/2026,-21.21,"BURLEIGH HDS RUGBY        MERMAID BEACH",Eating-out & Entertainment,Bars & clubs,ANZ Credit Card 2026-01.csv,false,false
+203,6/01/2026,-418.81,"COLES 4647                SIPPY DOWNS",Groceries,Supermarket,ANZ Credit Card 2026-01.csv,false,false
+204,6/01/2026,-15.68,"SQ *AN NAM VIETNAMESE KIT Sippy Downs",Eating-out & Entertainment,Lunches bought,ANZ Credit Card 2026-01.csv,false,false
+205,6/01/2026,-133,"LIQUORLAND 6476           SIPPY DOWNS",Eating-out & Entertainment,Drinks & alcohol,ANZ Credit Card 2026-01.csv,false,false
+206,6/01/2026,-54.65,"Kiosk                     Alexandra Hea",Eating-out & Entertainment,Restaurants,ANZ Credit Card 2026-01.csv,false,false
+207,6/01/2026,-11.99,"help.hbomax.com           St. Leonards",Home & utilities,Streaming Services,ANZ Credit Card 2026-01.csv,false,false
+208,6/01/2026,-83.59,"AMPOL SIPPY DOW 10262F    SIPPY DOWNS",Car & Transport,Petrol,ANZ Credit Card 2026-01.csv,false,false
+209,5/01/2026,-46.26,"COLES 4647                SIPPY DOWNS",Groceries,Supermarket,ANZ Credit Card 2026-01.csv,false,false
+210,5/01/2026,-14.9,"Nandos GARDEN CITY        Mt Gravatt",Eating-out & Entertainment,Take-away & snacks,ANZ Credit Card 2026-01.csv,false,false
+211,5/01/2026,-84.25,"Nandos GARDEN CITY        Mt Gravatt",Eating-out & Entertainment,Take-away & snacks,ANZ Credit Card 2026-01.csv,false,false
+212,5/01/2026,-43.48,"SQ *MOUSTACHE             Mermaid Beach",Eating-out & Entertainment,Restaurants,ANZ Credit Card 2026-01.csv,false,false
+213,5/01/2026,-11.18,"SQ *THE HOLLIDAY COFFEE   Mermaid Beach",Eating-out & Entertainment,Coffee & tea,ANZ Credit Card 2026-01.csv,false,false
+214,5/01/2026,-10,"BYRON SHIRE COUNCIL       MULLUMBIMBY",Eating-out & Entertainment,Coffee & tea,ANZ Credit Card 2026-01.csv,false,false
+215,5/01/2026,-23.3,"BRUNSWICK HOTEL OPCO P    BRUNSWICK HEA",Eating-out & Entertainment,Bars & clubs,ANZ Credit Card 2026-01.csv,false,false
+216,5/01/2026,-23.54,"BRUNSWICK HOTEL OPCO P    BRUNSWICK HEA",Eating-out & Entertainment,Bars & clubs,ANZ Credit Card 2026-01.csv,false,false
+217,5/01/2026,-7,"AMPOL EAGLEBY 10266F      EAGLEBY",Car & Transport,Petrol,ANZ Credit Card 2026-01.csv,false,false
+218,5/01/2026,-22.22,"BRUNSWICK HOTEL OPCO P    BRUNSWICK HEA",Eating-out & Entertainment,Bars & clubs,ANZ Credit Card 2026-01.csv,false,false
+219,5/01/2026,-56.67,"BRUNSWICK HOTEL OPCO P    BRUNSWICK HEA",Eating-out & Entertainment,Bars & clubs,ANZ Credit Card 2026-01.csv,false,false
+220,5/01/2026,-102.31,"SQ *MORE THAI RESTAURANT  Mermaid Beach",Eating-out & Entertainment,Restaurants,ANZ Credit Card 2026-01.csv,false,false
+221,5/01/2026,-30,"BWS/2223 GOLD COAST HWY-S MERMAID BCH",Eating-out & Entertainment,Drinks & alcohol,ANZ Credit Card 2026-01.csv,false,false
+222,5/01/2026,-545.5,"QTIX TICKETING            SOUTH BRISBAN",Eating-out & Entertainment,Movies, shows & music,ANZ Credit Card 2026-01.csv,false,false
+223,5/01/2026,-15,"SQ *MOOLOOLABA SURF LIFE  Mooloolaba",Eating-out & Entertainment,Bars & clubs,ANZ Credit Card 2026-01.csv,false,false
+224,5/01/2026,-15.99,"Disney Plus               1800-965160",Home & utilities,Streaming Services,ANZ Credit Card 2026-01.csv,false,false
+225,5/01/2026,-41.5,"BWS/163 KARAWATHA ST - SH BUDERIM",Eating-out & Entertainment,Drinks & alcohol,ANZ Credit Card 2026-01.csv,false,false
+226,5/01/2026,-31.99,"BUNNINGS 490000           MAROOCHYDORE",Home & utilities,Home improvements & Maintenance,ANZ Credit Card 2026-01.csv,false,false
+227,2/01/2026,-29.6,"ALH VENUES/NICKLIN WAY    BUDDINA",Eating-out & Entertainment,Bars & clubs,ANZ Credit Card 2026-01.csv,false,false
+228,2/01/2026,-124,"LIQUORLAND 6476           SIPPY DOWNS",Eating-out & Entertainment,Drinks & alcohol,ANZ Credit Card 2026-01.csv,false,false
+229,2/01/2026,-189,"Booking.com Hotel         Sydney",Eating-out & Entertainment,Holidays,ANZ Credit Card 2026-01.csv,false,false
+230,2/01/2026,-5.9,"SFS SCUH MERLOT           BIRTINYA",Eating-out & Entertainment,Coffee & tea,ANZ Credit Card 2026-01.csv,false,false
+231,2/01/2026,-10.82,"SQ *BLACK FOX             Mooloolaba",Eating-out & Entertainment,Coffee & tea,ANZ Credit Card 2026-01.csv,false,false
+232,2/01/2026,-847.83,"TRANSPORTMAINRDS          BRISBANE",Car & Transport,Rego & licence,ANZ Credit Card 2026-01.csv,false,false
+233,2/01/2026,-119.98,"COLES 4647                SIPPY DOWNS",Groceries,Supermarket,ANZ Credit Card 2026-01.csv,false,false
+234,2/01/2026,-42,"LIQUORLAND 6476           SIPPY DOWNS",Eating-out & Entertainment,Drinks & alcohol,ANZ Credit Card 2026-01.csv,false,false
+235,2/01/2026,-5.57,"SQ *ROCK HOP ESPRESSO     Coolum",Eating-out & Entertainment,Coffee & tea,ANZ Credit Card 2026-01.csv,false,false
+236,2/01/2026,-41.96,"LS Delifish Buderim       Buderim",Groceries,Deli & bakery,ANZ Credit Card 2026-01.csv,false,false
+237,2/01/2026,-59.48,"LIVELIFE PHARMACY CV      COOLUM BEACH",Medical, personal & education,Medicines & pharmacy,ANZ Credit Card 2026-01.csv,false,false
+238,2/01/2026,-171.81,"SUNCORP INSURANCE         BRISBANE CITY",Financial & Insurance,Home & contents insurance,ANZ Credit Card 2026-01.csv,false,false
+239,2/01/2026,13.12,"YOUI - PREMIUM            SIPPY DOWNS",Financial & Insurance,Car insurance,ANZ Credit Card 2026-01.csv,false,false
+240,2/01/2026,-25.47,"ALDI STORES               BIRTINYA",Groceries,Supermarket,ANZ Credit Card 2026-01.csv,false,false
+241,27/02/2026,-59.30,"WOOLWORTHS/OCEAN ST & HOR MAROOCHYDORE",Groceries,Supermarket,ANZ Credit Card 2026-02.csv,false,false
+242,27/02/2026,-48.95,"WOOLWORTHS/KARAWATHA DR & MOUNTAIN CRK",Groceries,Supermarket,ANZ Credit Card 2026-02.csv,false,false
+243,27/02/2026,-16.45,"KFC Sippy Downs           Sippy Downs",Eating-out & Entertainment,Take-away & snacks,ANZ Credit Card 2026-02.csv,false,false
+244,27/02/2026,-1355.20,"Sunshine Coast Regiona... Sunshine C...",Home & utilities,Council rates,ANZ Credit Card 2026-02.csv,false,false
+245,27/02/2026,-75.73,"Playa                     Bokarina",Eating-out & Entertainment,Restaurants,ANZ Credit Card 2026-02.csv,false,false
+246,27/02/2026,-88.86,"AMRITYU PTY LTD           BOKARINA",Car & Transport,Petrol,ANZ Credit Card 2026-02.csv,false,false
+247,26/02/2026,-20.00,"SOUTHBANK CARPARK         SOUTH BANK",Car & Transport,Road tolls & parking,ANZ Credit Card 2026-02.csv,false,false
+248,26/02/2026,-13.72,"Mebami                    South Brisban",Eating-out & Entertainment,Lunches bought,ANZ Credit Card 2026-02.csv,false,false
+249,26/02/2026,-5.30,"LS Micasa Cafe Soutban    South Brisban",Eating-out & Entertainment,Coffee & tea,ANZ Credit Card 2026-02.csv,false,false
+250,26/02/2026,-45.45,"SECURE PARKING PTY LTD    NORTH SYDNEY",Car & Transport,Road tolls & parking,ANZ Credit Card 2026-02.csv,false,false
+251,25/02/2026,-64.00,"FITSTOP SIPPY DO          SUNSHINE COAS",Medical, personal & education,Sports & gym,ANZ Credit Card 2026-02.csv,false,false
+252,25/02/2026,-64.00,"FITSTOP SIPPY DO          SUNSHINE COAS",Medical, personal & education,Sports & gym,ANZ Credit Card 2026-02.csv,false,false
+253,25/02/2026,-48.95,"WOOLWORTHS/KARAWATHA DR & MOUNTAIN CRK",Groceries,Supermarket,ANZ Credit Card 2026-02.csv,false,false
+254,25/02/2026,-20.99,"Netflix.com               Melbourne",Home & utilities,Streaming Services,ANZ Credit Card 2026-02.csv,false,false
+255,25/02/2026,-36.00,"THEPICKLEB* EVT SOCIAL    NAMBOUR",Medical, personal & education,Sports & gym,ANZ Credit Card 2026-02.csv,false,false
+256,25/02/2026,-62.10,"MCDONALDS SIPPY DOWN      SIPPY DOWNS",Eating-out & Entertainment,Take-away & snacks,ANZ Credit Card 2026-02.csv,false,false
+257,24/02/2026,-15.80,"ALH VENUES/2/46 DAVID LOW DIDDILLIBAH",Eating-out & Entertainment,Bars & clubs,ANZ Credit Card 2026-02.csv,false,false
+258,24/02/2026,-139.12,"COLES 7835                BUDERIM",Groceries,Supermarket,ANZ Credit Card 2026-02.csv,false,false
+259,24/02/2026,-99.34,"Liberty Tanawha           Tanawha",Car & Transport,Petrol,ANZ Credit Card 2026-02.csv,false,false
+260,24/02/2026,-99.98,"SQ *DEPOT NOOSA           Noosaville",Eating-out & Entertainment,Restaurants,ANZ Credit Card 2026-02.csv,false,false
+261,23/02/2026,-36.00,"BWS/23 VENNING STREET     MOOLOOLABA",Eating-out & Entertainment,Drinks & alcohol,ANZ Credit Card 2026-02.csv,false,false
+262,23/02/2026,-41.00,"ALH VENUES/23 VENNING ST  MOOLOOLABA",Eating-out & Entertainment,Bars & clubs,ANZ Credit Card 2026-02.csv,false,false
+263,23/02/2026,-96.00,"ALH VENUES/23 VENNING ST  MOOLOOLABA",Eating-out & Entertainment,Bars & clubs,ANZ Credit Card 2026-02.csv,false,false
+264,23/02/2026,-24.40,"WOOLWORTHS/KARAWATHA DR & MOUNTAIN CRK",Groceries,Supermarket,ANZ Credit Card 2026-02.csv,false,false
+265,23/02/2026,-22.80,"ALH VENUES/23 VENNING ST  MOOLOOLABA",Eating-out & Entertainment,Bars & clubs,ANZ Credit Card 2026-02.csv,false,false
+266,23/02/2026,-5.04,"ZLR*Brumby's Mountain C   Mountain Cree",Groceries,Deli & bakery,ANZ Credit Card 2026-02.csv,false,false
+267,23/02/2026,-9.99,"AMZNPRIMEA* AMZNPRIMEA    SYDNEY SOUTH",Eating-out & Entertainment,Movies, shows & music,ANZ Credit Card 2026-02.csv,false,false
+268,23/02/2026,-23.58,"UBER *TRIP HELP.UBER.COM  Sydney",Car & Transport,Uber & taxi,ANZ Credit Card 2026-02.csv,false,false
+269,23/02/2026,-141.30,"BWS/163 KARAWATHA ST - SH BUDERIM",Eating-out & Entertainment,Drinks & alcohol,ANZ Credit Card 2026-02.csv,false,false
+270,23/02/2026,-263.55,"AGL SALES 0308            MELBOURNE",Home & utilities,Electricity,ANZ Credit Card 2026-02.csv,false,false
+271,23/02/2026,-4.90,"AMPOL SIPPY DOW 10262F    SIPPY DOWNS",Car & Transport,Petrol,ANZ Credit Card 2026-02.csv,false,false
+272,23/02/2026,-48.95,"WOOLWORTHS/KARAWATHA DR & MOUNTAIN CRK",Groceries,Supermarket,ANZ Credit Card 2026-02.csv,false,false
+273,23/02/2026,-123.58,"COLES 4647                SIPPY DOWNS",Groceries,Supermarket,ANZ Credit Card 2026-02.csv,false,false
+274,23/02/2026,-4.05,"SFS SCUH ALICE & GEO      BIRTINYA",Eating-out & Entertainment,Coffee & tea,ANZ Credit Card 2026-02.csv,false,false
+275,23/02/2026,-14.00,"WOOLWORTHS/KARAWATHA DR & MOUNTAIN CRK",Groceries,Supermarket,ANZ Credit Card 2026-02.csv,false,false
+276,23/02/2026,-19.50,"MAROOCHYDORE STATE HIG    MAROOCHYDORE",Children,School uniforms,ANZ Credit Card 2026-02.csv,false,false
+277,23/02/2026,-35.95,"Microsoft*14 Day Trial Re msbill.info",Eating-out & Entertainment,Movies, shows & music,ANZ Credit Card 2026-02.csv,false,false
+278,23/02/2026,-33.47,"DBS*Goodlife Queen Str    Brisbane",Medical, personal & education,Sports & gym,ANZ Credit Card 2026-02.csv,false,false
+279,23/02/2026,-12.20,"SMP*Jamoke Espresso Ba    Nambour",Eating-out & Entertainment,Coffee & tea,ANZ Credit Card 2026-02.csv,false,false
+280,23/02/2026,-179.40,"DNH*GODADDY#4019909627    130-035-1076",Medical, personal & education,Computers & gadgets,ANZ Credit Card 2026-02.csv,false,false
+281,23/02/2026,-22.22,"SG BAKERY BUDERIM         BUDERIM",Groceries,Deli & bakery,ANZ Credit Card 2026-02.csv,false,false
+282,23/02/2026,-10.41,"BACKSTREET CAFE           MOOLOOLABA",Eating-out & Entertainment,Coffee & tea,ANZ Credit Card 2026-02.csv,false,false
+283,23/02/2026,-16.60,"POINTPARKING NAMBOUR      NAMBOUR",Car & Transport,Road tolls & parking,ANZ Credit Card 2026-02.csv,false,false
+284,20/02/2026,-16.45,"Audible Limited AU        MELBOURNE",Home & utilities,Streaming Services,ANZ Credit Card 2026-02.csv,false,false
+285,20/02/2026,-22.50,"ZLR*Wishlist Coffee Hou   Nambour",Eating-out & Entertainment,Coffee & tea,ANZ Credit Card 2026-02.csv,false,false
+286,20/02/2026,-118.67,"YOUI - PREMIUM            SIPPY DOWNS",Financial & Insurance,Car insurance,ANZ Credit Card 2026-02.csv,false,false
+287,20/02/2026,-80.67,"SPINTEL PTY LTD           SURRY HILLS",Home & utilities,Internet,ANZ Credit Card 2026-02.csv,false,false
+288,20/02/2026,-47.50,"AMPOL SIPPY DOW 10262F    SIPPY DOWNS",Car & Transport,Petrol,ANZ Credit Card 2026-02.csv,false,false
+289,19/02/2026,-132.90,"ALH VENUES/NICKLIN WAY    BUDDINA",Eating-out & Entertainment,Bars & clubs,ANZ Credit Card 2026-02.csv,false,false
+290,19/02/2026,-35.00,"BWS/163 KARAWATHA ST - SH BUDERIM",Eating-out & Entertainment,Drinks & alcohol,ANZ Credit Card 2026-02.csv,false,false
+291,19/02/2026,-201.91,"YOUI - PREMIUM            SIPPY DOWNS",Financial & Insurance,Car insurance,ANZ Credit Card 2026-02.csv,false,false
+292,19/02/2026,-87.41,"YOUI - PREMIUM            SIPPY DOWNS",Financial & Insurance,Car insurance,ANZ Credit Card 2026-02.csv,false,false
+293,18/02/2026,-64.00,"FITSTOP SIPPY DO          SUNSHINE COAS",Medical, personal & education,Sports & gym,ANZ Credit Card 2026-02.csv,false,false
+294,18/02/2026,-64.00,"FITSTOP SIPPY DO          SUNSHINE COAS",Medical, personal & education,Sports & gym,ANZ Credit Card 2026-02.csv,false,false
+295,18/02/2026,-151.20,"Amino Z                   Caringbah",Medical, personal & education,Sports & gym,ANZ Credit Card 2026-02.csv,false,false
+296,18/02/2026,-5.31,"SFS SCUH ALICE & GEO      BIRTINYA",Eating-out & Entertainment,Coffee & tea,ANZ Credit Card 2026-02.csv,false,false
+297,18/02/2026,-9.95,"BANJOS SIPPY DOWNS        SIPPY DOWNS",Groceries,Deli & bakery,ANZ Credit Card 2026-02.csv,false,false
+298,18/02/2026,-9.80,"SUSHI HUB SUNSHINE P      MAROOCHYDORE",Eating-out & Entertainment,Coffee & tea,ANZ Credit Card 2026-02.csv,false,false
+299,17/02/2026,-297.73,"COLES 4647                SIPPY DOWNS",Groceries,Supermarket,ANZ Credit Card 2026-02.csv,false,false
+300,17/02/2026,-60.85,"Somewhere Over Coffee     Rainbow Beach",Eating-out & Entertainment,Coffee & tea,ANZ Credit Card 2026-02.csv,false,false
+301,17/02/2026,-27.99,"SPOTIFY                   0012345678",Home & utilities,Streaming Services,ANZ Credit Card 2026-02.csv,false,false
+302,17/02/2026,-92.92,"THE DECK SEA SALT         RAINBOW BEACH",Eating-out & Entertainment,Bars & clubs,ANZ Credit Card 2026-02.csv,false,false
+303,17/02/2026,-46.46,"THE DECK SEA SALT         RAINBOW BEACH",Eating-out & Entertainment,Bars & clubs,ANZ Credit Card 2026-02.csv,false,false
+304,16/02/2026,8400.00,"PAYMENT THANKYOU 681977",Financial & Insurance,Transfer,ANZ Credit Card 2026-02.csv,false,false
+305,16/02/2026,-16.59,"Rainbow Beach Bakery      Rainbow Beach",Groceries,Deli & bakery,ANZ Credit Card 2026-02.csv,false,false
+306,16/02/2026,-29.00,"BWS/14 RAINBOW BEACH PARA RAINBOW BEACH",Eating-out & Entertainment,Drinks & alcohol,ANZ Credit Card 2026-02.csv,false,false
+307,16/02/2026,-50.75,"LITTLE PARLIAMENT         Rainbow Beach",Eating-out & Entertainment,Restaurants,ANZ Credit Card 2026-02.csv,false,false
+308,16/02/2026,-45.99,"HUBBL - KAYO SPORTS       131999",Home & utilities,Streaming Services,ANZ Credit Card 2026-02.csv,false,false
+309,16/02/2026,-19.00,"SP THE BODY SHOP          CHADSTONE",Medical, personal & education,Hair & beauty,ANZ Credit Card 2026-02.csv,false,false
+310,16/02/2026,-24.00,"RAINBOW BEACH SURF LI     Rainbow Beach",Eating-out & Entertainment,Bars & clubs,ANZ Credit Card 2026-02.csv,false,false
+311,16/02/2026,-66.04,"Galaxy Nails  sunshin     Maroochydore",Medical, personal & education,Hair & beauty,ANZ Credit Card 2026-02.csv,false,false
+312,16/02/2026,-7.40,"COLES 4647                SIPPY DOWNS",Groceries,Supermarket,ANZ Credit Card 2026-02.csv,false,false
+313,16/02/2026,-120.55,"COLES 4647                SIPPY DOWNS",Groceries,Supermarket,ANZ Credit Card 2026-02.csv,false,false
+314,16/02/2026,-9.90,"Noosa Chocolate Factory   Noosa Heads",Eating-out & Entertainment,Take-away & snacks,ANZ Credit Card 2026-02.csv,false,false
+315,16/02/2026,-84.00,"MYER  MAROOCHYDORE        MAROOCHYDORE",Medical, personal & education,Shopping,ANZ Credit Card 2026-02.csv,false,false
+316,16/02/2026,-24.00,"RAINBOW BEACH SURF LI     Rainbow Beach",Eating-out & Entertainment,Bars & clubs,ANZ Credit Card 2026-02.csv,false,false
+317,16/02/2026,-24.00,"RAINBOW BEACH SURF LI     Rainbow Beach",Eating-out & Entertainment,Bars & clubs,ANZ Credit Card 2026-02.csv,false,false
+318,16/02/2026,-38.67,"Liberty Tanawha           Tanawha",Car & Transport,Petrol,ANZ Credit Card 2026-02.csv,false,false
+319,16/02/2026,-20.00,"BWS/14 RAINBOW BEACH PARA RAINBOW BEACH",Eating-out & Entertainment,Drinks & alcohol,ANZ Credit Card 2026-02.csv,false,false
+320,16/02/2026,-29.00,"RAINBOW BEACH SURF LI     Rainbow Beach",Eating-out & Entertainment,Bars & clubs,ANZ Credit Card 2026-02.csv,false,false
+321,16/02/2026,-140.00,"TELSTRA SERVICES          MELBOURNE",Home & utilities,Mobile,ANZ Credit Card 2026-02.csv,false,false
+322,16/02/2026,-48.84,"snshn-kr-th-bdrm          Buderim",Eating-out & Entertainment,Restaurants,ANZ Credit Card 2026-02.csv,false,false
+323,16/02/2026,-18.12,"SUNNY SLOTHS PTY LTD      BIRTINYA",Children,Toys,ANZ Credit Card 2026-02.csv,false,false
+324,16/02/2026,-48.00,"BWS/163 KARAWATHA ST - SH BUDERIM",Eating-out & Entertainment,Drinks & alcohol,ANZ Credit Card 2026-02.csv,false,false
+325,16/02/2026,-16.09,"SQ *AN NAM VIETNAMESE KIT Sippy Downs",Eating-out & Entertainment,Lunches bought,ANZ Credit Card 2026-02.csv,false,false
+326,16/02/2026,-101.05,"Liberty Tanawha           Tanawha",Car & Transport,Petrol,ANZ Credit Card 2026-02.csv,false,false
+327,16/02/2026,-19.70,"MTN CREEK CHEM PHARM      MOUNTAIN CREE",Medical, personal & education,Medicines & pharmacy,ANZ Credit Card 2026-02.csv,false,false
+328,16/02/2026,-10.41,"BACKSTREET CAFE           MOOLOOLABA",Eating-out & Entertainment,Coffee & tea,ANZ Credit Card 2026-02.csv,false,false
+329,16/02/2026,-36.00,"THEPICKLEB* EVT SOCIAL    NAMBOUR",Medical, personal & education,Sports & gym,ANZ Credit Card 2026-02.csv,false,false
+330,13/02/2026,-113.80,"McAfee.com mcafee.com/aut Mahon  Cork",Medical, personal & education,Computers & gadgets,ANZ Credit Card 2026-02.csv,false,false
+331,13/02/2026,-75.60,"ALH VENUES/NICKLIN WAY    BUDDINA",Eating-out & Entertainment,Bars & clubs,ANZ Credit Card 2026-02.csv,false,false
+332,13/02/2026,-50.99,"WOOLWORTHS/KARAWATHA DR & MOUNTAIN CRK",Groceries,Supermarket,ANZ Credit Card 2026-02.csv,false,false
+333,13/02/2026,-5.00,"WOOLWORTHS/KARAWATHA DR & MOUNTAIN CRK",Groceries,Supermarket,ANZ Credit Card 2026-02.csv,false,false
+334,13/02/2026,-36.00,"ALH VENUES/NICKLIN WAY    BUDDINA",Eating-out & Entertainment,Bars & clubs,ANZ Credit Card 2026-02.csv,false,false
+335,13/02/2026,-24.20,"ALH VENUES/NICKLIN WAY    BUDDINA",Eating-out & Entertainment,Bars & clubs,ANZ Credit Card 2026-02.csv,false,false
+336,13/02/2026,-389.00,"Booking.com Hotel         Sydney",Eating-out & Entertainment,Holidays,ANZ Credit Card 2026-02.csv,false,false
+337,13/02/2026,-63.63,"SECURE PARKING PTY LTD    NORTH SYDNEY",Car & Transport,Road tolls & parking,ANZ Credit Card 2026-02.csv,false,false
+338,13/02/2026,-5.31,"SFS THE CONTAINER BY      BIRTINYA",Eating-out & Entertainment,Coffee & tea,ANZ Credit Card 2026-02.csv,false,false
+339,13/02/2026,-51.99,"AMPOL SIPPY DOW 10262F    SIPPY DOWNS",Car & Transport,Petrol,ANZ Credit Card 2026-02.csv,false,false
+340,12/02/2026,-31.00,"BWS/163 KARAWATHA ST - SH BUDERIM",Eating-out & Entertainment,Drinks & alcohol,ANZ Credit Card 2026-02.csv,false,false
+341,12/02/2026,-7.43,"SFS THE CONTAINER BY      BIRTINYA",Eating-out & Entertainment,Coffee & tea,ANZ Credit Card 2026-02.csv,false,false
+342,12/02/2026,-76.42,"AMPOL HAMILTON 11781F     HAMILTON",Car & Transport,Petrol,ANZ Credit Card 2026-02.csv,false,false
+343,11/02/2026,-64.00,"FITSTOP SIPPY DO          SUNSHINE COAS",Medical, personal & education,Sports & gym,ANZ Credit Card 2026-02.csv,false,false
+344,11/02/2026,-64.00,"FITSTOP SIPPY DO          SUNSHINE COAS",Medical, personal & education,Sports & gym,ANZ Credit Card 2026-02.csv,false,false
+345,11/02/2026,-50.37,"LINKT BRISBANE            BRISBANE",Car & Transport,Road tolls & parking,ANZ Credit Card 2026-02.csv,false,false
+346,11/02/2026,-9.80,"SUSHI HUB SUNSHINE P      MAROOCHYDORE",Eating-out & Entertainment,Coffee & tea,ANZ Credit Card 2026-02.csv,false,false
+347,11/02/2026,-9.42,"ALDI STORES               BIRTINYA",Groceries,Supermarket,ANZ Credit Card 2026-02.csv,false,false
+348,11/02/2026,-5.70,"BAKERS DELIGHT BIRTI      BIRTINYA",Groceries,Deli & bakery,ANZ Credit Card 2026-02.csv,false,false
+349,11/02/2026,-305.00,"SPECSAVERS MAROOCHYDOR    MAROOCHYDORE",Medical, personal & education,Glasses & eye care,ANZ Credit Card 2026-02.csv,false,false
+350,11/02/2026,-75.48,"THE BOATSHED              COTTON TREE",Eating-out & Entertainment,Restaurants,ANZ Credit Card 2026-02.csv,false,false
+351,11/02/2026,-36.00,"THEPICKLEB* EVT SOCIAL    NAMBOUR",Medical, personal & education,Sports & gym,ANZ Credit Card 2026-02.csv,false,false
+352,10/02/2026,-70.40,"OZT*HAYLEY MARY - QUIT    WOOLLOONGABBA",Eating-out & Entertainment,Movies, shows & music,ANZ Credit Card 2026-02.csv,false,false
+353,10/02/2026,-139.59,"COLES 7835                BUDERIM",Groceries,Supermarket,ANZ Credit Card 2026-02.csv,false,false
+354,10/02/2026,-20.00,"L/LAND QLD 6526           BUDERIM",Eating-out & Entertainment,Drinks & alcohol,ANZ Credit Card 2026-02.csv,false,false
+355,10/02/2026,-23.80,"ALH VENUES/2/46 DAVID LOW DIDDILLIBAH",Eating-out & Entertainment,Bars & clubs,ANZ Credit Card 2026-02.csv,false,false
+356,10/02/2026,-71.03,"SQ *AN NAM VIETNAMESE KIT Sippy Downs",Eating-out & Entertainment,Lunches bought,ANZ Credit Card 2026-02.csv,false,false
+357,09/02/2026,-120.00,"SP LSKD.CO                YATALA",Medical, personal & education,Clothing & shoes,ANZ Credit Card 2026-02.csv,false,false
+358,09/02/2026,-39.53,"The Pocket Espresso       Moffat Beach",Eating-out & Entertainment,Bars & clubs,ANZ Credit Card 2026-02.csv,false,false
+359,09/02/2026,-34.19,"The Pocket Espresso       Moffat Beach",Eating-out & Entertainment,Bars & clubs,ANZ Credit Card 2026-02.csv,false,false
+360,09/02/2026,-61.00,"KMART 1060                MAROOCHYDORE",Medical, personal & education,Shopping,ANZ Credit Card 2026-02.csv,false,false
+361,09/02/2026,-72.65,"COLES 7836                BIRTINYA",Groceries,Supermarket,ANZ Credit Card 2026-02.csv,false,false
+362,09/02/2026,-16.03,"The Pocket Espresso       Moffat Beach",Eating-out & Entertainment,Bars & clubs,ANZ Credit Card 2026-02.csv,false,false
+363,09/02/2026,-21.80,"Gun Cotton Coffee         INDOOROOPILLY",Eating-out & Entertainment,Restaurants,ANZ Credit Card 2026-02.csv,false,false
+364,09/02/2026,-121.60,"Gun Cotton Coffee         INDOOROOPILLY",Eating-out & Entertainment,Restaurants,ANZ Credit Card 2026-02.csv,false,false
+365,09/02/2026,-31.95,"A&E JONES PTY LTD         MAROOCHYDORE",Eating-out & Entertainment,Restaurants,ANZ Credit Card 2026-02.csv,false,false
+366,09/02/2026,-29.85,"Cotton Tree Ice Creame    Cotton Tree",Eating-out & Entertainment,Take-away & snacks,ANZ Credit Card 2026-02.csv,false,false
+367,09/02/2026,-6.00,"MAROOCHYDORE STATE HIG    MAROOCHYDORE",Children,School uniforms,ANZ Credit Card 2026-02.csv,false,false
+368,09/02/2026,-7.50,"MAROOCHYDORE STATE HIG    MAROOCHYDORE",Children,School uniforms,ANZ Credit Card 2026-02.csv,false,false
+369,09/02/2026,-50.18,"GLOW UP                   YANDINA",Eating-out & Entertainment,Restaurants,ANZ Credit Card 2026-02.csv,false,false
+370,09/02/2026,-9.99,"DD *DOORDASHDASHPASS      MELBOURNE",Eating-out & Entertainment,Take-away & snacks,ANZ Credit Card 2026-02.csv,false,false
+371,09/02/2026,-8.00,"WOOLWORTHS/OCEAN ST & HOR MAROOCHYDORE",Groceries,Supermarket,ANZ Credit Card 2026-02.csv,false,false
+372,09/02/2026,-40.00,"BWS/BIG TOP S/C HORTON PD MAROOCHYDORE",Eating-out & Entertainment,Drinks & alcohol,ANZ Credit Card 2026-02.csv,false,false
+373,09/02/2026,-36.00,"THEPICKLEB* EVT PAIRED    NAMBOUR",Medical, personal & education,Sports & gym,ANZ Credit Card 2026-02.csv,false,false
+374,09/02/2026,-31.99,"Adobe                     Sydney",Medical, personal & education,Computers & gadgets,ANZ Credit Card 2026-02.csv,false,false
+375,09/02/2026,-13.70,"KFC Caboolture BP Nort    Caboolture BP",Eating-out & Entertainment,Take-away & snacks,ANZ Credit Card 2026-02.csv,false,false
+376,09/02/2026,-18.30,"SMP*Mrs Luus Southpoin    Southbank",Eating-out & Entertainment,Lunches bought,ANZ Credit Card 2026-02.csv,false,false
+377,09/02/2026,-5.31,"SFS THE CONTAINER BY      BIRTINYA",Eating-out & Entertainment,Coffee & tea,ANZ Credit Card 2026-02.csv,false,false
+378,09/02/2026,-4.95,"CALTEX CALOUNDRA          CALOUNDRA",Car & Transport,Petrol,ANZ Credit Card 2026-02.csv,false,false
+379,09/02/2026,-36.36,"SECURE PARKING PTY LTD    NORTH SYDNEY",Car & Transport,Road tolls & parking,ANZ Credit Card 2026-02.csv,false,false
+380,09/02/2026,-4.49,"APPLE.COM/BILL            SYDNEY",Medical, personal & education,Computers & gadgets,ANZ Credit Card 2026-02.csv,false,false
+381,09/02/2026,-20.00,"SOUTHBANK CARPARK         SOUTH BANK",Car & Transport,Road tolls & parking,ANZ Credit Card 2026-02.csv,false,false
+382,09/02/2026,-23.48,"KINGS BEACH HOTEL APP     Caloundra",Eating-out & Entertainment,Bars & clubs,ANZ Credit Card 2026-02.csv,false,false
+383,09/02/2026,-23.28,"KINGS BEACH HOTEL APP     Caloundra",Eating-out & Entertainment,Bars & clubs,ANZ Credit Card 2026-02.csv,false,false
+384,09/02/2026,-23.48,"KINGS BEACH HOTEL APP     Caloundra",Eating-out & Entertainment,Bars & clubs,ANZ Credit Card 2026-02.csv,false,false
+385,09/02/2026,-23.48,"KINGS BEACH HOTEL APP     Caloundra",Eating-out & Entertainment,Bars & clubs,ANZ Credit Card 2026-02.csv,false,false
+386,09/02/2026,-5.30,"LS Micasa Cafe Soutban    South Brisban",Eating-out & Entertainment,Coffee & tea,ANZ Credit Card 2026-02.csv,false,false
+387,09/02/2026,-33.47,"DBS*Goodlife Queen Str    Brisbane",Medical, personal & education,Sports & gym,ANZ Credit Card 2026-02.csv,false,false
+388,09/02/2026,-5.56,"BACKSTREET CAFE           MOOLOOLABA",Eating-out & Entertainment,Coffee & tea,ANZ Credit Card 2026-02.csv,false,false
+389,09/02/2026,-20.14,"SUNNY SLOTHS PTY LTD      BIRTINYA",Children,Toys,ANZ Credit Card 2026-02.csv,false,false
+390,06/02/2026,-32.18,"SQ *AN NAM VIETNAMESE KIT Sippy Downs",Eating-out & Entertainment,Lunches bought,ANZ Credit Card 2026-02.csv,false,false
+391,06/02/2026,-5.31,"SFS SCUH ALICE & GEO      BIRTINYA",Eating-out & Entertainment,Coffee & tea,ANZ Credit Card 2026-02.csv,false,false
+392,06/02/2026,-11.99,"help.hbomax.com           St. Leonards",Home & utilities,Streaming Services,ANZ Credit Card 2026-02.csv,false,false
+393,06/02/2026,-5.31,"SFS THE CONTAINER BY      BIRTINYA",Eating-out & Entertainment,Coffee & tea,ANZ Credit Card 2026-02.csv,false,false
+394,05/02/2026,-262.46,"QANTAS AIR                MASCOT",Eating-out & Entertainment,Holidays,ANZ Credit Card 2026-02.csv,false,false
+395,05/02/2026,-1093.73,"Cars on Booking           London",Eating-out & Entertainment,Holidays,ANZ Credit Card 2026-02.csv,false,false
+396,05/02/2026,-100.02,"Liberty Tanawha           Tanawha",Car & Transport,Petrol,ANZ Credit Card 2026-02.csv,false,false
+397,05/02/2026,-53.34,"VODAFONE AUSTRALIA        NORTH SYDNEY",Home & utilities,Ellas Mobile,ANZ Credit Card 2026-02.csv,false,false
+398,04/02/2026,-64.00,"FITSTOP SIPPY DO          SUNSHINE COAS",Medical, personal & education,Sports & gym,ANZ Credit Card 2026-02.csv,false,false
+399,04/02/2026,-64.00,"FITSTOP SIPPY DO          SUNSHINE COAS",Medical, personal & education,Sports & gym,ANZ Credit Card 2026-02.csv,false,false
+400,04/02/2026,-43.32,"COLES 4647                SIPPY DOWNS",Groceries,Supermarket,ANZ Credit Card 2026-02.csv,false,false
+401,04/02/2026,-14.00,"LIQUORLAND 6476           SIPPY DOWNS",Eating-out & Entertainment,Drinks & alcohol,ANZ Credit Card 2026-02.csv,false,false
+402,04/02/2026,-83.97,"HARRIS SCARFE MRHYDR      MAROOCHYDORE",Home & utilities,Furniture & appliances,ANZ Credit Card 2026-02.csv,false,false
+403,04/02/2026,-110.00,"SPOTLIGHT                 MAROOCHYDORE",Home & utilities,Home improvements & Maintenance,ANZ Credit Card 2026-02.csv,false,false
+404,04/02/2026,-144.54,"BUNNINGS 490000           MAROOCHYDORE",Home & utilities,Home improvements & Maintenance,ANZ Credit Card 2026-02.csv,false,false
+405,04/02/2026,-36.00,"THEPICKLEB* EVT SOCIAL    NAMBOUR",Medical, personal & education,Sports & gym,ANZ Credit Card 2026-02.csv,false,false
+406,03/02/2026,9700.00,"PAYMENT THANKYOU 508136",Financial & Insurance,Transfer,ANZ Credit Card 2026-02.csv,false,false
+407,03/02/2026,-1997.26,"JETSTAR AIR KK2YQV        WWW.JETSTAR.C",Eating-out & Entertainment,Holidays,ANZ Credit Card 2026-02.csv,false,false
+408,03/02/2026,-569.50,"GORGE VIEW KATHERINE      KATHERINE",Eating-out & Entertainment,Holidays,ANZ Credit Card 2026-02.csv,false,false
+409,03/02/2026,-323.67,"COLES 4647                SIPPY DOWNS",Groceries,Supermarket,ANZ Credit Card 2026-02.csv,false,false
+410,03/02/2026,-15.99,"Disney Plus               1800-965160",Home & utilities,Streaming Services,ANZ Credit Card 2026-02.csv,false,false
+411,03/02/2026,-370.17,"Hotel at Booking.com      Sydney",Eating-out & Entertainment,Holidays,ANZ Credit Card 2026-02.csv,false,false
+412,03/02/2026,-65.50,"Riba Kai                  Maroochydore",Eating-out & Entertainment,Restaurants,ANZ Credit Card 2026-02.csv,false,false
+413,02/02/2026,-26.43,"Dock Mooloolaba           Mooloolaba",Eating-out & Entertainment,Bars & clubs,ANZ Credit Card 2026-02.csv,false,false
+414,02/02/2026,-27.38,"ZLR*The Beach Bar & Gri   Mooloolaba",Eating-out & Entertainment,Restaurants,ANZ Credit Card 2026-02.csv,false,false
+415,02/02/2026,-82.15,"ZLR*The Beach Bar & Gri   Mooloolaba",Eating-out & Entertainment,Restaurants,ANZ Credit Card 2026-02.csv,false,false
+416,02/02/2026,-26.37,"ZLR*The Beach Bar & Gri   Mooloolaba",Eating-out & Entertainment,Restaurants,ANZ Credit Card 2026-02.csv,false,false
+417,02/02/2026,-26.00,"BWS/RIVER ESP & PARKLYN P MOOLOOLABA",Eating-out & Entertainment,Drinks & alcohol,ANZ Credit Card 2026-02.csv,false,false
+418,02/02/2026,-486.40,"GARRY CRICKS NAMBOUR      MAROOCHYDORE",Car & Transport,Repairs & maintenance,ANZ Credit Card 2026-02.csv,false,false
+419,02/02/2026,18.00,"THEPICKLEB* EVT SOCIAL    NAMBOUR",Medical, personal & education,Sports & gym,ANZ Credit Card 2026-02.csv,false,false
+420,02/02/2026,18.00,"THEPICKLEB* EVT SOCIAL    NAMBOUR",Medical, personal & education,Sports & gym,ANZ Credit Card 2026-02.csv,false,false
+421,02/02/2026,-35.75,"UBER *EATS HELP.UBER.COM  Sydney",Eating-out & Entertainment,Take-away & snacks,ANZ Credit Card 2026-02.csv,false,false
+422,02/02/2026,-63.80,"Nandos MAROOCHYDORE       Maroochydore",Eating-out & Entertainment,Take-away & snacks,ANZ Credit Card 2026-02.csv,false,false
+423,02/02/2026,-5.59,"SMP*Jamoke Espresso Ba    Nambour",Eating-out & Entertainment,Coffee & tea,ANZ Credit Card 2026-02.csv,false,false
+424,02/02/2026,-16.60,"POINTPARKING NAMBOUR      NAMBOUR",Car & Transport,Road tolls & parking,ANZ Credit Card 2026-02.csv,false,false
+425,02/02/2026,-78.80,"WOOLWORTHS/KARAWATHA DR & MOUNTAIN CRK",Groceries,Supermarket,ANZ Credit Card 2026-02.csv,false,false
+426,02/02/2026,-5.56,"BACKSTREET CAFE           MOOLOOLABA",Eating-out & Entertainment,Coffee & tea,ANZ Credit Card 2026-02.csv,false,false
+427,31/01/2026,3.47,"Payment",,,Macquarie Pay 2026-01.csv,false,false
+428,30/01/2026,328.68,"From E552212Txn420196 - 552212*RP 18/02/20",Income,Other income,Macquarie Pay 2026-01.csv,false,false
+429,28/01/2026,-3500,"To Elizabeth Hawkins  - Funds transfer",Financial & Insurance,Transfer,Macquarie Pay 2026-01.csv,false,false
+430,28/01/2026,3112.39,"Salary from QLD DEPARTMENT O - SALARY 00428738",Income,Your partner's take-home pay,Macquarie Pay 2026-01.csv,false,false
+431,16/01/2026,328.68,"From E552212Txn419100 - 552212*RP 18/02/20",Income,Other income,Macquarie Pay 2026-01.csv,false,false
+432,16/01/2026,0.02,"From closed account xx5111",,,Macquarie Pay 2026-01.csv,false,false
+433,16/01/2026,0.07,"From closed account xx5695",,,Macquarie Pay 2026-01.csv,false,false
+434,14/01/2026,-6000,"To Elizabeth Hawkins  - Funds transfer",Financial & Insurance,Transfer,Macquarie Pay 2026-01.csv,false,false
+435,14/01/2026,-600,"To linked account xx2193 - Internal transfer",Financial & Insurance,Transfer,Macquarie Pay 2026-01.csv,false,false
+436,14/01/2026,3075.86,"Salary from QLD DEPARTMENT O - SALARY 00428738",Income,Your partner's take-home pay,Macquarie Pay 2026-01.csv,false,false
+437,02/01/2026,328.68,"From E552212Txn418095 - 552212*RP 18/02/20",Income,Other income,Macquarie Pay 2026-01.csv,false,false
+438,28/02/2026,0.59,"Payment",,,Macquarie Spending 2026-02.csv,false,false
+439,25/02/2026,-90.11,"Transfer To Elizabeth Hawkins - Kids expenses",Financial & Insurance,Transfer,Macquarie Spending 2026-02.csv,false,false
+440,25/02/2026,-12.89,"Transfer To Elizabeth Hawkins - Spotifyhealthmobil",Home & utilities,Streaming Services,Macquarie Spending 2026-02.csv,false,false
+441,22/02/2026,-10,"Transfer To Bailen Rouse-Upjohn - Family love",Children,Child support payment,Macquarie Spending 2026-02.csv,false,false
+442,22/02/2026,-10,"Transfer To Jasper Rouse-upjohn - Family love",Children,Child support payment,Macquarie Spending 2026-02.csv,false,false
+443,18/02/2026,-90.11,"Transfer To Elizabeth Hawkins - Kids expenses",Financial & Insurance,Transfer,Macquarie Spending 2026-02.csv,false,false
+444,18/02/2026,-12.89,"Transfer To Elizabeth Hawkins - Spotifyhealthmobil",Home & utilities,Streaming Services,Macquarie Spending 2026-02.csv,false,false
+445,16/02/2026,150,"From AUSTRALIAN UNITY - AU HEALTH 31246163",Income,Health insurance reimbursement,Macquarie Spending 2026-02.csv,false,false
+446,15/02/2026,-10,"Transfer To Bailen Rouse-Upjohn - Family love",Children,Child support payment,Macquarie Spending 2026-02.csv,false,false
+447,15/02/2026,-10,"Transfer To Jasper Rouse-upjohn - Family love",Children,Child support payment,Macquarie Spending 2026-02.csv,false,false
+448,11/02/2026,350,"From linked account xx4650 - Internal transfer",Financial & Insurance,Transfer,Macquarie Spending 2026-02.csv,false,false
+449,11/02/2026,-155,"To Jasper Rouse-Upjohn - Gift card exchange",Children,Child support payment,Macquarie Spending 2026-02.csv,false,false
+450,11/02/2026,-95,"To Bailen Rouse-Upjohn - Cash exchange",Children,Child support payment,Macquarie Spending 2026-02.csv,false,false
+451,11/02/2026,-90.11,"Transfer To Elizabeth Hawkins - Kids expenses",Financial & Insurance,Transfer,Macquarie Spending 2026-02.csv,false,false
+452,11/02/2026,-12.89,"Transfer To Elizabeth Hawkins - Spotifyhealthmobil",Home & utilities,Streaming Services,Macquarie Spending 2026-02.csv,false,false
+453,08/02/2026,-10,"Transfer To Bailen Rouse-Upjohn - Family love",Children,Child support payment,Macquarie Spending 2026-02.csv,false,false
+454,08/02/2026,-10,"Transfer To Jasper Rouse-upjohn - Family love",Children,Child support payment,Macquarie Spending 2026-02.csv,false,false
+455,06/02/2026,-20.34,"To Jasper Rouse-Upjohn - Yummy ribs",Children,Child support payment,Macquarie Spending 2026-02.csv,false,false
+456,05/02/2026,149,"From AUSTRALIAN UNITY - AU HEALTH 31246163",Income,Health insurance reimbursement,Macquarie Spending 2026-02.csv,false,false
+457,04/02/2026,-90.11,"Transfer To Elizabeth Hawkins - Kids expenses",Financial & Insurance,Transfer,Macquarie Spending 2026-02.csv,false,false
+458,04/02/2026,-12.89,"Transfer To Elizabeth Hawkins - Spotifyhealthmobil",Home & utilities,Streaming Services,Macquarie Spending 2026-02.csv,false,false
+459,02/02/2026,27,"From Elizabeth Hawkins - Pickleball",Medical, personal & education,Sports & gym,Macquarie Spending 2026-02.csv,false,false
+460,01/02/2026,-10,"Transfer To Bailen Rouse-Upjohn - Family love",Children,Child support payment,Macquarie Spending 2026-02.csv,false,false
+461,01/02/2026,-10,"Transfer To Jasper Rouse-upjohn - Family love",Children,Child support payment,Macquarie Spending 2026-02.csv,false,false
+462,28/02/2026,0.88,"Payment",,,Macquarie Pay 2026-02.csv,false,false
+463,25/02/2026,-3300,"To Elizabeth Hawkins  - Funds transfer",Financial & Insurance,Transfer,Macquarie Pay 2026-02.csv,false,false
+464,25/02/2026,3075,"Salary from QLD DEPARTMENT O - SALARY 00428738",Income,Your partner's take-home pay,Macquarie Pay 2026-02.csv,false,false
+465,13/02/2026,328.68,"From E552212Txn421241 - 552212*RP 18/02/20",Income,Other income,Macquarie Pay 2026-02.csv,false,false
+466,11/02/2026,-4000,"To Elizabeth Hawkins  - Funds transfer",Financial & Insurance,Transfer,Macquarie Pay 2026-02.csv,false,false
+467,11/02/2026,3867.35,"Salary from QLD DEPARTMENT O - SALARY 00428738",Income,Your partner's take-home pay,Macquarie Pay 2026-02.csv,false,false
+468,11/02/2026,-350,"To linked account xx2193 - Internal transfer",Financial & Insurance,Transfer,Macquarie Pay 2026-02.csv,false,false
+469,31/03/2026,-62.14,"COLES 7835                BUDERIM",Groceries,Supermarket,ANZ Credit Card 2026-03.csv,false,false
+470,31/03/2026,-17.5,"BWS/163 KARAWATHA ST - SH BUDERIM",Eating-out & Entertainment,Drinks & alcohol,ANZ Credit Card 2026-03.csv,false,false
+471,31/03/2026,-48.24,"UBER *TRIP HELP.UBER.COM  Sydney",Car & Transport,Uber & taxi,ANZ Credit Card 2026-03.csv,false,false
+472,31/03/2026,-60.35,"SPRINGBOK FOODS PTY LT    FOREST GLEN",Groceries,Deli & bakery,ANZ Credit Card 2026-03.csv,false,false
+473,31/03/2026,-9.95,"BANJOS SIPPY DOWNS        SIPPY DOWNS",Groceries,Deli & bakery,ANZ Credit Card 2026-03.csv,false,false
+474,30/03/2026,-143.32,"COLES 4647                SIPPY DOWNS",Groceries,Supermarket,ANZ Credit Card 2026-03.csv,false,false
+475,30/03/2026,-25.5,"SQ *COOROIBAH GREENS - KA Bokarina",,,ANZ Credit Card 2026-03.csv,false,false
+476,30/03/2026,-110,"LIQUORLAND 6476           SIPPY DOWNS",Eating-out & Entertainment,Drinks & alcohol,ANZ Credit Card 2026-03.csv,false,false
+477,30/03/2026,-12.24,"SQ *MYSTICA BURGERS       Noosa",,,ANZ Credit Card 2026-03.csv,false,false
+478,30/03/2026,-3.15,"SFS THE CONTAINER BY      BIRTINYA",Eating-out & Entertainment,Coffee & tea,ANZ Credit Card 2026-03.csv,false,false
+479,30/03/2026,-462.47,"UNITYWATER - CABOOLTUR    CABOOLTURE",Home & utilities,Water,ANZ Credit Card 2026-03.csv,false,false
+480,30/03/2026,-164.2,"AMPOL SIPPY DOW 10262F    SIPPY DOWNS",Car & Transport,Petrol,ANZ Credit Card 2026-03.csv,false,false
+481,30/03/2026,-31,"BWS/163 KARAWATHA ST - SH BUDERIM",Eating-out & Entertainment,Drinks & alcohol,ANZ Credit Card 2026-03.csv,false,false
+482,30/03/2026,-16.09,"SQ *AN NAM VIETNAMESE KIT Sippy Downs",Eating-out & Entertainment,Lunches bought,ANZ Credit Card 2026-03.csv,false,false
+483,30/03/2026,-20,"SQ *THE OLD AMBULANCE STA Nambour",,,ANZ Credit Card 2026-03.csv,false,false
+484,30/03/2026,-16,"SQ *THE OLD AMBULANCE STA Nambour",,,ANZ Credit Card 2026-03.csv,false,false
+485,30/03/2026,-171.81,"SUNCORP INSURANCE         BRISBANE CITY",Financial & Insurance,Home & contents insurance,ANZ Credit Card 2026-03.csv,false,false
+486,30/03/2026,-44,"COUNTRY CARE GROUP        MILDURA",,,ANZ Credit Card 2026-03.csv,false,false
+487,30/03/2026,-10,"MERTHYR BOWLS CLUB        NEW FARM",Eating-out & Entertainment,Bars & clubs,ANZ Credit Card 2026-03.csv,false,false
+488,30/03/2026,-10,"MERTHYR BOWLS CLUB        NEW FARM",Eating-out & Entertainment,Bars & clubs,ANZ Credit Card 2026-03.csv,false,false
+489,30/03/2026,-28.65,"MERTHYR BOWLS CLUB        NEW FARM",Eating-out & Entertainment,Bars & clubs,ANZ Credit Card 2026-03.csv,false,false
+490,30/03/2026,-29,"MERTHYR BOWLS CLUB        NEW FARM",Eating-out & Entertainment,Bars & clubs,ANZ Credit Card 2026-03.csv,false,false
+491,30/03/2026,-18.3,"SMP*Mrs Luus Southpoin    Southbank",Eating-out & Entertainment,Lunches bought,ANZ Credit Card 2026-03.csv,false,false
+492,30/03/2026,-5.59,"SMP*Jamoke Espresso Ba    Nambour",Eating-out & Entertainment,Coffee & tea,ANZ Credit Card 2026-03.csv,false,false
+493,30/03/2026,-59.14,"BACKSTREET CAFE           MOOLOOLABA",Eating-out & Entertainment,Coffee & tea,ANZ Credit Card 2026-03.csv,false,false
+494,30/03/2026,-16.6,"POINTPARKING NAMBOUR      NAMBOUR",Car & Transport,Road tolls & parking,ANZ Credit Card 2026-03.csv,false,false
+495,30/03/2026,-36,"THEPICKLEB* EVT PAIRED    NAMBOUR",Medical, personal & education,Sports & gym,ANZ Credit Card 2026-03.csv,false,false
+496,27/03/2026,-35,"LIQUORLAND 6687           BUDERIM",Eating-out & Entertainment,Drinks & alcohol,ANZ Credit Card 2026-03.csv,false,false
+497,27/03/2026,-11.2,"LS Micasa Cafe Soutban    South Brisban",Eating-out & Entertainment,Coffee & tea,ANZ Credit Card 2026-03.csv,false,false
+498,27/03/2026,-16.99,"SOUTHBANK PHARMACY        SOUTH BRISBAN",Medical, personal & education,Medicines & pharmacy,ANZ Credit Card 2026-03.csv,false,false
+499,27/03/2026,-203.87,"GLOW UP                   YANDINA",Eating-out & Entertainment,Restaurants,ANZ Credit Card 2026-03.csv,false,false
+500,27/03/2026,-115.2,"TICKETEK WEB              SYDNEY",Eating-out & Entertainment,Celebrations & gifts,ANZ Credit Card 2026-03.csv,false,false
+501,26/03/2026,-99.99,"SECURE PARKING PTY LTD    NORTH SYDNEY",Car & Transport,Road tolls & parking,ANZ Credit Card 2026-03.csv,false,false
+502,26/03/2026,-27,"THEPICKLEB* EVT SOCIAL    NAMBOUR",Medical, personal & education,Sports & gym,ANZ Credit Card 2026-03.csv,false,false
+503,25/03/2026,-64,"FITSTOP SIPPY DO          SUNSHINE COAS",Medical, personal & education,Sports & gym,ANZ Credit Card 2026-03.csv,false,false
+504,25/03/2026,-64,"FITSTOP SIPPY DO          SUNSHINE COAS",Medical, personal & education,Sports & gym,ANZ Credit Card 2026-03.csv,false,false
+505,25/03/2026,-151.2,"Amino Z                   Caringbah",Medical, personal & education,Sports & gym,ANZ Credit Card 2026-03.csv,false,false
+506,25/03/2026,-60.42,"BLI BLI HOTEL             BLI BLI",,,ANZ Credit Card 2026-03.csv,false,false
+507,25/03/2026,-10.4,"BLI BLI HOTEL             BLI BLI",,,ANZ Credit Card 2026-03.csv,false,false
+508,25/03/2026,-26.72,"BLI BLI HOTEL             BLI BLI",,,ANZ Credit Card 2026-03.csv,false,false
+509,25/03/2026,-87.91,"CALTEX BLI BLI            BLI BLI",Car & Transport,Petrol,ANZ Credit Card 2026-03.csv,false,false
+510,25/03/2026,-20.99,"Netflix.com               Melbourne",Home & utilities,Streaming Services,ANZ Credit Card 2026-03.csv,false,false
+511,25/03/2026,-4.65,"BALLINA BWLNGNREC LD      BALLINA",Eating-out & Entertainment,Bars & clubs,ANZ Credit Card 2026-03.csv,false,false
+512,25/03/2026,-81.81,"BALLINA BWLNGNREC LD      BALLINA",Eating-out & Entertainment,Bars & clubs,ANZ Credit Card 2026-03.csv,false,false
+513,25/03/2026,-38.95,"MCDONALDS SIPPY DOWN      SIPPY DOWNS",Eating-out & Entertainment,Take-away & snacks,ANZ Credit Card 2026-03.csv,false,false
+514,24/03/2026,-150.09,"COLES 4647                SIPPY DOWNS",Groceries,Supermarket,ANZ Credit Card 2026-03.csv,false,false
+515,24/03/2026,-22.36,"LS Buderim Distillery     Maroochydore",,,ANZ Credit Card 2026-03.csv,false,false
+516,24/03/2026,-22.36,"LS Buderim Distillery     Maroochydore",,,ANZ Credit Card 2026-03.csv,false,false
+517,24/03/2026,-148.16,"AMPOL CHINDERAH 22163F    CHINDERAH",Car & Transport,Petrol,ANZ Credit Card 2026-03.csv,false,false
+518,23/03/2026,-118.46,"SQ *ZABB BY MEOW          Buderim",,,ANZ Credit Card 2026-03.csv,false,false
+519,23/03/2026,-10.16,"SQ *MFC                   Kuluin",,,ANZ Credit Card 2026-03.csv,false,false
+520,23/03/2026,-9.99,"AMZNPRIMEA* AMZNPRIMEA    SYDNEY SOUTH",Eating-out & Entertainment,Movies, shows & music,ANZ Credit Card 2026-03.csv,false,false
+521,23/03/2026,-23.97,"UBER *TRIP HELP.UBER.COM  Sydney",Car & Transport,Uber & taxi,ANZ Credit Card 2026-03.csv,false,false
+522,23/03/2026,-5.76,"SFS THE CONTAINER BY      BIRTINYA",Eating-out & Entertainment,Coffee & tea,ANZ Credit Card 2026-03.csv,false,false
+523,23/03/2026,-10,"MISTERZIMI* MISTER ZIM    PORT MELBOURN",,,ANZ Credit Card 2026-03.csv,false,false
+524,23/03/2026,-17,"STAN.COM.AU               WWW.STAN.COM.",,,ANZ Credit Card 2026-03.csv,false,false
+525,23/03/2026,-20,"STAN.COM.AU               WWW.STAN.COM.",,,ANZ Credit Card 2026-03.csv,false,false
+526,23/03/2026,-32,"BWS/163 KARAWATHA ST - SH BUDERIM",Eating-out & Entertainment,Drinks & alcohol,ANZ Credit Card 2026-03.csv,false,false
+527,23/03/2026,-172.81,"AGL SALES 0308            MELBOURNE",Home & utilities,Electricity,ANZ Credit Card 2026-03.csv,false,false
+528,23/03/2026,-35,"EG GROUP/KARAWATHA DR & G MOUNTAIN CRK",,,ANZ Credit Card 2026-03.csv,false,false
+529,23/03/2026,-55.35,"SQ *AN NAM VIETNAMESE KIT Sippy Downs",Eating-out & Entertainment,Lunches bought,ANZ Credit Card 2026-03.csv,false,false
+530,23/03/2026,-56,"COLES 4647                SIPPY DOWNS",Groceries,Supermarket,ANZ Credit Card 2026-03.csv,false,false
+531,23/03/2026,-15,"BWS/163 KARAWATHA ST - SH BUDERIM",Eating-out & Entertainment,Drinks & alcohol,ANZ Credit Card 2026-03.csv,false,false
+532,23/03/2026,-76,"A1 MART                   WEST END",,,ANZ Credit Card 2026-03.csv,false,false
+533,23/03/2026,-35.95,"Microsoft*14 Day Trial Re msbill.info",Eating-out & Entertainment,Movies, shows & music,ANZ Credit Card 2026-03.csv,false,false
+534,23/03/2026,-18.3,"SMP*Mrs Luus Southpoin    Southbank",Eating-out & Entertainment,Lunches bought,ANZ Credit Card 2026-03.csv,false,false
+535,23/03/2026,-33.47,"DBS*Goodlife Queen Str    Brisbane",Medical, personal & education,Sports & gym,ANZ Credit Card 2026-03.csv,false,false
+536,20/03/2026,-150.08,"REMENTO                   REMENTO.CO",,,ANZ Credit Card 2026-03.csv,false,false
+537,20/03/2026,-20,"SOUTHBANK CARPARK         SOUTH BANK",Car & Transport,Road tolls & parking,ANZ Credit Card 2026-03.csv,false,false
+538,20/03/2026,-60.3,"LS PTC PHONE ACCESSOR     MAROOCHYDORE",,,ANZ Credit Card 2026-03.csv,false,false
+539,20/03/2026,-69.83,"King IT Maroochydore      Maroochydore",,,ANZ Credit Card 2026-03.csv,false,false
+540,20/03/2026,-35,"CASE KING                 Maroochydore",,,ANZ Credit Card 2026-03.csv,false,false
+541,20/03/2026,-197,"COLES 4523                MAROOCHYDORE",Groceries,Supermarket,ANZ Credit Card 2026-03.csv,false,false
+542,20/03/2026,-78,"KMART 1060                MAROOCHYDORE",Medical, personal & education,Shopping,ANZ Credit Card 2026-03.csv,false,false
+543,20/03/2026,-16.45,"Audible Limited AU        MELBOURNE",Home & utilities,Streaming Services,ANZ Credit Card 2026-03.csv,false,false
+544,20/03/2026,-10.3,"LS Micasa Cafe Soutban    South Brisban",Eating-out & Entertainment,Coffee & tea,ANZ Credit Card 2026-03.csv,false,false
+545,20/03/2026,-11.2,"LS Micasa Cafe Soutban    South Brisban",Eating-out & Entertainment,Coffee & tea,ANZ Credit Card 2026-03.csv,false,false
+546,20/03/2026,-72.76,"TICKETS*FUNNY COAS        0272026035",,,ANZ Credit Card 2026-03.csv,false,false
+547,19/03/2026,-133.3,"SP MISTER ZIMI            MALVERN",,,ANZ Credit Card 2026-03.csv,false,false
+548,19/03/2026,-82,"ALH VENUES/NICKLIN WAY    BUDDINA",Eating-out & Entertainment,Bars & clubs,ANZ Credit Card 2026-03.csv,false,false
+549,19/03/2026,-10.8,"ALH VENUES/NICKLIN WAY    BUDDINA",Eating-out & Entertainment,Bars & clubs,ANZ Credit Card 2026-03.csv,false,false
+550,19/03/2026,-121.63,"EG GROUP/KARAWATHA DR & G MOUNTAIN CRK",,,ANZ Credit Card 2026-03.csv,false,false
+551,19/03/2026,-16.49,"FAMDDS PTY LTD            MAROOCHYDORE",,,ANZ Credit Card 2026-03.csv,false,false
+552,19/03/2026,-323.4,"DNH*GODADDY#4039396544    130-035-1076",Medical, personal & education,Computers & gadgets,ANZ Credit Card 2026-03.csv,false,true
+553,19/03/2026,-5.31,"SFS THE CONTAINER BY      BIRTINYA",Eating-out & Entertainment,Coffee & tea,ANZ Credit Card 2026-03.csv,false,false
+554,19/03/2026,-118.67,"YOUI - PREMIUM            SIPPY DOWNS",Financial & Insurance,Car insurance,ANZ Credit Card 2026-03.csv,false,false
+555,19/03/2026,-201.91,"YOUI - PREMIUM            SIPPY DOWNS",Financial & Insurance,Car insurance,ANZ Credit Card 2026-03.csv,false,false
+556,19/03/2026,-87.41,"YOUI - PREMIUM            SIPPY DOWNS",Financial & Insurance,Car insurance,ANZ Credit Card 2026-03.csv,false,false
+557,19/03/2026,-9.95,"BANJOS SIPPY DOWNS        SIPPY DOWNS",Groceries,Deli & bakery,ANZ Credit Card 2026-03.csv,false,false
+558,19/03/2026,-40.5,"THEPICKLEB* EVT SOCIAL    NAMBOUR",Medical, personal & education,Sports & gym,ANZ Credit Card 2026-03.csv,false,false
+559,18/03/2026,-64,"FITSTOP SIPPY DO          SUNSHINE COAS",Medical, personal & education,Sports & gym,ANZ Credit Card 2026-03.csv,false,false
+560,18/03/2026,-64,"FITSTOP SIPPY DO          SUNSHINE COAS",Medical, personal & education,Sports & gym,ANZ Credit Card 2026-03.csv,false,false
+561,18/03/2026,-1601.06,"Partners on Booking BV    Sydney",,,ANZ Credit Card 2026-03.csv,false,false
+562,18/03/2026,-88,"COUNTY CARE BIRTINYA      BIRTINYA",,,ANZ Credit Card 2026-03.csv,false,false
+563,17/03/2026,-28.35,"THE DOONAN                WWW.THEDOONAN",,,ANZ Credit Card 2026-03.csv,false,false
+564,17/03/2026,-37.62,"THE DOONAN                WWW.THEDOONAN",,,ANZ Credit Card 2026-03.csv,false,false
+565,17/03/2026,-172,"COLES 4647                SIPPY DOWNS",Groceries,Supermarket,ANZ Credit Card 2026-03.csv,false,false
+566,17/03/2026,-373.77,"Kin Kin Hotel             Kin Kin",,,ANZ Credit Card 2026-03.csv,false,false
+567,17/03/2026,-50.5,"THE DOONAN PUB            DOONAN",,,ANZ Credit Card 2026-03.csv,false,false
+568,17/03/2026,-25.05,"THE DOONAN PUB            DOONAN",,,ANZ Credit Card 2026-03.csv,false,false
+569,17/03/2026,-27.99,"SPOTIFY                   0012345678",Home & utilities,Streaming Services,ANZ Credit Card 2026-03.csv,false,false
+570,16/03/2026,10000,"PAYMENT THANKYOU 740802",Financial & Insurance,Transfer,ANZ Credit Card 2026-03.csv,false,false
+571,16/03/2026,-21.26,"Matso'sSunshineCoast      Eumundi",,,ANZ Credit Card 2026-03.csv,false,false
+572,16/03/2026,-21.26,"Matso'sSunshineCoast      Eumundi",,,ANZ Credit Card 2026-03.csv,false,false
+573,16/03/2026,-49.83,"MATSOS - SUNSHINE COAS    EUMUNDI",,,ANZ Credit Card 2026-03.csv,false,false
+574,16/03/2026,-45.99,"HUBBL - KAYO SPORTS       131999",Home & utilities,Streaming Services,ANZ Credit Card 2026-03.csv,false,false
+575,16/03/2026,-100.21,"SPINTEL PTY LTD           ST PETERS",Home & utilities,Internet,ANZ Credit Card 2026-03.csv,false,false
+576,16/03/2026,-20.14,"KOMEKHUN PTY LTD          BIRTINYA",,,ANZ Credit Card 2026-03.csv,false,false
+577,16/03/2026,-33.4,"ALH VENUES/81 BURNETT ST  BUDERIM",Eating-out & Entertainment,Bars & clubs,ANZ Credit Card 2026-03.csv,false,false
+578,16/03/2026,-3.5,"WW METRO/67 BURNETT STREE BUDERIM",Groceries,Supermarket,ANZ Credit Card 2026-03.csv,false,false
+579,16/03/2026,-36,"BWS/163 KARAWATHA ST - SH BUDERIM",Eating-out & Entertainment,Drinks & alcohol,ANZ Credit Card 2026-03.csv,false,false
+580,16/03/2026,-5.63,"WOOLWORTHS/KARAWATHA DR & MOUNTAIN CRK",Groceries,Supermarket,ANZ Credit Card 2026-03.csv,false,false
+581,16/03/2026,-140,"TELSTRA SERVICES          MELBOURNE",Home & utilities,Mobile,ANZ Credit Card 2026-03.csv,false,false
+582,16/03/2026,-181.93,"BUSINESS ARCHITECTURE GUI 831-464-5344  125.00  USD 6.15 AUD",Renovations,Planning & design,ANZ Credit Card 2026-03.csv,false,false
+583,16/03/2026,-28.35,"MCDONALDS SIPPY DOWN      SIPPY DOWNS",Eating-out & Entertainment,Take-away & snacks,ANZ Credit Card 2026-03.csv,false,false
+584,16/03/2026,-5.56,"BACKSTREET CAFE           MOOLOOLABA",Eating-out & Entertainment,Coffee & tea,ANZ Credit Card 2026-03.csv,false,false
+585,16/03/2026,-50.36,"LINKT BRISBANE            BRISBANE",Car & Transport,Road tolls & parking,ANZ Credit Card 2026-03.csv,false,false
+586,16/03/2026,-18,"THEPICKLEB* EVT SOCIAL    NAMBOUR",Medical, personal & education,Sports & gym,ANZ Credit Card 2026-03.csv,false,false
+587,16/03/2026,-18,"THEPICKLEB* EVT SOCIAL    NAMBOUR",Medical, personal & education,Sports & gym,ANZ Credit Card 2026-03.csv,false,false
+588,13/03/2026,-50,"COLES 4647                SIPPY DOWNS",Groceries,Supermarket,ANZ Credit Card 2026-03.csv,false,false
+589,13/03/2026,-170,"QUT FINANCE OPS           KELVIN GROVE",,,ANZ Credit Card 2026-03.csv,false,false
+590,13/03/2026,-18,"THEPICKLEB* EVT SOCIAL    NAMBOUR",Medical, personal & education,Sports & gym,ANZ Credit Card 2026-03.csv,false,false
+591,13/03/2026,-18,"THEPICKLEB* EVT SOCIAL    NAMBOUR",Medical, personal & education,Sports & gym,ANZ Credit Card 2026-03.csv,false,false
+592,12/03/2026,-319.91,"CLAUDE.AI SUBSCRIPTION    ANTHROPIC.COM",Medical, personal & education,Computers & gadgets,ANZ Credit Card 2026-03.csv,false,false
+593,12/03/2026,-78.53,"WOOLWORTHS/OCEAN ST & HOR MAROOCHYDORE",Groceries,Supermarket,ANZ Credit Card 2026-03.csv,false,false
+594,12/03/2026,-55.99,"SQ *SUMAK MED EAST CUISIN Kelvin Grove",,,ANZ Credit Card 2026-03.csv,false,false
+595,12/03/2026,-5.3,"LS Micasa Cafe Soutban    South Brisban",Eating-out & Entertainment,Coffee & tea,ANZ Credit Card 2026-03.csv,false,false
+596,12/03/2026,-63.63,"SECURE PARKING PTY LTD    NORTH SYDNEY",Car & Transport,Road tolls & parking,ANZ Credit Card 2026-03.csv,false,false
+597,12/03/2026,-140.15,"AMRITYU PTY LTD           BOKARINA",Car & Transport,Petrol,ANZ Credit Card 2026-03.csv,false,false
+598,12/03/2026,-22.3,"GUZMAN Y GOMEZ            SURRY HILLS",Eating-out & Entertainment,Take-away & snacks,ANZ Credit Card 2026-03.csv,false,false
+599,12/03/2026,-16.99,"SOUTHBANK PHARMACY        SOUTH BRISBAN",Medical, personal & education,Medicines & pharmacy,ANZ Credit Card 2026-03.csv,false,false
+600,12/03/2026,-130.25,"AMPOL MAROOCHYDORE 111    MAROOCHYDORE",Car & Transport,Petrol,ANZ Credit Card 2026-03.csv,false,false
+601,11/03/2026,-190,"MAMMOTH FOREST GLEN       FOREST GLEN",Home & utilities,Furniture & appliances,ANZ Credit Card 2026-03.csv,false,false
+602,11/03/2026,-64,"FITSTOP SIPPY DO          SUNSHINE COAS",Medical, personal & education,Sports & gym,ANZ Credit Card 2026-03.csv,false,false
+603,11/03/2026,-64,"FITSTOP SIPPY DO          SUNSHINE COAS",Medical, personal & education,Sports & gym,ANZ Credit Card 2026-03.csv,false,false
+604,11/03/2026,-10,"BWS/163 KARAWATHA ST - SH BUDERIM",Eating-out & Entertainment,Drinks & alcohol,ANZ Credit Card 2026-03.csv,false,false
+605,11/03/2026,-25.18,"BLI BLI HOTEL             BLI BLI",,,ANZ Credit Card 2026-03.csv,false,false
+606,11/03/2026,-25.18,"BLI BLI HOTEL             BLI BLI",,,ANZ Credit Card 2026-03.csv,false,false
+607,11/03/2026,-30.6,"BLI BLI HOTEL             BLI BLI",,,ANZ Credit Card 2026-03.csv,false,false
+608,11/03/2026,-44.48,"THE CHARMING SQUIRE       SOUTH BRISBAN",,,ANZ Credit Card 2026-03.csv,false,false
+609,11/03/2026,-91,"QPAC                      SOUTH BRISBAN",,,ANZ Credit Card 2026-03.csv,false,false
+610,11/03/2026,-30,"QPAC                      SOUTH BRISBAN",,,ANZ Credit Card 2026-03.csv,false,false
+611,11/03/2026,-4.5,"CocaColaEPP               South Brisban",,,ANZ Credit Card 2026-03.csv,false,false
+612,10/03/2026,-63.95,"SQ *AN NAM VIETNAMESE KIT Sippy Downs",Eating-out & Entertainment,Lunches bought,ANZ Credit Card 2026-03.csv,false,false
+613,10/03/2026,-250.29,"COLES 4523                MAROOCHYDORE",Groceries,Supermarket,ANZ Credit Card 2026-03.csv,false,false
+614,10/03/2026,-28,"SQ *SCOOP HOUSE           Buderim",,,ANZ Credit Card 2026-03.csv,false,false
+615,10/03/2026,-18.01,"SQ *AN NAM VIETNAMESE KIT Sippy Downs",Eating-out & Entertainment,Lunches bought,ANZ Credit Card 2026-03.csv,false,false
+616,10/03/2026,-180,"Mecca Brands Pty Ltd      Richmond",Medical, personal & education,Hair & beauty,ANZ Credit Card 2026-03.csv,false,false
+617,10/03/2026,-10.02,"UBER *TRIP HELP.UBER.COM  Sydney",Car & Transport,Uber & taxi,ANZ Credit Card 2026-03.csv,false,false
+618,09/03/2026,-245.87,"SQ *LEMAK KITCHEN AND BAR Woolloongabba",,,ANZ Credit Card 2026-03.csv,false,false
+619,09/03/2026,-11.6,"UBER *TRIP HELP.UBER.COM  Sydney",Car & Transport,Uber & taxi,ANZ Credit Card 2026-03.csv,false,false
+620,09/03/2026,60,"OZT*HAYLEY MARY - QUIT    WOOLLOONGABBA",Eating-out & Entertainment,Movies, shows & music,ANZ Credit Card 2026-03.csv,false,false
+621,09/03/2026,-8.7,"WW METRO/67 BURNETT STREE BUDERIM",Groceries,Supermarket,ANZ Credit Card 2026-03.csv,false,false
+622,09/03/2026,-20,"Guzman y Gomez            Maroochydore",Eating-out & Entertainment,Take-away & snacks,ANZ Credit Card 2026-03.csv,false,false
+623,09/03/2026,-20,"Guzman y Gomez            Maroochydore",Eating-out & Entertainment,Take-away & snacks,ANZ Credit Card 2026-03.csv,false,false
+624,09/03/2026,-91.35,"PARADISE ARCADE COTTO     Maroochydore",,,ANZ Credit Card 2026-03.csv,false,false
+625,09/03/2026,-53.6,"GUZMAN Y GOMEZ            SURRY HILLS",Eating-out & Entertainment,Take-away & snacks,ANZ Credit Card 2026-03.csv,false,false
+626,09/03/2026,-9.99,"DD *DOORDASHDASHPASS      MELBOURNE",Eating-out & Entertainment,Take-away & snacks,ANZ Credit Card 2026-03.csv,false,false
+627,09/03/2026,-31.99,"Adobe                     Sydney",Medical, personal & education,Computers & gadgets,ANZ Credit Card 2026-03.csv,false,false
+628,09/03/2026,-4.05,"SFS THE CONTAINER BY      BIRTINYA",Eating-out & Entertainment,Coffee & tea,ANZ Credit Card 2026-03.csv,false,false
+629,09/03/2026,-4.49,"APPLE.COM/BILL            SYDNEY",Medical, personal & education,Computers & gadgets,ANZ Credit Card 2026-03.csv,false,false
+630,09/03/2026,-33.47,"DBS*Goodlife Queen Str    Brisbane",Medical, personal & education,Sports & gym,ANZ Credit Card 2026-03.csv,false,false
+631,09/03/2026,-16.5,"MAROOCHYDORE STATE HIG    MAROOCHYDORE",Children,School uniforms,ANZ Credit Card 2026-03.csv,false,false
+632,09/03/2026,-53.58,"BACKSTREET CAFE           MOOLOOLABA",Eating-out & Entertainment,Coffee & tea,ANZ Credit Card 2026-03.csv,false,false
+633,09/03/2026,-5.56,"BACKSTREET CAFE           MOOLOOLABA",Eating-out & Entertainment,Coffee & tea,ANZ Credit Card 2026-03.csv,false,false
+634,06/03/2026,-32.18,"SQ *AN NAM VIETNAMESE KIT Sippy Downs",Eating-out & Entertainment,Lunches bought,ANZ Credit Card 2026-03.csv,false,false
+635,06/03/2026,-39,"BWS/163 KARAWATHA ST - SH BUDERIM",Eating-out & Entertainment,Drinks & alcohol,ANZ Credit Card 2026-03.csv,false,false
+636,06/03/2026,-36.91,"Print Locker              Alphington",,,ANZ Credit Card 2026-03.csv,false,false
+637,06/03/2026,-8.7,"MCDONALDS SOUTHBANK       SOUTH BRISBAN",Eating-out & Entertainment,Take-away & snacks,ANZ Credit Card 2026-03.csv,false,false
+638,06/03/2026,-11.99,"help.hbomax.com           St. Leonards",Home & utilities,Streaming Services,ANZ Credit Card 2026-03.csv,false,false
+639,06/03/2026,-18.3,"SMP*SIAM SOUTH BANK   0   SOUTH BRISBAN",,,ANZ Credit Card 2026-03.csv,false,false
+640,06/03/2026,-53.34,"VODAFONE AUSTRALIA        NORTH SYDNEY",Home & utilities,Ellas Mobile,ANZ Credit Card 2026-03.csv,false,false
+641,06/03/2026,-10.8,"SFS THE CONTAINER BY      BIRTINYA",Eating-out & Entertainment,Coffee & tea,ANZ Credit Card 2026-03.csv,false,false
+642,06/03/2026,-45.45,"SECURE PARKING PTY LTD    NORTH SYDNEY",Car & Transport,Road tolls & parking,ANZ Credit Card 2026-03.csv,false,false
+643,05/03/2026,-20,"SOUTHBANK CARPARK         SOUTH BANK",Car & Transport,Road tolls & parking,ANZ Credit Card 2026-03.csv,false,false
+644,05/03/2026,-59.68,"FRUIT LOVERS/90 WISES ROA MAROOCHYDORE",,,ANZ Credit Card 2026-03.csv,false,false
+645,05/03/2026,-5.3,"LS Micasa Cafe Soutban    South Brisban",Eating-out & Entertainment,Coffee & tea,ANZ Credit Card 2026-03.csv,false,false
+646,05/03/2026,-149.14,"CHEMIST WAREHOUSE         BUDERIM",Medical, personal & education,Medicines & pharmacy,ANZ Credit Card 2026-03.csv,false,false
+647,05/03/2026,-61.53,"BUNNINGS 490000           MAROOCHYDORE",Home & utilities,Home improvements & Maintenance,ANZ Credit Card 2026-03.csv,false,false
+648,04/03/2026,-7.8,"COLES 4647                SIPPY DOWNS",Groceries,Supermarket,ANZ Credit Card 2026-03.csv,false,false
+649,04/03/2026,-4.95,"Liberty Tanawha           Tanawha",Car & Transport,Petrol,ANZ Credit Card 2026-03.csv,false,false
+650,04/03/2026,-62.2,"Liberty Tanawha           Tanawha",Car & Transport,Petrol,ANZ Credit Card 2026-03.csv,false,false
+651,04/03/2026,-64,"FITSTOP SIPPY DO          SUNSHINE COAS",Medical, personal & education,Sports & gym,ANZ Credit Card 2026-03.csv,false,false
+652,04/03/2026,-64,"FITSTOP SIPPY DO          SUNSHINE COAS",Medical, personal & education,Sports & gym,ANZ Credit Card 2026-03.csv,false,false
+653,04/03/2026,-49.89,"MTN CREEK CHEM PHARM      MOUNTAIN CREE",Medical, personal & education,Medicines & pharmacy,ANZ Credit Card 2026-03.csv,false,false
+654,03/03/2026,-6.95,"WOOLWORTHS/KARAWATHA DR & MOUNTAIN CRK",Groceries,Supermarket,ANZ Credit Card 2026-03.csv,false,false
+655,03/03/2026,-66,"OFFICEWORKS  0428         Maroochydore",Medical, personal & education,Computers & gadgets,ANZ Credit Card 2026-03.csv,false,false
+656,03/03/2026,-334.27,"COLES 4647                SIPPY DOWNS",Groceries,Supermarket,ANZ Credit Card 2026-03.csv,false,false
+657,03/03/2026,-48.95,"WOOLWORTHS/KARAWATHA DR & MOUNTAIN CRK",Groceries,Supermarket,ANZ Credit Card 2026-03.csv,false,false
+658,03/03/2026,-15.99,"Disney Plus               1800-965160",Home & utilities,Streaming Services,ANZ Credit Card 2026-03.csv,false,false
+659,03/03/2026,-32,"John Kyle Espresso        Buderim",Eating-out & Entertainment,Coffee & tea,ANZ Credit Card 2026-03.csv,false,false
+660,03/03/2026,-4.99,"PRIME VIDE* PRIMEVIDEO    SYDNEY",,,ANZ Credit Card 2026-03.csv,false,false
+661,03/03/2026,-20,"THEPICKLEB* EVT DRILL     NAMBOUR",Medical, personal & education,Sports & gym,ANZ Credit Card 2026-03.csv,false,false
+662,03/03/2026,-20,"THEPICKLEB* EVT DRILL     NAMBOUR",Medical, personal & education,Sports & gym,ANZ Credit Card 2026-03.csv,false,false
+663,02/03/2026,-31.05,"OPENAI *CHATGPT SUBSCR    OPENAI.COM",,,ANZ Credit Card 2026-03.csv,false,false
+664,02/03/2026,6000,"PAYMENT THANKYOU 125816",Financial & Insurance,Transfer,ANZ Credit Card 2026-03.csv,false,false
+665,02/03/2026,-10.16,"RICK'S GARAGE             Palmwoods",,,ANZ Credit Card 2026-03.csv,false,false
+666,02/03/2026,-54.86,"RICK'S GARAGE             Palmwoods",,,ANZ Credit Card 2026-03.csv,false,false
+667,02/03/2026,-32,"WW METRO/67 BURNETT STREE BUDERIM",Groceries,Supermarket,ANZ Credit Card 2026-03.csv,false,false
+668,02/03/2026,-10.16,"SQ *BE RIGHT BACK BUDERIM Buderim",,,ANZ Credit Card 2026-03.csv,false,false
+669,02/03/2026,-86,"BWS/81 BURNETT STREET     BUDERIM",Eating-out & Entertainment,Drinks & alcohol,ANZ Credit Card 2026-03.csv,false,false
+670,02/03/2026,-5000,"PACIFIC MOTOR GROUP PT    MAROOCHYDORE",,,ANZ Credit Card 2026-03.csv,false,false
+671,02/03/2026,-4.05,"SFS THE CONTAINER BY      BIRTINYA",Eating-out & Entertainment,Coffee & tea,ANZ Credit Card 2026-03.csv,false,false
+672,02/03/2026,-58.87,"SQ *GOODSLICE PIZZA NAPOL Maroochydore",,,ANZ Credit Card 2026-03.csv,false,false
+673,02/03/2026,-20,"BWS/64 AERODROME STREET   MAROOCHYDORE",Eating-out & Entertainment,Drinks & alcohol,ANZ Credit Card 2026-03.csv,false,false
+674,02/03/2026,-103.55,"COLES 7836                BIRTINYA",Groceries,Supermarket,ANZ Credit Card 2026-03.csv,false,false
+675,02/03/2026,-15,"WOOLWORTHS/UNI WAY CHANCE BUDERIM",Groceries,Supermarket,ANZ Credit Card 2026-03.csv,false,false
+676,02/03/2026,-48.95,"WOOLWORTHS/UNI WAY CHANCE BUDERIM",Groceries,Supermarket,ANZ Credit Card 2026-03.csv,false,false
+677,02/03/2026,-21.9,"SFS SCUH ALICE & GEO      BIRTINYA",Eating-out & Entertainment,Coffee & tea,ANZ Credit Card 2026-03.csv,false,false
+678,02/03/2026,-171.81,"SUNCORP INSURANCE         BRISBANE CITY",Financial & Insurance,Home & contents insurance,ANZ Credit Card 2026-03.csv,false,false
+679,02/03/2026,-20.81,"SOLBAR MAROOCHYDORE       MAROOCHYDORE",,,ANZ Credit Card 2026-03.csv,false,false
+680,02/03/2026,-83.76,"ZLR*Bombay Bliss - Maro   Maroochydore",Eating-out & Entertainment,Restaurants,ANZ Credit Card 2026-03.csv,false,false
+681,02/03/2026,-5.56,"BACKSTREET CAFE           MOOLOOLABA",Eating-out & Entertainment,Coffee & tea,ANZ Credit Card 2026-03.csv,false,false
+682,02/03/2026,-51.7,"GRILLD PTY LTD - GARDE    UPPER MT GRAV",,,ANZ Credit Card 2026-03.csv,false,false
+683,31/03/2026,-6125,"PAYMENT TO MOODIE STEVEN JAMES",Financial & Insurance,Home loan,ANZ Joint Offset 2026-03.csv,false,false
+684,25/03/2026,3000,"PAYMENT FROM Hawkins E A",_ignore,,ANZ Joint Offset 2026-03.csv,false,false
+685,20/03/2026,3000,"PAYMENT FROM Hawkins E A",_ignore,,ANZ Joint Offset 2026-03.csv,false,false
+686,11/03/2026,-10,"ACCOUNT SERVICING FEE",Financial & Insurance,Bank fees,ANZ Joint Offset 2026-03.csv,false,false
+687,03/03/2026,-8050.94,"PAYMENT TO MOODIE STEVEN JAMES",Financial & Insurance,Home loan,ANZ Joint Offset 2026-03.csv,false,false
+688,26/03/2026,-150,"ANZ INTERNET BANKING PAYMENT 775908 TO ELLA MOODIE",Children,Child support payment,ANZ Offset 2026-03.csv,false,false
+689,26/03/2026,6910.48,"PAY/SALARY FROM TALENT INTERNATI 500011896",Income,Your take-home pay,ANZ Offset 2026-03.csv,false,false
+690,19/03/2026,-150,"ANZ INTERNET BANKING PAYMENT 400378 TO ELLA MOODIE",Children,Child support payment,ANZ Offset 2026-03.csv,false,false
+691,17/03/2026,41.37,"TRANSFER FROM ATO              ATO001100022265823",,,ANZ Offset 2026-03.csv,false,false
+692,16/03/2026,-10000,"ANZ M-BANKING FUNDS TFER TRANSFER 740802  TO 4564XXXXXXXX0557",Financial & Insurance,Transfer,ANZ Offset 2026-03.csv,false,false
+693,12/03/2026,-402.04,"PAYMENT TO BUPA AUSTRALIA   661368390000189000",Financial & Insurance,Health insurance,ANZ Offset 2026-03.csv,false,false
+694,12/03/2026,-150,"ANZ INTERNET BANKING PAYMENT 764201 TO ELLA MOODIE",Children,Child support payment,ANZ Offset 2026-03.csv,false,false
+695,12/03/2026,6910.48,"PAY/SALARY FROM TALENT INTERNATI 500011896",Income,Your take-home pay,ANZ Offset 2026-03.csv,false,false
+696,09/03/2026,98.69,"PAYMENT FROM MATTHEW HAWKINS",Financial & Insurance,Transfer,ANZ Offset 2026-03.csv,false,false
+697,05/03/2026,-150,"ANZ INTERNET BANKING PAYMENT 374689 TO ELLA MOODIE",Children,Child support payment,ANZ Offset 2026-03.csv,false,false
+698,04/03/2026,-10,"ANZ MOBILE BANKING PAYMENT 989779 TO SCOTT ALLINGTON",,,ANZ Offset 2026-03.csv,false,false
+699,02/03/2026,-6000,"ANZ M-BANKING FUNDS TFER TRANSFER 125816  TO 4564XXXXXXXX0557",Financial & Insurance,Transfer,ANZ Offset 2026-03.csv,false,false
+700,31/03/2026,2.27,"Payment",,,Macquarie Pay 2026-03.csv,false,false
+701,25/03/2026,-3000,"To Elizabeth Hawkins  - Funds transfer",Financial & Insurance,Transfer,Macquarie Pay 2026-03.csv,false,false
+702,25/03/2026,3112.11,"Salary from QLD DEPARTMENT O - SALARY 00428738",Income,Your partner's take-home pay,Macquarie Pay 2026-03.csv,false,false
+703,20/03/2026,-300,"To linked account xx2193 - Internal transfer",Financial & Insurance,Transfer,Macquarie Pay 2026-03.csv,false,false
+704,20/03/2026,-3000,"To Elizabeth Hawkins  - Funds transfer",Financial & Insurance,Transfer,Macquarie Pay 2026-03.csv,false,false
+705,11/03/2026,3113.53,"Salary from QLD DEPARTMENT O - SALARY 00428738",Income,Your partner's take-home pay,Macquarie Pay 2026-03.csv,false,false
+782,31/03/2026,0.45,"Payment",,,Macquarie Spending 2026-03.csv,false,false
+783,30/03/2026,25,"From Elizabeth Hawkins - J bouldering",Financial & Insurance,Transfer,Macquarie Spending 2026-03.csv,false,false
+784,30/03/2026,-25,"To Jasper Rouse-Upjohn - Bouldering",Children,Child support payment,Macquarie Spending 2026-03.csv,false,false
+785,29/03/2026,-10,"Transfer To Bailen Rouse-Upjohn - Family love",Children,Child support payment,Macquarie Spending 2026-03.csv,false,false
+786,29/03/2026,-10,"Transfer To Jasper Rouse-upjohn - Family love",Children,Child support payment,Macquarie Spending 2026-03.csv,false,false
+787,25/03/2026,-90.11,"Transfer To Elizabeth Hawkins - Kids expenses",Financial & Insurance,Transfer,Macquarie Spending 2026-03.csv,false,false
+788,25/03/2026,-12.89,"Transfer To Elizabeth Hawkins - Spotifyhealthmobil",Home & utilities,Streaming Services,Macquarie Spending 2026-03.csv,false,false
+789,22/03/2026,-10,"Transfer To Bailen Rouse-Upjohn - Family love",Children,Child support payment,Macquarie Spending 2026-03.csv,false,false
+790,22/03/2026,-10,"Transfer To Jasper Rouse-upjohn - Family love",Children,Child support payment,Macquarie Spending 2026-03.csv,false,false
+791,20/03/2026,-5.5,"To Bailen Rouse-Upjohn - Burrito",Children,Child support payment,Macquarie Spending 2026-03.csv,false,false
+792,20/03/2026,300,"From linked account xx4650 - Internal transfer",Financial & Insurance,Transfer,Macquarie Spending 2026-03.csv,false,false
+793,18/03/2026,-90.11,"Transfer To Elizabeth Hawkins - Kids expenses",Financial & Insurance,Transfer,Macquarie Spending 2026-03.csv,false,false
+794,18/03/2026,-12.89,"Transfer To Elizabeth Hawkins - Spotifyhealthmobil",Home & utilities,Streaming Services,Macquarie Spending 2026-03.csv,false,false
+795,17/03/2026,80,"From Elizabeth Hawkins - Boys haircuts",Financial & Insurance,Transfer,Macquarie Spending 2026-03.csv,false,false
+796,15/03/2026,-10,"Transfer To Bailen Rouse-Upjohn - Family love",Children,Child support payment,Macquarie Spending 2026-03.csv,false,false
+797,15/03/2026,-10,"Transfer To Jasper Rouse-upjohn - Family love",Children,Child support payment,Macquarie Spending 2026-03.csv,false,false
+798,11/03/2026,-90.11,"Transfer To Elizabeth Hawkins - Kids expenses",Financial & Insurance,Transfer,Macquarie Spending 2026-03.csv,false,false
+799,11/03/2026,-12.89,"Transfer To Elizabeth Hawkins - Spotifyhealthmobil",Home & utilities,Streaming Services,Macquarie Spending 2026-03.csv,false,false
+800,08/03/2026,-10,"Transfer To Bailen Rouse-Upjohn - Family love",Children,Child support payment,Macquarie Spending 2026-03.csv,false,false
+801,08/03/2026,-10,"Transfer To Jasper Rouse-upjohn - Family love",Children,Child support payment,Macquarie Spending 2026-03.csv,false,false
+802,07/03/2026,80,"From Elizabeth Hawkins - Kids haircuts",Financial & Insurance,Transfer,Macquarie Spending 2026-03.csv,false,false
+803,06/03/2026,36,"From Elizabeth Hawkins - Boys pickleball",Medical, personal & education,Sports & gym,Macquarie Spending 2026-03.csv,false,false
+804,04/03/2026,-90.11,"Transfer To Elizabeth Hawkins - Kids expenses",Financial & Insurance,Transfer,Macquarie Spending 2026-03.csv,false,false
+805,04/03/2026,-12.89,"Transfer To Elizabeth Hawkins - Spotifyhealthmobil",Home & utilities,Streaming Services,Macquarie Spending 2026-03.csv,false,false
+806,01/03/2026,-10,"Transfer To Bailen Rouse-Upjohn - Family love",Children,Child support payment,Macquarie Spending 2026-03.csv,false,false
+807,01/03/2026,-10,"Transfer To Jasper Rouse-upjohn - Family love",Children,Child support payment,Macquarie Spending 2026-03.csv,false,false

--- a/migration-artifacts/budget-tracker/budget-tracker-export.json
+++ b/migration-artifacts/budget-tracker/budget-tracker-export.json
@@ -1,0 +1,7937 @@
+{
+  "exportedAt": "2026-04-18T06:12:53.523Z",
+  "sourceApp": "budget-categoriser.jsx",
+  "sourceChat": "2eafe99b-cff6-40fe-afaf-0587686d0830",
+  "transactions": [
+    {
+      "_id": 0,
+      "date": "30/01/2026",
+      "amount": "-8050.94",
+      "description": "PAYMENT TO MOODIE STEVEN JAMES",
+      "category": "Financial & Insurance",
+      "subcategory": "Home loan",
+      "file": "ANZ Joint Offset 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 1,
+      "date": "28/01/2026",
+      "amount": "3500.00",
+      "description": "PAYMENT FROM Hawkins E A",
+      "category": "_ignore",
+      "subcategory": "",
+      "file": "ANZ Joint Offset 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 2,
+      "date": "15/01/2026",
+      "amount": "-9775.00",
+      "description": "ANZ M-BANKING FUNDS TFER TRANSFER 279885  TO 4564X",
+      "category": "Financial & Insurance",
+      "subcategory": "Transfer",
+      "file": "ANZ Joint Offset 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 3,
+      "date": "14/01/2026",
+      "amount": "6000.00",
+      "description": "PAYMENT FROM Hawkins E A",
+      "category": "_ignore",
+      "subcategory": "",
+      "file": "ANZ Joint Offset 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 4,
+      "date": "09/01/2026",
+      "amount": "-10.00",
+      "description": "ACCOUNT SERVICING FEE",
+      "category": "Financial & Insurance",
+      "subcategory": "Bank fees",
+      "file": "ANZ Joint Offset 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 5,
+      "date": "07/01/2026",
+      "amount": "43.90",
+      "description": "EFTPOS MEDICARE BENEFIT",
+      "category": "Income",
+      "subcategory": "Health insurance reimbursement",
+      "file": "ANZ Joint Offset 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 6,
+      "date": "25/02/2026",
+      "amount": "3300.00",
+      "description": "PAYMENT FROM Hawkins E A",
+      "category": "_ignore",
+      "subcategory": "",
+      "file": "ANZ Joint Offset 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 7,
+      "date": "11/02/2026",
+      "amount": "-10.00",
+      "description": "ACCOUNT SERVICING FEE",
+      "category": "Financial & Insurance",
+      "subcategory": "Bank fees",
+      "file": "ANZ Joint Offset 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 8,
+      "date": "11/02/2026",
+      "amount": "4000.00",
+      "description": "PAYMENT FROM Hawkins E A",
+      "category": "_ignore",
+      "subcategory": "",
+      "file": "ANZ Joint Offset 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 9,
+      "date": "29/01/2026",
+      "amount": "-150.00",
+      "description": "ANZ INTERNET BANKING PAYMENT 858073 TO ELLA MOODIE",
+      "category": "Children",
+      "subcategory": "Child support payment",
+      "file": "ANZ Offset 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 10,
+      "date": "29/01/2026",
+      "amount": "6350.03",
+      "description": "PAY/SALARY FROM TALENT INTERNATI 500011896",
+      "category": "Income",
+      "subcategory": "Your take-home pay",
+      "file": "ANZ Offset 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 11,
+      "date": "22/01/2026",
+      "amount": "-150.00",
+      "description": "ANZ INTERNET BANKING PAYMENT 687595 TO ELLA MOODIE",
+      "category": "Children",
+      "subcategory": "Child support payment",
+      "file": "ANZ Offset 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 12,
+      "date": "22/01/2026",
+      "amount": "-26.00",
+      "description": "ANZ MOBILE BANKING PAYMENT 844618 TO ELLA MOODIE",
+      "category": "Children",
+      "subcategory": "Child support payment",
+      "file": "ANZ Offset 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 13,
+      "date": "20/01/2026",
+      "amount": "-100.00",
+      "description": "ANZ MOBILE BANKING PAYMENT 501243 TO ELLA MOODIE",
+      "category": "Children",
+      "subcategory": "Child support payment",
+      "file": "ANZ Offset 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 14,
+      "date": "15/01/2026",
+      "amount": "-150.00",
+      "description": "ANZ INTERNET BANKING PAYMENT 272737 TO ELLA MOODIE",
+      "category": "Children",
+      "subcategory": "Child support payment",
+      "file": "ANZ Offset 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 15,
+      "date": "15/01/2026",
+      "amount": "3944.24",
+      "description": "PAY/SALARY FROM TALENT INTERNATI 500011896",
+      "category": "Income",
+      "subcategory": "Your take-home pay",
+      "file": "ANZ Offset 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 16,
+      "date": "13/01/2026",
+      "amount": "-402.04",
+      "description": "PAYMENT TO BUPA AUSTRALIA   661368390000187000",
+      "category": "Financial & Insurance",
+      "subcategory": "Health insurance",
+      "file": "ANZ Offset 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 17,
+      "date": "08/01/2026",
+      "amount": "-150.00",
+      "description": "ANZ INTERNET BANKING PAYMENT 975600 TO ELLA MOODIE",
+      "category": "Children",
+      "subcategory": "Child support payment",
+      "file": "ANZ Offset 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 18,
+      "date": "02/01/2026",
+      "amount": "-150.00",
+      "description": "ANZ INTERNET BANKING PAYMENT 795103 TO ELLA MOODIE",
+      "category": "Children",
+      "subcategory": "Child support payment",
+      "file": "ANZ Offset 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 19,
+      "date": "26/02/2026",
+      "amount": "-421.30",
+      "description": "ANZ INTERNET BANKING BPAY TMR REG RENEW 4817      ",
+      "category": "Car & Transport",
+      "subcategory": "Rego & licence",
+      "file": "ANZ Offset 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 20,
+      "date": "26/02/2026",
+      "amount": "-150.00",
+      "description": "ANZ INTERNET BANKING PAYMENT 258399 TO ELLA MOODIE",
+      "category": "Children",
+      "subcategory": "Child support payment",
+      "file": "ANZ Offset 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 21,
+      "date": "26/02/2026",
+      "amount": "6350.03",
+      "description": "PAY/SALARY FROM TALENT INTERNATI 500011896",
+      "category": "Income",
+      "subcategory": "Your take-home pay",
+      "file": "ANZ Offset 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 22,
+      "date": "19/02/2026",
+      "amount": "-150.00",
+      "description": "ANZ INTERNET BANKING PAYMENT 735869 TO ELLA MOODIE",
+      "category": "Children",
+      "subcategory": "Child support payment",
+      "file": "ANZ Offset 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 23,
+      "date": "16/02/2026",
+      "amount": "-8400.00",
+      "description": "ANZ M-BANKING FUNDS TFER TRANSFER 681977  TO 4564X",
+      "category": "Financial & Insurance",
+      "subcategory": "Transfer",
+      "file": "ANZ Offset 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 24,
+      "date": "12/02/2026",
+      "amount": "-402.04",
+      "description": "PAYMENT TO BUPA AUSTRALIA   661368390000188000",
+      "category": "Financial & Insurance",
+      "subcategory": "Health insurance",
+      "file": "ANZ Offset 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 25,
+      "date": "12/02/2026",
+      "amount": "-150.00",
+      "description": "ANZ INTERNET BANKING PAYMENT 211935 TO ELLA MOODIE",
+      "category": "Children",
+      "subcategory": "Child support payment",
+      "file": "ANZ Offset 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 26,
+      "date": "12/02/2026",
+      "amount": "6350.03",
+      "description": "PAY/SALARY FROM TALENT INTERNATI 500011896",
+      "category": "Income",
+      "subcategory": "Your take-home pay",
+      "file": "ANZ Offset 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 27,
+      "date": "05/02/2026",
+      "amount": "-150.00",
+      "description": "ANZ INTERNET BANKING PAYMENT 701230 TO ELLA MOODIE",
+      "category": "Children",
+      "subcategory": "Child support payment",
+      "file": "ANZ Offset 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 28,
+      "date": "03/02/2026",
+      "amount": "-9700.00",
+      "description": "ANZ M-BANKING FUNDS TFER TRANSFER 508136  TO 4564X",
+      "category": "Financial & Insurance",
+      "subcategory": "Transfer",
+      "file": "ANZ Offset 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 29,
+      "date": "30/01/2026",
+      "amount": "-203.87",
+      "description": "GLOW UP                   YANDINA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Restaurants",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 30,
+      "date": "30/01/2026",
+      "amount": "-16.09",
+      "description": "SQ *AN NAM VIETNAMESE KIT Sippy Downs",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Lunches bought",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 31,
+      "date": "30/01/2026",
+      "amount": "-171.81",
+      "description": "SUNCORP INSURANCE         BRISBANE CITY",
+      "category": "Financial & Insurance",
+      "subcategory": "Home & contents insurance",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 32,
+      "date": "30/01/2026",
+      "amount": "-45.45",
+      "description": "SECURE PARKING PTY LTD    NORTH SYDNEY",
+      "category": "Car & Transport",
+      "subcategory": "Road tolls & parking",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 33,
+      "date": "30/01/2026",
+      "amount": "-100.03",
+      "description": "AMRITYU PTY LTD           BOKARINA",
+      "category": "Car & Transport",
+      "subcategory": "Petrol",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 34,
+      "date": "30/01/2026",
+      "amount": "-18.9",
+      "description": "POINT PARKING             KAWANA",
+      "category": "Car & Transport",
+      "subcategory": "Road tolls & parking",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 35,
+      "date": "30/01/2026",
+      "amount": "-16.6",
+      "description": "POINTPARKING NAMBOUR      NAMBOUR",
+      "category": "Car & Transport",
+      "subcategory": "Road tolls & parking",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 36,
+      "date": "29/01/2026",
+      "amount": "-40.2",
+      "description": "THE BOATSHED              COTTON TREE",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Restaurants",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 37,
+      "date": "29/01/2026",
+      "amount": "-64",
+      "description": "SP BANDIFY AUSTRALIA      AIRPORT WEST",
+      "category": "Medical, personal & education",
+      "subcategory": "Computers & gadgets",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 38,
+      "date": "29/01/2026",
+      "amount": "-23.75",
+      "description": "MCDONALDS SIPPY DOWN      SIPPY DOWNS",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Take-away & snacks",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 39,
+      "date": "29/01/2026",
+      "amount": "-57",
+      "description": "CHANCE PARK CHM PHARM     SIPPY DOWNS",
+      "category": "Medical, personal & education",
+      "subcategory": "Medicines & pharmacy",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 40,
+      "date": "29/01/2026",
+      "amount": "-13.5",
+      "description": "THEPICKLEB* EVT SOCIAL    NAMBOUR",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 41,
+      "date": "29/01/2026",
+      "amount": "-13.5",
+      "description": "THEPICKLEB* EVT SOCIAL    NAMBOUR",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 42,
+      "date": "28/01/2026",
+      "amount": "-800",
+      "description": "Coles Group Limited -     Hawthorn East",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Celebrations & gifts",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 43,
+      "date": "28/01/2026",
+      "amount": "-64",
+      "description": "FITSTOP SIPPY DO          SUNSHINE COAS",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 44,
+      "date": "28/01/2026",
+      "amount": "-64",
+      "description": "FITSTOP SIPPY DO          SUNSHINE COAS",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 45,
+      "date": "28/01/2026",
+      "amount": "-4.05",
+      "description": "MEGA FRESH FOOD MARKET    MOUNTAIN CREE",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 46,
+      "date": "28/01/2026",
+      "amount": "-50.36",
+      "description": "BUNNINGS 490000           MAROOCHYDORE",
+      "category": "Home & utilities",
+      "subcategory": "Home improvements & Maintenance",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 47,
+      "date": "27/01/2026",
+      "amount": "-170",
+      "description": "BWS/163 KARAWATHA ST - SH BUDERIM",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Drinks & alcohol",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 48,
+      "date": "27/01/2026",
+      "amount": "-181.77",
+      "description": "COLES 4647                SIPPY DOWNS",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 49,
+      "date": "27/01/2026",
+      "amount": "-54.15",
+      "description": "WOOLWORTHS/KARAWATHA DR & MOUNTAIN CRK",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 50,
+      "date": "27/01/2026",
+      "amount": "-90.45",
+      "description": "SQ *AN NAM VIETNAMESE KIT Sippy Downs",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Lunches bought",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 51,
+      "date": "27/01/2026",
+      "amount": "-25.46",
+      "description": "COLES 4647                SIPPY DOWNS",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 52,
+      "date": "27/01/2026",
+      "amount": "-45.45",
+      "description": "ZLR*Somewhere On Buderi   Buderim",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Restaurants",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 53,
+      "date": "27/01/2026",
+      "amount": "-5.31",
+      "description": "SFS THE CONTAINER BY      BIRTINYA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 54,
+      "date": "27/01/2026",
+      "amount": "-82.32",
+      "description": "THE FOREST BLEND CAFE     FOREST GLEN",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 55,
+      "date": "27/01/2026",
+      "amount": "-7.2",
+      "description": "WOOLWORTHS/KARAWATHA DR & MOUNTAIN CRK",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 56,
+      "date": "27/01/2026",
+      "amount": "-20.99",
+      "description": "Netflix.com               Melbourne",
+      "category": "Home & utilities",
+      "subcategory": "Streaming Services",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 57,
+      "date": "27/01/2026",
+      "amount": "-18",
+      "description": "THEPICKLEB* EVT SOCIAL    NAMBOUR",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 58,
+      "date": "27/01/2026",
+      "amount": "-18",
+      "description": "THEPICKLEB* EVT SOCIAL    NAMBOUR",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 59,
+      "date": "27/01/2026",
+      "amount": "-18",
+      "description": "THEPICKLEB* EVT SOCIAL    NAMBOUR",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 60,
+      "date": "27/01/2026",
+      "amount": "-53.4",
+      "description": "WOOLWORTHS/KARAWATHA DR & MOUNTAIN CRK",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 61,
+      "date": "27/01/2026",
+      "amount": "-80.85",
+      "description": "COLES 7835                BUDERIM",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 62,
+      "date": "27/01/2026",
+      "amount": "-33.47",
+      "description": "DBS*Goodlife Queen Str    Brisbane",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 63,
+      "date": "27/01/2026",
+      "amount": "-50.35",
+      "description": "LINKT BRISBANE            BRISBANE",
+      "category": "Car & Transport",
+      "subcategory": "Road tolls & parking",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 64,
+      "date": "27/01/2026",
+      "amount": "-18",
+      "description": "THEPICKLEB* EVT SOCIAL    NAMBOUR",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 65,
+      "date": "27/01/2026",
+      "amount": "-13.4",
+      "description": "MCDONALDS SOUTHBANK       SOUTH BRISBAN",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Take-away & snacks",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 66,
+      "date": "27/01/2026",
+      "amount": "-5.59",
+      "description": "SMP*Jamoke Espresso Ba    Nambour",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 67,
+      "date": "27/01/2026",
+      "amount": "-96.75",
+      "description": "AMPOL SIPPY DOW 10262F    SIPPY DOWNS",
+      "category": "Car & Transport",
+      "subcategory": "Petrol",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 68,
+      "date": "23/01/2026",
+      "amount": "-9.99",
+      "description": "AMZNPRIMEA* AMZNPRIMEA    SYDNEY SOUTH",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Movies, shows & music",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 69,
+      "date": "23/01/2026",
+      "amount": "-20",
+      "description": "SOUTHBANK CARPARK         SOUTH BANK",
+      "category": "Car & Transport",
+      "subcategory": "Road tolls & parking",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 70,
+      "date": "23/01/2026",
+      "amount": "-13.2",
+      "description": "ROSE & CROWN              South Brisban",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 71,
+      "date": "23/01/2026",
+      "amount": "-13.72",
+      "description": "Mebami                    South Brisban",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Lunches bought",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 72,
+      "date": "23/01/2026",
+      "amount": "-6.12",
+      "description": "SQ *BLACK FOX             Mooloolaba",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 73,
+      "date": "23/01/2026",
+      "amount": "-480",
+      "description": "COASTAL AESTHETIC INJE    MAROOCHYDORE",
+      "category": "Medical, personal & education",
+      "subcategory": "Hair & beauty",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 74,
+      "date": "22/01/2026",
+      "amount": "129.95",
+      "description": "MYER  MAROOCHYDORE        MAROOCHYDORE",
+      "category": "Medical, personal & education",
+      "subcategory": "Shopping",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 75,
+      "date": "22/01/2026",
+      "amount": "-47.45",
+      "description": "COLES 4523                MAROOCHYDORE",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 76,
+      "date": "22/01/2026",
+      "amount": "-30",
+      "description": "TARGET 5038               MAROOCHYDORE",
+      "category": "Medical, personal & education",
+      "subcategory": "Shopping",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 77,
+      "date": "22/01/2026",
+      "amount": "-24",
+      "description": "KMART 1060                MAROOCHYDORE",
+      "category": "Medical, personal & education",
+      "subcategory": "Shopping",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 78,
+      "date": "22/01/2026",
+      "amount": "-253.94",
+      "description": "MYER  MAROOCHYDORE        MAROOCHYDORE",
+      "category": "Medical, personal & education",
+      "subcategory": "Shopping",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 79,
+      "date": "22/01/2026",
+      "amount": "-341",
+      "description": "NDC SERVICE CO PTY LIM    MAROOCHYDORE",
+      "category": "Medical, personal & education",
+      "subcategory": "Dental",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 80,
+      "date": "22/01/2026",
+      "amount": "-163.27",
+      "description": "AGL SALES 0308            MELBOURNE",
+      "category": "Home & utilities",
+      "subcategory": "Electricity",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 81,
+      "date": "22/01/2026",
+      "amount": "-58.44",
+      "description": "DECJUBA PTY LTD           MAROOCHYDORE",
+      "category": "Medical, personal & education",
+      "subcategory": "Clothing & shoes",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 82,
+      "date": "22/01/2026",
+      "amount": "-287.3",
+      "description": "QTIX TICKETING            SOUTH BRISBAN",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Movies, shows & music",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 83,
+      "date": "22/01/2026",
+      "amount": "-13.5",
+      "description": "THEPICKLEB* EVT SOCIAL    NAMBOUR",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 84,
+      "date": "22/01/2026",
+      "amount": "-40.5",
+      "description": "THEPICKLEB* EVT SOCIAL    NAMBOUR",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 85,
+      "date": "21/01/2026",
+      "amount": "-122.2",
+      "description": "ALH VENUES/81 BURNETT ST  BUDERIM",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 86,
+      "date": "21/01/2026",
+      "amount": "-132.98",
+      "description": "THE GREEN AT TANAWHA      TANAWHA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Restaurants",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 87,
+      "date": "21/01/2026",
+      "amount": "-115.36",
+      "description": "Bli Bli Watersports Compl Bli Bli",
+      "category": "Medical, personal & education",
+      "subcategory": "Hobbies",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 88,
+      "date": "21/01/2026",
+      "amount": "-64",
+      "description": "FITSTOP SIPPY DO          SUNSHINE COAS",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 89,
+      "date": "21/01/2026",
+      "amount": "-64",
+      "description": "FITSTOP SIPPY DO          SUNSHINE COAS",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 90,
+      "date": "21/01/2026",
+      "amount": "-14.1",
+      "description": "WELLINGTON BAKERY PART    MAROOCHYDORE",
+      "category": "Groceries",
+      "subcategory": "Deli & bakery",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 91,
+      "date": "20/01/2026",
+      "amount": "-9.3",
+      "description": "Boost Sunshine Plaza      Maroochydore",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Take-away & snacks",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 92,
+      "date": "20/01/2026",
+      "amount": "-308.14",
+      "description": "WOOLWORTHS/SUNSHINE PLZ S MAROOCHYDORE",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 93,
+      "date": "20/01/2026",
+      "amount": "-20",
+      "description": "BWS/50 PARK PLAZA         MAROOCHYDORE",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Drinks & alcohol",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 94,
+      "date": "20/01/2026",
+      "amount": "-68.07",
+      "description": "SQ *WALTER'S DINER        Maroochydore",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Restaurants",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 95,
+      "date": "20/01/2026",
+      "amount": "-1.02",
+      "description": "SQ *WALTER'S DINER        Maroochydore",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Restaurants",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 96,
+      "date": "20/01/2026",
+      "amount": "-120",
+      "description": "TARGET 5038               MAROOCHYDORE",
+      "category": "Medical, personal & education",
+      "subcategory": "Shopping",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 97,
+      "date": "20/01/2026",
+      "amount": "-16.45",
+      "description": "Audible Limited AU        MELBOURNE",
+      "category": "Home & utilities",
+      "subcategory": "Streaming Services",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 98,
+      "date": "20/01/2026",
+      "amount": "-35.95",
+      "description": "Microsoft*14 Day Trial Re msbill.info",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Movies, shows & music",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 99,
+      "date": "20/01/2026",
+      "amount": "-253.91",
+      "description": "MYER  MAROOCHYDORE        MAROOCHYDORE",
+      "category": "Medical, personal & education",
+      "subcategory": "Shopping",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 100,
+      "date": "20/01/2026",
+      "amount": "-28.99",
+      "description": "Bonds Sunshine Plaza      Maroochydore",
+      "category": "Medical, personal & education",
+      "subcategory": "Clothing & shoes",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 101,
+      "date": "20/01/2026",
+      "amount": "-112.46",
+      "description": "DECJUBA PTY LTD           MAROOCHYDORE",
+      "category": "Medical, personal & education",
+      "subcategory": "Clothing & shoes",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 102,
+      "date": "20/01/2026",
+      "amount": "-66.7",
+      "description": "Sunshine Krua Thai        Buderim",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Restaurants",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 103,
+      "date": "20/01/2026",
+      "amount": "-107.9",
+      "description": "SMP*Orchid Massage in03   Sippy Downs",
+      "category": "Medical, personal & education",
+      "subcategory": "Hair & beauty",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 104,
+      "date": "20/01/2026",
+      "amount": "-130",
+      "description": "SMP*Orchid Massage in03   Sippy Downs",
+      "category": "Medical, personal & education",
+      "subcategory": "Hair & beauty",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 105,
+      "date": "19/01/2026",
+      "amount": "-85",
+      "description": "L/LAND QLD    2266        SIPPY DOWNS",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Drinks & alcohol",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 106,
+      "date": "19/01/2026",
+      "amount": "-54.43",
+      "description": "SQ *AN NAM VIETNAMESE KIT Sippy Downs",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Lunches bought",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 107,
+      "date": "19/01/2026",
+      "amount": "-24.36",
+      "description": "Aussie World              Palmview",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 108,
+      "date": "19/01/2026",
+      "amount": "-24.36",
+      "description": "Aussie World              Palmview",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 109,
+      "date": "19/01/2026",
+      "amount": "-24.36",
+      "description": "Aussie World              Palmview",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 110,
+      "date": "19/01/2026",
+      "amount": "-75.11",
+      "description": "Aussie World              Palmview",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 111,
+      "date": "19/01/2026",
+      "amount": "-34.51",
+      "description": "Aussie World              Palmview",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 112,
+      "date": "19/01/2026",
+      "amount": "-165.85",
+      "description": "SPER QLD TREASURY         BRISBANE",
+      "category": "Car & Transport",
+      "subcategory": "Road tolls & parking",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 113,
+      "date": "19/01/2026",
+      "amount": "-65.64",
+      "description": "SPINTEL PTY LTD           SURRY HILLS",
+      "category": "Home & utilities",
+      "subcategory": "Internet",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 114,
+      "date": "19/01/2026",
+      "amount": "-87.41",
+      "description": "YOUI - PREMIUM            SIPPY DOWNS",
+      "category": "Financial & Insurance",
+      "subcategory": "Car insurance",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 115,
+      "date": "19/01/2026",
+      "amount": "-44.96",
+      "description": "DAVID JONES PTY LTD -     MAROOCHYDORE",
+      "category": "Medical, personal & education",
+      "subcategory": "Shopping",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 116,
+      "date": "19/01/2026",
+      "amount": "-16",
+      "description": "KMART 1060                MAROOCHYDORE",
+      "category": "Medical, personal & education",
+      "subcategory": "Shopping",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 117,
+      "date": "19/01/2026",
+      "amount": "-79.94",
+      "description": "Forever New Clothing      Richmond",
+      "category": "Medical, personal & education",
+      "subcategory": "Clothing & shoes",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 118,
+      "date": "19/01/2026",
+      "amount": "-24.36",
+      "description": "Aussie World              Palmview",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 119,
+      "date": "19/01/2026",
+      "amount": "-51",
+      "description": "Mecca Brands Pty Ltd      Richmond",
+      "category": "Medical, personal & education",
+      "subcategory": "Hair & beauty",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 120,
+      "date": "19/01/2026",
+      "amount": "-4",
+      "description": "POINTPARKING SUNSHINE     MAROOCHYDORE",
+      "category": "Car & Transport",
+      "subcategory": "Road tolls & parking",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 121,
+      "date": "19/01/2026",
+      "amount": "-56.99",
+      "description": "COTTON ON BODY 4839       MAROOCHYDORE",
+      "category": "Medical, personal & education",
+      "subcategory": "Clothing & shoes",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 122,
+      "date": "19/01/2026",
+      "amount": "-83",
+      "description": "Sunshine Coast Regiona... Sunshine C...",
+      "category": "Home & utilities",
+      "subcategory": "Council rates",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 123,
+      "date": "19/01/2026",
+      "amount": "-51.99",
+      "description": "AMPOL SIPPY DOW 10262F    SIPPY DOWNS",
+      "category": "Car & Transport",
+      "subcategory": "Petrol",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 124,
+      "date": "19/01/2026",
+      "amount": "-36.03",
+      "description": "CHANCELLOR TAVERN APP     Sippy Downs",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 125,
+      "date": "19/01/2026",
+      "amount": "-14.85",
+      "description": "MCDONALDS MEADOWBROO      MEADOWBROOK",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Take-away & snacks",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 126,
+      "date": "19/01/2026",
+      "amount": "-13.4",
+      "description": "MCDONALDS SOUTHBANK       SOUTH BRISBAN",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Take-away & snacks",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 127,
+      "date": "19/01/2026",
+      "amount": "-18.3",
+      "description": "SMP*Mrs Luus Southpoin    Southbank",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Lunches bought",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 128,
+      "date": "19/01/2026",
+      "amount": "-4.05",
+      "description": "SFS THE CONTAINER BY      BIRTINYA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 129,
+      "date": "19/01/2026",
+      "amount": "-201.87",
+      "description": "YOUI - PREMIUM            SIPPY DOWNS",
+      "category": "Financial & Insurance",
+      "subcategory": "Car insurance",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 130,
+      "date": "19/01/2026",
+      "amount": "-27.99",
+      "description": "SPOTIFY                   SYDNEY",
+      "category": "Home & utilities",
+      "subcategory": "Streaming Services",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 131,
+      "date": "16/01/2026",
+      "amount": "-20",
+      "description": "SOUTHBANK CARPARK         SOUTH BANK",
+      "category": "Car & Transport",
+      "subcategory": "Road tolls & parking",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 132,
+      "date": "16/01/2026",
+      "amount": "-4.3",
+      "description": "WOOLWORTHS/217 GREY STREE STH BRISBANE",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 133,
+      "date": "16/01/2026",
+      "amount": "-38",
+      "description": "BWS/163 KARAWATHA ST - SH BUDERIM",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Drinks & alcohol",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 134,
+      "date": "16/01/2026",
+      "amount": "-9.09",
+      "description": "SECURE PARKING PTY LTD    NORTH SYDNEY",
+      "category": "Car & Transport",
+      "subcategory": "Road tolls & parking",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 135,
+      "date": "16/01/2026",
+      "amount": "-40",
+      "description": "HUBBL - KAYO SPORTS       131999",
+      "category": "Home & utilities",
+      "subcategory": "Streaming Services",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 136,
+      "date": "16/01/2026",
+      "amount": "-140",
+      "description": "TELSTRA SERVICES          MELBOURNE",
+      "category": "Home & utilities",
+      "subcategory": "Mobile",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 137,
+      "date": "15/01/2026",
+      "amount": "9775",
+      "description": "PAYMENT THANKYOU 279885",
+      "category": "Financial & Insurance",
+      "subcategory": "Transfer",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 138,
+      "date": "15/01/2026",
+      "amount": "-33",
+      "description": "BWS/163 KARAWATHA ST - SH BUDERIM",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Drinks & alcohol",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 139,
+      "date": "15/01/2026",
+      "amount": "-12.5",
+      "description": "WOOLWORTHS/KARAWATHA DR & MOUNTAIN CRK",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 140,
+      "date": "15/01/2026",
+      "amount": "-725",
+      "description": "EZI*Dietitians Austral    DEAKIN",
+      "category": "Medical, personal & education",
+      "subcategory": "Education & Professional Memberships",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 141,
+      "date": "15/01/2026",
+      "amount": "-160",
+      "description": "IPY*COBBCO NINE MILE      Tandur",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Holidays",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 142,
+      "date": "15/01/2026",
+      "amount": "-51.99",
+      "description": "AMPOL SIPPY DOW 10262F    SIPPY DOWNS",
+      "category": "Car & Transport",
+      "subcategory": "Petrol",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 143,
+      "date": "14/01/2026",
+      "amount": "-8.3",
+      "description": "COLES 4647                SIPPY DOWNS",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 144,
+      "date": "14/01/2026",
+      "amount": "-16.09",
+      "description": "SQ *AN NAM VIETNAMESE KIT Sippy Downs",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Lunches bought",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 145,
+      "date": "14/01/2026",
+      "amount": "-39.18",
+      "description": "WOOLWORTHS/KARAWATHA DR & MOUNTAIN CRK",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 146,
+      "date": "14/01/2026",
+      "amount": "-151.2",
+      "description": "Amino Z                   Caringbah",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 147,
+      "date": "14/01/2026",
+      "amount": "-64",
+      "description": "FITSTOP SIPPY DO          SUNSHINE COAS",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 148,
+      "date": "14/01/2026",
+      "amount": "-64",
+      "description": "FITSTOP SIPPY DO          SUNSHINE COAS",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 149,
+      "date": "14/01/2026",
+      "amount": "-69.18",
+      "description": "TERRY WHITE CHEMAR        MINYAMA",
+      "category": "Medical, personal & education",
+      "subcategory": "Medicines & pharmacy",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 150,
+      "date": "14/01/2026",
+      "amount": "-7.7",
+      "description": "EVENT CINEMAS KAWANA      BUDDINA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Movies, shows & music",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 151,
+      "date": "13/01/2026",
+      "amount": "-650",
+      "description": "THEKINKINWOOD260314NB     KIN KIN",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Holidays",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 152,
+      "date": "13/01/2026",
+      "amount": "-105.93",
+      "description": "Liberty Tanawha           Tanawha",
+      "category": "Car & Transport",
+      "subcategory": "Petrol",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 153,
+      "date": "13/01/2026",
+      "amount": "-23.8",
+      "description": "ALH VENUES/2/46 DAVID LOW DIDDILLIBAH",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 154,
+      "date": "13/01/2026",
+      "amount": "-25",
+      "description": "BWS/163 KARAWATHA ST - SH BUDERIM",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Drinks & alcohol",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 155,
+      "date": "13/01/2026",
+      "amount": "-134.38",
+      "description": "COLES 4647                SIPPY DOWNS",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 156,
+      "date": "13/01/2026",
+      "amount": "-23.8",
+      "description": "ALH VENUES/2/46 DAVID LOW DIDDILLIBAH",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 157,
+      "date": "13/01/2026",
+      "amount": "-83.6",
+      "description": "SPRINGBOK FOODS PTY LT    FOREST GLEN",
+      "category": "Groceries",
+      "subcategory": "Deli & bakery",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 158,
+      "date": "13/01/2026",
+      "amount": "-141.3",
+      "description": "EVENT KAWANA              BUDDINA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Celebrations & gifts",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 159,
+      "date": "12/01/2026",
+      "amount": "-146.45",
+      "description": "POMONA DISTILLING CO      POMONA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Restaurants",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 160,
+      "date": "12/01/2026",
+      "amount": "-104.07",
+      "description": "COLES 4647                SIPPY DOWNS",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 161,
+      "date": "12/01/2026",
+      "amount": "-113.38",
+      "description": "Liberty Tanawha           Tanawha",
+      "category": "Car & Transport",
+      "subcategory": "Petrol",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 162,
+      "date": "12/01/2026",
+      "amount": "-37.61",
+      "description": "Pomona Distilling Co      Pomona",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Restaurants",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 163,
+      "date": "12/01/2026",
+      "amount": "-19.95",
+      "description": "POMONA TRUE VALUE HA      POMONA",
+      "category": "Home & utilities",
+      "subcategory": "Home improvements & Maintenance",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 164,
+      "date": "12/01/2026",
+      "amount": "-69.54",
+      "description": "ZLR*Bombay Bliss - Maro   Maroochydore",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Restaurants",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 165,
+      "date": "12/01/2026",
+      "amount": "-4.05",
+      "description": "SFS THE CONTAINER BY      BIRTINYA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 166,
+      "date": "12/01/2026",
+      "amount": "-8.7",
+      "description": "COLES 4647                SIPPY DOWNS",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 167,
+      "date": "12/01/2026",
+      "amount": "-23.1",
+      "description": "Maroochy RSL              Maroochydore",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 168,
+      "date": "12/01/2026",
+      "amount": "-32.18",
+      "description": "SQ *AN NAM VIETNAMESE KIT Sippy Downs",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Lunches bought",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 169,
+      "date": "12/01/2026",
+      "amount": "-32",
+      "description": "Dominos Estore Buderim    dominos.com.a",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Take-away & snacks",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 170,
+      "date": "12/01/2026",
+      "amount": "-4.9",
+      "description": "AMPOL SIPPY DOW 10262F    SIPPY DOWNS",
+      "category": "Car & Transport",
+      "subcategory": "Petrol",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 171,
+      "date": "12/01/2026",
+      "amount": "-190",
+      "description": "MAMMOTH FOREST GLEN       FOREST GLEN",
+      "category": "Home & utilities",
+      "subcategory": "Furniture & appliances",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 172,
+      "date": "12/01/2026",
+      "amount": "-18",
+      "description": "THEPICKLEB* EVT SOCIAL    NAMBOUR",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 173,
+      "date": "12/01/2026",
+      "amount": "-18",
+      "description": "THEPICKLEB* EVT SOCIAL    NAMBOUR",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 174,
+      "date": "12/01/2026",
+      "amount": "-194.88",
+      "description": "Pavilion Mooloolaba       Mooloolaba",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Restaurants",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 175,
+      "date": "12/01/2026",
+      "amount": "-25",
+      "description": "MCDONALDS SIPPY DOWN      SIPPY DOWNS",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Take-away & snacks",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 176,
+      "date": "12/01/2026",
+      "amount": "-16.25",
+      "description": "SUBWAY SIPPYDOWNS         SIPPY DOWNS",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Take-away & snacks",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 177,
+      "date": "12/01/2026",
+      "amount": "-5.31",
+      "description": "SFS THE CONTAINER BY      BIRTINYA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 178,
+      "date": "12/01/2026",
+      "amount": "-154",
+      "description": "SpaghettiHouse            South Brisban",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Restaurants",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 179,
+      "date": "12/01/2026",
+      "amount": "-10.7",
+      "description": "MCDONALDS SOUTHBANK       SOUTH BRISBAN",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Take-away & snacks",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 180,
+      "date": "12/01/2026",
+      "amount": "-33.47",
+      "description": "DBS*Goodlife Queen Str    Brisbane",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 181,
+      "date": "12/01/2026",
+      "amount": "-4.75",
+      "description": "ROBINSON'S VENDING PTY LT NARANGBA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Take-away & snacks",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 182,
+      "date": "9/01/2026",
+      "amount": "-20",
+      "description": "SOUTHBANK CARPARK         SOUTH BANK",
+      "category": "Car & Transport",
+      "subcategory": "Road tolls & parking",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 183,
+      "date": "9/01/2026",
+      "amount": "-95.95",
+      "description": "Suncoast Health Cntre     Forest Glen",
+      "category": "Medical, personal & education",
+      "subcategory": "Doctors & medical",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 184,
+      "date": "9/01/2026",
+      "amount": "-5.3",
+      "description": "LS Micasa Cafe Soutban    South Brisban",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 185,
+      "date": "9/01/2026",
+      "amount": "-5.3",
+      "description": "LS Micasa Cafe Soutban    South Brisban",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 186,
+      "date": "9/01/2026",
+      "amount": "-72.72",
+      "description": "SECURE PARKING PTY LTD    NORTH SYDNEY",
+      "category": "Car & Transport",
+      "subcategory": "Road tolls & parking",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 187,
+      "date": "9/01/2026",
+      "amount": "-24.2",
+      "description": "GUZMAN Y GOMEZ            SURRY HILLS",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Take-away & snacks",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 188,
+      "date": "8/01/2026",
+      "amount": "-9.99",
+      "description": "DD *DOORDASHDASHPASS      MELBOURNE",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Take-away & snacks",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 189,
+      "date": "8/01/2026",
+      "amount": "-46.34",
+      "description": "WW METRO/67 BURNETT STREE BUDERIM",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 190,
+      "date": "8/01/2026",
+      "amount": "-31.99",
+      "description": "Adobe                     Sydney",
+      "category": "Medical, personal & education",
+      "subcategory": "Computers & gadgets",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 191,
+      "date": "8/01/2026",
+      "amount": "-5.31",
+      "description": "SFS THE CONTAINER BY      BIRTINYA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 192,
+      "date": "8/01/2026",
+      "amount": "-4.49",
+      "description": "APPLE.COM/BILL            SYDNEY",
+      "category": "Medical, personal & education",
+      "subcategory": "Computers & gadgets",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 193,
+      "date": "8/01/2026",
+      "amount": "-27",
+      "description": "THEPICKLEB* EVT SOCIAL    NAMBOUR",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 194,
+      "date": "8/01/2026",
+      "amount": "-13.5",
+      "description": "THEPICKLEB* EVT SOCIAL    NAMBOUR",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 195,
+      "date": "7/01/2026",
+      "amount": "-53.34",
+      "description": "VODAFONE AUSTRALIA        NORTH SYDNEY",
+      "category": "Home & utilities",
+      "subcategory": "Ellas Mobile",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 196,
+      "date": "7/01/2026",
+      "amount": "-9.95",
+      "description": "BANJOS SIPPY DOWNS        SIPPY DOWNS",
+      "category": "Groceries",
+      "subcategory": "Deli & bakery",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 197,
+      "date": "7/01/2026",
+      "amount": "-64",
+      "description": "FITSTOP SIPPY DO          SUNSHINE COAS",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 198,
+      "date": "7/01/2026",
+      "amount": "-64",
+      "description": "FITSTOP SIPPY DO          SUNSHINE COAS",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 199,
+      "date": "7/01/2026",
+      "amount": "-10",
+      "description": "FOSTER & BLACK P/L        UPPER MOUNT G",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 200,
+      "date": "7/01/2026",
+      "amount": "-58.49",
+      "description": "UNITED BETHANIA           BETHANIA",
+      "category": "Car & Transport",
+      "subcategory": "Petrol",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 201,
+      "date": "7/01/2026",
+      "amount": "-31.31",
+      "description": "BURLEIGH HDS RUGBY        MERMAID BEACH",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 202,
+      "date": "7/01/2026",
+      "amount": "-21.21",
+      "description": "BURLEIGH HDS RUGBY        MERMAID BEACH",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 203,
+      "date": "6/01/2026",
+      "amount": "-418.81",
+      "description": "COLES 4647                SIPPY DOWNS",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 204,
+      "date": "6/01/2026",
+      "amount": "-15.68",
+      "description": "SQ *AN NAM VIETNAMESE KIT Sippy Downs",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Lunches bought",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 205,
+      "date": "6/01/2026",
+      "amount": "-133",
+      "description": "LIQUORLAND 6476           SIPPY DOWNS",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Drinks & alcohol",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 206,
+      "date": "6/01/2026",
+      "amount": "-54.65",
+      "description": "Kiosk                     Alexandra Hea",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Restaurants",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 207,
+      "date": "6/01/2026",
+      "amount": "-11.99",
+      "description": "help.hbomax.com           St. Leonards",
+      "category": "Home & utilities",
+      "subcategory": "Streaming Services",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 208,
+      "date": "6/01/2026",
+      "amount": "-83.59",
+      "description": "AMPOL SIPPY DOW 10262F    SIPPY DOWNS",
+      "category": "Car & Transport",
+      "subcategory": "Petrol",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 209,
+      "date": "5/01/2026",
+      "amount": "-46.26",
+      "description": "COLES 4647                SIPPY DOWNS",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 210,
+      "date": "5/01/2026",
+      "amount": "-14.9",
+      "description": "Nandos GARDEN CITY        Mt Gravatt",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Take-away & snacks",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 211,
+      "date": "5/01/2026",
+      "amount": "-84.25",
+      "description": "Nandos GARDEN CITY        Mt Gravatt",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Take-away & snacks",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 212,
+      "date": "5/01/2026",
+      "amount": "-43.48",
+      "description": "SQ *MOUSTACHE             Mermaid Beach",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Restaurants",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 213,
+      "date": "5/01/2026",
+      "amount": "-11.18",
+      "description": "SQ *THE HOLLIDAY COFFEE   Mermaid Beach",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 214,
+      "date": "5/01/2026",
+      "amount": "-10",
+      "description": "BYRON SHIRE COUNCIL       MULLUMBIMBY",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 215,
+      "date": "5/01/2026",
+      "amount": "-23.3",
+      "description": "BRUNSWICK HOTEL OPCO P    BRUNSWICK HEA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 216,
+      "date": "5/01/2026",
+      "amount": "-23.54",
+      "description": "BRUNSWICK HOTEL OPCO P    BRUNSWICK HEA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 217,
+      "date": "5/01/2026",
+      "amount": "-7",
+      "description": "AMPOL EAGLEBY 10266F      EAGLEBY",
+      "category": "Car & Transport",
+      "subcategory": "Petrol",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 218,
+      "date": "5/01/2026",
+      "amount": "-22.22",
+      "description": "BRUNSWICK HOTEL OPCO P    BRUNSWICK HEA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 219,
+      "date": "5/01/2026",
+      "amount": "-56.67",
+      "description": "BRUNSWICK HOTEL OPCO P    BRUNSWICK HEA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 220,
+      "date": "5/01/2026",
+      "amount": "-102.31",
+      "description": "SQ *MORE THAI RESTAURANT  Mermaid Beach",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Restaurants",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 221,
+      "date": "5/01/2026",
+      "amount": "-30",
+      "description": "BWS/2223 GOLD COAST HWY-S MERMAID BCH",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Drinks & alcohol",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 222,
+      "date": "5/01/2026",
+      "amount": "-545.5",
+      "description": "QTIX TICKETING            SOUTH BRISBAN",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Movies, shows & music",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 223,
+      "date": "5/01/2026",
+      "amount": "-15",
+      "description": "SQ *MOOLOOLABA SURF LIFE  Mooloolaba",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 224,
+      "date": "5/01/2026",
+      "amount": "-15.99",
+      "description": "Disney Plus               1800-965160",
+      "category": "Home & utilities",
+      "subcategory": "Streaming Services",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 225,
+      "date": "5/01/2026",
+      "amount": "-41.5",
+      "description": "BWS/163 KARAWATHA ST - SH BUDERIM",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Drinks & alcohol",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 226,
+      "date": "5/01/2026",
+      "amount": "-31.99",
+      "description": "BUNNINGS 490000           MAROOCHYDORE",
+      "category": "Home & utilities",
+      "subcategory": "Home improvements & Maintenance",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 227,
+      "date": "2/01/2026",
+      "amount": "-29.6",
+      "description": "ALH VENUES/NICKLIN WAY    BUDDINA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 228,
+      "date": "2/01/2026",
+      "amount": "-124",
+      "description": "LIQUORLAND 6476           SIPPY DOWNS",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Drinks & alcohol",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 229,
+      "date": "2/01/2026",
+      "amount": "-189",
+      "description": "Booking.com Hotel         Sydney",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Holidays",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 230,
+      "date": "2/01/2026",
+      "amount": "-5.9",
+      "description": "SFS SCUH MERLOT           BIRTINYA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 231,
+      "date": "2/01/2026",
+      "amount": "-10.82",
+      "description": "SQ *BLACK FOX             Mooloolaba",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 232,
+      "date": "2/01/2026",
+      "amount": "-847.83",
+      "description": "TRANSPORTMAINRDS          BRISBANE",
+      "category": "Car & Transport",
+      "subcategory": "Rego & licence",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 233,
+      "date": "2/01/2026",
+      "amount": "-119.98",
+      "description": "COLES 4647                SIPPY DOWNS",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 234,
+      "date": "2/01/2026",
+      "amount": "-42",
+      "description": "LIQUORLAND 6476           SIPPY DOWNS",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Drinks & alcohol",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 235,
+      "date": "2/01/2026",
+      "amount": "-5.57",
+      "description": "SQ *ROCK HOP ESPRESSO     Coolum",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 236,
+      "date": "2/01/2026",
+      "amount": "-41.96",
+      "description": "LS Delifish Buderim       Buderim",
+      "category": "Groceries",
+      "subcategory": "Deli & bakery",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 237,
+      "date": "2/01/2026",
+      "amount": "-59.48",
+      "description": "LIVELIFE PHARMACY CV      COOLUM BEACH",
+      "category": "Medical, personal & education",
+      "subcategory": "Medicines & pharmacy",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 238,
+      "date": "2/01/2026",
+      "amount": "-171.81",
+      "description": "SUNCORP INSURANCE         BRISBANE CITY",
+      "category": "Financial & Insurance",
+      "subcategory": "Home & contents insurance",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 239,
+      "date": "2/01/2026",
+      "amount": "13.12",
+      "description": "YOUI - PREMIUM            SIPPY DOWNS",
+      "category": "Financial & Insurance",
+      "subcategory": "Car insurance",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 240,
+      "date": "2/01/2026",
+      "amount": "-25.47",
+      "description": "ALDI STORES               BIRTINYA",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 241,
+      "date": "27/02/2026",
+      "amount": "-59.30",
+      "description": "WOOLWORTHS/OCEAN ST & HOR MAROOCHYDORE",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 242,
+      "date": "27/02/2026",
+      "amount": "-48.95",
+      "description": "WOOLWORTHS/KARAWATHA DR & MOUNTAIN CRK",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 243,
+      "date": "27/02/2026",
+      "amount": "-16.45",
+      "description": "KFC Sippy Downs           Sippy Downs",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Take-away & snacks",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 244,
+      "date": "27/02/2026",
+      "amount": "-1355.20",
+      "description": "Sunshine Coast Regiona... Sunshine C...",
+      "category": "Home & utilities",
+      "subcategory": "Council rates",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 245,
+      "date": "27/02/2026",
+      "amount": "-75.73",
+      "description": "Playa                     Bokarina",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Restaurants",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 246,
+      "date": "27/02/2026",
+      "amount": "-88.86",
+      "description": "AMRITYU PTY LTD           BOKARINA",
+      "category": "Car & Transport",
+      "subcategory": "Petrol",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 247,
+      "date": "26/02/2026",
+      "amount": "-20.00",
+      "description": "SOUTHBANK CARPARK         SOUTH BANK",
+      "category": "Car & Transport",
+      "subcategory": "Road tolls & parking",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 248,
+      "date": "26/02/2026",
+      "amount": "-13.72",
+      "description": "Mebami                    South Brisban",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Lunches bought",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 249,
+      "date": "26/02/2026",
+      "amount": "-5.30",
+      "description": "LS Micasa Cafe Soutban    South Brisban",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 250,
+      "date": "26/02/2026",
+      "amount": "-45.45",
+      "description": "SECURE PARKING PTY LTD    NORTH SYDNEY",
+      "category": "Car & Transport",
+      "subcategory": "Road tolls & parking",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 251,
+      "date": "25/02/2026",
+      "amount": "-64.00",
+      "description": "FITSTOP SIPPY DO          SUNSHINE COAS",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 252,
+      "date": "25/02/2026",
+      "amount": "-64.00",
+      "description": "FITSTOP SIPPY DO          SUNSHINE COAS",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 253,
+      "date": "25/02/2026",
+      "amount": "-48.95",
+      "description": "WOOLWORTHS/KARAWATHA DR & MOUNTAIN CRK",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 254,
+      "date": "25/02/2026",
+      "amount": "-20.99",
+      "description": "Netflix.com               Melbourne",
+      "category": "Home & utilities",
+      "subcategory": "Streaming Services",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 255,
+      "date": "25/02/2026",
+      "amount": "-36.00",
+      "description": "THEPICKLEB* EVT SOCIAL    NAMBOUR",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 256,
+      "date": "25/02/2026",
+      "amount": "-62.10",
+      "description": "MCDONALDS SIPPY DOWN      SIPPY DOWNS",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Take-away & snacks",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 257,
+      "date": "24/02/2026",
+      "amount": "-15.80",
+      "description": "ALH VENUES/2/46 DAVID LOW DIDDILLIBAH",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 258,
+      "date": "24/02/2026",
+      "amount": "-139.12",
+      "description": "COLES 7835                BUDERIM",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 259,
+      "date": "24/02/2026",
+      "amount": "-99.34",
+      "description": "Liberty Tanawha           Tanawha",
+      "category": "Car & Transport",
+      "subcategory": "Petrol",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 260,
+      "date": "24/02/2026",
+      "amount": "-99.98",
+      "description": "SQ *DEPOT NOOSA           Noosaville",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Restaurants",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 261,
+      "date": "23/02/2026",
+      "amount": "-36.00",
+      "description": "BWS/23 VENNING STREET     MOOLOOLABA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Drinks & alcohol",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 262,
+      "date": "23/02/2026",
+      "amount": "-41.00",
+      "description": "ALH VENUES/23 VENNING ST  MOOLOOLABA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 263,
+      "date": "23/02/2026",
+      "amount": "-96.00",
+      "description": "ALH VENUES/23 VENNING ST  MOOLOOLABA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 264,
+      "date": "23/02/2026",
+      "amount": "-24.40",
+      "description": "WOOLWORTHS/KARAWATHA DR & MOUNTAIN CRK",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 265,
+      "date": "23/02/2026",
+      "amount": "-22.80",
+      "description": "ALH VENUES/23 VENNING ST  MOOLOOLABA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 266,
+      "date": "23/02/2026",
+      "amount": "-5.04",
+      "description": "ZLR*Brumby's Mountain C   Mountain Cree",
+      "category": "Groceries",
+      "subcategory": "Deli & bakery",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 267,
+      "date": "23/02/2026",
+      "amount": "-9.99",
+      "description": "AMZNPRIMEA* AMZNPRIMEA    SYDNEY SOUTH",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Movies, shows & music",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 268,
+      "date": "23/02/2026",
+      "amount": "-23.58",
+      "description": "UBER *TRIP HELP.UBER.COM  Sydney",
+      "category": "Car & Transport",
+      "subcategory": "Uber & taxi",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 269,
+      "date": "23/02/2026",
+      "amount": "-141.30",
+      "description": "BWS/163 KARAWATHA ST - SH BUDERIM",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Drinks & alcohol",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 270,
+      "date": "23/02/2026",
+      "amount": "-263.55",
+      "description": "AGL SALES 0308            MELBOURNE",
+      "category": "Home & utilities",
+      "subcategory": "Electricity",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 271,
+      "date": "23/02/2026",
+      "amount": "-4.90",
+      "description": "AMPOL SIPPY DOW 10262F    SIPPY DOWNS",
+      "category": "Car & Transport",
+      "subcategory": "Petrol",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 272,
+      "date": "23/02/2026",
+      "amount": "-48.95",
+      "description": "WOOLWORTHS/KARAWATHA DR & MOUNTAIN CRK",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 273,
+      "date": "23/02/2026",
+      "amount": "-123.58",
+      "description": "COLES 4647                SIPPY DOWNS",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 274,
+      "date": "23/02/2026",
+      "amount": "-4.05",
+      "description": "SFS SCUH ALICE & GEO      BIRTINYA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 275,
+      "date": "23/02/2026",
+      "amount": "-14.00",
+      "description": "WOOLWORTHS/KARAWATHA DR & MOUNTAIN CRK",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 276,
+      "date": "23/02/2026",
+      "amount": "-19.50",
+      "description": "MAROOCHYDORE STATE HIG    MAROOCHYDORE",
+      "category": "Children",
+      "subcategory": "School uniforms",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 277,
+      "date": "23/02/2026",
+      "amount": "-35.95",
+      "description": "Microsoft*14 Day Trial Re msbill.info",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Movies, shows & music",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 278,
+      "date": "23/02/2026",
+      "amount": "-33.47",
+      "description": "DBS*Goodlife Queen Str    Brisbane",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 279,
+      "date": "23/02/2026",
+      "amount": "-12.20",
+      "description": "SMP*Jamoke Espresso Ba    Nambour",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 280,
+      "date": "23/02/2026",
+      "amount": "-179.40",
+      "description": "DNH*GODADDY#4019909627    130-035-1076",
+      "category": "Medical, personal & education",
+      "subcategory": "Computers & gadgets",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 281,
+      "date": "23/02/2026",
+      "amount": "-22.22",
+      "description": "SG BAKERY BUDERIM         BUDERIM",
+      "category": "Groceries",
+      "subcategory": "Deli & bakery",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 282,
+      "date": "23/02/2026",
+      "amount": "-10.41",
+      "description": "BACKSTREET CAFE           MOOLOOLABA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 283,
+      "date": "23/02/2026",
+      "amount": "-16.60",
+      "description": "POINTPARKING NAMBOUR      NAMBOUR",
+      "category": "Car & Transport",
+      "subcategory": "Road tolls & parking",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 284,
+      "date": "20/02/2026",
+      "amount": "-16.45",
+      "description": "Audible Limited AU        MELBOURNE",
+      "category": "Home & utilities",
+      "subcategory": "Streaming Services",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 285,
+      "date": "20/02/2026",
+      "amount": "-22.50",
+      "description": "ZLR*Wishlist Coffee Hou   Nambour",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 286,
+      "date": "20/02/2026",
+      "amount": "-118.67",
+      "description": "YOUI - PREMIUM            SIPPY DOWNS",
+      "category": "Financial & Insurance",
+      "subcategory": "Car insurance",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 287,
+      "date": "20/02/2026",
+      "amount": "-80.67",
+      "description": "SPINTEL PTY LTD           SURRY HILLS",
+      "category": "Home & utilities",
+      "subcategory": "Internet",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 288,
+      "date": "20/02/2026",
+      "amount": "-47.50",
+      "description": "AMPOL SIPPY DOW 10262F    SIPPY DOWNS",
+      "category": "Car & Transport",
+      "subcategory": "Petrol",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 289,
+      "date": "19/02/2026",
+      "amount": "-132.90",
+      "description": "ALH VENUES/NICKLIN WAY    BUDDINA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 290,
+      "date": "19/02/2026",
+      "amount": "-35.00",
+      "description": "BWS/163 KARAWATHA ST - SH BUDERIM",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Drinks & alcohol",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 291,
+      "date": "19/02/2026",
+      "amount": "-201.91",
+      "description": "YOUI - PREMIUM            SIPPY DOWNS",
+      "category": "Financial & Insurance",
+      "subcategory": "Car insurance",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 292,
+      "date": "19/02/2026",
+      "amount": "-87.41",
+      "description": "YOUI - PREMIUM            SIPPY DOWNS",
+      "category": "Financial & Insurance",
+      "subcategory": "Car insurance",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 293,
+      "date": "18/02/2026",
+      "amount": "-64.00",
+      "description": "FITSTOP SIPPY DO          SUNSHINE COAS",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 294,
+      "date": "18/02/2026",
+      "amount": "-64.00",
+      "description": "FITSTOP SIPPY DO          SUNSHINE COAS",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 295,
+      "date": "18/02/2026",
+      "amount": "-151.20",
+      "description": "Amino Z                   Caringbah",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 296,
+      "date": "18/02/2026",
+      "amount": "-5.31",
+      "description": "SFS SCUH ALICE & GEO      BIRTINYA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 297,
+      "date": "18/02/2026",
+      "amount": "-9.95",
+      "description": "BANJOS SIPPY DOWNS        SIPPY DOWNS",
+      "category": "Groceries",
+      "subcategory": "Deli & bakery",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 298,
+      "date": "18/02/2026",
+      "amount": "-9.80",
+      "description": "SUSHI HUB SUNSHINE P      MAROOCHYDORE",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 299,
+      "date": "17/02/2026",
+      "amount": "-297.73",
+      "description": "COLES 4647                SIPPY DOWNS",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 300,
+      "date": "17/02/2026",
+      "amount": "-60.85",
+      "description": "Somewhere Over Coffee     Rainbow Beach",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 301,
+      "date": "17/02/2026",
+      "amount": "-27.99",
+      "description": "SPOTIFY                   0012345678",
+      "category": "Home & utilities",
+      "subcategory": "Streaming Services",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 302,
+      "date": "17/02/2026",
+      "amount": "-92.92",
+      "description": "THE DECK SEA SALT         RAINBOW BEACH",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 303,
+      "date": "17/02/2026",
+      "amount": "-46.46",
+      "description": "THE DECK SEA SALT         RAINBOW BEACH",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 304,
+      "date": "16/02/2026",
+      "amount": "8400.00",
+      "description": "PAYMENT THANKYOU 681977",
+      "category": "Financial & Insurance",
+      "subcategory": "Transfer",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 305,
+      "date": "16/02/2026",
+      "amount": "-16.59",
+      "description": "Rainbow Beach Bakery      Rainbow Beach",
+      "category": "Groceries",
+      "subcategory": "Deli & bakery",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 306,
+      "date": "16/02/2026",
+      "amount": "-29.00",
+      "description": "BWS/14 RAINBOW BEACH PARA RAINBOW BEACH",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Drinks & alcohol",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 307,
+      "date": "16/02/2026",
+      "amount": "-50.75",
+      "description": "LITTLE PARLIAMENT         Rainbow Beach",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Restaurants",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 308,
+      "date": "16/02/2026",
+      "amount": "-45.99",
+      "description": "HUBBL - KAYO SPORTS       131999",
+      "category": "Home & utilities",
+      "subcategory": "Streaming Services",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 309,
+      "date": "16/02/2026",
+      "amount": "-19.00",
+      "description": "SP THE BODY SHOP          CHADSTONE",
+      "category": "Medical, personal & education",
+      "subcategory": "Hair & beauty",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 310,
+      "date": "16/02/2026",
+      "amount": "-24.00",
+      "description": "RAINBOW BEACH SURF LI     Rainbow Beach",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 311,
+      "date": "16/02/2026",
+      "amount": "-66.04",
+      "description": "Galaxy Nails  sunshin     Maroochydore",
+      "category": "Medical, personal & education",
+      "subcategory": "Hair & beauty",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 312,
+      "date": "16/02/2026",
+      "amount": "-7.40",
+      "description": "COLES 4647                SIPPY DOWNS",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 313,
+      "date": "16/02/2026",
+      "amount": "-120.55",
+      "description": "COLES 4647                SIPPY DOWNS",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 314,
+      "date": "16/02/2026",
+      "amount": "-9.90",
+      "description": "Noosa Chocolate Factory   Noosa Heads",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Take-away & snacks",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 315,
+      "date": "16/02/2026",
+      "amount": "-84.00",
+      "description": "MYER  MAROOCHYDORE        MAROOCHYDORE",
+      "category": "Medical, personal & education",
+      "subcategory": "Shopping",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 316,
+      "date": "16/02/2026",
+      "amount": "-24.00",
+      "description": "RAINBOW BEACH SURF LI     Rainbow Beach",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 317,
+      "date": "16/02/2026",
+      "amount": "-24.00",
+      "description": "RAINBOW BEACH SURF LI     Rainbow Beach",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 318,
+      "date": "16/02/2026",
+      "amount": "-38.67",
+      "description": "Liberty Tanawha           Tanawha",
+      "category": "Car & Transport",
+      "subcategory": "Petrol",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 319,
+      "date": "16/02/2026",
+      "amount": "-20.00",
+      "description": "BWS/14 RAINBOW BEACH PARA RAINBOW BEACH",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Drinks & alcohol",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 320,
+      "date": "16/02/2026",
+      "amount": "-29.00",
+      "description": "RAINBOW BEACH SURF LI     Rainbow Beach",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 321,
+      "date": "16/02/2026",
+      "amount": "-140.00",
+      "description": "TELSTRA SERVICES          MELBOURNE",
+      "category": "Home & utilities",
+      "subcategory": "Mobile",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 322,
+      "date": "16/02/2026",
+      "amount": "-48.84",
+      "description": "snshn-kr-th-bdrm          Buderim",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Restaurants",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 323,
+      "date": "16/02/2026",
+      "amount": "-18.12",
+      "description": "SUNNY SLOTHS PTY LTD      BIRTINYA",
+      "category": "Children",
+      "subcategory": "Toys",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 324,
+      "date": "16/02/2026",
+      "amount": "-48.00",
+      "description": "BWS/163 KARAWATHA ST - SH BUDERIM",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Drinks & alcohol",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 325,
+      "date": "16/02/2026",
+      "amount": "-16.09",
+      "description": "SQ *AN NAM VIETNAMESE KIT Sippy Downs",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Lunches bought",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 326,
+      "date": "16/02/2026",
+      "amount": "-101.05",
+      "description": "Liberty Tanawha           Tanawha",
+      "category": "Car & Transport",
+      "subcategory": "Petrol",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 327,
+      "date": "16/02/2026",
+      "amount": "-19.70",
+      "description": "MTN CREEK CHEM PHARM      MOUNTAIN CREE",
+      "category": "Medical, personal & education",
+      "subcategory": "Medicines & pharmacy",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 328,
+      "date": "16/02/2026",
+      "amount": "-10.41",
+      "description": "BACKSTREET CAFE           MOOLOOLABA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 329,
+      "date": "16/02/2026",
+      "amount": "-36.00",
+      "description": "THEPICKLEB* EVT SOCIAL    NAMBOUR",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 330,
+      "date": "13/02/2026",
+      "amount": "-113.80",
+      "description": "McAfee.com mcafee.com/aut Mahon  Cork",
+      "category": "Medical, personal & education",
+      "subcategory": "Computers & gadgets",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 331,
+      "date": "13/02/2026",
+      "amount": "-75.60",
+      "description": "ALH VENUES/NICKLIN WAY    BUDDINA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 332,
+      "date": "13/02/2026",
+      "amount": "-50.99",
+      "description": "WOOLWORTHS/KARAWATHA DR & MOUNTAIN CRK",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 333,
+      "date": "13/02/2026",
+      "amount": "-5.00",
+      "description": "WOOLWORTHS/KARAWATHA DR & MOUNTAIN CRK",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 334,
+      "date": "13/02/2026",
+      "amount": "-36.00",
+      "description": "ALH VENUES/NICKLIN WAY    BUDDINA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 335,
+      "date": "13/02/2026",
+      "amount": "-24.20",
+      "description": "ALH VENUES/NICKLIN WAY    BUDDINA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 336,
+      "date": "13/02/2026",
+      "amount": "-389.00",
+      "description": "Booking.com Hotel         Sydney",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Holidays",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 337,
+      "date": "13/02/2026",
+      "amount": "-63.63",
+      "description": "SECURE PARKING PTY LTD    NORTH SYDNEY",
+      "category": "Car & Transport",
+      "subcategory": "Road tolls & parking",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 338,
+      "date": "13/02/2026",
+      "amount": "-5.31",
+      "description": "SFS THE CONTAINER BY      BIRTINYA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 339,
+      "date": "13/02/2026",
+      "amount": "-51.99",
+      "description": "AMPOL SIPPY DOW 10262F    SIPPY DOWNS",
+      "category": "Car & Transport",
+      "subcategory": "Petrol",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 340,
+      "date": "12/02/2026",
+      "amount": "-31.00",
+      "description": "BWS/163 KARAWATHA ST - SH BUDERIM",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Drinks & alcohol",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 341,
+      "date": "12/02/2026",
+      "amount": "-7.43",
+      "description": "SFS THE CONTAINER BY      BIRTINYA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 342,
+      "date": "12/02/2026",
+      "amount": "-76.42",
+      "description": "AMPOL HAMILTON 11781F     HAMILTON",
+      "category": "Car & Transport",
+      "subcategory": "Petrol",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 343,
+      "date": "11/02/2026",
+      "amount": "-64.00",
+      "description": "FITSTOP SIPPY DO          SUNSHINE COAS",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 344,
+      "date": "11/02/2026",
+      "amount": "-64.00",
+      "description": "FITSTOP SIPPY DO          SUNSHINE COAS",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 345,
+      "date": "11/02/2026",
+      "amount": "-50.37",
+      "description": "LINKT BRISBANE            BRISBANE",
+      "category": "Car & Transport",
+      "subcategory": "Road tolls & parking",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 346,
+      "date": "11/02/2026",
+      "amount": "-9.80",
+      "description": "SUSHI HUB SUNSHINE P      MAROOCHYDORE",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 347,
+      "date": "11/02/2026",
+      "amount": "-9.42",
+      "description": "ALDI STORES               BIRTINYA",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 348,
+      "date": "11/02/2026",
+      "amount": "-5.70",
+      "description": "BAKERS DELIGHT BIRTI      BIRTINYA",
+      "category": "Groceries",
+      "subcategory": "Deli & bakery",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 349,
+      "date": "11/02/2026",
+      "amount": "-305.00",
+      "description": "SPECSAVERS MAROOCHYDOR    MAROOCHYDORE",
+      "category": "Medical, personal & education",
+      "subcategory": "Glasses & eye care",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 350,
+      "date": "11/02/2026",
+      "amount": "-75.48",
+      "description": "THE BOATSHED              COTTON TREE",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Restaurants",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 351,
+      "date": "11/02/2026",
+      "amount": "-36.00",
+      "description": "THEPICKLEB* EVT SOCIAL    NAMBOUR",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 352,
+      "date": "10/02/2026",
+      "amount": "-70.40",
+      "description": "OZT*HAYLEY MARY - QUIT    WOOLLOONGABBA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Movies, shows & music",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 353,
+      "date": "10/02/2026",
+      "amount": "-139.59",
+      "description": "COLES 7835                BUDERIM",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 354,
+      "date": "10/02/2026",
+      "amount": "-20.00",
+      "description": "L/LAND QLD 6526           BUDERIM",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Drinks & alcohol",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 355,
+      "date": "10/02/2026",
+      "amount": "-23.80",
+      "description": "ALH VENUES/2/46 DAVID LOW DIDDILLIBAH",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 356,
+      "date": "10/02/2026",
+      "amount": "-71.03",
+      "description": "SQ *AN NAM VIETNAMESE KIT Sippy Downs",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Lunches bought",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 357,
+      "date": "09/02/2026",
+      "amount": "-120.00",
+      "description": "SP LSKD.CO                YATALA",
+      "category": "Medical, personal & education",
+      "subcategory": "Clothing & shoes",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 358,
+      "date": "09/02/2026",
+      "amount": "-39.53",
+      "description": "The Pocket Espresso       Moffat Beach",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 359,
+      "date": "09/02/2026",
+      "amount": "-34.19",
+      "description": "The Pocket Espresso       Moffat Beach",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 360,
+      "date": "09/02/2026",
+      "amount": "-61.00",
+      "description": "KMART 1060                MAROOCHYDORE",
+      "category": "Medical, personal & education",
+      "subcategory": "Shopping",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 361,
+      "date": "09/02/2026",
+      "amount": "-72.65",
+      "description": "COLES 7836                BIRTINYA",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 362,
+      "date": "09/02/2026",
+      "amount": "-16.03",
+      "description": "The Pocket Espresso       Moffat Beach",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 363,
+      "date": "09/02/2026",
+      "amount": "-21.80",
+      "description": "Gun Cotton Coffee         INDOOROOPILLY",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Restaurants",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 364,
+      "date": "09/02/2026",
+      "amount": "-121.60",
+      "description": "Gun Cotton Coffee         INDOOROOPILLY",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Restaurants",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 365,
+      "date": "09/02/2026",
+      "amount": "-31.95",
+      "description": "A&E JONES PTY LTD         MAROOCHYDORE",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Restaurants",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 366,
+      "date": "09/02/2026",
+      "amount": "-29.85",
+      "description": "Cotton Tree Ice Creame    Cotton Tree",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Take-away & snacks",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 367,
+      "date": "09/02/2026",
+      "amount": "-6.00",
+      "description": "MAROOCHYDORE STATE HIG    MAROOCHYDORE",
+      "category": "Children",
+      "subcategory": "School uniforms",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 368,
+      "date": "09/02/2026",
+      "amount": "-7.50",
+      "description": "MAROOCHYDORE STATE HIG    MAROOCHYDORE",
+      "category": "Children",
+      "subcategory": "School uniforms",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 369,
+      "date": "09/02/2026",
+      "amount": "-50.18",
+      "description": "GLOW UP                   YANDINA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Restaurants",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 370,
+      "date": "09/02/2026",
+      "amount": "-9.99",
+      "description": "DD *DOORDASHDASHPASS      MELBOURNE",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Take-away & snacks",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 371,
+      "date": "09/02/2026",
+      "amount": "-8.00",
+      "description": "WOOLWORTHS/OCEAN ST & HOR MAROOCHYDORE",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 372,
+      "date": "09/02/2026",
+      "amount": "-40.00",
+      "description": "BWS/BIG TOP S/C HORTON PD MAROOCHYDORE",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Drinks & alcohol",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 373,
+      "date": "09/02/2026",
+      "amount": "-36.00",
+      "description": "THEPICKLEB* EVT PAIRED    NAMBOUR",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 374,
+      "date": "09/02/2026",
+      "amount": "-31.99",
+      "description": "Adobe                     Sydney",
+      "category": "Medical, personal & education",
+      "subcategory": "Computers & gadgets",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 375,
+      "date": "09/02/2026",
+      "amount": "-13.70",
+      "description": "KFC Caboolture BP Nort    Caboolture BP",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Take-away & snacks",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 376,
+      "date": "09/02/2026",
+      "amount": "-18.30",
+      "description": "SMP*Mrs Luus Southpoin    Southbank",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Lunches bought",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 377,
+      "date": "09/02/2026",
+      "amount": "-5.31",
+      "description": "SFS THE CONTAINER BY      BIRTINYA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 378,
+      "date": "09/02/2026",
+      "amount": "-4.95",
+      "description": "CALTEX CALOUNDRA          CALOUNDRA",
+      "category": "Car & Transport",
+      "subcategory": "Petrol",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 379,
+      "date": "09/02/2026",
+      "amount": "-36.36",
+      "description": "SECURE PARKING PTY LTD    NORTH SYDNEY",
+      "category": "Car & Transport",
+      "subcategory": "Road tolls & parking",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 380,
+      "date": "09/02/2026",
+      "amount": "-4.49",
+      "description": "APPLE.COM/BILL            SYDNEY",
+      "category": "Medical, personal & education",
+      "subcategory": "Computers & gadgets",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 381,
+      "date": "09/02/2026",
+      "amount": "-20.00",
+      "description": "SOUTHBANK CARPARK         SOUTH BANK",
+      "category": "Car & Transport",
+      "subcategory": "Road tolls & parking",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 382,
+      "date": "09/02/2026",
+      "amount": "-23.48",
+      "description": "KINGS BEACH HOTEL APP     Caloundra",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 383,
+      "date": "09/02/2026",
+      "amount": "-23.28",
+      "description": "KINGS BEACH HOTEL APP     Caloundra",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 384,
+      "date": "09/02/2026",
+      "amount": "-23.48",
+      "description": "KINGS BEACH HOTEL APP     Caloundra",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 385,
+      "date": "09/02/2026",
+      "amount": "-23.48",
+      "description": "KINGS BEACH HOTEL APP     Caloundra",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 386,
+      "date": "09/02/2026",
+      "amount": "-5.30",
+      "description": "LS Micasa Cafe Soutban    South Brisban",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 387,
+      "date": "09/02/2026",
+      "amount": "-33.47",
+      "description": "DBS*Goodlife Queen Str    Brisbane",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 388,
+      "date": "09/02/2026",
+      "amount": "-5.56",
+      "description": "BACKSTREET CAFE           MOOLOOLABA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 389,
+      "date": "09/02/2026",
+      "amount": "-20.14",
+      "description": "SUNNY SLOTHS PTY LTD      BIRTINYA",
+      "category": "Children",
+      "subcategory": "Toys",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 390,
+      "date": "06/02/2026",
+      "amount": "-32.18",
+      "description": "SQ *AN NAM VIETNAMESE KIT Sippy Downs",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Lunches bought",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 391,
+      "date": "06/02/2026",
+      "amount": "-5.31",
+      "description": "SFS SCUH ALICE & GEO      BIRTINYA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 392,
+      "date": "06/02/2026",
+      "amount": "-11.99",
+      "description": "help.hbomax.com           St. Leonards",
+      "category": "Home & utilities",
+      "subcategory": "Streaming Services",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 393,
+      "date": "06/02/2026",
+      "amount": "-5.31",
+      "description": "SFS THE CONTAINER BY      BIRTINYA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 394,
+      "date": "05/02/2026",
+      "amount": "-262.46",
+      "description": "QANTAS AIR                MASCOT",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Holidays",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 395,
+      "date": "05/02/2026",
+      "amount": "-1093.73",
+      "description": "Cars on Booking           London",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Holidays",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 396,
+      "date": "05/02/2026",
+      "amount": "-100.02",
+      "description": "Liberty Tanawha           Tanawha",
+      "category": "Car & Transport",
+      "subcategory": "Petrol",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 397,
+      "date": "05/02/2026",
+      "amount": "-53.34",
+      "description": "VODAFONE AUSTRALIA        NORTH SYDNEY",
+      "category": "Home & utilities",
+      "subcategory": "Ellas Mobile",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 398,
+      "date": "04/02/2026",
+      "amount": "-64.00",
+      "description": "FITSTOP SIPPY DO          SUNSHINE COAS",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 399,
+      "date": "04/02/2026",
+      "amount": "-64.00",
+      "description": "FITSTOP SIPPY DO          SUNSHINE COAS",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 400,
+      "date": "04/02/2026",
+      "amount": "-43.32",
+      "description": "COLES 4647                SIPPY DOWNS",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 401,
+      "date": "04/02/2026",
+      "amount": "-14.00",
+      "description": "LIQUORLAND 6476           SIPPY DOWNS",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Drinks & alcohol",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 402,
+      "date": "04/02/2026",
+      "amount": "-83.97",
+      "description": "HARRIS SCARFE MRHYDR      MAROOCHYDORE",
+      "category": "Home & utilities",
+      "subcategory": "Furniture & appliances",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 403,
+      "date": "04/02/2026",
+      "amount": "-110.00",
+      "description": "SPOTLIGHT                 MAROOCHYDORE",
+      "category": "Home & utilities",
+      "subcategory": "Home improvements & Maintenance",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 404,
+      "date": "04/02/2026",
+      "amount": "-144.54",
+      "description": "BUNNINGS 490000           MAROOCHYDORE",
+      "category": "Home & utilities",
+      "subcategory": "Home improvements & Maintenance",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 405,
+      "date": "04/02/2026",
+      "amount": "-36.00",
+      "description": "THEPICKLEB* EVT SOCIAL    NAMBOUR",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 406,
+      "date": "03/02/2026",
+      "amount": "9700.00",
+      "description": "PAYMENT THANKYOU 508136",
+      "category": "Financial & Insurance",
+      "subcategory": "Transfer",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 407,
+      "date": "03/02/2026",
+      "amount": "-1997.26",
+      "description": "JETSTAR AIR KK2YQV        WWW.JETSTAR.C",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Holidays",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 408,
+      "date": "03/02/2026",
+      "amount": "-569.50",
+      "description": "GORGE VIEW KATHERINE      KATHERINE",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Holidays",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 409,
+      "date": "03/02/2026",
+      "amount": "-323.67",
+      "description": "COLES 4647                SIPPY DOWNS",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 410,
+      "date": "03/02/2026",
+      "amount": "-15.99",
+      "description": "Disney Plus               1800-965160",
+      "category": "Home & utilities",
+      "subcategory": "Streaming Services",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 411,
+      "date": "03/02/2026",
+      "amount": "-370.17",
+      "description": "Hotel at Booking.com      Sydney",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Holidays",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 412,
+      "date": "03/02/2026",
+      "amount": "-65.50",
+      "description": "Riba Kai                  Maroochydore",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Restaurants",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 413,
+      "date": "02/02/2026",
+      "amount": "-26.43",
+      "description": "Dock Mooloolaba           Mooloolaba",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 414,
+      "date": "02/02/2026",
+      "amount": "-27.38",
+      "description": "ZLR*The Beach Bar & Gri   Mooloolaba",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Restaurants",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 415,
+      "date": "02/02/2026",
+      "amount": "-82.15",
+      "description": "ZLR*The Beach Bar & Gri   Mooloolaba",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Restaurants",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 416,
+      "date": "02/02/2026",
+      "amount": "-26.37",
+      "description": "ZLR*The Beach Bar & Gri   Mooloolaba",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Restaurants",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 417,
+      "date": "02/02/2026",
+      "amount": "-26.00",
+      "description": "BWS/RIVER ESP & PARKLYN P MOOLOOLABA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Drinks & alcohol",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 418,
+      "date": "02/02/2026",
+      "amount": "-486.40",
+      "description": "GARRY CRICKS NAMBOUR      MAROOCHYDORE",
+      "category": "Car & Transport",
+      "subcategory": "Repairs & maintenance",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 419,
+      "date": "02/02/2026",
+      "amount": "18.00",
+      "description": "THEPICKLEB* EVT SOCIAL    NAMBOUR",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 420,
+      "date": "02/02/2026",
+      "amount": "18.00",
+      "description": "THEPICKLEB* EVT SOCIAL    NAMBOUR",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 421,
+      "date": "02/02/2026",
+      "amount": "-35.75",
+      "description": "UBER *EATS HELP.UBER.COM  Sydney",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Take-away & snacks",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 422,
+      "date": "02/02/2026",
+      "amount": "-63.80",
+      "description": "Nandos MAROOCHYDORE       Maroochydore",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Take-away & snacks",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 423,
+      "date": "02/02/2026",
+      "amount": "-5.59",
+      "description": "SMP*Jamoke Espresso Ba    Nambour",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 424,
+      "date": "02/02/2026",
+      "amount": "-16.60",
+      "description": "POINTPARKING NAMBOUR      NAMBOUR",
+      "category": "Car & Transport",
+      "subcategory": "Road tolls & parking",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 425,
+      "date": "02/02/2026",
+      "amount": "-78.80",
+      "description": "WOOLWORTHS/KARAWATHA DR & MOUNTAIN CRK",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 426,
+      "date": "02/02/2026",
+      "amount": "-5.56",
+      "description": "BACKSTREET CAFE           MOOLOOLABA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 427,
+      "date": "31/01/2026",
+      "amount": "3.47",
+      "description": "Payment",
+      "category": "",
+      "subcategory": "",
+      "file": "Macquarie Pay 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 428,
+      "date": "30/01/2026",
+      "amount": "328.68",
+      "description": "From E552212Txn420196 - 552212*RP 18/02/20",
+      "category": "Income",
+      "subcategory": "Other income",
+      "file": "Macquarie Pay 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 429,
+      "date": "28/01/2026",
+      "amount": "-3500",
+      "description": "To Elizabeth Hawkins  - Funds transfer",
+      "category": "Financial & Insurance",
+      "subcategory": "Transfer",
+      "file": "Macquarie Pay 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 430,
+      "date": "28/01/2026",
+      "amount": "3112.39",
+      "description": "Salary from QLD DEPARTMENT O - SALARY 00428738",
+      "category": "Income",
+      "subcategory": "Your partner's take-home pay",
+      "file": "Macquarie Pay 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 431,
+      "date": "16/01/2026",
+      "amount": "328.68",
+      "description": "From E552212Txn419100 - 552212*RP 18/02/20",
+      "category": "Income",
+      "subcategory": "Other income",
+      "file": "Macquarie Pay 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 432,
+      "date": "16/01/2026",
+      "amount": "0.02",
+      "description": "From closed account xx5111",
+      "category": "",
+      "subcategory": "",
+      "file": "Macquarie Pay 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 433,
+      "date": "16/01/2026",
+      "amount": "0.07",
+      "description": "From closed account xx5695",
+      "category": "",
+      "subcategory": "",
+      "file": "Macquarie Pay 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 434,
+      "date": "14/01/2026",
+      "amount": "-6000",
+      "description": "To Elizabeth Hawkins  - Funds transfer",
+      "category": "Financial & Insurance",
+      "subcategory": "Transfer",
+      "file": "Macquarie Pay 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 435,
+      "date": "14/01/2026",
+      "amount": "-600",
+      "description": "To linked account xx2193 - Internal transfer",
+      "category": "Financial & Insurance",
+      "subcategory": "Transfer",
+      "file": "Macquarie Pay 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 436,
+      "date": "14/01/2026",
+      "amount": "3075.86",
+      "description": "Salary from QLD DEPARTMENT O - SALARY 00428738",
+      "category": "Income",
+      "subcategory": "Your partner's take-home pay",
+      "file": "Macquarie Pay 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 437,
+      "date": "02/01/2026",
+      "amount": "328.68",
+      "description": "From E552212Txn418095 - 552212*RP 18/02/20",
+      "category": "Income",
+      "subcategory": "Other income",
+      "file": "Macquarie Pay 2026-01.csv",
+      "_manual": false
+    },
+    {
+      "_id": 438,
+      "date": "28/02/2026",
+      "amount": "0.59",
+      "description": "Payment",
+      "category": "",
+      "subcategory": "",
+      "file": "Macquarie Spending 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 439,
+      "date": "25/02/2026",
+      "amount": "-90.11",
+      "description": "Transfer To Elizabeth Hawkins - Kids expenses",
+      "category": "Financial & Insurance",
+      "subcategory": "Transfer",
+      "file": "Macquarie Spending 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 440,
+      "date": "25/02/2026",
+      "amount": "-12.89",
+      "description": "Transfer To Elizabeth Hawkins - Spotifyhealthmobil",
+      "category": "Home & utilities",
+      "subcategory": "Streaming Services",
+      "file": "Macquarie Spending 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 441,
+      "date": "22/02/2026",
+      "amount": "-10",
+      "description": "Transfer To Bailen Rouse-Upjohn - Family love",
+      "category": "Children",
+      "subcategory": "Child support payment",
+      "file": "Macquarie Spending 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 442,
+      "date": "22/02/2026",
+      "amount": "-10",
+      "description": "Transfer To Jasper Rouse-upjohn - Family love",
+      "category": "Children",
+      "subcategory": "Child support payment",
+      "file": "Macquarie Spending 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 443,
+      "date": "18/02/2026",
+      "amount": "-90.11",
+      "description": "Transfer To Elizabeth Hawkins - Kids expenses",
+      "category": "Financial & Insurance",
+      "subcategory": "Transfer",
+      "file": "Macquarie Spending 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 444,
+      "date": "18/02/2026",
+      "amount": "-12.89",
+      "description": "Transfer To Elizabeth Hawkins - Spotifyhealthmobil",
+      "category": "Home & utilities",
+      "subcategory": "Streaming Services",
+      "file": "Macquarie Spending 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 445,
+      "date": "16/02/2026",
+      "amount": "150",
+      "description": "From AUSTRALIAN UNITY - AU HEALTH 31246163",
+      "category": "Income",
+      "subcategory": "Health insurance reimbursement",
+      "file": "Macquarie Spending 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 446,
+      "date": "15/02/2026",
+      "amount": "-10",
+      "description": "Transfer To Bailen Rouse-Upjohn - Family love",
+      "category": "Children",
+      "subcategory": "Child support payment",
+      "file": "Macquarie Spending 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 447,
+      "date": "15/02/2026",
+      "amount": "-10",
+      "description": "Transfer To Jasper Rouse-upjohn - Family love",
+      "category": "Children",
+      "subcategory": "Child support payment",
+      "file": "Macquarie Spending 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 448,
+      "date": "11/02/2026",
+      "amount": "350",
+      "description": "From linked account xx4650 - Internal transfer",
+      "category": "Financial & Insurance",
+      "subcategory": "Transfer",
+      "file": "Macquarie Spending 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 449,
+      "date": "11/02/2026",
+      "amount": "-155",
+      "description": "To Jasper Rouse-Upjohn - Gift card exchange",
+      "category": "Children",
+      "subcategory": "Child support payment",
+      "file": "Macquarie Spending 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 450,
+      "date": "11/02/2026",
+      "amount": "-95",
+      "description": "To Bailen Rouse-Upjohn - Cash exchange",
+      "category": "Children",
+      "subcategory": "Child support payment",
+      "file": "Macquarie Spending 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 451,
+      "date": "11/02/2026",
+      "amount": "-90.11",
+      "description": "Transfer To Elizabeth Hawkins - Kids expenses",
+      "category": "Financial & Insurance",
+      "subcategory": "Transfer",
+      "file": "Macquarie Spending 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 452,
+      "date": "11/02/2026",
+      "amount": "-12.89",
+      "description": "Transfer To Elizabeth Hawkins - Spotifyhealthmobil",
+      "category": "Home & utilities",
+      "subcategory": "Streaming Services",
+      "file": "Macquarie Spending 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 453,
+      "date": "08/02/2026",
+      "amount": "-10",
+      "description": "Transfer To Bailen Rouse-Upjohn - Family love",
+      "category": "Children",
+      "subcategory": "Child support payment",
+      "file": "Macquarie Spending 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 454,
+      "date": "08/02/2026",
+      "amount": "-10",
+      "description": "Transfer To Jasper Rouse-upjohn - Family love",
+      "category": "Children",
+      "subcategory": "Child support payment",
+      "file": "Macquarie Spending 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 455,
+      "date": "06/02/2026",
+      "amount": "-20.34",
+      "description": "To Jasper Rouse-Upjohn - Yummy ribs",
+      "category": "Children",
+      "subcategory": "Child support payment",
+      "file": "Macquarie Spending 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 456,
+      "date": "05/02/2026",
+      "amount": "149",
+      "description": "From AUSTRALIAN UNITY - AU HEALTH 31246163",
+      "category": "Income",
+      "subcategory": "Health insurance reimbursement",
+      "file": "Macquarie Spending 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 457,
+      "date": "04/02/2026",
+      "amount": "-90.11",
+      "description": "Transfer To Elizabeth Hawkins - Kids expenses",
+      "category": "Financial & Insurance",
+      "subcategory": "Transfer",
+      "file": "Macquarie Spending 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 458,
+      "date": "04/02/2026",
+      "amount": "-12.89",
+      "description": "Transfer To Elizabeth Hawkins - Spotifyhealthmobil",
+      "category": "Home & utilities",
+      "subcategory": "Streaming Services",
+      "file": "Macquarie Spending 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 459,
+      "date": "02/02/2026",
+      "amount": "27",
+      "description": "From Elizabeth Hawkins - Pickleball",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "Macquarie Spending 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 460,
+      "date": "01/02/2026",
+      "amount": "-10",
+      "description": "Transfer To Bailen Rouse-Upjohn - Family love",
+      "category": "Children",
+      "subcategory": "Child support payment",
+      "file": "Macquarie Spending 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 461,
+      "date": "01/02/2026",
+      "amount": "-10",
+      "description": "Transfer To Jasper Rouse-upjohn - Family love",
+      "category": "Children",
+      "subcategory": "Child support payment",
+      "file": "Macquarie Spending 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 462,
+      "date": "28/02/2026",
+      "amount": "0.88",
+      "description": "Payment",
+      "category": "",
+      "subcategory": "",
+      "file": "Macquarie Pay 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 463,
+      "date": "25/02/2026",
+      "amount": "-3300",
+      "description": "To Elizabeth Hawkins  - Funds transfer",
+      "category": "Financial & Insurance",
+      "subcategory": "Transfer",
+      "file": "Macquarie Pay 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 464,
+      "date": "25/02/2026",
+      "amount": "3075",
+      "description": "Salary from QLD DEPARTMENT O - SALARY 00428738",
+      "category": "Income",
+      "subcategory": "Your partner's take-home pay",
+      "file": "Macquarie Pay 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 465,
+      "date": "13/02/2026",
+      "amount": "328.68",
+      "description": "From E552212Txn421241 - 552212*RP 18/02/20",
+      "category": "Income",
+      "subcategory": "Other income",
+      "file": "Macquarie Pay 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 466,
+      "date": "11/02/2026",
+      "amount": "-4000",
+      "description": "To Elizabeth Hawkins  - Funds transfer",
+      "category": "Financial & Insurance",
+      "subcategory": "Transfer",
+      "file": "Macquarie Pay 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 467,
+      "date": "11/02/2026",
+      "amount": "3867.35",
+      "description": "Salary from QLD DEPARTMENT O - SALARY 00428738",
+      "category": "Income",
+      "subcategory": "Your partner's take-home pay",
+      "file": "Macquarie Pay 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 468,
+      "date": "11/02/2026",
+      "amount": "-350",
+      "description": "To linked account xx2193 - Internal transfer",
+      "category": "Financial & Insurance",
+      "subcategory": "Transfer",
+      "file": "Macquarie Pay 2026-02.csv",
+      "_manual": false
+    },
+    {
+      "_id": 469,
+      "date": "31/03/2026",
+      "amount": "-62.14",
+      "description": "COLES 7835                BUDERIM",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 470,
+      "date": "31/03/2026",
+      "amount": "-17.5",
+      "description": "BWS/163 KARAWATHA ST - SH BUDERIM",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Drinks & alcohol",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 471,
+      "date": "31/03/2026",
+      "amount": "-48.24",
+      "description": "UBER *TRIP HELP.UBER.COM  Sydney",
+      "category": "Car & Transport",
+      "subcategory": "Uber & taxi",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 472,
+      "date": "31/03/2026",
+      "amount": "-60.35",
+      "description": "SPRINGBOK FOODS PTY LT    FOREST GLEN",
+      "category": "Groceries",
+      "subcategory": "Deli & bakery",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 473,
+      "date": "31/03/2026",
+      "amount": "-9.95",
+      "description": "BANJOS SIPPY DOWNS        SIPPY DOWNS",
+      "category": "Groceries",
+      "subcategory": "Deli & bakery",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 474,
+      "date": "30/03/2026",
+      "amount": "-143.32",
+      "description": "COLES 4647                SIPPY DOWNS",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 475,
+      "date": "30/03/2026",
+      "amount": "-25.5",
+      "description": "SQ *COOROIBAH GREENS - KA Bokarina",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 476,
+      "date": "30/03/2026",
+      "amount": "-110",
+      "description": "LIQUORLAND 6476           SIPPY DOWNS",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Drinks & alcohol",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 477,
+      "date": "30/03/2026",
+      "amount": "-12.24",
+      "description": "SQ *MYSTICA BURGERS       Noosa",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 478,
+      "date": "30/03/2026",
+      "amount": "-3.15",
+      "description": "SFS THE CONTAINER BY      BIRTINYA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 479,
+      "date": "30/03/2026",
+      "amount": "-462.47",
+      "description": "UNITYWATER - CABOOLTUR    CABOOLTURE",
+      "category": "Home & utilities",
+      "subcategory": "Water",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 480,
+      "date": "30/03/2026",
+      "amount": "-164.2",
+      "description": "AMPOL SIPPY DOW 10262F    SIPPY DOWNS",
+      "category": "Car & Transport",
+      "subcategory": "Petrol",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 481,
+      "date": "30/03/2026",
+      "amount": "-31",
+      "description": "BWS/163 KARAWATHA ST - SH BUDERIM",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Drinks & alcohol",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 482,
+      "date": "30/03/2026",
+      "amount": "-16.09",
+      "description": "SQ *AN NAM VIETNAMESE KIT Sippy Downs",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Lunches bought",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 483,
+      "date": "30/03/2026",
+      "amount": "-20",
+      "description": "SQ *THE OLD AMBULANCE STA Nambour",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 484,
+      "date": "30/03/2026",
+      "amount": "-16",
+      "description": "SQ *THE OLD AMBULANCE STA Nambour",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 485,
+      "date": "30/03/2026",
+      "amount": "-171.81",
+      "description": "SUNCORP INSURANCE         BRISBANE CITY",
+      "category": "Financial & Insurance",
+      "subcategory": "Home & contents insurance",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 486,
+      "date": "30/03/2026",
+      "amount": "-44",
+      "description": "COUNTRY CARE GROUP        MILDURA",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 487,
+      "date": "30/03/2026",
+      "amount": "-10",
+      "description": "MERTHYR BOWLS CLUB        NEW FARM",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 488,
+      "date": "30/03/2026",
+      "amount": "-10",
+      "description": "MERTHYR BOWLS CLUB        NEW FARM",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 489,
+      "date": "30/03/2026",
+      "amount": "-28.65",
+      "description": "MERTHYR BOWLS CLUB        NEW FARM",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 490,
+      "date": "30/03/2026",
+      "amount": "-29",
+      "description": "MERTHYR BOWLS CLUB        NEW FARM",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 491,
+      "date": "30/03/2026",
+      "amount": "-18.3",
+      "description": "SMP*Mrs Luus Southpoin    Southbank",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Lunches bought",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 492,
+      "date": "30/03/2026",
+      "amount": "-5.59",
+      "description": "SMP*Jamoke Espresso Ba    Nambour",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 493,
+      "date": "30/03/2026",
+      "amount": "-59.14",
+      "description": "BACKSTREET CAFE           MOOLOOLABA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 494,
+      "date": "30/03/2026",
+      "amount": "-16.6",
+      "description": "POINTPARKING NAMBOUR      NAMBOUR",
+      "category": "Car & Transport",
+      "subcategory": "Road tolls & parking",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 495,
+      "date": "30/03/2026",
+      "amount": "-36",
+      "description": "THEPICKLEB* EVT PAIRED    NAMBOUR",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 496,
+      "date": "27/03/2026",
+      "amount": "-35",
+      "description": "LIQUORLAND 6687           BUDERIM",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Drinks & alcohol",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 497,
+      "date": "27/03/2026",
+      "amount": "-11.2",
+      "description": "LS Micasa Cafe Soutban    South Brisban",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 498,
+      "date": "27/03/2026",
+      "amount": "-16.99",
+      "description": "SOUTHBANK PHARMACY        SOUTH BRISBAN",
+      "category": "Medical, personal & education",
+      "subcategory": "Medicines & pharmacy",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 499,
+      "date": "27/03/2026",
+      "amount": "-203.87",
+      "description": "GLOW UP                   YANDINA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Restaurants",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 500,
+      "date": "27/03/2026",
+      "amount": "-115.2",
+      "description": "TICKETEK WEB              SYDNEY",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Celebrations & gifts",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 501,
+      "date": "26/03/2026",
+      "amount": "-99.99",
+      "description": "SECURE PARKING PTY LTD    NORTH SYDNEY",
+      "category": "Car & Transport",
+      "subcategory": "Road tolls & parking",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 502,
+      "date": "26/03/2026",
+      "amount": "-27",
+      "description": "THEPICKLEB* EVT SOCIAL    NAMBOUR",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 503,
+      "date": "25/03/2026",
+      "amount": "-64",
+      "description": "FITSTOP SIPPY DO          SUNSHINE COAS",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 504,
+      "date": "25/03/2026",
+      "amount": "-64",
+      "description": "FITSTOP SIPPY DO          SUNSHINE COAS",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 505,
+      "date": "25/03/2026",
+      "amount": "-151.2",
+      "description": "Amino Z                   Caringbah",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 506,
+      "date": "25/03/2026",
+      "amount": "-60.42",
+      "description": "BLI BLI HOTEL             BLI BLI",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 507,
+      "date": "25/03/2026",
+      "amount": "-10.4",
+      "description": "BLI BLI HOTEL             BLI BLI",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 508,
+      "date": "25/03/2026",
+      "amount": "-26.72",
+      "description": "BLI BLI HOTEL             BLI BLI",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 509,
+      "date": "25/03/2026",
+      "amount": "-87.91",
+      "description": "CALTEX BLI BLI            BLI BLI",
+      "category": "Car & Transport",
+      "subcategory": "Petrol",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 510,
+      "date": "25/03/2026",
+      "amount": "-20.99",
+      "description": "Netflix.com               Melbourne",
+      "category": "Home & utilities",
+      "subcategory": "Streaming Services",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 511,
+      "date": "25/03/2026",
+      "amount": "-4.65",
+      "description": "BALLINA BWLNGNREC LD      BALLINA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 512,
+      "date": "25/03/2026",
+      "amount": "-81.81",
+      "description": "BALLINA BWLNGNREC LD      BALLINA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 513,
+      "date": "25/03/2026",
+      "amount": "-38.95",
+      "description": "MCDONALDS SIPPY DOWN      SIPPY DOWNS",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Take-away & snacks",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 514,
+      "date": "24/03/2026",
+      "amount": "-150.09",
+      "description": "COLES 4647                SIPPY DOWNS",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 515,
+      "date": "24/03/2026",
+      "amount": "-22.36",
+      "description": "LS Buderim Distillery     Maroochydore",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 516,
+      "date": "24/03/2026",
+      "amount": "-22.36",
+      "description": "LS Buderim Distillery     Maroochydore",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 517,
+      "date": "24/03/2026",
+      "amount": "-148.16",
+      "description": "AMPOL CHINDERAH 22163F    CHINDERAH",
+      "category": "Car & Transport",
+      "subcategory": "Petrol",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 518,
+      "date": "23/03/2026",
+      "amount": "-118.46",
+      "description": "SQ *ZABB BY MEOW          Buderim",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 519,
+      "date": "23/03/2026",
+      "amount": "-10.16",
+      "description": "SQ *MFC                   Kuluin",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 520,
+      "date": "23/03/2026",
+      "amount": "-9.99",
+      "description": "AMZNPRIMEA* AMZNPRIMEA    SYDNEY SOUTH",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Movies, shows & music",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 521,
+      "date": "23/03/2026",
+      "amount": "-23.97",
+      "description": "UBER *TRIP HELP.UBER.COM  Sydney",
+      "category": "Car & Transport",
+      "subcategory": "Uber & taxi",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 522,
+      "date": "23/03/2026",
+      "amount": "-5.76",
+      "description": "SFS THE CONTAINER BY      BIRTINYA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 523,
+      "date": "23/03/2026",
+      "amount": "-10",
+      "description": "MISTERZIMI* MISTER ZIM    PORT MELBOURN",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 524,
+      "date": "23/03/2026",
+      "amount": "-17",
+      "description": "STAN.COM.AU               WWW.STAN.COM.",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 525,
+      "date": "23/03/2026",
+      "amount": "-20",
+      "description": "STAN.COM.AU               WWW.STAN.COM.",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 526,
+      "date": "23/03/2026",
+      "amount": "-32",
+      "description": "BWS/163 KARAWATHA ST - SH BUDERIM",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Drinks & alcohol",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 527,
+      "date": "23/03/2026",
+      "amount": "-172.81",
+      "description": "AGL SALES 0308            MELBOURNE",
+      "category": "Home & utilities",
+      "subcategory": "Electricity",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 528,
+      "date": "23/03/2026",
+      "amount": "-35",
+      "description": "EG GROUP/KARAWATHA DR & G MOUNTAIN CRK",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 529,
+      "date": "23/03/2026",
+      "amount": "-55.35",
+      "description": "SQ *AN NAM VIETNAMESE KIT Sippy Downs",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Lunches bought",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 530,
+      "date": "23/03/2026",
+      "amount": "-56",
+      "description": "COLES 4647                SIPPY DOWNS",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 531,
+      "date": "23/03/2026",
+      "amount": "-15",
+      "description": "BWS/163 KARAWATHA ST - SH BUDERIM",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Drinks & alcohol",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 532,
+      "date": "23/03/2026",
+      "amount": "-76",
+      "description": "A1 MART                   WEST END",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 533,
+      "date": "23/03/2026",
+      "amount": "-35.95",
+      "description": "Microsoft*14 Day Trial Re msbill.info",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Movies, shows & music",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 534,
+      "date": "23/03/2026",
+      "amount": "-18.3",
+      "description": "SMP*Mrs Luus Southpoin    Southbank",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Lunches bought",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 535,
+      "date": "23/03/2026",
+      "amount": "-33.47",
+      "description": "DBS*Goodlife Queen Str    Brisbane",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 536,
+      "date": "20/03/2026",
+      "amount": "-150.08",
+      "description": "REMENTO                   REMENTO.CO",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 537,
+      "date": "20/03/2026",
+      "amount": "-20",
+      "description": "SOUTHBANK CARPARK         SOUTH BANK",
+      "category": "Car & Transport",
+      "subcategory": "Road tolls & parking",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 538,
+      "date": "20/03/2026",
+      "amount": "-60.3",
+      "description": "LS PTC PHONE ACCESSOR     MAROOCHYDORE",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 539,
+      "date": "20/03/2026",
+      "amount": "-69.83",
+      "description": "King IT Maroochydore      Maroochydore",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 540,
+      "date": "20/03/2026",
+      "amount": "-35",
+      "description": "CASE KING                 Maroochydore",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 541,
+      "date": "20/03/2026",
+      "amount": "-197",
+      "description": "COLES 4523                MAROOCHYDORE",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 542,
+      "date": "20/03/2026",
+      "amount": "-78",
+      "description": "KMART 1060                MAROOCHYDORE",
+      "category": "Medical, personal & education",
+      "subcategory": "Shopping",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 543,
+      "date": "20/03/2026",
+      "amount": "-16.45",
+      "description": "Audible Limited AU        MELBOURNE",
+      "category": "Home & utilities",
+      "subcategory": "Streaming Services",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 544,
+      "date": "20/03/2026",
+      "amount": "-10.3",
+      "description": "LS Micasa Cafe Soutban    South Brisban",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 545,
+      "date": "20/03/2026",
+      "amount": "-11.2",
+      "description": "LS Micasa Cafe Soutban    South Brisban",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 546,
+      "date": "20/03/2026",
+      "amount": "-72.76",
+      "description": "TICKETS*FUNNY COAS        0272026035",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 547,
+      "date": "19/03/2026",
+      "amount": "-133.3",
+      "description": "SP MISTER ZIMI            MALVERN",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 548,
+      "date": "19/03/2026",
+      "amount": "-82",
+      "description": "ALH VENUES/NICKLIN WAY    BUDDINA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 549,
+      "date": "19/03/2026",
+      "amount": "-10.8",
+      "description": "ALH VENUES/NICKLIN WAY    BUDDINA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 550,
+      "date": "19/03/2026",
+      "amount": "-121.63",
+      "description": "EG GROUP/KARAWATHA DR & G MOUNTAIN CRK",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 551,
+      "date": "19/03/2026",
+      "amount": "-16.49",
+      "description": "FAMDDS PTY LTD            MAROOCHYDORE",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 552,
+      "date": "19/03/2026",
+      "amount": "-323.4",
+      "description": "DNH*GODADDY#4039396544    130-035-1076",
+      "category": "Medical, personal & education",
+      "subcategory": "Computers & gadgets",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false,
+      "_business": true
+    },
+    {
+      "_id": 553,
+      "date": "19/03/2026",
+      "amount": "-5.31",
+      "description": "SFS THE CONTAINER BY      BIRTINYA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 554,
+      "date": "19/03/2026",
+      "amount": "-118.67",
+      "description": "YOUI - PREMIUM            SIPPY DOWNS",
+      "category": "Financial & Insurance",
+      "subcategory": "Car insurance",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 555,
+      "date": "19/03/2026",
+      "amount": "-201.91",
+      "description": "YOUI - PREMIUM            SIPPY DOWNS",
+      "category": "Financial & Insurance",
+      "subcategory": "Car insurance",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 556,
+      "date": "19/03/2026",
+      "amount": "-87.41",
+      "description": "YOUI - PREMIUM            SIPPY DOWNS",
+      "category": "Financial & Insurance",
+      "subcategory": "Car insurance",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 557,
+      "date": "19/03/2026",
+      "amount": "-9.95",
+      "description": "BANJOS SIPPY DOWNS        SIPPY DOWNS",
+      "category": "Groceries",
+      "subcategory": "Deli & bakery",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 558,
+      "date": "19/03/2026",
+      "amount": "-40.5",
+      "description": "THEPICKLEB* EVT SOCIAL    NAMBOUR",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 559,
+      "date": "18/03/2026",
+      "amount": "-64",
+      "description": "FITSTOP SIPPY DO          SUNSHINE COAS",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 560,
+      "date": "18/03/2026",
+      "amount": "-64",
+      "description": "FITSTOP SIPPY DO          SUNSHINE COAS",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 561,
+      "date": "18/03/2026",
+      "amount": "-1601.06",
+      "description": "Partners on Booking BV    Sydney",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 562,
+      "date": "18/03/2026",
+      "amount": "-88",
+      "description": "COUNTY CARE BIRTINYA      BIRTINYA",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 563,
+      "date": "17/03/2026",
+      "amount": "-28.35",
+      "description": "THE DOONAN                WWW.THEDOONAN",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 564,
+      "date": "17/03/2026",
+      "amount": "-37.62",
+      "description": "THE DOONAN                WWW.THEDOONAN",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 565,
+      "date": "17/03/2026",
+      "amount": "-172",
+      "description": "COLES 4647                SIPPY DOWNS",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 566,
+      "date": "17/03/2026",
+      "amount": "-373.77",
+      "description": "Kin Kin Hotel             Kin Kin",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 567,
+      "date": "17/03/2026",
+      "amount": "-50.5",
+      "description": "THE DOONAN PUB            DOONAN",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 568,
+      "date": "17/03/2026",
+      "amount": "-25.05",
+      "description": "THE DOONAN PUB            DOONAN",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 569,
+      "date": "17/03/2026",
+      "amount": "-27.99",
+      "description": "SPOTIFY                   0012345678",
+      "category": "Home & utilities",
+      "subcategory": "Streaming Services",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 570,
+      "date": "16/03/2026",
+      "amount": "10000",
+      "description": "PAYMENT THANKYOU 740802",
+      "category": "Financial & Insurance",
+      "subcategory": "Transfer",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 571,
+      "date": "16/03/2026",
+      "amount": "-21.26",
+      "description": "Matso'sSunshineCoast      Eumundi",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 572,
+      "date": "16/03/2026",
+      "amount": "-21.26",
+      "description": "Matso'sSunshineCoast      Eumundi",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 573,
+      "date": "16/03/2026",
+      "amount": "-49.83",
+      "description": "MATSOS - SUNSHINE COAS    EUMUNDI",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 574,
+      "date": "16/03/2026",
+      "amount": "-45.99",
+      "description": "HUBBL - KAYO SPORTS       131999",
+      "category": "Home & utilities",
+      "subcategory": "Streaming Services",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 575,
+      "date": "16/03/2026",
+      "amount": "-100.21",
+      "description": "SPINTEL PTY LTD           ST PETERS",
+      "category": "Home & utilities",
+      "subcategory": "Internet",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 576,
+      "date": "16/03/2026",
+      "amount": "-20.14",
+      "description": "KOMEKHUN PTY LTD          BIRTINYA",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 577,
+      "date": "16/03/2026",
+      "amount": "-33.4",
+      "description": "ALH VENUES/81 BURNETT ST  BUDERIM",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 578,
+      "date": "16/03/2026",
+      "amount": "-3.5",
+      "description": "WW METRO/67 BURNETT STREE BUDERIM",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 579,
+      "date": "16/03/2026",
+      "amount": "-36",
+      "description": "BWS/163 KARAWATHA ST - SH BUDERIM",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Drinks & alcohol",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 580,
+      "date": "16/03/2026",
+      "amount": "-5.63",
+      "description": "WOOLWORTHS/KARAWATHA DR & MOUNTAIN CRK",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 581,
+      "date": "16/03/2026",
+      "amount": "-140",
+      "description": "TELSTRA SERVICES          MELBOURNE",
+      "category": "Home & utilities",
+      "subcategory": "Mobile",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 582,
+      "date": "16/03/2026",
+      "amount": "-181.93",
+      "description": "BUSINESS ARCHITECTURE GUI 831-464-5344  125.00  USD 6.15 AUD",
+      "category": "Renovations",
+      "subcategory": "Planning & design",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 583,
+      "date": "16/03/2026",
+      "amount": "-28.35",
+      "description": "MCDONALDS SIPPY DOWN      SIPPY DOWNS",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Take-away & snacks",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 584,
+      "date": "16/03/2026",
+      "amount": "-5.56",
+      "description": "BACKSTREET CAFE           MOOLOOLABA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 585,
+      "date": "16/03/2026",
+      "amount": "-50.36",
+      "description": "LINKT BRISBANE            BRISBANE",
+      "category": "Car & Transport",
+      "subcategory": "Road tolls & parking",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 586,
+      "date": "16/03/2026",
+      "amount": "-18",
+      "description": "THEPICKLEB* EVT SOCIAL    NAMBOUR",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 587,
+      "date": "16/03/2026",
+      "amount": "-18",
+      "description": "THEPICKLEB* EVT SOCIAL    NAMBOUR",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 588,
+      "date": "13/03/2026",
+      "amount": "-50",
+      "description": "COLES 4647                SIPPY DOWNS",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 589,
+      "date": "13/03/2026",
+      "amount": "-170",
+      "description": "QUT FINANCE OPS           KELVIN GROVE",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 590,
+      "date": "13/03/2026",
+      "amount": "-18",
+      "description": "THEPICKLEB* EVT SOCIAL    NAMBOUR",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 591,
+      "date": "13/03/2026",
+      "amount": "-18",
+      "description": "THEPICKLEB* EVT SOCIAL    NAMBOUR",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 592,
+      "date": "12/03/2026",
+      "amount": "-319.91",
+      "description": "CLAUDE.AI SUBSCRIPTION    ANTHROPIC.COM",
+      "category": "Medical, personal & education",
+      "subcategory": "Computers & gadgets",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 593,
+      "date": "12/03/2026",
+      "amount": "-78.53",
+      "description": "WOOLWORTHS/OCEAN ST & HOR MAROOCHYDORE",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 594,
+      "date": "12/03/2026",
+      "amount": "-55.99",
+      "description": "SQ *SUMAK MED EAST CUISIN Kelvin Grove",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 595,
+      "date": "12/03/2026",
+      "amount": "-5.3",
+      "description": "LS Micasa Cafe Soutban    South Brisban",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 596,
+      "date": "12/03/2026",
+      "amount": "-63.63",
+      "description": "SECURE PARKING PTY LTD    NORTH SYDNEY",
+      "category": "Car & Transport",
+      "subcategory": "Road tolls & parking",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 597,
+      "date": "12/03/2026",
+      "amount": "-140.15",
+      "description": "AMRITYU PTY LTD           BOKARINA",
+      "category": "Car & Transport",
+      "subcategory": "Petrol",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 598,
+      "date": "12/03/2026",
+      "amount": "-22.3",
+      "description": "GUZMAN Y GOMEZ            SURRY HILLS",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Take-away & snacks",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 599,
+      "date": "12/03/2026",
+      "amount": "-16.99",
+      "description": "SOUTHBANK PHARMACY        SOUTH BRISBAN",
+      "category": "Medical, personal & education",
+      "subcategory": "Medicines & pharmacy",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 600,
+      "date": "12/03/2026",
+      "amount": "-130.25",
+      "description": "AMPOL MAROOCHYDORE 111    MAROOCHYDORE",
+      "category": "Car & Transport",
+      "subcategory": "Petrol",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 601,
+      "date": "11/03/2026",
+      "amount": "-190",
+      "description": "MAMMOTH FOREST GLEN       FOREST GLEN",
+      "category": "Home & utilities",
+      "subcategory": "Furniture & appliances",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 602,
+      "date": "11/03/2026",
+      "amount": "-64",
+      "description": "FITSTOP SIPPY DO          SUNSHINE COAS",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 603,
+      "date": "11/03/2026",
+      "amount": "-64",
+      "description": "FITSTOP SIPPY DO          SUNSHINE COAS",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 604,
+      "date": "11/03/2026",
+      "amount": "-10",
+      "description": "BWS/163 KARAWATHA ST - SH BUDERIM",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Drinks & alcohol",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 605,
+      "date": "11/03/2026",
+      "amount": "-25.18",
+      "description": "BLI BLI HOTEL             BLI BLI",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 606,
+      "date": "11/03/2026",
+      "amount": "-25.18",
+      "description": "BLI BLI HOTEL             BLI BLI",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 607,
+      "date": "11/03/2026",
+      "amount": "-30.6",
+      "description": "BLI BLI HOTEL             BLI BLI",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 608,
+      "date": "11/03/2026",
+      "amount": "-44.48",
+      "description": "THE CHARMING SQUIRE       SOUTH BRISBAN",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 609,
+      "date": "11/03/2026",
+      "amount": "-91",
+      "description": "QPAC                      SOUTH BRISBAN",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 610,
+      "date": "11/03/2026",
+      "amount": "-30",
+      "description": "QPAC                      SOUTH BRISBAN",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 611,
+      "date": "11/03/2026",
+      "amount": "-4.5",
+      "description": "CocaColaEPP               South Brisban",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 612,
+      "date": "10/03/2026",
+      "amount": "-63.95",
+      "description": "SQ *AN NAM VIETNAMESE KIT Sippy Downs",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Lunches bought",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 613,
+      "date": "10/03/2026",
+      "amount": "-250.29",
+      "description": "COLES 4523                MAROOCHYDORE",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 614,
+      "date": "10/03/2026",
+      "amount": "-28",
+      "description": "SQ *SCOOP HOUSE           Buderim",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 615,
+      "date": "10/03/2026",
+      "amount": "-18.01",
+      "description": "SQ *AN NAM VIETNAMESE KIT Sippy Downs",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Lunches bought",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 616,
+      "date": "10/03/2026",
+      "amount": "-180",
+      "description": "Mecca Brands Pty Ltd      Richmond",
+      "category": "Medical, personal & education",
+      "subcategory": "Hair & beauty",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 617,
+      "date": "10/03/2026",
+      "amount": "-10.02",
+      "description": "UBER *TRIP HELP.UBER.COM  Sydney",
+      "category": "Car & Transport",
+      "subcategory": "Uber & taxi",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 618,
+      "date": "09/03/2026",
+      "amount": "-245.87",
+      "description": "SQ *LEMAK KITCHEN AND BAR Woolloongabba",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 619,
+      "date": "09/03/2026",
+      "amount": "-11.6",
+      "description": "UBER *TRIP HELP.UBER.COM  Sydney",
+      "category": "Car & Transport",
+      "subcategory": "Uber & taxi",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 620,
+      "date": "09/03/2026",
+      "amount": "60",
+      "description": "OZT*HAYLEY MARY - QUIT    WOOLLOONGABBA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Movies, shows & music",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 621,
+      "date": "09/03/2026",
+      "amount": "-8.7",
+      "description": "WW METRO/67 BURNETT STREE BUDERIM",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 622,
+      "date": "09/03/2026",
+      "amount": "-20",
+      "description": "Guzman y Gomez            Maroochydore",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Take-away & snacks",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 623,
+      "date": "09/03/2026",
+      "amount": "-20",
+      "description": "Guzman y Gomez            Maroochydore",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Take-away & snacks",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 624,
+      "date": "09/03/2026",
+      "amount": "-91.35",
+      "description": "PARADISE ARCADE COTTO     Maroochydore",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 625,
+      "date": "09/03/2026",
+      "amount": "-53.6",
+      "description": "GUZMAN Y GOMEZ            SURRY HILLS",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Take-away & snacks",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 626,
+      "date": "09/03/2026",
+      "amount": "-9.99",
+      "description": "DD *DOORDASHDASHPASS      MELBOURNE",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Take-away & snacks",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 627,
+      "date": "09/03/2026",
+      "amount": "-31.99",
+      "description": "Adobe                     Sydney",
+      "category": "Medical, personal & education",
+      "subcategory": "Computers & gadgets",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 628,
+      "date": "09/03/2026",
+      "amount": "-4.05",
+      "description": "SFS THE CONTAINER BY      BIRTINYA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 629,
+      "date": "09/03/2026",
+      "amount": "-4.49",
+      "description": "APPLE.COM/BILL            SYDNEY",
+      "category": "Medical, personal & education",
+      "subcategory": "Computers & gadgets",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 630,
+      "date": "09/03/2026",
+      "amount": "-33.47",
+      "description": "DBS*Goodlife Queen Str    Brisbane",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 631,
+      "date": "09/03/2026",
+      "amount": "-16.5",
+      "description": "MAROOCHYDORE STATE HIG    MAROOCHYDORE",
+      "category": "Children",
+      "subcategory": "School uniforms",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 632,
+      "date": "09/03/2026",
+      "amount": "-53.58",
+      "description": "BACKSTREET CAFE           MOOLOOLABA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 633,
+      "date": "09/03/2026",
+      "amount": "-5.56",
+      "description": "BACKSTREET CAFE           MOOLOOLABA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 634,
+      "date": "06/03/2026",
+      "amount": "-32.18",
+      "description": "SQ *AN NAM VIETNAMESE KIT Sippy Downs",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Lunches bought",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 635,
+      "date": "06/03/2026",
+      "amount": "-39",
+      "description": "BWS/163 KARAWATHA ST - SH BUDERIM",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Drinks & alcohol",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 636,
+      "date": "06/03/2026",
+      "amount": "-36.91",
+      "description": "Print Locker              Alphington",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 637,
+      "date": "06/03/2026",
+      "amount": "-8.7",
+      "description": "MCDONALDS SOUTHBANK       SOUTH BRISBAN",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Take-away & snacks",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 638,
+      "date": "06/03/2026",
+      "amount": "-11.99",
+      "description": "help.hbomax.com           St. Leonards",
+      "category": "Home & utilities",
+      "subcategory": "Streaming Services",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 639,
+      "date": "06/03/2026",
+      "amount": "-18.3",
+      "description": "SMP*SIAM SOUTH BANK   0   SOUTH BRISBAN",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 640,
+      "date": "06/03/2026",
+      "amount": "-53.34",
+      "description": "VODAFONE AUSTRALIA        NORTH SYDNEY",
+      "category": "Home & utilities",
+      "subcategory": "Ellas Mobile",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 641,
+      "date": "06/03/2026",
+      "amount": "-10.8",
+      "description": "SFS THE CONTAINER BY      BIRTINYA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 642,
+      "date": "06/03/2026",
+      "amount": "-45.45",
+      "description": "SECURE PARKING PTY LTD    NORTH SYDNEY",
+      "category": "Car & Transport",
+      "subcategory": "Road tolls & parking",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 643,
+      "date": "05/03/2026",
+      "amount": "-20",
+      "description": "SOUTHBANK CARPARK         SOUTH BANK",
+      "category": "Car & Transport",
+      "subcategory": "Road tolls & parking",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 644,
+      "date": "05/03/2026",
+      "amount": "-59.68",
+      "description": "FRUIT LOVERS/90 WISES ROA MAROOCHYDORE",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 645,
+      "date": "05/03/2026",
+      "amount": "-5.3",
+      "description": "LS Micasa Cafe Soutban    South Brisban",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 646,
+      "date": "05/03/2026",
+      "amount": "-149.14",
+      "description": "CHEMIST WAREHOUSE         BUDERIM",
+      "category": "Medical, personal & education",
+      "subcategory": "Medicines & pharmacy",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 647,
+      "date": "05/03/2026",
+      "amount": "-61.53",
+      "description": "BUNNINGS 490000           MAROOCHYDORE",
+      "category": "Home & utilities",
+      "subcategory": "Home improvements & Maintenance",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 648,
+      "date": "04/03/2026",
+      "amount": "-7.8",
+      "description": "COLES 4647                SIPPY DOWNS",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 649,
+      "date": "04/03/2026",
+      "amount": "-4.95",
+      "description": "Liberty Tanawha           Tanawha",
+      "category": "Car & Transport",
+      "subcategory": "Petrol",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 650,
+      "date": "04/03/2026",
+      "amount": "-62.2",
+      "description": "Liberty Tanawha           Tanawha",
+      "category": "Car & Transport",
+      "subcategory": "Petrol",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 651,
+      "date": "04/03/2026",
+      "amount": "-64",
+      "description": "FITSTOP SIPPY DO          SUNSHINE COAS",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 652,
+      "date": "04/03/2026",
+      "amount": "-64",
+      "description": "FITSTOP SIPPY DO          SUNSHINE COAS",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 653,
+      "date": "04/03/2026",
+      "amount": "-49.89",
+      "description": "MTN CREEK CHEM PHARM      MOUNTAIN CREE",
+      "category": "Medical, personal & education",
+      "subcategory": "Medicines & pharmacy",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 654,
+      "date": "03/03/2026",
+      "amount": "-6.95",
+      "description": "WOOLWORTHS/KARAWATHA DR & MOUNTAIN CRK",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 655,
+      "date": "03/03/2026",
+      "amount": "-66",
+      "description": "OFFICEWORKS  0428         Maroochydore",
+      "category": "Medical, personal & education",
+      "subcategory": "Computers & gadgets",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 656,
+      "date": "03/03/2026",
+      "amount": "-334.27",
+      "description": "COLES 4647                SIPPY DOWNS",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 657,
+      "date": "03/03/2026",
+      "amount": "-48.95",
+      "description": "WOOLWORTHS/KARAWATHA DR & MOUNTAIN CRK",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 658,
+      "date": "03/03/2026",
+      "amount": "-15.99",
+      "description": "Disney Plus               1800-965160",
+      "category": "Home & utilities",
+      "subcategory": "Streaming Services",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 659,
+      "date": "03/03/2026",
+      "amount": "-32",
+      "description": "John Kyle Espresso        Buderim",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 660,
+      "date": "03/03/2026",
+      "amount": "-4.99",
+      "description": "PRIME VIDE* PRIMEVIDEO    SYDNEY",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 661,
+      "date": "03/03/2026",
+      "amount": "-20",
+      "description": "THEPICKLEB* EVT DRILL     NAMBOUR",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 662,
+      "date": "03/03/2026",
+      "amount": "-20",
+      "description": "THEPICKLEB* EVT DRILL     NAMBOUR",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 663,
+      "date": "02/03/2026",
+      "amount": "-31.05",
+      "description": "OPENAI *CHATGPT SUBSCR    OPENAI.COM",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 664,
+      "date": "02/03/2026",
+      "amount": "6000",
+      "description": "PAYMENT THANKYOU 125816",
+      "category": "Financial & Insurance",
+      "subcategory": "Transfer",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 665,
+      "date": "02/03/2026",
+      "amount": "-10.16",
+      "description": "RICK'S GARAGE             Palmwoods",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 666,
+      "date": "02/03/2026",
+      "amount": "-54.86",
+      "description": "RICK'S GARAGE             Palmwoods",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 667,
+      "date": "02/03/2026",
+      "amount": "-32",
+      "description": "WW METRO/67 BURNETT STREE BUDERIM",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 668,
+      "date": "02/03/2026",
+      "amount": "-10.16",
+      "description": "SQ *BE RIGHT BACK BUDERIM Buderim",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 669,
+      "date": "02/03/2026",
+      "amount": "-86",
+      "description": "BWS/81 BURNETT STREET     BUDERIM",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Drinks & alcohol",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 670,
+      "date": "02/03/2026",
+      "amount": "-5000",
+      "description": "PACIFIC MOTOR GROUP PT    MAROOCHYDORE",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 671,
+      "date": "02/03/2026",
+      "amount": "-4.05",
+      "description": "SFS THE CONTAINER BY      BIRTINYA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 672,
+      "date": "02/03/2026",
+      "amount": "-58.87",
+      "description": "SQ *GOODSLICE PIZZA NAPOL Maroochydore",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 673,
+      "date": "02/03/2026",
+      "amount": "-20",
+      "description": "BWS/64 AERODROME STREET   MAROOCHYDORE",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Drinks & alcohol",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 674,
+      "date": "02/03/2026",
+      "amount": "-103.55",
+      "description": "COLES 7836                BIRTINYA",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 675,
+      "date": "02/03/2026",
+      "amount": "-15",
+      "description": "WOOLWORTHS/UNI WAY CHANCE BUDERIM",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 676,
+      "date": "02/03/2026",
+      "amount": "-48.95",
+      "description": "WOOLWORTHS/UNI WAY CHANCE BUDERIM",
+      "category": "Groceries",
+      "subcategory": "Supermarket",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 677,
+      "date": "02/03/2026",
+      "amount": "-21.9",
+      "description": "SFS SCUH ALICE & GEO      BIRTINYA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 678,
+      "date": "02/03/2026",
+      "amount": "-171.81",
+      "description": "SUNCORP INSURANCE         BRISBANE CITY",
+      "category": "Financial & Insurance",
+      "subcategory": "Home & contents insurance",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 679,
+      "date": "02/03/2026",
+      "amount": "-20.81",
+      "description": "SOLBAR MAROOCHYDORE       MAROOCHYDORE",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 680,
+      "date": "02/03/2026",
+      "amount": "-83.76",
+      "description": "ZLR*Bombay Bliss - Maro   Maroochydore",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Restaurants",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 681,
+      "date": "02/03/2026",
+      "amount": "-5.56",
+      "description": "BACKSTREET CAFE           MOOLOOLABA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 682,
+      "date": "02/03/2026",
+      "amount": "-51.7",
+      "description": "GRILLD PTY LTD - GARDE    UPPER MT GRAV",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Credit Card 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 683,
+      "date": "31/03/2026",
+      "amount": "-6125",
+      "description": "PAYMENT TO MOODIE STEVEN JAMES",
+      "category": "Financial & Insurance",
+      "subcategory": "Home loan",
+      "file": "ANZ Joint Offset 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 684,
+      "date": "25/03/2026",
+      "amount": "3000",
+      "description": "PAYMENT FROM Hawkins E A",
+      "category": "_ignore",
+      "subcategory": "",
+      "file": "ANZ Joint Offset 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 685,
+      "date": "20/03/2026",
+      "amount": "3000",
+      "description": "PAYMENT FROM Hawkins E A",
+      "category": "_ignore",
+      "subcategory": "",
+      "file": "ANZ Joint Offset 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 686,
+      "date": "11/03/2026",
+      "amount": "-10",
+      "description": "ACCOUNT SERVICING FEE",
+      "category": "Financial & Insurance",
+      "subcategory": "Bank fees",
+      "file": "ANZ Joint Offset 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 687,
+      "date": "03/03/2026",
+      "amount": "-8050.94",
+      "description": "PAYMENT TO MOODIE STEVEN JAMES",
+      "category": "Financial & Insurance",
+      "subcategory": "Home loan",
+      "file": "ANZ Joint Offset 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 688,
+      "date": "26/03/2026",
+      "amount": "-150",
+      "description": "ANZ INTERNET BANKING PAYMENT 775908 TO ELLA MOODIE",
+      "category": "Children",
+      "subcategory": "Child support payment",
+      "file": "ANZ Offset 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 689,
+      "date": "26/03/2026",
+      "amount": "6910.48",
+      "description": "PAY/SALARY FROM TALENT INTERNATI 500011896",
+      "category": "Income",
+      "subcategory": "Your take-home pay",
+      "file": "ANZ Offset 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 690,
+      "date": "19/03/2026",
+      "amount": "-150",
+      "description": "ANZ INTERNET BANKING PAYMENT 400378 TO ELLA MOODIE",
+      "category": "Children",
+      "subcategory": "Child support payment",
+      "file": "ANZ Offset 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 691,
+      "date": "17/03/2026",
+      "amount": "41.37",
+      "description": "TRANSFER FROM ATO              ATO001100022265823",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Offset 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 692,
+      "date": "16/03/2026",
+      "amount": "-10000",
+      "description": "ANZ M-BANKING FUNDS TFER TRANSFER 740802  TO 4564XXXXXXXX0557",
+      "category": "Financial & Insurance",
+      "subcategory": "Transfer",
+      "file": "ANZ Offset 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 693,
+      "date": "12/03/2026",
+      "amount": "-402.04",
+      "description": "PAYMENT TO BUPA AUSTRALIA   661368390000189000",
+      "category": "Financial & Insurance",
+      "subcategory": "Health insurance",
+      "file": "ANZ Offset 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 694,
+      "date": "12/03/2026",
+      "amount": "-150",
+      "description": "ANZ INTERNET BANKING PAYMENT 764201 TO ELLA MOODIE",
+      "category": "Children",
+      "subcategory": "Child support payment",
+      "file": "ANZ Offset 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 695,
+      "date": "12/03/2026",
+      "amount": "6910.48",
+      "description": "PAY/SALARY FROM TALENT INTERNATI 500011896",
+      "category": "Income",
+      "subcategory": "Your take-home pay",
+      "file": "ANZ Offset 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 696,
+      "date": "09/03/2026",
+      "amount": "98.69",
+      "description": "PAYMENT FROM MATTHEW HAWKINS",
+      "category": "Financial & Insurance",
+      "subcategory": "Transfer",
+      "file": "ANZ Offset 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 697,
+      "date": "05/03/2026",
+      "amount": "-150",
+      "description": "ANZ INTERNET BANKING PAYMENT 374689 TO ELLA MOODIE",
+      "category": "Children",
+      "subcategory": "Child support payment",
+      "file": "ANZ Offset 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 698,
+      "date": "04/03/2026",
+      "amount": "-10",
+      "description": "ANZ MOBILE BANKING PAYMENT 989779 TO SCOTT ALLINGTON",
+      "category": "",
+      "subcategory": "",
+      "file": "ANZ Offset 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 699,
+      "date": "02/03/2026",
+      "amount": "-6000",
+      "description": "ANZ M-BANKING FUNDS TFER TRANSFER 125816  TO 4564XXXXXXXX0557",
+      "category": "Financial & Insurance",
+      "subcategory": "Transfer",
+      "file": "ANZ Offset 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 700,
+      "date": "31/03/2026",
+      "amount": "2.27",
+      "description": "Payment",
+      "category": "",
+      "subcategory": "",
+      "file": "Macquarie Pay 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 701,
+      "date": "25/03/2026",
+      "amount": "-3000",
+      "description": "To Elizabeth Hawkins  - Funds transfer",
+      "category": "Financial & Insurance",
+      "subcategory": "Transfer",
+      "file": "Macquarie Pay 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 702,
+      "date": "25/03/2026",
+      "amount": "3112.11",
+      "description": "Salary from QLD DEPARTMENT O - SALARY 00428738",
+      "category": "Income",
+      "subcategory": "Your partner's take-home pay",
+      "file": "Macquarie Pay 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 703,
+      "date": "20/03/2026",
+      "amount": "-300",
+      "description": "To linked account xx2193 - Internal transfer",
+      "category": "Financial & Insurance",
+      "subcategory": "Transfer",
+      "file": "Macquarie Pay 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 704,
+      "date": "20/03/2026",
+      "amount": "-3000",
+      "description": "To Elizabeth Hawkins  - Funds transfer",
+      "category": "Financial & Insurance",
+      "subcategory": "Transfer",
+      "file": "Macquarie Pay 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 705,
+      "date": "11/03/2026",
+      "amount": "3113.53",
+      "description": "Salary from QLD DEPARTMENT O - SALARY 00428738",
+      "category": "Income",
+      "subcategory": "Your partner's take-home pay",
+      "file": "Macquarie Pay 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 782,
+      "date": "31/03/2026",
+      "amount": "0.45",
+      "description": "Payment",
+      "category": "",
+      "subcategory": "",
+      "file": "Macquarie Spending 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 783,
+      "date": "30/03/2026",
+      "amount": "25",
+      "description": "From Elizabeth Hawkins - J bouldering",
+      "category": "Financial & Insurance",
+      "subcategory": "Transfer",
+      "file": "Macquarie Spending 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 784,
+      "date": "30/03/2026",
+      "amount": "-25",
+      "description": "To Jasper Rouse-Upjohn - Bouldering",
+      "category": "Children",
+      "subcategory": "Child support payment",
+      "file": "Macquarie Spending 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 785,
+      "date": "29/03/2026",
+      "amount": "-10",
+      "description": "Transfer To Bailen Rouse-Upjohn - Family love",
+      "category": "Children",
+      "subcategory": "Child support payment",
+      "file": "Macquarie Spending 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 786,
+      "date": "29/03/2026",
+      "amount": "-10",
+      "description": "Transfer To Jasper Rouse-upjohn - Family love",
+      "category": "Children",
+      "subcategory": "Child support payment",
+      "file": "Macquarie Spending 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 787,
+      "date": "25/03/2026",
+      "amount": "-90.11",
+      "description": "Transfer To Elizabeth Hawkins - Kids expenses",
+      "category": "Financial & Insurance",
+      "subcategory": "Transfer",
+      "file": "Macquarie Spending 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 788,
+      "date": "25/03/2026",
+      "amount": "-12.89",
+      "description": "Transfer To Elizabeth Hawkins - Spotifyhealthmobil",
+      "category": "Home & utilities",
+      "subcategory": "Streaming Services",
+      "file": "Macquarie Spending 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 789,
+      "date": "22/03/2026",
+      "amount": "-10",
+      "description": "Transfer To Bailen Rouse-Upjohn - Family love",
+      "category": "Children",
+      "subcategory": "Child support payment",
+      "file": "Macquarie Spending 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 790,
+      "date": "22/03/2026",
+      "amount": "-10",
+      "description": "Transfer To Jasper Rouse-upjohn - Family love",
+      "category": "Children",
+      "subcategory": "Child support payment",
+      "file": "Macquarie Spending 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 791,
+      "date": "20/03/2026",
+      "amount": "-5.5",
+      "description": "To Bailen Rouse-Upjohn - Burrito",
+      "category": "Children",
+      "subcategory": "Child support payment",
+      "file": "Macquarie Spending 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 792,
+      "date": "20/03/2026",
+      "amount": "300",
+      "description": "From linked account xx4650 - Internal transfer",
+      "category": "Financial & Insurance",
+      "subcategory": "Transfer",
+      "file": "Macquarie Spending 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 793,
+      "date": "18/03/2026",
+      "amount": "-90.11",
+      "description": "Transfer To Elizabeth Hawkins - Kids expenses",
+      "category": "Financial & Insurance",
+      "subcategory": "Transfer",
+      "file": "Macquarie Spending 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 794,
+      "date": "18/03/2026",
+      "amount": "-12.89",
+      "description": "Transfer To Elizabeth Hawkins - Spotifyhealthmobil",
+      "category": "Home & utilities",
+      "subcategory": "Streaming Services",
+      "file": "Macquarie Spending 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 795,
+      "date": "17/03/2026",
+      "amount": "80",
+      "description": "From Elizabeth Hawkins - Boys haircuts",
+      "category": "Financial & Insurance",
+      "subcategory": "Transfer",
+      "file": "Macquarie Spending 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 796,
+      "date": "15/03/2026",
+      "amount": "-10",
+      "description": "Transfer To Bailen Rouse-Upjohn - Family love",
+      "category": "Children",
+      "subcategory": "Child support payment",
+      "file": "Macquarie Spending 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 797,
+      "date": "15/03/2026",
+      "amount": "-10",
+      "description": "Transfer To Jasper Rouse-upjohn - Family love",
+      "category": "Children",
+      "subcategory": "Child support payment",
+      "file": "Macquarie Spending 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 798,
+      "date": "11/03/2026",
+      "amount": "-90.11",
+      "description": "Transfer To Elizabeth Hawkins - Kids expenses",
+      "category": "Financial & Insurance",
+      "subcategory": "Transfer",
+      "file": "Macquarie Spending 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 799,
+      "date": "11/03/2026",
+      "amount": "-12.89",
+      "description": "Transfer To Elizabeth Hawkins - Spotifyhealthmobil",
+      "category": "Home & utilities",
+      "subcategory": "Streaming Services",
+      "file": "Macquarie Spending 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 800,
+      "date": "08/03/2026",
+      "amount": "-10",
+      "description": "Transfer To Bailen Rouse-Upjohn - Family love",
+      "category": "Children",
+      "subcategory": "Child support payment",
+      "file": "Macquarie Spending 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 801,
+      "date": "08/03/2026",
+      "amount": "-10",
+      "description": "Transfer To Jasper Rouse-upjohn - Family love",
+      "category": "Children",
+      "subcategory": "Child support payment",
+      "file": "Macquarie Spending 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 802,
+      "date": "07/03/2026",
+      "amount": "80",
+      "description": "From Elizabeth Hawkins - Kids haircuts",
+      "category": "Financial & Insurance",
+      "subcategory": "Transfer",
+      "file": "Macquarie Spending 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 803,
+      "date": "06/03/2026",
+      "amount": "36",
+      "description": "From Elizabeth Hawkins - Boys pickleball",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "file": "Macquarie Spending 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 804,
+      "date": "04/03/2026",
+      "amount": "-90.11",
+      "description": "Transfer To Elizabeth Hawkins - Kids expenses",
+      "category": "Financial & Insurance",
+      "subcategory": "Transfer",
+      "file": "Macquarie Spending 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 805,
+      "date": "04/03/2026",
+      "amount": "-12.89",
+      "description": "Transfer To Elizabeth Hawkins - Spotifyhealthmobil",
+      "category": "Home & utilities",
+      "subcategory": "Streaming Services",
+      "file": "Macquarie Spending 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 806,
+      "date": "01/03/2026",
+      "amount": "-10",
+      "description": "Transfer To Bailen Rouse-Upjohn - Family love",
+      "category": "Children",
+      "subcategory": "Child support payment",
+      "file": "Macquarie Spending 2026-03.csv",
+      "_manual": false
+    },
+    {
+      "_id": 807,
+      "date": "01/03/2026",
+      "amount": "-10",
+      "description": "Transfer To Jasper Rouse-upjohn - Family love",
+      "category": "Children",
+      "subcategory": "Child support payment",
+      "file": "Macquarie Spending 2026-03.csv",
+      "_manual": false
+    }
+  ],
+  "customRules": [
+    {
+      "match": "qantas|jetstar",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Holidays",
+      "learned": false
+    },
+    {
+      "match": "VODAFONE AUSTRALIA",
+      "category": "Home & utilities",
+      "subcategory": "Ellas Mobile",
+      "learned": false
+    },
+    {
+      "match": "sfs scuh|sfs the container|sfs scuh alice",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "learned": false
+    },
+    {
+      "match": "mcafee",
+      "category": "Medical, personal & education",
+      "subcategory": "Computers & gadgets",
+      "learned": false
+    },
+    {
+      "match": "Dietitians Austral",
+      "category": "Medical, personal & education",
+      "subcategory": "Education & Professional Memberships",
+      "learned": false
+    },
+    {
+      "match": "COBBCO",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Holidays",
+      "learned": false
+    },
+    {
+      "match": "TRANSPORTMAINRDS",
+      "category": "Car & Transport",
+      "subcategory": "Rego & licence",
+      "learned": false
+    },
+    {
+      "match": "pickleball",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "learned": false
+    },
+    {
+      "match": "brunswick hotel|alh venues|maroochy rsl|rose.*crown|chancellor tavern|Maroochy RSL|deck sea salt|dock mooloolaba|MOOLOOLABA SURF LIFE",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "learned": false
+    },
+    {
+      "match": "bws|liquorland|l/land",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Drinks & alcohol",
+      "learned": false
+    },
+    {
+      "match": "Pavilion Mooloolaba|pomona distilling|boatshed|little parliament|beach bar|green at tanawha",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Restaurants",
+      "learned": false
+    },
+    {
+      "match": "Noosa Chocolate Factory",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Take-away & snacks",
+      "learned": false
+    },
+    {
+      "match": "The Beach Bar & Gri",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Restaurants",
+      "learned": false
+    },
+    {
+      "match": "RAINBOW BEACH SURF LI",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "learned": false
+    },
+    {
+      "match": "OZT*",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Movies, shows & music",
+      "learned": false
+    },
+    {
+      "match": "SFS SCUH ALICE & GEO",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "learned": false
+    },
+    {
+      "match": "Salary from QLD DEPARTMENT",
+      "category": "Income",
+      "subcategory": "Your partner's take-home pay",
+      "learned": false
+    },
+    {
+      "match": "snshn-kr-th-bdrm",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Restaurants",
+      "learned": false
+    },
+    {
+      "match": "From AUSTRALIAN UNITY|MEDICARE BENEFIT",
+      "category": "Income",
+      "subcategory": "Health insurance reimbursement",
+      "learned": false
+    },
+    {
+      "match": "To Jasper Rouse-upjohn",
+      "category": "Children",
+      "subcategory": "Child support payment",
+      "learned": false
+    },
+    {
+      "match": "To Bailen Rouse-Upjohn",
+      "category": "Children",
+      "subcategory": "Child support payment",
+      "learned": false
+    },
+    {
+      "match": "From E552212",
+      "category": "Income",
+      "subcategory": "Other income",
+      "learned": false
+    },
+    {
+      "match": "BYRON SHIRE COUNCIL",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "learned": true
+    },
+    {
+      "match": "snshn-kr-th-bdrm Buderim",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Restaurants",
+      "learned": true
+    },
+    {
+      "match": "FUNDS TFER TRANSFER ",
+      "category": "Financial & Insurance",
+      "subcategory": "Transfer",
+      "learned": false
+    },
+    {
+      "match": "ALH VENUES",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Restaurants",
+      "learned": false
+    },
+    {
+      "match": "SUNCORP INSURANCE",
+      "category": "Financial & Insurance",
+      "subcategory": "Home & contents insurance",
+      "learned": false
+    },
+    {
+      "match": "MAROOCHYDORE STATE HIG",
+      "category": "Children",
+      "subcategory": "School uniforms",
+      "learned": false
+    },
+    {
+      "match": "ELLA MOODIE",
+      "category": "Children",
+      "subcategory": "Child support payment",
+      "learned": false
+    },
+    {
+      "match": "ANZ INTERNET BANKING",
+      "category": "Car & Transport",
+      "subcategory": "Rego & licence",
+      "learned": true
+    },
+    {
+      "match": "ACCOUNT SERVICING FEE",
+      "category": "Financial & Insurance",
+      "subcategory": "Bank fees",
+      "learned": true
+    },
+    {
+      "match": "A&E JONES PTY",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Restaurants",
+      "learned": true
+    },
+    {
+      "match": "DEPOT NOOSA|MOUSTACHE Mermaid",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Restaurants",
+      "learned": true
+    },
+    {
+      "match": "Kiosk Alexandra Hea",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Restaurants",
+      "learned": true
+    },
+    {
+      "match": "PAYMENT TO BUPA",
+      "category": "Financial & Insurance",
+      "subcategory": "Health insurance",
+      "learned": true
+    },
+    {
+      "match": "PAY/SALARY FROM TALENT",
+      "category": "Income",
+      "subcategory": "Your take-home pay",
+      "learned": true
+    },
+    {
+      "match": "PAYMENT FROM Hawkins",
+      "category": "_ignore",
+      "subcategory": "",
+      "learned": true
+    },
+    {
+      "match": "PAYMENT TO MOODIE",
+      "category": "Financial & Insurance",
+      "subcategory": "Home loan",
+      "learned": true
+    },
+    {
+      "match": "SUNCORP INSURANCE BRISBANE",
+      "category": "Financial & Insurance",
+      "subcategory": "Home & contents insurance",
+      "learned": true
+    },
+    {
+      "match": "Cotton Tree Ice",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Take-away & snacks",
+      "learned": true
+    },
+    {
+      "match": "NDC SERVICE CO",
+      "category": "Medical, personal & education",
+      "subcategory": "Dental",
+      "learned": true
+    },
+    {
+      "match": "Aussie World Palmview",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "learned": true
+    },
+    {
+      "match": "The Pocket Espresso",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "learned": true
+    },
+    {
+      "match": "Gun Cotton Coffee",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Restaurants",
+      "learned": true
+    },
+    {
+      "match": "KINGS BEACH HOTEL",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "learned": true
+    },
+    {
+      "match": "Cars on Booking",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Holidays",
+      "learned": true
+    },
+    {
+      "match": "HARRIS SCARFE MRHYDR",
+      "category": "Home & utilities",
+      "subcategory": "Furniture & appliances",
+      "learned": true
+    },
+    {
+      "match": "Disney Plus 1800-965160",
+      "category": "Home & utilities",
+      "subcategory": "Streaming Services",
+      "learned": true
+    },
+    {
+      "match": "QTIX TICKETING",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Movies, shows & music",
+      "learned": true
+    },
+    {
+      "match": "help.hbomax.com St. Leonards",
+      "category": "Home & utilities",
+      "subcategory": "Streaming Services",
+      "learned": true
+    },
+    {
+      "match": "BURLEIGH HDS RUGBY",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Bars & clubs",
+      "learned": true
+    },
+    {
+      "match": "FOSTER & BLACK",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Coffee & tea",
+      "learned": true
+    },
+    {
+      "match": "BANJOS SIPPY DOWNS",
+      "category": "Groceries",
+      "subcategory": "Deli & bakery",
+      "learned": true
+    },
+    {
+      "match": "APPLE.COM/BILL SYDNEY",
+      "category": "Medical, personal & education",
+      "subcategory": "Computers & gadgets",
+      "learned": true
+    },
+    {
+      "match": "MAMMOTH FOREST GLEN",
+      "category": "Home & utilities",
+      "subcategory": "Furniture & appliances",
+      "learned": true
+    },
+    {
+      "match": "SPRINGBOK FOODS PTY",
+      "category": "Groceries",
+      "subcategory": "Deli & bakery",
+      "learned": true
+    },
+    {
+      "match": "EVENT CINEMAS",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Movies, shows & music",
+      "learned": true
+    },
+    {
+      "match": "IPY*COBBCO NINE MILE",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Holidays",
+      "learned": true
+    },
+    {
+      "match": "HUBBL - KAYO",
+      "category": "Home & utilities",
+      "subcategory": "Streaming Services",
+      "learned": true
+    },
+    {
+      "match": "SPOTIFY",
+      "category": "Home & utilities",
+      "subcategory": "Streaming Services",
+      "learned": true
+    },
+    {
+      "match": "Mrs Luus",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Lunches bought",
+      "learned": true
+    },
+    {
+      "match": "SPINTEL PTY LTD",
+      "category": "Home & utilities",
+      "subcategory": "Internet",
+      "learned": true
+    },
+    {
+      "match": "Audible Limited AU",
+      "category": "Home & utilities",
+      "subcategory": "Streaming Services",
+      "learned": true
+    },
+    {
+      "match": "Boost Sunshine Plaza",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Take-away & snacks",
+      "learned": true
+    },
+    {
+      "match": "Bli Bli Watersports",
+      "category": "Medical, personal & education",
+      "subcategory": "Hobbies",
+      "learned": true
+    },
+    {
+      "match": "THE GREEN AT",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "learned": true
+    },
+    {
+      "match": "Mebami South Brisban",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Lunches bought",
+      "learned": true
+    },
+    {
+      "match": "THEPICKLEB*",
+      "category": "Medical, personal & education",
+      "subcategory": "Sports & gym",
+      "learned": true
+    },
+    {
+      "match": "Netflix.com Melbourne",
+      "category": "Home & utilities",
+      "subcategory": "Streaming Services",
+      "learned": true
+    },
+    {
+      "match": "Coles Group Limited",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Celebrations & gifts",
+      "learned": true
+    },
+    {
+      "match": "GLOW UP YANDINA",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Restaurants",
+      "learned": true
+    },
+    {
+      "match": "AMRITYU PTY LTD",
+      "category": "Car & Transport",
+      "subcategory": "Petrol",
+      "learned": true
+    },
+    {
+      "match": "AN NAM VIETNAMESE|Mebami",
+      "category": "Eating-out & Entertainment",
+      "subcategory": "Lunches bought",
+      "learned": true
+    }
+  ],
+  "budgetOverrides": {
+    "Your take-home pay": 11641,
+    "Your partner's take-home pay": 6391.666666666666,
+    "Gas": 0,
+    "Electricity": 86.66666666666666,
+    "Mobile": 100,
+    "Internet": 100,
+    "Streaming Services": 155,
+    "Home improvements & Maintenance": 100,
+    "Council rates": 451.66666666666663,
+    "Kierans Mobile": 58,
+    "Ellas Mobile": 74,
+    "Savings": 1000,
+    "Investments & super contributions": 0,
+    "Charity donations": 0,
+    "Home loan": 6125,
+    "Home & contents insurance": 350,
+    "Health insurance": 400,
+    "Car insurance": 410,
+    "Personal & life insurance": 0,
+    "Bank fees": 10,
+    "Supermarket": 1650,
+    "Holidays": 1200,
+    "Airfares": 0,
+    "Petrol": 675,
+    "Restaurants": 800,
+    "Bars & clubs": 500,
+    "Lunches bought": 150,
+    "Drinks & alcohol": 200,
+    "Movies, shows & music": 100,
+    "Books, newspapers & magazines": 13,
+    "Coffee & tea": 200,
+    "Rego & licence": 141.66666666666666,
+    "Road tolls & parking": 250,
+    "Public Transport": 52,
+    "Sports & gym": 975,
+    "Fruit & veg market": 0,
+    "Cleaning products": 0,
+    "Toiletries": 0,
+    "Pet food": 0,
+    "Education": 0,
+    "School uniforms": 0,
+    "School fees": 0,
+    "Mortgage / rent": 0,
+    "Hair & beauty": 66.66666666666666,
+    "Cosmetics": 52,
+    "Pet care / vet / pet insurance": 0,
+    "Child support payment": 650,
+    "Children Clothing": 2,
+    "Babysitting": 0,
+    "Excursions": 0,
+    "Other school needs": 0,
+    "Children Sports & activities": 0,
+    "Toys": 0
+  },
+  "budgetFreqs": {
+    "Your partner's take-home pay": "fortnightly",
+    "Electricity": "quarterly",
+    "Council rates": "quarterly",
+    "Your take-home pay": "monthly",
+    "Rego & licence": "annually",
+    "School uniforms": "quarterly",
+    "Hair & beauty": "quarterly",
+    "Child support payment": "weekly"
+  },
+  "customCategories": {
+    "Financial & Insurance": [
+      "Savings",
+      "Investments & super contributions",
+      "Charity donations",
+      "Home loan",
+      "Credit card interest",
+      "Other loans",
+      "Car loan",
+      "Home & contents insurance",
+      "Health insurance",
+      "Car insurance",
+      "Personal & life insurance",
+      "Bank fees"
+    ],
+    "Medical, personal & education": [
+      "Doctors & medical",
+      "Medicines & pharmacy",
+      "Glasses & eye care",
+      "Dental",
+      "Education & Professional Memberships",
+      "Computers & gadgets",
+      "Sports & gym",
+      "Clothing & shoes",
+      "Cosmetics",
+      "Hair & beauty",
+      "Shopping",
+      "Hobbies",
+      "Pet care / vet / pet insurance"
+    ],
+    "Income": [
+      "Your take-home pay",
+      "Your partner's take-home pay",
+      "Bonuses / overtime",
+      "Income from savings and investments",
+      "Child support received",
+      "Health insurance reimbursement",
+      "Rent (investment property)",
+      "Other income"
+    ],
+    "Home & utilities": [
+      "Water",
+      "Gas",
+      "Electricity",
+      "Mobile",
+      "Internet",
+      "Streaming Services",
+      "Home improvements & Maintenance",
+      "Furniture & appliances",
+      "Council rates",
+      "Body corporate fees",
+      "Kierans Mobile",
+      "Ellas Mobile"
+    ]
+  },
+  "projectBudgets": {
+    "Financial & Insurance": 150000,
+    "Renovations": 3500
+  },
+  "deletedSubs": [],
+  "csvFormatMappings": {},
+  "businessExpenseFlags": {
+    "552": true
+  },
+  "summary": {
+    "totalTransactions": 732,
+    "dateRange": {
+      "from": "01/02/2026",
+      "to": "9/01/2026"
+    },
+    "byCategory": {
+      "Financial & Insurance": 55,
+      "_ignore": 6,
+      "Income": 19,
+      "Children": 44,
+      "Car & Transport": 61,
+      "Eating-out & Entertainment": 242,
+      "Medical, personal & education": 112,
+      "Groceries": 73,
+      "Home & utilities": 50,
+      "Uncategorised": 69,
+      "Renovations": 1
+    },
+    "bySourceFile": {
+      "ANZ Joint Offset 2026-01.csv": 6,
+      "ANZ Joint Offset 2026-02.csv": 3,
+      "ANZ Offset 2026-01.csv": 10,
+      "ANZ Offset 2026-02.csv": 10,
+      "ANZ Credit Card 2026-01.csv": 212,
+      "ANZ Credit Card 2026-02.csv": 186,
+      "Macquarie Pay 2026-01.csv": 11,
+      "Macquarie Spending 2026-02.csv": 24,
+      "Macquarie Pay 2026-02.csv": 7,
+      "ANZ Credit Card 2026-03.csv": 214,
+      "ANZ Joint Offset 2026-03.csv": 5,
+      "ANZ Offset 2026-03.csv": 12,
+      "Macquarie Pay 2026-03.csv": 6,
+      "Macquarie Spending 2026-03.csv": 26
+    },
+    "businessFlaggedCount": 1,
+    "manuallyCategoirsedCount": 0,
+    "uncategorisedCount": 69,
+    "customRulesCount": 73
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `/contracts/budget-tracker/` — 9 contract docs (data models, API endpoints, AWS infra, state management, UI patterns, AI prompts, gap analysis, changelog, README)
- Adds `/migration-artifacts/budget-tracker/` — 3 export files from the existing Budget Tracker app (JSON + CSV)
- Updates root `CLAUDE.md` to document both directories

## Why
These contracts are the source of truth for Task 2 (domain logic) and Task 3 (AWS backend). Landing them first lets subsequent PRs reference concrete type definitions and API shapes.

## Test plan
- [ ] CI passes (no build/typecheck changes — docs only)
- [ ] Contracts readable at `contracts/budget-tracker/`
- [ ] Migration data at `migration-artifacts/budget-tracker/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)