### PR TITLE
feat(budget-tracker): AWS backend — tables, lambdas, CDK stacks

### DIFF
--- a/apps/budget-tracker/functions/budget-ai/package.json
+++ b/apps/budget-tracker/functions/budget-ai/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@transformotion/fn-budget-ai",
+  "version": "0.0.0",
+  "private": true,
+  "main": "./src/index.ts",
+  "scripts": {
+    "build": "tsc --noEmit",
+    "typecheck": "tsc --noEmit",
+    "lint": "echo \"lint: budget-ai\""
+  },
+  "dependencies": {
+    "@transformotion/budget-domain": "workspace:*",
+    "@transformotion/lambda-middleware": "workspace:*"
+  },
+  "devDependencies": {
+    "@aws-sdk/client-dynamodb": "^3",
+    "@aws-sdk/lib-dynamodb": "^3",
+    "@aws-sdk/client-lambda": "^3",
+    "@types/aws-lambda": "^8",
+    "@types/node": "^22",
+    "typescript": "*"
+  }
+}

--- a/apps/budget-tracker/functions/budget-ai/src/index.ts
+++ b/apps/budget-tracker/functions/budget-ai/src/index.ts
@@ -1,0 +1,205 @@
+import { LambdaClient, InvokeCommand } from '@aws-sdk/client-lambda';
+import { withAuth, parseBody, ok, requireGroup } from '@transformotion/lambda-middleware';
+import type { AuthClaims } from '@transformotion/lambda-middleware';
+import type {
+  CategoryTree,
+  AiCategoriseResponse,
+  AiReviewResponse,
+  AiCsvAnalysisResponse,
+} from '@transformotion/budget-domain';
+
+const lambdaClient = new LambdaClient({});
+const PROXY_FN     = process.env.CLAUDE_PROXY_FUNCTION_NAME!;
+const AI_MODEL     = 'claude-sonnet-4-20250514';
+const BATCH_CATEGORISE = 50;
+const BATCH_REVIEW     = 20;
+
+// ── Invoke the shared claude-proxy Lambda ─────────────────────────────────────
+// Formats a minimal API Gateway proxy event so the proxy's withAuth middleware
+// can extract claims without requiring a raw JWT token.
+async function invokeProxy(
+  auth: AuthClaims,
+  accountId: string,
+  body: object
+): Promise<Record<string, unknown>> {
+  const fakeEvent = {
+    httpMethod: 'POST',
+    path: '/api/claude',
+    headers: {},
+    queryStringParameters: null,
+    pathParameters: null,
+    requestContext: {
+      authorizer: {
+        claims: {
+          sub:                     auth.userId,
+          email:                   auth.email,
+          'cognito:groups':        auth.groups.join(' '),
+          'custom:active_account': accountId,
+        },
+      },
+    },
+    body: JSON.stringify(body),
+    isBase64Encoded: false,
+  };
+
+  const result = await lambdaClient.send(new InvokeCommand({
+    FunctionName: PROXY_FN,
+    Payload:      Buffer.from(JSON.stringify(fakeEvent)),
+  }));
+
+  const response = JSON.parse(Buffer.from(result.Payload!).toString()) as {
+    statusCode: number;
+    body: string;
+  };
+
+  if (response.statusCode !== 200) {
+    const err = JSON.parse(response.body || '{}');
+    throw { statusCode: response.statusCode, message: err.error ?? 'Claude proxy error' };
+  }
+
+  return JSON.parse(response.body) as Record<string, unknown>;
+}
+
+function formatCategoryList(categories: CategoryTree): string {
+  return Object.entries(categories)
+    .map(([cat, subs]) => `${cat}: ${subs.join(', ')}`)
+    .join('\n');
+}
+
+function formatTxList(txs: Array<{ index: number; description: string; amount: string }>): string {
+  return txs.map(t => `${t.index}: ${t.description} — ${t.amount}`).join('\n');
+}
+
+// ── POST /api/budget/v1/ai/categorise ────────────────────────────────────────
+async function categorise(
+  auth: AuthClaims,
+  accountId: string,
+  event: Parameters<typeof parseBody>[0]
+) {
+  const { transactions, categories } = parseBody<{
+    transactions: Array<{ index: number; description: string; amount: string }>;
+    categories: CategoryTree;
+  }>(event);
+
+  const categoryList = formatCategoryList(categories);
+  const allResults: AiCategoriseResponse['results'] = [];
+
+  for (let i = 0; i < transactions.length; i += BATCH_CATEGORISE) {
+    const batch = transactions.slice(i, i + BATCH_CATEGORISE);
+    const proxyResponse = await invokeProxy(auth, accountId, {
+      model:      AI_MODEL,
+      max_tokens: 4096,
+      system:     `You are a personal finance assistant. You categorise Australian bank transactions into household budget categories.\n\nYou will be given:\n- A list of budget categories, each with allowed subcategories\n- A list of transactions to categorise (index, description, amount)\n\nYou must:\n- Return ONLY a JSON array, one object per transaction you can confidently categorise\n- Each object has exactly: {"index": <int>, "category": <string>, "subcategory": <string>}\n- The category value must be one of the provided categories exactly\n- The subcategory value must be one of the subcategories listed under that category exactly\n- Omit any transaction you cannot confidently categorise — do not guess\n- Do not include any text outside the JSON array\n- Do not wrap the JSON in markdown code fences`,
+      messages: [{
+        role: 'user',
+        content: `BUDGET CATEGORIES AND SUBCATEGORIES:\n${categoryList}\n\nTRANSACTIONS TO CATEGORISE (index: description — amount):\n${formatTxList(batch)}`,
+      }],
+    });
+
+    // Extract text content from the proxy's Claude response
+    const content = proxyResponse['content'] as Array<{ type: string; text?: string }> | undefined;
+    const text = (content ?? []).filter(c => c.type === 'text').map(c => c.text ?? '').join('');
+
+    try {
+      const clean = text.replace(/```json|```/g, '').trim();
+      const parsed = JSON.parse(clean.slice(clean.indexOf('['), clean.lastIndexOf(']') + 1)) as AiCategoriseResponse['results'];
+      // Validate category/subcategory against provided tree; drop invalid items
+      for (const item of parsed) {
+        const validSubs = categories[item.category];
+        if (validSubs && validSubs.includes(item.subcategory)) {
+          allResults.push(item);
+        }
+      }
+    } catch {
+      // Log and continue — don't fail the whole request for one bad batch
+      console.error('[budget-ai] categorise: failed to parse batch response', text.slice(0, 200));
+    }
+  }
+
+  return ok({ results: allResults });
+}
+
+// ── POST /api/budget/v1/ai/review ─────────────────────────────────────────────
+async function review(
+  auth: AuthClaims,
+  accountId: string,
+  event: Parameters<typeof parseBody>[0]
+) {
+  const { transactions, categories } = parseBody<{
+    transactions: Array<{ index: number; description: string; amount: string }>;
+    categories: CategoryTree;
+  }>(event);
+
+  const categoryList = formatCategoryList(categories);
+  const allResults: AiReviewResponse['results'] = [];
+
+  for (let i = 0; i < transactions.length; i += BATCH_REVIEW) {
+    const batch = transactions.slice(i, i + BATCH_REVIEW);
+    const proxyResponse = await invokeProxy(auth, accountId, {
+      model:      AI_MODEL,
+      max_tokens: 4096,
+      webSearch:  true,
+      system:     `You are a personal finance assistant helping to categorise Australian bank transactions that a fast categorisation pass could not handle.\n\nYou will be given:\n- A list of budget categories, each with allowed subcategories\n- A list of unknown or ambiguous transactions (index, description, amount)\n\nYou have access to a web_search tool. If a merchant or description is unfamiliar, you MAY search to identify the business type before categorising. Use web_search sparingly — only when the description is genuinely ambiguous.\n\nYou must:\n- Return ONLY a JSON array, one object per transaction\n- Each object has exactly: {"index": <int>, "category": <string>, "subcategory": <string>, "reason": <string>}\n- The category must be one of the provided categories exactly\n- The subcategory must be one of the subcategories listed under that category exactly\n- The reason must be a single sentence explaining your choice in plain English\n- If a transaction is genuinely uncategorisable, return it with category: "", subcategory: "", and reason explaining why\n- Do not include any text outside the JSON array\n- Do not wrap the JSON in markdown code fences`,
+      messages: [{
+        role: 'user',
+        content: `BUDGET CATEGORIES AND SUBCATEGORIES:\n${categoryList}\n\nTRANSACTIONS TO CATEGORISE (index: description — amount):\n${formatTxList(batch)}`,
+      }],
+    });
+
+    const content = proxyResponse['content'] as Array<{ type: string; text?: string }> | undefined;
+    const text = (content ?? []).filter(c => c.type === 'text').map(c => c.text ?? '').join('');
+
+    try {
+      const clean = text.replace(/```json|```/g, '').trim();
+      const parsed = JSON.parse(clean.slice(clean.indexOf('['), clean.lastIndexOf(']') + 1)) as AiReviewResponse['results'];
+      allResults.push(...parsed);
+    } catch {
+      console.error('[budget-ai] review: failed to parse batch response', text.slice(0, 200));
+    }
+  }
+
+  return ok({ results: allResults });
+}
+
+// ── POST /api/budget/v1/ai/csv-analysis ──────────────────────────────────────
+async function csvAnalysis(
+  auth: AuthClaims,
+  accountId: string,
+  event: Parameters<typeof parseBody>[0]
+) {
+  const { sampleRows } = parseBody<{ sampleRows: string[][] }>(event);
+
+  const proxyResponse = await invokeProxy(auth, accountId, {
+    model:      AI_MODEL,
+    max_tokens: 1024,
+    system:     `You are a CSV format detective. Given the first few rows of a bank transaction CSV, identify which column is which.\n\nYou must return ONLY a JSON object with this exact shape:\n{\n  "dateColumn": <int>,\n  "descriptionColumn": <int>,\n  "amountColumn": <int>,\n  "debitColumn": <int>,\n  "creditColumn": <int>,\n  "dateFormat": <string>,\n  "hasHeader": <bool>,\n  "confidence": "high" | "medium" | "low",\n  "notes": <string>\n}\n\nEither amountColumn OR (debitColumn + creditColumn) must be present, not both. Columns are 0-indexed.\n\nIf you cannot determine the format with reasonable confidence, set confidence: "low" and describe the issue in notes.\n\nDo not include any text outside the JSON object.\nDo not wrap the JSON in markdown code fences.`,
+    messages: [{
+      role: 'user',
+      content: `Sample rows from uploaded CSV (each row is an array of cell values):\n${JSON.stringify(sampleRows, null, 2)}\n\nThe first row above MAY be a header row, or it may be a data row. Use the content to decide.`,
+    }],
+  });
+
+  const content = proxyResponse['content'] as Array<{ type: string; text?: string }> | undefined;
+  const text = (content ?? []).filter(c => c.type === 'text').map(c => c.text ?? '').join('');
+
+  try {
+    const clean = text.replace(/```json|```/g, '').trim();
+    const result = JSON.parse(clean) as AiCsvAnalysisResponse;
+    return ok(result);
+  } catch {
+    console.error('[budget-ai] csv-analysis: failed to parse response', text.slice(0, 200));
+    throw { statusCode: 502, message: 'Failed to parse AI response for CSV analysis' };
+  }
+}
+
+// ── Handler ───────────────────────────────────────────────────────────────────
+export const handler = withAuth(async ({ auth, account, event }) => {
+  requireGroup(auth, 'budget-app', 'admin');
+  const resource = event.resource ?? '';
+
+  if (resource === '/api/budget/v1/ai/categorise')    return categorise(auth, account.accountId, event);
+  if (resource === '/api/budget/v1/ai/review')        return review(auth, account.accountId, event);
+  if (resource === '/api/budget/v1/ai/csv-analysis')  return csvAnalysis(auth, account.accountId, event);
+
+  throw { statusCode: 400, message: `Unrecognised route: ${event.httpMethod} ${resource}` };
+});

