### PR TITLE
feat(launchpad): enable Budget Tracker tile

### DIFF
--- a/apps/web-vite-backup/src/components/launchpad/AppTile.tsx
+++ b/apps/web-vite-backup/src/components/launchpad/AppTile.tsx
@@ -11,9 +11,17 @@ export function AppTile({ app, currentPhase = 1 }: AppTileProps) {
   const isBuilt  = app.phase <= currentPhase;
   const { Icon, accentColor } = app;
 
+  function handleClick() {
+    if (app.external) {
+      window.location.href = app.route;
+    } else {
+      navigate(app.route);
+    }
+  }
+
   return (
     <button
-      onClick={() => navigate(app.route)}
+      onClick={handleClick}
       disabled={!isBuilt}
       className="group w-full text-left rounded-2xl p-5 flex flex-col gap-4 transition-all focus:outline-none disabled:cursor-default"
       style={{

--- a/apps/web-vite-backup/src/lib/appRegistry.ts
+++ b/apps/web-vite-backup/src/lib/appRegistry.ts
@@ -14,8 +14,10 @@ export interface AppDefinition {
   id: string;
   name: string;
   description: string;
-  /** Root route — React Router path prefix. */
+  /** Root route — React Router path prefix, or full URL for external apps. */
   route: string;
+  /** If true, clicking opens route in the current tab via window.location (not React Router). */
+  external?: boolean;
   /** Cognito groups (other than 'admin') that grant access. */
   groups: string[];
   /** SVG icon component rendered on tiles and nav. */
@@ -41,11 +43,12 @@ export const APP_REGISTRY: AppDefinition[] = [
     id:          'budget-tracker',
     name:        'Budget Tracker',
     description: 'Track income, expenses, and savings goals across accounts. Shared budgets for households and families.',
-    route:       '/budget',
+    route:       import.meta.env.VITE_BUDGET_URL ?? 'http://localhost:3002',
+    external:    true,
     groups:      ['budget-app'],
     Icon:        BudgetIcon,
     accentColor: '#E8A838',   // gold
-    phase:       5,
+    phase:       3,
   },
   {
     id:          'transformotion-framework',


### PR DESCRIPTION
## Summary

- Budget Tracker phase `5` → `3` — tile is now active at `currentPhase={3}`
- `external: true` added to the registry entry — clicking navigates via `window.location.href` rather than React Router (Budget Tracker is a separate Next.js app, not a route within the launchpad SPA)
- `AppTile` updated to respect the `external` flag
- Route resolved from `VITE_BUDGET_URL` env var; defaults to `http://localhost:3002` so dev works without config

Set `VITE_BUDGET_URL` to the production budget tracker URL when deploying to prod.

## Test plan

- [ ] Budget Tracker tile is visible and clickable on launchpad (not "Coming soon")
- [ ] Clicking the tile opens `http://localhost:3002` (dev) or the production URL
- [ ] Stock Signal Analyser tile still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)