--- a/apps/budget-tracker/functions/budget-ai/tsconfig.json
+++ b/apps/budget-tracker/functions/budget-ai/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "types": ["node", "aws-lambda"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/apps/budget-tracker/functions/budget-export/package.json
+++ b/apps/budget-tracker/functions/budget-export/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@transformotion/fn-budget-export",
+  "version": "0.0.0",
+  "private": true,
+  "main": "./src/index.ts",
+  "scripts": {
+    "build": "tsc --noEmit",
+    "typecheck": "tsc --noEmit",
+    "lint": "echo \"lint: budget-export\""
+  },
+  "dependencies": {
+    "@transformotion/budget-domain": "workspace:*",
+    "@transformotion/lambda-middleware": "workspace:*"
+  },
+  "devDependencies": {
+    "@aws-sdk/client-dynamodb": "^3",
+    "@aws-sdk/lib-dynamodb": "^3",
+    "@aws-sdk/client-lambda": "^3",
+    "@types/aws-lambda": "^8",
+    "@types/node": "^22",
+    "typescript": "*"
+  }
+}

--- a/apps/budget-tracker/functions/budget-export/src/index.ts
+++ b/apps/budget-tracker/functions/budget-export/src/index.ts
@@ -1,0 +1,77 @@
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import { DynamoDBDocumentClient, QueryCommand } from '@aws-sdk/lib-dynamodb';
+import { withAuth, getQueryParam, requireGroup } from '@transformotion/lambda-middleware';
+import type { Transaction } from '@transformotion/budget-domain';
+
+const ddb = DynamoDBDocumentClient.from(new DynamoDBClient({}));
+const TABLE = process.env.TRANSACTIONS_TABLE!;
+const GSI   = 'accountId-dateIso-index';
+
+function toIso(ddmmyyyy: string): string {
+  const p = ddmmyyyy.split('/');
+  return p.length === 3 ? `${p[2]}-${p[1]}-${p[0]}` : ddmmyyyy;
+}
+
+// GET /api/budget/v1/business-export
+export const handler = withAuth(async ({ auth, account, event }) => {
+  requireGroup(auth, 'budget-app', 'admin');
+  const { accountId } = account;
+
+  const from = getQueryParam(event, 'from', false);
+  const to   = getQueryParam(event, 'to',   false);
+
+  let KeyConditionExpression = 'accountId = :aid';
+  const ExpressionAttributeValues: Record<string, unknown> = { ':aid': accountId };
+
+  if (from && to) {
+    KeyConditionExpression += ' AND dateIso BETWEEN :from AND :to';
+    ExpressionAttributeValues[':from'] = from;
+    ExpressionAttributeValues[':to']   = to;
+  } else if (from) {
+    KeyConditionExpression += ' AND dateIso >= :from';
+    ExpressionAttributeValues[':from'] = from;
+  } else if (to) {
+    KeyConditionExpression += ' AND dateIso <= :to';
+    ExpressionAttributeValues[':to'] = to;
+  }
+
+  const txs: Transaction[] = [];
+  let lastKey: Record<string, unknown> | undefined;
+
+  do {
+    const res = await ddb.send(new QueryCommand({
+      TableName: TABLE,
+      IndexName: from || to ? GSI : undefined,
+      KeyConditionExpression,
+      FilterExpression: '_business = :true',
+      ExpressionAttributeValues: { ...ExpressionAttributeValues, ':true': true },
+      ExclusiveStartKey: lastKey,
+    }));
+    txs.push(...(res.Items ?? []) as Transaction[]);
+    lastKey = res.LastEvaluatedKey as Record<string, unknown> | undefined;
+  } while (lastKey);
+
+  const rows = [
+    ['Date', 'Amount', 'Description', 'Category', 'Subcategory', 'File'],
+    ...txs.map(t => [
+      t.date,
+      t.amount,
+      `"${t.description.replace(/"/g, '""')}"`,
+      t.category,
+      t.subcategory,
+      t.file,
+    ]),
+  ];
+
+  const csv = rows.map(r => r.join(',')).join('\n');
+  const timestamp = new Date().toISOString().slice(0, 10);
+
+  return {
+    statusCode: 200,
+    headers: {
+      'Content-Type': 'text/csv',
+      'Content-Disposition': `attachment; filename="business-expenses-${accountId}-${timestamp}.csv"`,
+    },
+    body: csv,
+  };
+});

--- a/apps/budget-tracker/functions/budget-export/tsconfig.json
+++ b/apps/budget-tracker/functions/budget-export/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "types": ["node", "aws-lambda"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/apps/budget-tracker/functions/budget-migrate/package.json
+++ b/apps/budget-tracker/functions/budget-migrate/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@transformotion/fn-budget-migrate",
+  "version": "0.0.0",
+  "private": true,
+  "main": "./src/index.ts",
+  "scripts": {
+    "build": "tsc --noEmit",
+    "typecheck": "tsc --noEmit",
+    "lint": "echo \"lint: budget-migrate\""
+  },
+  "dependencies": {
+    "@transformotion/budget-domain": "workspace:*",
+    "@transformotion/lambda-middleware": "workspace:*"
+  },
+  "devDependencies": {
+    "@aws-sdk/client-dynamodb": "^3",
+    "@aws-sdk/lib-dynamodb": "^3",
+    "@aws-sdk/client-lambda": "^3",
+    "@types/aws-lambda": "^8",
+    "@types/node": "^22",
+    "typescript": "*"
+  }
+}

--- a/apps/budget-tracker/functions/budget-migrate/src/index.ts
+++ b/apps/budget-tracker/functions/budget-migrate/src/index.ts
@@ -1,0 +1,163 @@
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import {
+  DynamoDBDocumentClient,
+  QueryCommand,
+  BatchWriteCommand,
+  PutCommand,
+} from '@aws-sdk/lib-dynamodb';
+import { withAuth, parseBody, ok, requireGroup } from '@transformotion/lambda-middleware';
+import { randomUUID } from 'crypto';
+import type { Transaction, CustomRule, BudgetSettings } from '@transformotion/budget-domain';
+
+const ddb = DynamoDBDocumentClient.from(new DynamoDBClient({}));
+const TRANSACTIONS_TABLE = process.env.TRANSACTIONS_TABLE!;
+const RULES_TABLE        = process.env.RULES_TABLE!;
+const SETTINGS_TABLE     = process.env.SETTINGS_TABLE!;
+
+const SETTING_KEYS: Array<keyof Omit<BudgetSettings, 'accountId'>> = [
+  'budgetOverrides', 'budgetFreqs', 'customCategories',
+  'projectBudgets', 'deletedSubs', 'csvFormatMappings',
+];
+
+function toIso(ddmmyyyy: string): string {
+  const p = ddmmyyyy.split('/');
+  return p.length === 3 ? `${p[2]}-${p[1]}-${p[0]}` : ddmmyyyy;
+}
+
+function txNaturalKey(t: Pick<Transaction, 'date' | 'amount' | 'description' | 'file'>): string {
+  return `${t.date}|${t.amount}|${t.description}|${t.file}`;
+}
+
+function ruleNaturalKey(r: Pick<CustomRule, 'match' | 'category' | 'subcategory'>): string {
+  return `${r.match}|${r.category}|${r.subcategory}`;
+}
+
+// ── Transformation 1: _ignore → Financial & Insurance / Transfer ──────────────
+// Hawkins E A payments received into the ANZ account are inter-account transfers.
+function transformTransaction(tx: Omit<Transaction, 'accountId'>): Omit<Transaction, 'accountId'> {
+  if (tx.category === '_ignore') {
+    return { ...tx, category: 'Financial & Insurance', subcategory: 'Transfer', _manual: true };
+  }
+  return tx;
+}
+
+// ── Transformation 2: projectBudgets key rename ───────────────────────────────
+// "Financial & Insurance" project budget was a model error; rename to "New Car".
+function transformSettings(settings: Partial<BudgetSettings>): Partial<BudgetSettings> {
+  if (!settings.projectBudgets) return settings;
+  const pb = { ...settings.projectBudgets };
+  if ('Financial & Insurance' in pb) {
+    pb['New Car'] = pb['Financial & Insurance'];
+    delete pb['Financial & Insurance'];
+  }
+  return { ...settings, projectBudgets: pb };
+}
+
+async function batchWrite(table: string, items: Record<string, unknown>[]) {
+  for (let i = 0; i < items.length; i += 25) {
+    const chunk = items.slice(i, i + 25);
+    await ddb.send(new BatchWriteCommand({
+      RequestItems: {
+        [table]: chunk.map(Item => ({ PutRequest: { Item } })),
+      },
+    }));
+  }
+}
+
+// POST /api/budget/v1/migrate-from-localstorage
+export const handler = withAuth(async ({ auth, account, event }) => {
+  requireGroup(auth, 'budget-app', 'admin');
+  const { accountId } = account;
+
+  const { transactions, rules, settings } = parseBody<{
+    transactions: Omit<Transaction, 'accountId'>[];
+    rules: Omit<CustomRule, 'accountId'>[];
+    settings: Partial<BudgetSettings>;
+  }>(event);
+
+  // ── Load existing data for deduplication ──────────────────────────────────
+  const [existingTxRes, existingRulesRes] = await Promise.all([
+    ddb.send(new QueryCommand({
+      TableName: TRANSACTIONS_TABLE,
+      KeyConditionExpression: 'accountId = :aid',
+      ExpressionAttributeValues: { ':aid': accountId },
+      ProjectionExpression: 'transactionId, #d, amount, description, #f',
+      ExpressionAttributeNames: { '#d': 'date', '#f': 'file' },
+    })),
+    ddb.send(new QueryCommand({
+      TableName: RULES_TABLE,
+      KeyConditionExpression: 'accountId = :aid',
+      ExpressionAttributeValues: { ':aid': accountId },
+      ProjectionExpression: '#m, category, subcategory',
+      ExpressionAttributeNames: { '#m': 'match' },
+    })),
+  ]);
+
+  const existingTxKeys  = new Set((existingTxRes.Items ?? []).map(t => txNaturalKey(t as Transaction)));
+  const existingRuleKeys = new Set((existingRulesRes.Items ?? []).map(r => ruleNaturalKey(r as CustomRule)));
+
+  // ── Migrate transactions ───────────────────────────────────────────────────
+  let txMigrated = 0; let txAlreadyPresent = 0;
+  const txItems: Record<string, unknown>[] = [];
+
+  for (const tx of transactions ?? []) {
+    const transformed = transformTransaction(tx);
+    const key = txNaturalKey(transformed);
+    if (existingTxKeys.has(key)) { txAlreadyPresent++; continue; }
+    txItems.push({
+      ...transformed,
+      accountId,
+      transactionId: randomUUID(),
+      dateIso:       toIso(transformed.date),
+      _manual:       transformed._manual ?? false,
+      _business:     transformed._business ?? false,
+    });
+    txMigrated++;
+  }
+  await batchWrite(TRANSACTIONS_TABLE, txItems);
+
+  // ── Migrate rules ─────────────────────────────────────────────────────────
+  let rulesMigrated = 0; let rulesAlreadyPresent = 0;
+  const ruleItems: Record<string, unknown>[] = [];
+
+  for (const rule of rules ?? []) {
+    const key = ruleNaturalKey(rule);
+    if (existingRuleKeys.has(key)) { rulesAlreadyPresent++; continue; }
+    ruleItems.push({
+      ...rule,
+      accountId,
+      ruleId:    randomUUID(),
+      createdAt: new Date().toISOString(),
+      learned:   rule.learned ?? false,
+    });
+    rulesMigrated++;
+  }
+  await batchWrite(RULES_TABLE, ruleItems);
+
+  // ── Migrate settings ──────────────────────────────────────────────────────
+  const transformedSettings = transformSettings(settings ?? {});
+  const now = new Date().toISOString();
+  const migratedSettingKeys: string[] = [];
+
+  for (const key of SETTING_KEYS) {
+    if (key in transformedSettings && transformedSettings[key] !== undefined) {
+      await ddb.send(new PutCommand({
+        TableName: SETTINGS_TABLE,
+        Item: { accountId, settingKey: key, value: transformedSettings[key], updatedAt: now },
+      }));
+      migratedSettingKeys.push(key);
+    }
+  }
+
+  return ok({
+    migrated: {
+      transactions: txMigrated,
+      rules:        rulesMigrated,
+      settings:     migratedSettingKeys,
+    },
+    alreadyPresent: {
+      transactions: txAlreadyPresent,
+      rules:        rulesAlreadyPresent,
+    },
+  });
+});

--- a/apps/budget-tracker/functions/budget-migrate/tsconfig.json
+++ b/apps/budget-tracker/functions/budget-migrate/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "types": ["node", "aws-lambda"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/apps/budget-tracker/functions/budget-rules/package.json
+++ b/apps/budget-tracker/functions/budget-rules/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@transformotion/fn-budget-rules",
+  "version": "0.0.0",
+  "private": true,
+  "main": "./src/index.ts",
+  "scripts": {
+    "build": "tsc --noEmit",
+    "typecheck": "tsc --noEmit",
+    "lint": "echo \"lint: budget-rules\""
+  },
+  "dependencies": {
+    "@transformotion/budget-domain": "workspace:*",
+    "@transformotion/lambda-middleware": "workspace:*"
+  },
+  "devDependencies": {
+    "@aws-sdk/client-dynamodb": "^3",
+    "@aws-sdk/lib-dynamodb": "^3",
+    "@aws-sdk/client-lambda": "^3",
+    "@types/aws-lambda": "^8",
+    "@types/node": "^22",
+    "typescript": "*"
+  }
+}

--- a/apps/budget-tracker/functions/budget-rules/src/index.ts
+++ b/apps/budget-tracker/functions/budget-rules/src/index.ts
@@ -1,0 +1,108 @@
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import {
+  DynamoDBDocumentClient,
+  QueryCommand,
+  PutCommand,
+  UpdateCommand,
+  DeleteCommand,
+} from '@aws-sdk/lib-dynamodb';
+import {
+  withAuth,
+  parseBody,
+  getPathParam,
+  ok,
+  notFound,
+  requireGroup,
+  type APIGatewayProxyEvent,
+} from '@transformotion/lambda-middleware';
+import { randomUUID } from 'crypto';
+import type { CustomRule } from '@transformotion/budget-domain';
+
+const ddb = DynamoDBDocumentClient.from(new DynamoDBClient({}));
+const TABLE = process.env.RULES_TABLE!;
+
+// ── GET /api/budget/v1/rules ──────────────────────────────────────────────────
+async function listRules(accountId: string) {
+  const res = await ddb.send(new QueryCommand({
+    TableName: TABLE,
+    KeyConditionExpression: 'accountId = :aid',
+    ExpressionAttributeValues: { ':aid': accountId },
+  }));
+  return ok({ rules: res.Items ?? [] });
+}
+
+// ── POST /api/budget/v1/rules ─────────────────────────────────────────────────
+async function createRule(event: APIGatewayProxyEvent, accountId: string) {
+  const body = parseBody<Pick<CustomRule, 'match' | 'category' | 'subcategory' | 'learned'>>(event);
+  if (!body.match?.trim()) throw { statusCode: 400, message: 'match is required' };
+  if (!body.category?.trim()) throw { statusCode: 400, message: 'category is required' };
+
+  const rule: CustomRule = {
+    id: randomUUID(),
+    accountId,
+    match: body.match.trim(),
+    category: body.category.trim(),
+    subcategory: body.subcategory?.trim() ?? '',
+    learned: body.learned ?? false,
+    createdAt: new Date().toISOString(),
+  };
+
+  await ddb.send(new PutCommand({ TableName: TABLE, Item: { ...rule, ruleId: rule.id } }));
+  return ok({ rule });
+}
+
+// ── PATCH /api/budget/v1/rules/:id ───────────────────────────────────────────
+async function updateRule(event: APIGatewayProxyEvent, accountId: string, ruleId: string) {
+  const body = parseBody<Partial<Pick<CustomRule, 'match' | 'category' | 'subcategory'>>>(event);
+
+  const expressions: string[] = [];
+  const names: Record<string, string> = {};
+  const values: Record<string, unknown> = { ':aid': accountId };
+
+  if (body.match !== undefined) { expressions.push('#match = :match'); names['#match'] = 'match'; values[':match'] = body.match.trim(); }
+  if (body.category !== undefined) { expressions.push('category = :cat'); values[':cat'] = body.category.trim(); }
+  if (body.subcategory !== undefined) { expressions.push('subcategory = :sub'); values[':sub'] = body.subcategory.trim(); }
+  if (expressions.length === 0) throw { statusCode: 400, message: 'No fields to update' };
+
+  const res = await ddb.send(new UpdateCommand({
+    TableName: TABLE,
+    Key: { accountId, ruleId },
+    UpdateExpression: `SET ${expressions.join(', ')}`,
+    ExpressionAttributeNames: Object.keys(names).length ? names : undefined,
+    ExpressionAttributeValues: values,
+    ConditionExpression: 'accountId = :aid',
+    ReturnValues: 'ALL_NEW',
+  }));
+
+  const item = res.Attributes;
+  if (!item) throw notFound(`Rule ${ruleId} not found`);
+  return ok({ rule: { ...item, id: item['ruleId'] } });
+}
+
+// ── DELETE /api/budget/v1/rules/:id ──────────────────────────────────────────
+async function deleteRule(accountId: string, ruleId: string) {
+  await ddb.send(new DeleteCommand({
+    TableName: TABLE,
+    Key: { accountId, ruleId },
+    ConditionExpression: 'accountId = :aid',
+    ExpressionAttributeValues: { ':aid': accountId },
+  }));
+  return ok({ deleted: true });
+}
+
+// ── Handler ───────────────────────────────────────────────────────────────────
+export const handler = withAuth(async ({ auth, account, event }) => {
+  requireGroup(auth, 'budget-app', 'admin');
+  const { accountId } = account;
+  const method = event.httpMethod;
+  const resource = event.resource ?? '';
+
+  if (resource === '/api/budget/v1/rules' && method === 'GET')  return listRules(accountId);
+  if (resource === '/api/budget/v1/rules' && method === 'POST') return createRule(event, accountId);
+
+  const ruleId = getPathParam(event, 'id');
+  if (method === 'PATCH')  return updateRule(event, accountId, ruleId);
+  if (method === 'DELETE') return deleteRule(accountId, ruleId);
+
+  throw { statusCode: 400, message: `Unrecognised route: ${method} ${resource}` };
+});

--- a/apps/budget-tracker/functions/budget-rules/tsconfig.json
+++ b/apps/budget-tracker/functions/budget-rules/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "types": ["node", "aws-lambda"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/apps/budget-tracker/functions/budget-settings/package.json
+++ b/apps/budget-tracker/functions/budget-settings/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@transformotion/fn-budget-settings",
+  "version": "0.0.0",
+  "private": true,
+  "main": "./src/index.ts",
+  "scripts": {
+    "build": "tsc --noEmit",
+    "typecheck": "tsc --noEmit",
+    "lint": "echo \"lint: budget-settings\""
+  },
+  "dependencies": {
+    "@transformotion/budget-domain": "workspace:*",
+    "@transformotion/lambda-middleware": "workspace:*"
+  },
+  "devDependencies": {
+    "@aws-sdk/client-dynamodb": "^3",
+    "@aws-sdk/lib-dynamodb": "^3",
+    "@aws-sdk/client-lambda": "^3",
+    "@types/aws-lambda": "^8",
+    "@types/node": "^22",
+    "typescript": "*"
+  }
+}

--- a/apps/budget-tracker/functions/budget-settings/src/index.ts
+++ b/apps/budget-tracker/functions/budget-settings/src/index.ts
@@ -1,0 +1,62 @@
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import { DynamoDBDocumentClient, QueryCommand, PutCommand } from '@aws-sdk/lib-dynamodb';
+import { withAuth, parseBody, ok, requireGroup } from '@transformotion/lambda-middleware';
+import type { BudgetSettings } from '@transformotion/budget-domain';
+
+const ddb = DynamoDBDocumentClient.from(new DynamoDBClient({}));
+const TABLE = process.env.SETTINGS_TABLE!;
+
+const SETTING_KEYS: Array<keyof Omit<BudgetSettings, 'accountId'>> = [
+  'budgetOverrides', 'budgetFreqs', 'customCategories',
+  'projectBudgets', 'deletedSubs', 'csvFormatMappings',
+];
+
+const DEFAULT_SETTINGS: Omit<BudgetSettings, 'accountId'> = {
+  budgetOverrides: {},
+  budgetFreqs: {},
+  customCategories: {},
+  projectBudgets: {},
+  deletedSubs: [],
+  csvFormatMappings: {},
+};
+
+async function getSettings(accountId: string) {
+  const res = await ddb.send(new QueryCommand({
+    TableName: TABLE,
+    KeyConditionExpression: 'accountId = :aid',
+    ExpressionAttributeValues: { ':aid': accountId },
+  }));
+
+  const settings: BudgetSettings = { accountId, ...DEFAULT_SETTINGS };
+  for (const item of res.Items ?? []) {
+    const key = item['settingKey'] as keyof BudgetSettings;
+    if (SETTING_KEYS.includes(key as keyof Omit<BudgetSettings, 'accountId'>)) {
+      (settings as unknown as Record<string, unknown>)[key] = item['value'];
+    }
+  }
+  return ok({ settings });
+}
+
+async function updateSettings(event: Parameters<typeof parseBody>[0], accountId: string) {
+  const patch = parseBody<Partial<Omit<BudgetSettings, 'accountId'>>>(event);
+  const now = new Date().toISOString();
+
+  const writes = SETTING_KEYS
+    .filter(key => key in patch && patch[key] !== undefined)
+    .map(key => ddb.send(new PutCommand({
+      TableName: TABLE,
+      Item: { accountId, settingKey: key, value: patch[key], updatedAt: now },
+    })));
+
+  if (writes.length === 0) throw { statusCode: 400, message: 'No settings fields provided' };
+  await Promise.all(writes);
+  return getSettings(accountId);
+}
+
+export const handler = withAuth(async ({ auth, account, event }) => {
+  requireGroup(auth, 'budget-app', 'admin');
+  const { accountId } = account;
+  if (event.httpMethod === 'GET')   return getSettings(accountId);
+  if (event.httpMethod === 'PATCH') return updateSettings(event, accountId);
+  throw { statusCode: 400, message: `Unrecognised route: ${event.httpMethod}` };
+});

--- a/apps/budget-tracker/functions/budget-settings/tsconfig.json
+++ b/apps/budget-tracker/functions/budget-settings/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "types": ["node", "aws-lambda"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/apps/budget-tracker/functions/budget-transactions/package.json
+++ b/apps/budget-tracker/functions/budget-transactions/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@transformotion/fn-budget-transactions",
+  "version": "0.0.0",
+  "private": true,
+  "main": "./src/index.ts",
+  "scripts": {
+    "build": "tsc --noEmit",
+    "typecheck": "tsc --noEmit",
+    "lint": "echo \"lint: budget-transactions\""
+  },
+  "dependencies": {
+    "@transformotion/budget-domain": "workspace:*",
+    "@transformotion/lambda-middleware": "workspace:*"
+  },
+  "devDependencies": {
+    "@aws-sdk/client-dynamodb": "^3",
+    "@aws-sdk/lib-dynamodb": "^3",
+    "@aws-sdk/client-lambda": "^3",
+    "@types/aws-lambda": "^8",
+    "@types/node": "^22",
+    "typescript": "*"
+  }
+}

--- a/apps/budget-tracker/functions/budget-transactions/src/index.ts
+++ b/apps/budget-tracker/functions/budget-transactions/src/index.ts
@@ -1,0 +1,191 @@
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import {
+  DynamoDBDocumentClient,
+  QueryCommand,
+  PutCommand,
+  UpdateCommand,
+  DeleteCommand,
+  BatchWriteCommand,
+} from '@aws-sdk/lib-dynamodb';
+import {
+  withAuth,
+  parseBody,
+  getPathParam,
+  getQueryParam,
+  ok,
+  notFound,
+  requireGroup,
+  type APIGatewayProxyEvent,
+} from '@transformotion/lambda-middleware';
+import { randomUUID } from 'crypto';
+import type { Transaction } from '@transformotion/budget-domain';
+
+const ddb = DynamoDBDocumentClient.from(new DynamoDBClient({}));
+const TABLE = process.env.TRANSACTIONS_TABLE!;
+const GSI   = 'accountId-dateIso-index';
+
+function toIso(ddmmyyyy: string): string {
+  const p = ddmmyyyy.split('/');
+  return p.length === 3 ? `${p[2]}-${p[1]}-${p[0]}` : ddmmyyyy;
+}
+
+function naturalKey(t: Pick<Transaction, 'date' | 'amount' | 'description' | 'file'>): string {
+  return `${t.date}|${t.amount}|${t.description}|${t.file}`;
+}
+
+// ── GET /api/budget/v1/transactions ───────────────────────────────────────────
+async function listTransactions(event: APIGatewayProxyEvent, accountId: string) {
+  const from  = getQueryParam(event, 'from',   false);
+  const to    = getQueryParam(event, 'to',     false);
+  const limit = parseInt(getQueryParam(event, 'limit', false) ?? '1000', 10);
+  const cursor = getQueryParam(event, 'cursor', false);
+
+  let KeyConditionExpression = 'accountId = :aid';
+  const ExpressionAttributeValues: Record<string, unknown> = { ':aid': accountId };
+
+  if (from && to) {
+    KeyConditionExpression += ' AND dateIso BETWEEN :from AND :to';
+    ExpressionAttributeValues[':from'] = from;
+    ExpressionAttributeValues[':to']   = to;
+  } else if (from) {
+    KeyConditionExpression += ' AND dateIso >= :from';
+    ExpressionAttributeValues[':from'] = from;
+  } else if (to) {
+    KeyConditionExpression += ' AND dateIso <= :to';
+    ExpressionAttributeValues[':to'] = to;
+  }
+
+  const res = await ddb.send(new QueryCommand({
+    TableName: from || to ? undefined : TABLE,
+    IndexName: from || to ? GSI : undefined,
+    ...(from || to ? { TableName: TABLE } : {}),
+    KeyConditionExpression,
+    ExpressionAttributeValues,
+    Limit: Math.min(limit, 5000),
+    ExclusiveStartKey: cursor ? JSON.parse(Buffer.from(cursor, 'base64').toString()) : undefined,
+  }));
+
+  const nextCursor = res.LastEvaluatedKey
+    ? Buffer.from(JSON.stringify(res.LastEvaluatedKey)).toString('base64')
+    : undefined;
+
+  return ok({ transactions: res.Items ?? [], nextCursor });
+}
+
+// ── POST /api/budget/v1/transactions/bulk ─────────────────────────────────────
+async function bulkUpsert(event: APIGatewayProxyEvent, accountId: string) {
+  const { transactions } = parseBody<{ transactions: Omit<Transaction, 'accountId'>[] }>(event);
+  if (!Array.isArray(transactions) || transactions.length === 0) {
+    return ok({ created: 0, updated: 0, skipped: 0, transactions: [] });
+  }
+
+  // Load existing transactions to deduplicate by natural key
+  const existing: Transaction[] = [];
+  let lastKey: Record<string, unknown> | undefined;
+  do {
+    const res = await ddb.send(new QueryCommand({
+      TableName: TABLE,
+      KeyConditionExpression: 'accountId = :aid',
+      ExpressionAttributeValues: { ':aid': accountId },
+      ProjectionExpression: 'transactionId, #d, amount, description, #f',
+      ExpressionAttributeNames: { '#d': 'date', '#f': 'file' },
+      ExclusiveStartKey: lastKey,
+    }));
+    existing.push(...(res.Items ?? []) as Transaction[]);
+    lastKey = res.LastEvaluatedKey as Record<string, unknown> | undefined;
+  } while (lastKey);
+
+  const existingKeys = new Set(existing.map(naturalKey));
+
+  let created = 0; let updated = 0; let skipped = 0;
+  const resultTxs: Transaction[] = [];
+  const toWrite: Transaction[] = [];
+
+  for (const tx of transactions) {
+    const key = naturalKey(tx);
+    if (existingKeys.has(key)) { skipped++; continue; }
+    const full: Transaction = {
+      ...tx,
+      accountId,
+      _id: randomUUID(),
+      _manual: tx._manual ?? false,
+      _business: tx._business ?? false,
+    };
+    toWrite.push(full);
+    resultTxs.push(full);
+    created++;
+  }
+
+  // BatchWriteItem in chunks of 25
+  for (let i = 0; i < toWrite.length; i += 25) {
+    const chunk = toWrite.slice(i, i + 25);
+    await ddb.send(new BatchWriteCommand({
+      RequestItems: {
+        [TABLE]: chunk.map(tx => ({
+          PutRequest: {
+            Item: { ...tx, transactionId: tx._id, dateIso: toIso(tx.date) },
+          },
+        })),
+      },
+    }));
+  }
+
+  return ok({ created, updated, skipped, transactions: resultTxs });
+}
+
+// ── PATCH /api/budget/v1/transactions/:id ─────────────────────────────────────
+async function updateTransaction(event: APIGatewayProxyEvent, accountId: string, transactionId: string) {
+  const body = parseBody<Partial<Pick<Transaction, 'category' | 'subcategory' | '_manual' | '_business'>>>(event);
+
+  const expressions: string[] = [];
+  const names: Record<string, string> = {};
+  const values: Record<string, unknown> = { ':aid': accountId };
+
+  if (body.category !== undefined)    { expressions.push('category = :cat');      values[':cat'] = body.category; }
+  if (body.subcategory !== undefined) { expressions.push('subcategory = :sub');   values[':sub'] = body.subcategory; }
+  if (body._manual !== undefined)     { expressions.push('#manual = :manual');    names['#manual'] = '_manual'; values[':manual'] = body._manual; }
+  if (body._business !== undefined)   { expressions.push('#business = :biz');     names['#business'] = '_business'; values[':biz'] = body._business; }
+  if (expressions.length === 0) throw { statusCode: 400, message: 'No fields to update' };
+
+  const res = await ddb.send(new UpdateCommand({
+    TableName: TABLE,
+    Key: { accountId, transactionId },
+    UpdateExpression: `SET ${expressions.join(', ')}`,
+    ExpressionAttributeNames: Object.keys(names).length ? names : undefined,
+    ExpressionAttributeValues: values,
+    ConditionExpression: 'accountId = :aid',
+    ReturnValues: 'ALL_NEW',
+  }));
+
+  if (!res.Attributes) throw notFound(`Transaction ${transactionId} not found`);
+  const item = res.Attributes;
+  return ok({ transaction: { ...item, _id: item['transactionId'] } });
+}
+
+// ── DELETE /api/budget/v1/transactions/:id ────────────────────────────────────
+async function deleteTransaction(accountId: string, transactionId: string) {
+  await ddb.send(new DeleteCommand({
+    TableName: TABLE,
+    Key: { accountId, transactionId },
+    ConditionExpression: 'accountId = :aid',
+    ExpressionAttributeValues: { ':aid': accountId },
+  }));
+  return ok({ deleted: true });
+}
+
+// ── Handler ───────────────────────────────────────────────────────────────────
+export const handler = withAuth(async ({ auth, account, event }) => {
+  requireGroup(auth, 'budget-app', 'admin');
+  const { accountId } = account;
+  const method   = event.httpMethod;
+  const resource = event.resource ?? '';
+
+  if (resource === '/api/budget/v1/transactions'      && method === 'GET')  return listTransactions(event, accountId);
+  if (resource === '/api/budget/v1/transactions/bulk' && method === 'POST') return bulkUpsert(event, accountId);
+
+  const transactionId = getPathParam(event, 'id');
+  if (method === 'PATCH')  return updateTransaction(event, accountId, transactionId);
+  if (method === 'DELETE') return deleteTransaction(accountId, transactionId);
+
+  throw { statusCode: 400, message: `Unrecognised route: ${method} ${resource}` };
+});

--- a/apps/budget-tracker/functions/budget-transactions/tsconfig.json
+++ b/apps/budget-tracker/functions/budget-transactions/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "types": ["node", "aws-lambda"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/infrastructure/bin/app.ts
+++ b/infrastructure/bin/app.ts
@@ -13,6 +13,10 @@ import { PlatformTablesStack } from '../lib/platform/platform-tables-stack';
 import { StockAnalyserApiStack }    from '../lib/stock-analyser/stock-analyser-api-stack';
 import { StockAnalyserTablesStack } from '../lib/stock-analyser/stock-analyser-tables-stack';
 
+// ── Budget Tracker stacks ─────────────────────────────────────────────────────
+import { BudgetTrackerTablesStack } from '../lib/budget-tracker/budget-tracker-tables-stack';
+import { BudgetTrackerApiStack }    from '../lib/budget-tracker/budget-tracker-api-stack';
+
 const app = new cdk.App();
 
 const env = {
@@ -73,6 +77,22 @@ new StockAnalyserApiStack(app, 'TransformotionDev-StockAnalyserApi', {
   authoriser:  devPlatformApi.authoriser,
 });
 
+new BudgetTrackerTablesStack(app, 'TransformotionDev-BudgetTrackerTables', {
+  env,
+  stage:       'dev',
+  description: 'Transformotion Apps — Dev Budget Tracker DynamoDB tables + Cognito client',
+  userPool:    devAuth.userPool,
+});
+
+new BudgetTrackerApiStack(app, 'TransformotionDev-BudgetTrackerApi', {
+  env,
+  stage:       'dev',
+  description: 'Transformotion Apps — Dev Budget Tracker API routes',
+  api:         devPlatformApi.api,
+  authoriser:  devPlatformApi.authoriser,
+  apiResource: devPlatformApi.apiResource,
+});
+
 // ── Prod stacks ────────────────────────────────────────────────────────────────
 
 new NetworkStack(app, 'TransformotionProd-Network', {
@@ -122,4 +142,20 @@ new StockAnalyserApiStack(app, 'TransformotionProd-StockAnalyserApi', {
   description: 'Transformotion Apps — Prod Stock Analyser API routes',
   api:         prodPlatformApi.api,
   authoriser:  prodPlatformApi.authoriser,
+});
+
+new BudgetTrackerTablesStack(app, 'TransformotionProd-BudgetTrackerTables', {
+  env,
+  stage:       'prod',
+  description: 'Transformotion Apps — Prod Budget Tracker DynamoDB tables + Cognito client',
+  userPool:    prodAuth.userPool,
+});
+
+new BudgetTrackerApiStack(app, 'TransformotionProd-BudgetTrackerApi', {
+  env,
+  stage:       'prod',
+  description: 'Transformotion Apps — Prod Budget Tracker API routes',
+  api:         prodPlatformApi.api,
+  authoriser:  prodPlatformApi.authoriser,
+  apiResource: prodPlatformApi.apiResource,
 });

--- a/infrastructure/lib/budget-tracker/budget-tracker-api-stack.ts
+++ b/infrastructure/lib/budget-tracker/budget-tracker-api-stack.ts
@@ -1,0 +1,232 @@
+import * as path from 'path';
+import * as cdk from 'aws-cdk-lib';
+import * as apigateway from 'aws-cdk-lib/aws-apigateway';
+import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
+import * as iam from 'aws-cdk-lib/aws-iam';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import * as lambdaNodejs from 'aws-cdk-lib/aws-lambda-nodejs';
+import { Construct } from 'constructs';
+
+export interface BudgetTrackerApiStackProps extends cdk.StackProps {
+  stage: 'dev' | 'prod';
+  /** Shared API Gateway from PlatformApiStack. */
+  api: apigateway.RestApi;
+  /** Shared JWT authoriser from PlatformApiStack. */
+  authoriser: apigateway.CognitoUserPoolsAuthorizer;
+  /** /api resource from PlatformApiStack — budget routes mount under /api/budget/v1. */
+  apiResource: apigateway.Resource;
+}
+
+/**
+ * BudgetTrackerApiStack — Lambda functions and API routes for the Budget Tracker.
+ *
+ * Mounts under /api/budget/v1/:
+ *   GET    /transactions
+ *   POST   /transactions/bulk
+ *   PATCH  /transactions/:id
+ *   DELETE /transactions/:id
+ *   GET    /rules
+ *   POST   /rules
+ *   PATCH  /rules/:id
+ *   DELETE /rules/:id
+ *   GET    /settings
+ *   PATCH  /settings
+ *   POST   /ai/categorise
+ *   POST   /ai/review
+ *   POST   /ai/csv-analysis
+ *   GET    /business-export
+ *   POST   /migrate-from-localstorage
+ */
+export class BudgetTrackerApiStack extends cdk.Stack {
+  constructor(scope: Construct, id: string, props: BudgetTrackerApiStackProps) {
+    super(scope, id, props);
+
+    const { stage, api, authoriser, apiResource } = props;
+    const auth = authMethodOptions(authoriser);
+
+    // Apply per-app tags to every resource in this stack
+    cdk.Tags.of(this).add('app',         'budget-tracker');
+    cdk.Tags.of(this).add('environment', stage);
+
+    // ── Import shared tables by name ──────────────────────────────────────────
+    const txTable       = dynamodb.Table.fromTableName(this, 'TxTable',       `budget-tracker.transactions-${stage}`);
+    const rulesTable    = dynamodb.Table.fromTableName(this, 'RulesTable',    `budget-tracker.rules-${stage}`);
+    const settingsTable = dynamodb.Table.fromTableName(this, 'SettingsTable', `budget-tracker.settings-${stage}`);
+
+    const claudeProxyFnName = `transformotion-claude-proxy-${stage}`;
+
+    const bundling: lambdaNodejs.BundlingOptions = {
+      externalModules: ['@aws-sdk/*'],
+      minify: true,
+      sourceMap: false,
+      forceDockerBundling: false,
+    };
+
+    const fnDir = path.join(__dirname, '../../../apps/budget-tracker/functions');
+
+    // ── budget-transactions-handler ──────────────────────────────────────────
+    const txFn = new lambdaNodejs.NodejsFunction(this, 'TransactionsFn', {
+      functionName: `budget-transactions-handler-${stage}`,
+      entry:        path.join(fnDir, 'budget-transactions/src/index.ts'),
+      handler:      'handler',
+      runtime:      lambda.Runtime.NODEJS_20_X,
+      timeout:      cdk.Duration.seconds(30),
+      memorySize:   512,
+      environment:  { TRANSACTIONS_TABLE: txTable.tableName },
+      bundling,
+    });
+    txTable.grantReadWriteData(txFn);
+
+    // ── budget-rules-handler ─────────────────────────────────────────────────
+    const rulesFn = new lambdaNodejs.NodejsFunction(this, 'RulesFn', {
+      functionName: `budget-rules-handler-${stage}`,
+      entry:        path.join(fnDir, 'budget-rules/src/index.ts'),
+      handler:      'handler',
+      runtime:      lambda.Runtime.NODEJS_20_X,
+      timeout:      cdk.Duration.seconds(15),
+      memorySize:   256,
+      environment:  { RULES_TABLE: rulesTable.tableName },
+      bundling,
+    });
+    rulesTable.grantReadWriteData(rulesFn);
+
+    // ── budget-settings-handler ──────────────────────────────────────────────
+    const settingsFn = new lambdaNodejs.NodejsFunction(this, 'SettingsFn', {
+      functionName: `budget-settings-handler-${stage}`,
+      entry:        path.join(fnDir, 'budget-settings/src/index.ts'),
+      handler:      'handler',
+      runtime:      lambda.Runtime.NODEJS_20_X,
+      timeout:      cdk.Duration.seconds(15),
+      memorySize:   256,
+      environment:  { SETTINGS_TABLE: settingsTable.tableName },
+      bundling,
+    });
+    settingsTable.grantReadWriteData(settingsFn);
+
+    // ── budget-ai-handler (categorise + review + csv-analysis) ───────────────
+    const aiFn = new lambdaNodejs.NodejsFunction(this, 'AiFn', {
+      functionName: `budget-ai-handler-${stage}`,
+      entry:        path.join(fnDir, 'budget-ai/src/index.ts'),
+      handler:      'handler',
+      runtime:      lambda.Runtime.NODEJS_20_X,
+      timeout:      cdk.Duration.seconds(300),
+      memorySize:   512,
+      environment:  { CLAUDE_PROXY_FUNCTION_NAME: claudeProxyFnName },
+      bundling,
+    });
+    aiFn.addToRolePolicy(new iam.PolicyStatement({
+      actions:   ['lambda:InvokeFunction'],
+      resources: [`arn:aws:lambda:${this.region}:${this.account}:function:${claudeProxyFnName}`],
+    }));
+
+    // ── budget-export-handler ─────────────────────────────────────────────────
+    const exportFn = new lambdaNodejs.NodejsFunction(this, 'ExportFn', {
+      functionName: `budget-export-handler-${stage}`,
+      entry:        path.join(fnDir, 'budget-export/src/index.ts'),
+      handler:      'handler',
+      runtime:      lambda.Runtime.NODEJS_20_X,
+      timeout:      cdk.Duration.seconds(30),
+      memorySize:   256,
+      environment:  { TRANSACTIONS_TABLE: txTable.tableName },
+      bundling,
+    });
+    txTable.grantReadData(exportFn);
+
+    // ── budget-migrate-handler ────────────────────────────────────────────────
+    const migrateFn = new lambdaNodejs.NodejsFunction(this, 'MigrateFn', {
+      functionName: `budget-migrate-handler-${stage}`,
+      entry:        path.join(fnDir, 'budget-migrate/src/index.ts'),
+      handler:      'handler',
+      runtime:      lambda.Runtime.NODEJS_20_X,
+      timeout:      cdk.Duration.seconds(120),
+      memorySize:   512,
+      environment: {
+        TRANSACTIONS_TABLE: txTable.tableName,
+        RULES_TABLE:        rulesTable.tableName,
+        SETTINGS_TABLE:     settingsTable.tableName,
+      },
+      bundling,
+    });
+    txTable.grantReadWriteData(migrateFn);
+    rulesTable.grantReadWriteData(migrateFn);
+    settingsTable.grantReadWriteData(migrateFn);
+
+    // ── API routes ────────────────────────────────────────────────────────────
+    // Mount at /api/budget/v1/
+    const budget = apiResource.addResource('budget');
+    const v1     = budget.addResource('v1');
+
+    // /transactions
+    const txRes     = v1.addResource('transactions');
+    const txIdRes   = txRes.addResource('{id}');
+    const txBulkRes = txRes.addResource('bulk');
+    const txInt     = new apigateway.LambdaIntegration(txFn, { proxy: true });
+    txRes.addMethod('GET', txInt, auth);
+    txBulkRes.addMethod('POST', txInt, auth);
+    txIdRes.addMethod('PATCH',  txInt, auth);
+    txIdRes.addMethod('DELETE', txInt, auth);
+
+    // /rules
+    const rulesRes   = v1.addResource('rules');
+    const ruleIdRes  = rulesRes.addResource('{id}');
+    const rulesInt   = new apigateway.LambdaIntegration(rulesFn, { proxy: true });
+    rulesRes.addMethod('GET',  rulesInt, auth);
+    rulesRes.addMethod('POST', rulesInt, auth);
+    ruleIdRes.addMethod('PATCH',  rulesInt, auth);
+    ruleIdRes.addMethod('DELETE', rulesInt, auth);
+
+    // /settings
+    const settingsRes = v1.addResource('settings');
+    const settingsInt = new apigateway.LambdaIntegration(settingsFn, { proxy: true });
+    settingsRes.addMethod('GET',   settingsInt, auth);
+    settingsRes.addMethod('PATCH', settingsInt, auth);
+
+    // /ai
+    const aiRes = v1.addResource('ai');
+    const aiInt = new apigateway.LambdaIntegration(aiFn, { proxy: true });
+    aiRes.addResource('categorise').addMethod('POST',    aiInt, auth);
+    aiRes.addResource('review').addMethod('POST',        aiInt, auth);
+    aiRes.addResource('csv-analysis').addMethod('POST',  aiInt, auth);
+
+    // /business-export
+    v1.addResource('business-export').addMethod(
+      'GET', new apigateway.LambdaIntegration(exportFn, { proxy: true }), auth
+    );
+
+    // /migrate-from-localstorage
+    v1.addResource('migrate-from-localstorage').addMethod(
+      'POST', new apigateway.LambdaIntegration(migrateFn, { proxy: true }), auth
+    );
+
+    // ── Output: Budget Tracker API base ───────────────────────────────────────
+    new cdk.CfnOutput(this, 'BudgetApiBase', {
+      value:       `${api.url}api/budget/v1`,
+      description: `Budget Tracker API base URL for ${stage}`,
+      exportName:  `Transformotion-${stage}-BudgetApiBase`,
+    });
+  }
+}
+
+function authMethodOptions(
+  authoriser: apigateway.CognitoUserPoolsAuthorizer,
+): apigateway.MethodOptions {
+  return {
+    authorizer:        authoriser,
+    authorizationType: apigateway.AuthorizationType.COGNITO,
+    methodResponses: [
+      {
+        statusCode: '200',
+        responseParameters: {
+          'method.response.header.Access-Control-Allow-Origin':  true,
+          'method.response.header.Access-Control-Allow-Headers': true,
+        },
+      },
+      { statusCode: '400' },
+      { statusCode: '401' },
+      { statusCode: '403' },
+      { statusCode: '429' },
+      { statusCode: '500' },
+      { statusCode: '502' },
+    ],
+  };
+}

--- a/infrastructure/lib/budget-tracker/budget-tracker-tables-stack.ts
+++ b/infrastructure/lib/budget-tracker/budget-tracker-tables-stack.ts
@@ -1,0 +1,130 @@
+import * as cdk from 'aws-cdk-lib';
+import * as cognito from 'aws-cdk-lib/aws-cognito';
+import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
+import { Construct } from 'constructs';
+
+export interface BudgetTrackerTablesStackProps extends cdk.StackProps {
+  stage: 'dev' | 'prod';
+  userPool: cognito.IUserPool;
+}
+
+/**
+ * BudgetTrackerTablesStack — DynamoDB tables and Cognito app client for Budget Tracker.
+ *
+ * Tables (all prefixed budget-tracker.):
+ *   budget-tracker.accounts      PK: accountId
+ *   budget-tracker.transactions  PK: accountId  SK: transactionId
+ *                                GSI: accountId-dateIso-index (PK: accountId, SK: dateIso)
+ *   budget-tracker.rules         PK: accountId  SK: ruleId
+ *   budget-tracker.settings      PK: accountId  SK: settingKey
+ *
+ * Tags: app=budget-tracker, environment=dev|prod applied at stack level.
+ */
+export class BudgetTrackerTablesStack extends cdk.Stack {
+  public readonly transactionsTable: dynamodb.Table;
+  public readonly rulesTable:        dynamodb.Table;
+  public readonly settingsTable:     dynamodb.Table;
+  public readonly accountsTable:     dynamodb.Table;
+  public readonly appClient:         cognito.UserPoolClient;
+
+  constructor(scope: Construct, id: string, props: BudgetTrackerTablesStackProps) {
+    super(scope, id, props);
+
+    const { stage, userPool } = props;
+    const isProd   = stage === 'prod';
+    const removal  = isProd ? cdk.RemovalPolicy.RETAIN : cdk.RemovalPolicy.DESTROY;
+
+    // Apply per-app tags to every resource in this stack
+    cdk.Tags.of(this).add('app',         'budget-tracker');
+    cdk.Tags.of(this).add('environment', stage);
+
+    // ── budget-tracker.accounts ───────────────────────────────────────────────
+    this.accountsTable = new dynamodb.Table(this, 'AccountsTable', {
+      tableName:     `budget-tracker.accounts-${stage}`,
+      partitionKey:  { name: 'accountId', type: dynamodb.AttributeType.STRING },
+      billingMode:   dynamodb.BillingMode.PAY_PER_REQUEST,
+      removalPolicy: removal,
+    });
+
+    // ── budget-tracker.transactions ───────────────────────────────────────────
+    this.transactionsTable = new dynamodb.Table(this, 'TransactionsTable', {
+      tableName:     `budget-tracker.transactions-${stage}`,
+      partitionKey:  { name: 'accountId',     type: dynamodb.AttributeType.STRING },
+      sortKey:       { name: 'transactionId', type: dynamodb.AttributeType.STRING },
+      billingMode:   dynamodb.BillingMode.PAY_PER_REQUEST,
+      removalPolicy: removal,
+    });
+
+    this.transactionsTable.addGlobalSecondaryIndex({
+      indexName:     'accountId-dateIso-index',
+      partitionKey:  { name: 'accountId', type: dynamodb.AttributeType.STRING },
+      sortKey:       { name: 'dateIso',   type: dynamodb.AttributeType.STRING },
+      projectionType: dynamodb.ProjectionType.ALL,
+    });
+
+    // ── budget-tracker.rules ──────────────────────────────────────────────────
+    this.rulesTable = new dynamodb.Table(this, 'RulesTable', {
+      tableName:     `budget-tracker.rules-${stage}`,
+      partitionKey:  { name: 'accountId', type: dynamodb.AttributeType.STRING },
+      sortKey:       { name: 'ruleId',    type: dynamodb.AttributeType.STRING },
+      billingMode:   dynamodb.BillingMode.PAY_PER_REQUEST,
+      removalPolicy: removal,
+    });
+
+    // ── budget-tracker.settings ───────────────────────────────────────────────
+    this.settingsTable = new dynamodb.Table(this, 'SettingsTable', {
+      tableName:     `budget-tracker.settings-${stage}`,
+      partitionKey:  { name: 'accountId',  type: dynamodb.AttributeType.STRING },
+      sortKey:       { name: 'settingKey', type: dynamodb.AttributeType.STRING },
+      billingMode:   dynamodb.BillingMode.PAY_PER_REQUEST,
+      removalPolicy: removal,
+    });
+
+    // ── Cognito app client — budget-tracker-${stage} ──────────────────────────
+    const callbackUrls = isProd
+      ? [
+          'https://apps.transformotion.com.au/budget',
+          'https://apps.transformotion.com.au/budget/callback',
+        ]
+      : [
+          'http://localhost:3002',
+          'http://localhost:3002/callback',
+          'https://dev.apps.transformotion.com.au/budget',
+          'https://dev.apps.transformotion.com.au/budget/callback',
+        ];
+
+    this.appClient = userPool.addClient('BudgetTrackerClient', {
+      userPoolClientName: `budget-tracker-${stage}`,
+      generateSecret: false,
+      oAuth: {
+        flows:  { authorizationCodeGrant: true },
+        scopes: [cognito.OAuthScope.OPENID, cognito.OAuthScope.EMAIL, cognito.OAuthScope.PROFILE],
+        callbackUrls,
+        logoutUrls: isProd
+          ? ['https://apps.transformotion.com.au/budget']
+          : ['http://localhost:3002', 'https://dev.apps.transformotion.com.au/budget'],
+      },
+      authFlows: { userSrp: true },
+      accessTokenValidity:  cdk.Duration.hours(1),
+      idTokenValidity:      cdk.Duration.hours(1),
+      refreshTokenValidity: cdk.Duration.days(30),
+      readAttributes: new cognito.ClientAttributes()
+        .withStandardAttributes({ email: true, emailVerified: true, givenName: true, familyName: true })
+        .withCustomAttributes('active_account', 'accounts'),
+      writeAttributes: new cognito.ClientAttributes()
+        .withStandardAttributes({ email: true, givenName: true, familyName: true })
+        .withCustomAttributes('active_account', 'accounts'),
+      preventUserExistenceErrors: true,
+    });
+
+    // ── Outputs ───────────────────────────────────────────────────────────────
+    const out = (id: string, value: string, description: string) =>
+      new cdk.CfnOutput(this, id, { value, description, exportName: `Transformotion-${stage}-${id}` });
+
+    out('BTAccountsTableArn',     this.accountsTable.tableArn,     'budget-tracker.accounts table ARN');
+    out('BTTransactionsTableArn', this.transactionsTable.tableArn, 'budget-tracker.transactions table ARN');
+    out('BTRulesTableArn',        this.rulesTable.tableArn,        'budget-tracker.rules table ARN');
+    out('BTSettingsTableArn',     this.settingsTable.tableArn,     'budget-tracker.settings table ARN');
+    out('BTAppClientId',          this.appClient.userPoolClientId, 'Budget Tracker Cognito app client ID');
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,174 @@ importers:
         specifier: '*'
         version: 5.7.3
 
+  apps/budget-tracker/functions/budget-ai:
+    dependencies:
+      '@transformotion/budget-domain':
+        specifier: workspace:*
+        version: link:../../../../packages/budget-domain
+      '@transformotion/lambda-middleware':
+        specifier: workspace:*
+        version: link:../../../../packages/lambda-middleware
+    devDependencies:
+      '@aws-sdk/client-dynamodb':
+        specifier: ^3
+        version: 3.1032.0
+      '@aws-sdk/client-lambda':
+        specifier: ^3
+        version: 3.1032.0
+      '@aws-sdk/lib-dynamodb':
+        specifier: ^3
+        version: 3.1032.0(@aws-sdk/client-dynamodb@3.1032.0)
+      '@types/aws-lambda':
+        specifier: ^8
+        version: 8.10.161
+      '@types/node':
+        specifier: ^22
+        version: 22.19.17
+      typescript:
+        specifier: '*'
+        version: 5.7.3
+
+  apps/budget-tracker/functions/budget-export:
+    dependencies:
+      '@transformotion/budget-domain':
+        specifier: workspace:*
+        version: link:../../../../packages/budget-domain
+      '@transformotion/lambda-middleware':
+        specifier: workspace:*
+        version: link:../../../../packages/lambda-middleware
+    devDependencies:
+      '@aws-sdk/client-dynamodb':
+        specifier: ^3
+        version: 3.1032.0
+      '@aws-sdk/client-lambda':
+        specifier: ^3
+        version: 3.1032.0
+      '@aws-sdk/lib-dynamodb':
+        specifier: ^3
+        version: 3.1032.0(@aws-sdk/client-dynamodb@3.1032.0)
+      '@types/aws-lambda':
+        specifier: ^8
+        version: 8.10.161
+      '@types/node':
+        specifier: ^22
+        version: 22.19.17
+      typescript:
+        specifier: '*'
+        version: 5.7.3
+
+  apps/budget-tracker/functions/budget-migrate:
+    dependencies:
+      '@transformotion/budget-domain':
+        specifier: workspace:*
+        version: link:../../../../packages/budget-domain
+      '@transformotion/lambda-middleware':
+        specifier: workspace:*
+        version: link:../../../../packages/lambda-middleware
+    devDependencies:
+      '@aws-sdk/client-dynamodb':
+        specifier: ^3
+        version: 3.1032.0
+      '@aws-sdk/client-lambda':
+        specifier: ^3
+        version: 3.1032.0
+      '@aws-sdk/lib-dynamodb':
+        specifier: ^3
+        version: 3.1032.0(@aws-sdk/client-dynamodb@3.1032.0)
+      '@types/aws-lambda':
+        specifier: ^8
+        version: 8.10.161
+      '@types/node':
+        specifier: ^22
+        version: 22.19.17
+      typescript:
+        specifier: '*'
+        version: 5.7.3
+
+  apps/budget-tracker/functions/budget-rules:
+    dependencies:
+      '@transformotion/budget-domain':
+        specifier: workspace:*
+        version: link:../../../../packages/budget-domain
+      '@transformotion/lambda-middleware':
+        specifier: workspace:*
+        version: link:../../../../packages/lambda-middleware
+    devDependencies:
+      '@aws-sdk/client-dynamodb':
+        specifier: ^3
+        version: 3.1032.0
+      '@aws-sdk/client-lambda':
+        specifier: ^3
+        version: 3.1032.0
+      '@aws-sdk/lib-dynamodb':
+        specifier: ^3
+        version: 3.1032.0(@aws-sdk/client-dynamodb@3.1032.0)
+      '@types/aws-lambda':
+        specifier: ^8
+        version: 8.10.161
+      '@types/node':
+        specifier: ^22
+        version: 22.19.17
+      typescript:
+        specifier: '*'
+        version: 5.7.3
+
+  apps/budget-tracker/functions/budget-settings:
+    dependencies:
+      '@transformotion/budget-domain':
+        specifier: workspace:*
+        version: link:../../../../packages/budget-domain
+      '@transformotion/lambda-middleware':
+        specifier: workspace:*
+        version: link:../../../../packages/lambda-middleware
+    devDependencies:
+      '@aws-sdk/client-dynamodb':
+        specifier: ^3
+        version: 3.1032.0
+      '@aws-sdk/client-lambda':
+        specifier: ^3
+        version: 3.1032.0
+      '@aws-sdk/lib-dynamodb':
+        specifier: ^3
+        version: 3.1032.0(@aws-sdk/client-dynamodb@3.1032.0)
+      '@types/aws-lambda':
+        specifier: ^8
+        version: 8.10.161
+      '@types/node':
+        specifier: ^22
+        version: 22.19.17
+      typescript:
+        specifier: '*'
+        version: 5.7.3
+
+  apps/budget-tracker/functions/budget-transactions:
+    dependencies:
+      '@transformotion/budget-domain':
+        specifier: workspace:*
+        version: link:../../../../packages/budget-domain
+      '@transformotion/lambda-middleware':
+        specifier: workspace:*
+        version: link:../../../../packages/lambda-middleware
+    devDependencies:
+      '@aws-sdk/client-dynamodb':
+        specifier: ^3
+        version: 3.1032.0
+      '@aws-sdk/client-lambda':
+        specifier: ^3
+        version: 3.1032.0
+      '@aws-sdk/lib-dynamodb':
+        specifier: ^3
+        version: 3.1032.0(@aws-sdk/client-dynamodb@3.1032.0)
+      '@types/aws-lambda':
+        specifier: ^8
+        version: 8.10.161
+      '@types/node':
+        specifier: ^22
+        version: 22.19.17
+      typescript:
+        specifier: '*'
+        version: 5.7.3
+
   apps/stock-analyser:
     dependencies:
       '@hookform/resolvers':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,7 @@ packages:
   - 'apps/*'
   - '!apps/web-vite-backup'
   - 'apps/stock-analyser/functions/*'
+  - 'apps/budget-tracker/functions/*'
   - 'packages/*'
   - 'functions/*'
   - 'infrastructure'


### PR DESCRIPTION
## Summary

- **4 DynamoDB tables**: `budget-tracker.{transactions,rules,settings,accounts}-{stage}`, transactions table has `accountId-dateIso-index` GSI for date-range queries
- **Cognito app client** `budget-tracker-{stage}` with authorization code + PKCE, callback URLs for localhost/dev/prod
- **6 Lambda functions**: `budget-{transactions,rules,settings,ai,export,migrate}` — each with its own `package.json`, `tsconfig.json`, and `src/index.ts`
- **2 CDK stacks**: `BudgetTrackerTablesStack` + `BudgetTrackerApiStack` wired into `app.ts` for both dev and prod
- **API routes** mounted at `/api/budget/v1/` on the shared PlatformApiStack gateway with Cognito auth
- **`budget-ai`** invokes `transformotion-claude-proxy-{stage}` Lambda via `InvokeCommand` with a minimal fake API Gateway event carrying auth claims — no raw JWT required
- **`budget-migrate`** is idempotent: deduplicates on natural key, applies two data transformations (`_ignore` → Financial & Insurance/Transfer; projectBudgets key rename)
- `pnpm-workspace.yaml` updated to include `apps/budget-tracker/functions/*`

## Test plan

- [x] `pnpm install` — 26 workspace packages resolved cleanly
- [x] `pnpm run typecheck` — 27/27 tasks successful

🤖 Generated with [Claude Code](https://claude.com/claude-code)