### PR TITLE
chore: Phase 0 — stabilisation freeze and migration invariants

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,12 @@ v0-reference/
 # Logs
 *.log
 npm-debug.log*
+
+# Auto-generated build artefacts
+tsconfig.tsbuildinfo
+**/tsconfig.tsbuildinfo
+next-env.d.ts
+**/next-env.d.ts
+
+# Claude Code local settings (per-machine, not committed)
+.claude/

--- a/STABILISATION_FREEZE.md
+++ b/STABILISATION_FREEZE.md
@@ -1,0 +1,46 @@
+# Stabilisation Freeze
+
+**Status:** ACTIVE
+**Started:** 2026-04-20
+**Expected end:** Once Phase 4 (stock analyser migration) is complete
+and stable in production.
+
+## What this means
+
+No new features will be built in any Transformotion repo during this
+freeze. Only stabilisation work is permitted:
+
+- Turning on existing enforcement (ESLint, boundary rules, pre-commit
+  hooks, CI test gates)
+- Converting markdown contracts to executable Zod schemas
+- Adding IaC policy checks (cdk-nag)
+- Migrating the monolithic stock analyser HTML into the monorepo
+- Fixing documented architectural drift (e.g. Budget Tracker API
+  Gateway rollback to shared platform Gateway)
+- Bug fixes required to ship the above
+
+## What this does not mean
+
+The freeze is not a halt. Work continues on the stabilisation sequence.
+The freeze restricts *scope*, not *activity*.
+
+## Why
+
+The architecture documented in `MONOREPO.md` and `DEVELOPMENT_PLAN.md`
+is sound. The enforcement layer under it has been partially or fully
+disabled. Until enforcement is restored and contracts are executable,
+new features compound drift rather than ship value.
+
+## How to know the freeze is lifting
+
+The freeze lifts when:
+
+- ESLint boundary rules run in CI for all apps and must pass
+- Existing tests are wired into CI and must pass
+- Contract schemas are executable (Zod) and validated in Lambda
+  handlers and API client
+- `cdk-nag` runs on CDK synth and must pass
+- The monolithic stock analyser is migrated and decommissioned
+- The Budget Tracker API Gateway is rolled back to the shared platform
+  Gateway and the underlying CDK circular dependency is resolved
+  properly

--- a/apps/stock-analyser/MIGRATION_INVARIANTS.md
+++ b/apps/stock-analyser/MIGRATION_INVARIANTS.md
@@ -1,0 +1,78 @@
+# Stock Analyser Migration Invariants
+
+These behaviours must be preserved when the monolithic
+`stock-signal-analyser.html` (currently in the separate
+`transformotion/stock-analyser` repo) is migrated into this Next.js
+app during Phase 4 of the stabilisation plan.
+
+Each item below has caused a production bug at least once. The
+migrated version MUST include an automated test that fails if the
+corresponding invariant is violated. Do not declare the migration
+complete until every invariant below has a failing-then-passing test
+in the monorepo's test suite.
+
+## Historical incidents (root causes that must not recur)
+
+1. BUY tags must render green, not amber. Root cause: exact-match
+   comparison of `s.signal` failed for lowercase responses from
+   Claude. Fix: signal normalisation via `rawSig.trim().toUpperCase()`
+   plus `startsWith('BUY')`. Test: `normaliseSignal('buy')` and
+   `normaliseSignal('STRONG BUY')` both map to class `buy`.
+
+2. `computeLiveCycle` must work without a DOM container. Root cause:
+   an early `if (!container) return` guard silently skipped portfolio
+   cycle updates in batch mode. Fix: the function must compute and
+   return results regardless of DOM presence. Test: call
+   `computeLiveCycle(ticker, cacheKey)` with no container argument
+   and assert a full result object is returned.
+
+3. `isLive()` must always exist and return a boolean. Root cause: the
+   function was accidentally deleted during an edit, causing all AI
+   calls to silently degrade to Fast mode. Fix: function must exist
+   and return `false` when the toggle element is absent. Test: call
+   `isLive()` in a context without a toggle and assert `false`, not
+   `undefined`.
+
+4. Watchlist refresh must use `Promise.all`, not serial awaits. Root
+   cause: serial `for` loop with `await` caused 30+ second refreshes.
+   Test: performance test asserting concurrent fetches, or a
+   code-level assertion that the relevant function calls `Promise.all`.
+
+5. Claude tickers may not string-match portfolio tickers exactly
+   (e.g. `BRN` vs `BRN.AX`). Root cause: exact string equality. Fix:
+   match by array position first, then bare-code fuzzy match. Test:
+   `matchTickers(['BRN'], ['BRN.AX'])` returns a positive match.
+
+6. Claude may append prose after a JSON block. Root cause: naive
+   `JSON.parse()`. Fix: depth-tracking parser that stops at the final
+   closing brace. Test: `parseClaudeJson('{"a":1} Note: ...')`
+   returns `{a:1}` without error.
+
+7. AI prompts must include an explicit "no emoji, JSON only"
+   instruction. Root cause: emoji in JSON responses caused parse
+   failures. Test: snapshot test of the system prompt asserting the
+   phrase "no emoji" appears.
+
+## Additional invariants from the stock analyser testing brief
+
+8. `normaliseTicker('VOO:US')` returns `'VOO'`.
+9. `normaliseTicker('A200')` returns `'A200.AX'`.
+10. `normaliseTicker('BRN:ASX')` returns `'BRN.AX'`.
+11. `cmcCost(100)` returns `11` (brokerage floor).
+12. `cmcCost(20000)` returns `15` (0.075% of $20,000).
+13. Cache staleness thresholds match the documented table per context
+    (`analyser`, `recommendations`, `metals`, `etfs`, `markets`).
+14. Tab switching uses text match or panel ID, not `tabs[0]` index.
+15. `confirm()` dialogs must not be used — use the double-tap
+    confirmation pattern for UX consistency with the monolith origin.
+16. Market Analysis and Analyser system prompts specify "no emoji,
+    JSON only".
+
+## Source references
+
+These invariants were preserved from:
+- `CLAUDE.md` in the monolithic `transformotion/stock-analyser` repo,
+  section "Things That Have Bitten Us"
+- Monolithic stock analyser `docs/cowork-testing-brief.md`, sections 4
+  ("Key Invariants to Test") and 5 ("Things That Have Bitten Us
+  Before")

--- a/docs/architecture-audit.md
+++ b/docs/architecture-audit.md
@@ -1,0 +1,513 @@
+# Transformotion Apps — Architecture & Enforcement Discovery Audit
+
+**Audit Date:** 2026-04-20
+**Repository:** https://github.com/transformotion/transformotion-apps
+**Default Branch:** develop
+**AWS Region:** ap-southeast-2
+
+---
+
+## 1. Repository & Project Structure
+
+**Repository Details:**
+- **Name:** transformotion-apps
+- **Remote URLs:**
+  - origin: https://github.com/transformotion/transformotion-apps.git
+  - v0-designs: https://github.com/transformotion/transformotion-apps-b8.git
+- **Default Branch:** develop
+
+**Monorepo Tool:** pnpm workspaces (v10.33.0) + Turborepo 2.0.0
+
+**Top-level folder structure:**
+```
+transformotion-apps/
+├── apps/
+│   ├── stock-analyser/      ← Next.js frontend + Lambda functions
+│   ├── budget-tracker/      ← Lambda functions only (UI lives in stock-analyser)
+│   └── web/                 ← Platform launchpad (Next.js)
+├── functions/               ← Platform-level Lambda handlers
+│   ├── accounts/
+│   ├── claude-proxy/
+│   ├── first-login/
+│   ├── forgot-provider/
+│   ├── invitations/
+│   └── user/
+├── infrastructure/          ← AWS CDK (TypeScript)
+├── packages/                ← Shared workspace packages
+│   ├── api-client/
+│   ├── auth-client/
+│   ├── budget-domain/
+│   ├── cycle-engine/
+│   ├── lambda-middleware/
+│   └── ui/
+├── contracts/               ← Data model docs per app
+├── docs/                    ← Architecture/testing briefs
+├── migration-artifacts/     ← Export fixtures for testing
+└── MONOREPO.md
+```
+
+**Project Manifests (package.json paths, excl. node_modules):**
+- `./package.json` (root)
+- `apps/stock-analyser/package.json`
+- `apps/budget-tracker/package.json`
+- `apps/web/package.json`
+- `apps/stock-analyser/functions/portfolio/package.json`
+- `apps/stock-analyser/functions/watchlist/package.json`
+- `apps/stock-analyser/functions/analysis-cache/package.json`
+- `apps/stock-analyser/functions/cycle-check/package.json`
+- `apps/budget-tracker/functions/budget-transactions/package.json`
+- `apps/budget-tracker/functions/budget-rules/package.json`
+- `apps/budget-tracker/functions/budget-settings/package.json`
+- `apps/budget-tracker/functions/budget-ai/package.json`
+- `apps/budget-tracker/functions/budget-export/package.json`
+- `apps/budget-tracker/functions/budget-migrate/package.json`
+- `functions/accounts/package.json`
+- `functions/claude-proxy/package.json`
+- `functions/first-login/package.json`
+- `functions/forgot-provider/package.json`
+- `functions/invitations/package.json`
+- `functions/user/package.json`
+- `packages/api-client/package.json`
+- `packages/auth-client/package.json`
+- `packages/budget-domain/package.json`
+- `packages/cycle-engine/package.json`
+- `packages/lambda-middleware/package.json`
+- `packages/ui/package.json`
+- `infrastructure/package.json`
+
+**pnpm-workspace.yaml:**
+```yaml
+packages:
+  - 'apps/*'
+  - '!apps/web-vite-backup'
+  - 'apps/stock-analyser/functions/*'
+  - 'apps/budget-tracker/functions/*'
+  - 'packages/*'
+  - 'functions/*'
+  - 'infrastructure'
+```
+
+---
+
+## 2. Tech Stack
+
+**Primary Languages:**
+- TypeScript 5.4.0 (root), 5.7.3 (apps)
+- Node.js ≥22.0.0 (engines requirement)
+
+**Frontend:**
+- React 19.x + Next.js 16.2.0 (App Router, static export)
+- Tailwind CSS v4.2.0
+- Radix UI (component primitives)
+- Zustand (state management)
+- react-hook-form + Zod (forms + runtime validation)
+- Recharts (charting)
+
+**Backend:**
+- AWS Lambda (Node.js 22 runtime)
+- AWS API Gateway (REST and HTTP)
+- AWS DynamoDB (On-Demand)
+- AWS Cognito (authentication)
+- AWS SES (email)
+- AWS Secrets Manager (API keys)
+
+**Package Manager:** pnpm 10.33.0
+**Build Orchestration:** Turborepo 2.0.0
+**IaC:** AWS CDK v2.100.0 (TypeScript)
+
+**Third-party Services:**
+- Anthropic Claude API (via claude-proxy Lambda)
+- AWS Cognito (multi-tenant auth with custom groups)
+
+---
+
+## 3. Architecture
+
+**Pattern:** Multi-tenant SaaS platform — monorepo container with per-app bounded contexts. Each app owns its UI, Lambda functions, infrastructure stacks, and data contracts. Shared platform layer handles auth, accounts, and shared API routes.
+
+**Layers:**
+1. **Presentation:** React/Next.js in `apps/` (static export to S3 + CloudFront)
+2. **API Gateway:** Shared platform API (HTTP) + per-app separate gateways (Budget Tracker has its own)
+3. **Lambda:** Platform functions in `functions/`; app functions in `apps/<app>/functions/`
+4. **Data:** DynamoDB (all tables account-scoped via `accountId` partition key)
+5. **Infrastructure:** CDK in `infrastructure/` (platform stacks + per-app stacks)
+
+**Bounded Contexts:**
+- **Stock Analyser** — market cycle analysis (RSI/MACD/volume), portfolio tracking, watchlist
+- **Budget Tracker** — expense tracking, classification, budget vs actual, cashflow
+- **Platform/Launchpad** — multi-tenant entry point, Cognito group-based app access
+
+**Import Rules (from MONOREPO.md, enforced by eslint-plugin-boundaries):**
+
+| From | Can Import | Cannot Import |
+|---|---|---|
+| apps/stock-analyser/ | packages/* | apps/budget-tracker/, apps/web/ |
+| apps/budget-tracker/ | packages/* | apps/stock-analyser/, apps/web/ |
+| packages/* | (nothing outside packages/) | apps/*, infrastructure/* |
+| infrastructure/* | functions/* (file paths) | apps/* directly |
+
+**Data Contracts:**
+- `apps/stock-analyser/contracts/DATA_CONTRACTS.md` — PortfolioHolding, StockAnalysisResult, WatchlistItem, EnrichedHolding; cache keys with TTLs; mock/real separation
+- `apps/budget-tracker/contracts/` — Transaction, BudgetSettings, CustomRule, BuiltinRule (v1.1); separate contract files per domain area
+- `contracts/<app>/` — top-level canonical contract docs (mirrored to app directories)
+
+**Key Architectural Decisions (from DEVELOPMENT_PLAN.md):**
+- Multi-tenancy via `accountId` (not user-based); all DynamoDB queries scoped
+- Cognito groups control app access: `stock-app`, `budget-app`, `admin`, `transformotion`, `family`
+- Static export to S3 + CloudFront (Next.js `output: 'export'`)
+- OIDC authentication for GitHub Actions (no long-lived AWS keys)
+- On-Demand DynamoDB capacity
+- Mobile-first design (375px baseline)
+
+---
+
+## 4. Infrastructure as Code
+
+**Tool:** AWS CDK (TypeScript) v2.100.0
+**Location:** `infrastructure/`
+**CDK Entry:** `infrastructure/bin/app.ts`
+**Target Cloud:** AWS
+**Region:** ap-southeast-2
+**Account:** 959516291617
+
+**Stack Inventory (14 total, 7 per environment):**
+
+| Stack | Purpose |
+|---|---|
+| `TransformotionDev/Prod-Network` | S3 bucket + CloudFront distribution + ACM cert |
+| `TransformotionDev/Prod-Auth` | Cognito User Pool + groups + custom attributes |
+| `TransformotionDev/Prod-AuthApi` | forgot-provider Lambda + API Gateway |
+| `TransformotionDev/Prod-PlatformTables` | DynamoDB: users, accounts, invitations, analysis-cache |
+| `TransformotionDev/Prod-Api` | Platform REST API Gateway + Cognito authoriser + platform Lambda routes |
+| `TransformotionDev/Prod-StockAnalyserTables` | DynamoDB: portfolio-v2, watchlist-v2 |
+| `TransformotionDev/Prod-StockAnalyserApi` | Stock Analyser Lambda functions + routes on platform API |
+| `TransformotionDev/Prod-BudgetTrackerTables` | DynamoDB: budget transactions, rules, settings |
+| `TransformotionDev/Prod-BudgetTrackerApi` | Budget Tracker Lambda functions + own API Gateway |
+
+**IaC Source Layout:**
+```
+infrastructure/
+├── bin/app.ts                  ← CDK app entry, all stack instantiations
+├── lib/
+│   ├── platform/               ← NetworkStack, AuthStack, PlatformApiStack, etc.
+│   ├── stock-analyser/         ← StockAnalyserTablesStack, StockAnalyserApiStack
+│   └── budget-tracker/         ← BudgetTrackerTablesStack, BudgetTrackerApiStack
+└── cdk.json
+```
+
+**Shared Construct Library:** None — CDK constructs are defined inline in each stack file. No separate construct library package.
+
+---
+
+## 5. CI/CD
+
+**Platform:** GitHub Actions
+**Auth:** OIDC (`GitHubActionsDeployRole`, no long-lived credentials)
+**ROLE_ARN:** `arn:aws:iam::959516291617:role/GitHubActionsDeployRole`
+
+**Workflows (`.github/workflows/`):**
+
+### ci.yml — PR Validation
+- **Trigger:** PR to `main` or `develop`
+- **Jobs:** typecheck (`pnpm turbo typecheck`), lint (`pnpm turbo lint`), CDK synth dev + prod
+- **Note:** Lint currently partially disabled — Stock Analyser and Budget Tracker skip ESLint (ESLint 10 flat config incompatibility)
+
+### deploy-platform.yml — Platform Infrastructure
+- **Trigger:** Push to `develop`/`main` on paths: `infrastructure/lib/platform/**`, `infrastructure/bin/**`, `functions/**`
+- **Dev job:** CDK deploy all platform stacks → dev; deploys web app to S3
+- **Prod job:** Same for prod (main branch only)
+- **Commands:** `cdk deploy`, `aws s3 sync`, `aws cloudfront create-invalidation`
+
+### deploy-stock-analyser.yml — Stock Analyser
+- **Trigger:** Push to `develop`/`main` on `apps/stock-analyser/**`, `infrastructure/lib/stock-analyser/**`, `packages/**`, `functions/**`; also `workflow_dispatch` with `target: dev|prod`
+- **Dev job:** `cdk deploy TransformotionDev-StockAnalyserApi` → `pnpm build` (Next.js static) → `aws s3 sync` → CloudFront invalidation
+- **Prod job:** Same with prod stacks + prod S3 bucket
+- **Env vars baked at build:** `NEXT_PUBLIC_API_URL`, `NEXT_PUBLIC_CLAUDE_API_URL`, `NEXT_PUBLIC_COGNITO_*`, `NEXT_PUBLIC_BUDGET_API_URL`
+
+### deploy-budget-tracker.yml — Budget Tracker
+- **Trigger:** Push to `develop`/`main` on `apps/budget-tracker/**`, `infrastructure/lib/budget-tracker/**`
+- **Status:** Placeholder — `echo` only; activates when scaffolding complete
+
+### cd.yml — Full Platform Redeploy
+- **Trigger:** `workflow_dispatch` only
+- **Purpose:** Manual full redeploy of all stacks + apps
+
+**CloudFront Distribution:** `E1128DYYBLMWYK` (dev), `${{ vars.CLOUDFRONT_DISTRIBUTION_ID_PROD }}` (prod)
+
+---
+
+## 6. Testing
+
+**Frameworks:** Vitest 1.0.0
+
+**Test File Locations:**
+- `packages/budget-domain/src/__tests__/` — 6 files:
+  - `budget-tracking.test.ts`
+  - `cashflow.test.ts`
+  - `category-tree.test.ts`
+  - `csv.test.ts`
+  - `exclusions.test.ts`
+  - `rules.test.ts`
+
+**Test Count:** ~60–80 unit tests total; all in `packages/budget-domain`
+
+**Zero test coverage for:**
+- `apps/stock-analyser/` (no test files)
+- `apps/budget-tracker/` (no test files)
+- `apps/web/` (no test files)
+- All Lambda functions (`functions/`, `apps/*/functions/`)
+- All shared packages except `budget-domain`
+
+**Coverage Threshold:** Not configured
+
+**Disabled Tests:** None found (no `.skip` or `xit()`)
+
+**Contract Tests:** None. Contracts are markdown documents only — no schema validation, no Pact tests, no OpenAPI spec validation.
+
+**Vitest Config:** `packages/budget-domain/vitest.config.ts`
+
+**Test Run Command:**
+```bash
+cd packages/budget-domain && pnpm test
+```
+
+---
+
+## 7. Existing Enforcement Mechanisms
+
+### ESLint
+
+**Status:** ✅ Configured at root; ❌ Disabled for app workspaces in CI
+
+**Config:** `.eslintrc.cjs` (root)
+
+**Active Rule Sets:**
+- `eslint-plugin-boundaries` (v6.0.2) — cross-app import enforcement
+  - Apps cannot import from other apps
+  - Packages cannot import from apps
+
+**CI Status:** `pnpm turbo lint` runs on PRs but:
+- `apps/stock-analyser/` — ESLint skipped (commit 46cfad4): ESLint 10 flat config incompatibility with eslint-plugin-boundaries
+- `apps/budget-tracker/` — ESLint skipped (commit 3bceb35): same reason
+
+**Net effect:** Boundary rules are defined but **not enforced in CI**.
+
+### Prettier
+
+**Status:** ❌ Not configured. No `.prettierrc`, `prettier.config.*`, or Prettier dependency at root.
+
+### TypeScript
+
+**Status:** ✅ Configured; strict mode enabled
+
+**Root `tsconfig.json` key flags:**
+```json
+{
+  "strict": true,
+  "esModuleInterop": true,
+  "skipLibCheck": true,
+  "moduleResolution": "bundler"
+}
+```
+
+**CI Enforcement:** `pnpm turbo typecheck` runs on all PRs — this is the primary working quality gate.
+
+**Notable exception:** `transactions-tab.tsx` has `// @ts-nocheck` at top (disables all TS checks for that file).
+
+### Architecture / Boundary Enforcement
+
+**Tool:** `eslint-plugin-boundaries` (v6.0.2)
+**Status:** ✅ Rules defined; ❌ **Not enforced in CI** (apps skip linting)
+
+### Schema Validation
+
+**Status:** Zod (runtime, forms only — not used to validate API responses or Lambda I/O)
+
+No build-time schema enforcement. Contracts are markdown.
+
+### IaC Policy Checks
+
+**Status:** ❌ Not configured. No cdk-nag, Checkov, tfsec, or OPA.
+
+### Pre-commit Hooks
+
+**Status:** ❌ Not configured. No Husky, lefthook, or `.pre-commit-config.yaml`.
+
+### Commit Message Conventions
+
+**Status:** ❌ Not enforced. Commits follow Conventional Commits style in practice but no commitlint configured.
+
+### Secret Scanning / SAST / Dependency Scanning
+
+**Status:** ❌ None configured in CI or pre-commit.
+
+### Suppressions
+
+**`@ts-ignore` / `@ts-nocheck`:** Present in at least `transactions-tab.tsx` (file-level `@ts-nocheck`). Rough count across the codebase: ~10–15 suppressions.
+
+**`eslint-disable`:** Present in several files; exact count not enumerated.
+
+---
+
+## 8. Agent-Facing Configuration
+
+### Root `CLAUDE.md`
+```
+# Transformotion Apps — Claude Code Instructions
+
+This is a pnpm workspace monorepo. Each app lives in `apps/<app>/` with its own
+CLAUDE.md, contracts, infrastructure, and tests.
+
+When working on a specific app, read that app's CLAUDE.md first.
+
+Cross-app contracts live in `/contracts/`. Shared code lives in `/packages/`.
+Platform infrastructure lives in `/infrastructure/`.
+
+Before modifying shared code or platform infrastructure, consider the impact
+on every app — these changes deploy to all of them.
+
+## Branching strategy
+
+- `main` — production. Never commit directly.
+- `develop` — integration branch. Never commit directly.
+- Feature branches: `claude-code/<feature-name>` off `develop`, PR back to `develop`.
+- v0 branches: `v0/<feature-name>` off `develop`, PR back to `develop`.
+- After merge to `develop`, CD pipeline deploys to dev automatically.
+
+## Where to find things
+
+| What | Where |
+|---|---|
+| Monorepo structure, import rules, deploy triggers | `MONOREPO.md` |
+| Stock Analyser app | `apps/stock-analyser/CLAUDE.md` |
+| Budget Tracker app | `apps/budget-tracker/CLAUDE.md` |
+| Shared packages | `packages/` |
+| Platform Lambda handlers | `functions/` |
+| AWS CDK infrastructure | `infrastructure/` |
+| App contracts (data models, API, state) | `contracts/<app>/` |
+| Migration data artifacts | `migration-artifacts/<app>/` |
+```
+
+### Per-App CLAUDE.md Files
+- `apps/stock-analyser/CLAUDE.md` — exists (content not reproduced here)
+- `apps/budget-tracker/CLAUDE.md` — exists (content not reproduced here)
+
+### Other Agent Config
+- `.cursorrules` — ❌ Not found
+- `.github/copilot-instructions.md` — ❌ Not found
+
+---
+
+## 9. Pain Points (Evidence Gathering)
+
+### Recent Commits (last 20, `git log --oneline -20 develop`)
+```
+2a1b29a feat(budget): add getBudgetApiClient and budget config
+4a037ff fix(ci): skip StockAnalyserTables CDK deploy — tables already exist in AWS
+fdc1536 fix(infra): give BudgetTrackerApiStack its own API Gateway
+8df41ac chore: merge feat/incorporate-web-launchpad into develop
+fa5898e fix(budget): contract compliance + budget API URL in CI deploy
+2e120bb fix(budget): convert const arrow helpers to function declarations + add migration page
+9ca2f17 feat(web): incorporate v0 launchpad and sign-in into apps/web Next.js app
+d779d4a fix(auth): resolve sign-in loop — navigate after React commits session state
+858954a feat(budget-tracker): incorporate v0 UI into apps/budget-tracker
+3bceb35 fix: skip eslint in budget-tracker (same ESLint 10 flat config issue)
+46cfad4 fix: skip eslint run in stock-analyser to unblock CI
+789a3db fix: resolve all stock-analyser TypeScript errors for CI
+c578e14 fix: resolve pre-existing TypeScript errors in stock-analyser app
+8c5c9d8 feat(budget): S2.7 migration endpoint + CDK stack
+...
+```
+
+### Pain Signals
+
+1. **ESLint disabled** (commits 46cfad4, 3bceb35) — ESLint 10 flat config incompatibility with eslint-plugin-boundaries. Boundary enforcement is now entirely manual.
+
+2. **TypeScript migration strain** (commits c578e14, 789a3db) — pre-existing type errors required fixing when CI was introduced. Indicates code was developed without type checking.
+
+3. **Auth race condition** (commit d779d4a) — sign-in loop caused by navigating before React committed session state to context.
+
+4. **CDK infra drift** (commits 4a037ff, fdc1536) — DynamoDB tables and Lambda functions existed outside CloudFormation; required skipping CDK deploy steps. Root cause: early infra was deployed ad-hoc, not via CDK.
+
+5. **API Gateway contention** (commit fdc1536) — BudgetTrackerApiStack shared platform API Gateway causing CDK circular dependency; fixed by giving budget tracker its own API Gateway late in development.
+
+6. **Repeated fix pattern:** Multiple "fix:" commits close together suggest rapid iteration without stable testing baseline.
+
+### TODO/FIXME/HACK Comments
+
+Minimal — well-maintained. One notable location: `functions/invitations/src/index.ts`. No widespread HACK/XXX comments found.
+
+### Disabled Tests
+
+None found (no `.skip`, `xit`, or `@pytest.mark.skip`).
+
+### `@ts-ignore` / `eslint-disable`
+
+- `// @ts-nocheck` at top of `transactions-tab.tsx` — disables all type checking for that file
+- Scattered `eslint-disable` comments for `react-hooks/exhaustive-deps` in budget tracker components
+- Rough total: ~10–20 suppressions across the codebase
+
+---
+
+## 10. What's Missing
+
+### Architectural Rules Documented but Not Enforced
+
+| Rule | Documented | Enforced |
+|---|---|---|
+| Cross-app import boundary (apps cannot import each other) | ✅ MONOREPO.md | ❌ ESLint disabled in CI |
+| Packages cannot import from apps | ✅ MONOREPO.md | ❌ ESLint disabled in CI |
+| Lambda layer must not contain domain logic | ✅ cowork-testing-brief.md | ❌ No linting rule |
+| UI layer must not call repos directly | ✅ cowork-testing-brief.md | ❌ No linting rule |
+| All DynamoDB queries scoped to accountId | ✅ DEVELOPMENT_PLAN.md | ❌ No integration test |
+| Mobile-first design (375px baseline) | ✅ DEVELOPMENT_PLAN.md | ❌ No automated visual tests |
+
+### Contract Definitions Not Validated
+
+| Contract | Location | Validated? |
+|---|---|---|
+| Budget Tracker data models (v1.1) | `contracts/budget-tracker/*.md` | ❌ Markdown only |
+| Stock Analyser data contracts | `contracts/stock-analyser/*.md` | ❌ Markdown only |
+| Lambda API request/response shapes | Implicit in handler code | ❌ No schema |
+| Cognito JWT custom claims | Implicit in middleware | ❌ No validation test |
+
+### Tests That Would Catch Common Regressions
+
+1. **API contract tests** — Validate Lambda response shapes against TypeScript interfaces; catch breaking changes when Lambda code changes
+2. **Cross-account data isolation tests** — Integration test confirming `accountId` scoping prevents cross-account DynamoDB reads
+3. **Cross-app import tests** — Re-enable ESLint boundary rules in CI; currently zero enforcement
+4. **Mobile regression tests** — Playwright tests at 375px, 768px, 1024px breakpoints
+5. **Migration idempotency tests** — Run `/migrate-from-localstorage` twice; assert no duplicates in DynamoDB
+6. **Settings round-trip tests** — Write all 12 `SETTING_KEYS`; read back and assert equality
+7. **Auth middleware tests** — Assert `withAuth()` rejects requests without valid Cognito JWT
+
+### Enforcement Mechanisms Not Configured
+
+| Mechanism | Status |
+|---|---|
+| Prettier | ❌ Not configured |
+| Husky / pre-commit hooks | ❌ Not configured |
+| Commitlint | ❌ Not configured |
+| CDK-nag (AWS security best practices) | ❌ Not configured |
+| GitHub Actions secret scanning | ❌ Not configured |
+| SAST (CodeQL, Semgrep) | ❌ Not configured |
+| Dependency vulnerability scanning | ❌ Not configured |
+
+---
+
+## Summary: Enforcement Status
+
+| Mechanism | Configured | Enforced in CI | Enforced Pre-commit |
+|---|---|---|---|
+| ESLint (boundaries) | ✅ | ❌ Disabled | ❌ |
+| Prettier | ❌ | N/A | N/A |
+| TypeScript strict | ✅ | ✅ (`turbo typecheck`) | ❌ |
+| Architecture boundary tests | ❌ | N/A | N/A |
+| Contract (schema) validation | ❌ | N/A | N/A |
+| CDK-nag | ❌ | N/A | N/A |
+| Husky | ❌ | N/A | N/A |
+| Commitlint | ❌ | N/A | N/A |
+| Secret scanning | ❌ | N/A | N/A |
+| Unit tests (budget-domain) | ✅ | ❌ Not in CI | ❌ |
+
+**Summary:** TypeScript type-checking is the only reliably enforced quality gate. ESLint boundary rules exist but are bypassed. No tests run in CI. No pre-commit hooks. No IaC policy checks. Contracts are documentation only.

--- a/docs/budget-tracker-prd.md
+++ b/docs/budget-tracker-prd.md
@@ -1,0 +1,456 @@
+# Budget Tracker — Product Requirements Document
+### For v0 UI Recreation + Claude Code AWS Integration
+
+---
+
+## 1. Context & Platform
+
+The Budget Tracker is **App 2** on the Transformotion platform hosted at `apps.transformotion.com.au`. It must integrate seamlessly with the existing platform infrastructure:
+
+- **Monorepo:** `github.com/transformotion/transformotion-apps`
+- **Frontend:** React + Vite + TypeScript + Tailwind v4, lives at `apps/budget-tracker/`
+- **Auth:** AWS Cognito (existing User Pool), protected by Cognito group `budget-app`
+- **Backend:** API Gateway + Lambda, following same patterns as Stock Analyser (App 1)
+- **Database:** DynamoDB, following naming convention `budget-tracker.<tablename>`
+- **Deployment:** Same CI/CD pipeline — develop branch → dev, main → prod
+- **Domain:** `apps.transformotion.com.au/budget`
+
+Users: Steve (admin) and Liz (family group). Both have access to this app. Their data is **shared** (one household budget, not per-user scoped — use a shared `accountId`).
+
+---
+
+## 2. Brand & Design
+
+### Colour Palette (match Stock Analyser exactly)
+```
+Background:       #0D1B2A
+Card/surface:     #141720
+Accent (teal):    #00C4B3
+Secondary (gold): #E8A838
+Success/positive: #22c87a
+Danger/negative:  #f05656
+Warning:          #f0a030
+Primary text:     #e8eaf0
+Muted text:       #6b7280
+```
+
+### Design Principles
+- Dark theme only — matches Stock Analyser
+- Mobile-first — frequently used on phone
+- Clean and legible — lots of financial data
+- Premium fintech aesthetic — consistent with Stock Analyser
+- v0 has full creative freedom on layout — do not replicate the current UI
+- Mobile: bottom tab navigation
+- Desktop: sidebar or top nav
+
+---
+
+## 3. AWS Architecture (must match existing platform)
+
+### Authentication
+- Use existing Cognito User Pool (already deployed)
+- Cognito group required: `budget-app`
+- Auth via AWS Amplify (already configured in monorepo)
+- Steve and Liz share one household data set — use shared `accountId`, not per-user scoping
+
+### Backend Lambda Functions (new — follow existing Stock Analyser patterns)
+- `budget-categorise` — Anthropic API proxy for AI categorisation (key from Secrets Manager at `/prod/anthropic/api-key`)
+- `budget-ai-review` — Anthropic API proxy with web_search tool enabled
+- `budget-transactions` — CRUD for transactions
+- `budget-rules` — CRUD for custom rules
+- `budget-settings` — CRUD for budget amounts, frequencies, project budgets, custom categories
+
+### DynamoDB Tables (new — follow naming convention)
+```
+budget-tracker.transactions    PK: accountId,  SK: transactionId
+budget-tracker.rules           PK: accountId,  SK: ruleId
+budget-tracker.settings        PK: accountId,  SK: settingKey
+```
+
+Settings keys: `budgetOverrides`, `budgetFreqs`, `customCategories`, `projectBudgets`
+
+### Data Migration (first login)
+- Offer one-click migration from browser localStorage to DynamoDB
+- Idempotent — safe to run multiple times
+- localStorage keys: `transactions`, `custom-rules`, `budget-overrides`, `budget-freqs`, `custom-categories`, `project-budgets`
+
+---
+
+## 4. Data Model
+
+### Transaction
+```typescript
+{
+  _id: number
+  date: string           // DD/MM/YYYY
+  amount: string         // negative = expense, positive = income or refund
+  description: string
+  category: string
+  subcategory: string
+  file: string           // source CSV filename
+  _manual: boolean       // user manually set — rules will not overwrite
+  _business: boolean     // business expense — excluded from personal P&L
+}
+```
+
+### Custom Rule
+```typescript
+{
+  match: string          // keyword or regex pattern, case-insensitive
+  category: string
+  subcategory: string
+  learned: boolean       // created via Learn button on a transaction
+}
+```
+
+### Settings stored as key/value:
+- `budgetOverrides` — `{ [subcategory]: monthlyAmount }` — NOTE: -1 means deleted (tombstone), NOT 0. Zero is a valid budget amount.
+- `budgetFreqs` — `{ [subcategory]: "weekly"|"fortnightly"|"monthly"|"quarterly"|"annually" }`
+- `customCategories` — `{ [category]: string[] }`
+- `projectBudgets` — `{ [projectCategory]: totalLumpSum }`
+
+---
+
+## 5. Category Structure
+
+### Standard Categories (included in monthly P&L)
+```
+Income: Your take-home pay, Your partner's take-home pay, Bonuses / overtime,
+  Income from savings and investments, Child support received,
+  School fees reimbursement, Rent (investment property), Other income
+
+Home & utilities: Mortgage / rent, Water, Gas, Electricity, Mobile, Internet,
+  Streaming Services, Home improvements & Maintenance, Furniture & appliances,
+  Council rates, Body corporate fees, Kierans Mobile, Ellas Mobile
+
+Financial & Insurance: Savings, Investments & super contributions, Charity donations,
+  Paying off debt, Credit card interest, Other loans, Car loan,
+  Home & contents insurance, Health insurance, Car insurance,
+  Personal & life insurance, Transfer, Capital purchases
+
+Groceries: Supermarket, Deli & bakery, Fruit & veg market,
+  Cleaning products, Toiletries, Pet food
+
+Medical, personal & education: Doctors & medical, Medicines & pharmacy,
+  Glasses & eye care, Dental, Education, Computers & gadgets, Sports & gym,
+  Clothing & shoes, Cosmetics, Hair & beauty, Shopping, Hobbies,
+  Pet care / vet / pet insurance
+
+Eating-out & Entertainment: Coffee & tea, Lunches bought, Take-away & snacks,
+  Drinks & alcohol, Restaurants, Bars & clubs, Movies shows & music,
+  Books newspapers & magazines, Celebrations & gifts, Holidays
+
+Car & Transport: Petrol, Road tolls & parking, Repairs & maintenance,
+  Rego & licence, Uber & taxi, Public Transport, Airfares
+
+Children: Children Clothing, Childcare, Babysitting, School fees, School uniforms,
+  Excursions, Other school needs, Children Sports & activities, Toys,
+  Child support payment
+```
+
+### Project Categories (excluded from P&L — lump sum budget tracking)
+```
+Renovations: Planning & design, Building & labour, Materials & supplies,
+  Fixtures & fittings, Appliances, Landscaping & outdoor, Other renovation costs
+```
+
+### Also excluded from P&L:
+- Any transaction with subcategory = "Transfer"
+- Any transaction with subcategory = "Capital purchases"
+- Any transaction with `_business: true`
+
+---
+
+## 6. Rules Engine
+
+**Priority order:** Custom rules first, built-in rules second. First match wins.
+Custom rules ALWAYS beat built-in rules — this is how users override incorrect categorisation.
+
+**Matching:** Case-insensitive regex. Normalise whitespace before matching: `.replace(/\s+/g, " ").trim()`
+
+**Reference to `customRules` in event handlers:** Use `useRef` to avoid stale closures — `customRulesRef.current = customRules` on every render.
+
+### Built-in Rules (~45 rules, listed in priority order)
+```
+Transfers (highest priority):
+  /payment thank/i → Financial & Insurance > Transfer
+  /credit card payment|cc payment|visa payment|anz credit|mastercard payment/i → Financial & Insurance > Transfer
+  /^(from|to) .*(internal transfer|linked account)/i → Financial & Insurance > Transfer
+  /hawkins/i → Financial & Insurance > Transfer
+
+Groceries:
+  /woolworths|coles|aldi|ww metro|mega fresh/i → Groceries > Supermarket
+  /bakers delight|wellington bakery|rainbow beach bakery|brumby|sg bakery|delifish/i → Groceries > Deli & bakery
+
+Take-away:
+  /mcdonald|kfc|subway|nandos|guzman|domino|uber.*eats|doordash|donut king|zambrero|oporto|red rooster|hungry jacks|pizza hut/i → Eating-out & Entertainment > Take-away & snacks
+
+Coffee:
+  /coffee|cafe|espresso|backstreet cafe|jamoke|micasa|holliday coffee|rock hop|black fox|somewhere over coffee|the pocket espresso|wishlist coffee|gun cotton|sushi hub|container by|boost|banjos/i → Eating-out & Entertainment > Coffee & tea
+
+Drinks — bottleshops only:
+  /bws|liquorland|dan murphy|vintage cellars|first choice liquor|aldi liquor/i → Eating-out & Entertainment > Drinks & alcohol
+  /pomona distilling|noosa chocolate/i → Eating-out & Entertainment > Drinks & alcohol
+
+Bars & clubs — venues only (NOT bottleshops):
+  /brunswick hotel|alh venues|maroochy rsl|rose.*crown|boatshed|little parliament|deck sea salt|dock mooloolaba|beach bar|chancellor tavern|mammoth|green at tanawha/i → Eating-out & Entertainment > Bars & clubs
+  /bwlngnrec|bwling|bowlsclub|bowling rec|bowling club/i → Eating-out & Entertainment > Bars & clubs
+  /rugby|football club|soccer club|netball club|cricket club/i → Eating-out & Entertainment > Bars & clubs
+
+Restaurants:
+  /restaurant|thai|vietnamese|an nam|bombay bliss|walter.*diner|spaghetti|riba kai|playa|mebami|forest blend|springbok/i → Eating-out & Entertainment > Restaurants
+
+Entertainment:
+  /spotify|netflix|disney plus|hbomax|kayo|hubbl|audible|amazon prime|amznprime|apple.*bill|microsoft.*365/i → Eating-out & Entertainment > Movies shows & music
+  /event cinema|event kawana|qtix|ticketek|ticketmaster|moshtix|humanitix|aussie world|bli bli water|surf life|pickleb/i → Eating-out & Entertainment > Celebrations & gifts
+  /booking\.com|hotel at booking|gorge view|thekinkinwood|kings beach hotel/i → Eating-out & Entertainment > Holidays
+
+Transport:
+  /ampol|liberty tanawha|united bethania|caltex/i → Car & Transport > Petrol
+  /linkt|parking|southbank carpark|secure parking|transportmainrds|sper qld/i → Car & Transport > Road tolls & parking
+  /uber.*trip|taxi/i → Car & Transport > Uber & taxi
+  /qantas|jetstar/i → Car & Transport > Airfares
+  /cars on booking|garry cricks/i → Car & Transport > Repairs & maintenance
+  /maroochydore state hig/i → Car & Transport > Rego & licence
+
+Home & utilities:
+  /agl sales|agl energy/i → Home & utilities > Electricity
+  /telstra|vodafone|spintel/i → Home & utilities > Mobile
+  /sunshine coast regiona/i → Home & utilities > Council rates
+  /unitywater|unity water/i → Home & utilities > Water
+  /bunnings|spotlight|harris scarfe|pomona true value/i → Home & utilities > Home improvements & Maintenance
+
+Financial:
+  /youi|suncorp insurance/i → Financial & Insurance > Car insurance
+  /racq|nrma|aami/i → Financial & Insurance > Car insurance
+  /medibank|bupa|hcf|hbf|ahm health/i → Financial & Insurance > Health insurance
+  /interest charge/i → Financial & Insurance > Credit card interest
+
+Computers (note: category is Medical not Financial):
+  /mcafee|godaddy|adobe|bandify/i → Medical, personal & education > Computers & gadgets
+  /claude\.ai|anthropic/i → Medical, personal & education > Computers & gadgets
+  /officeworks/i → Medical, personal & education > Computers & gadgets
+  /harvey norman|jb hi.fi|apple store|samsung/i → Medical, personal & education > Computers & gadgets
+  /canva/i → Medical, personal & education > Computers & gadgets
+  /amazon|amzn/i → Medical, personal & education > Shopping
+  /google.*play|apple.*itunes|itunes/i → Eating-out & Entertainment > Movies shows & music
+
+Personal:
+  /fitstop|goodlife|gym/i → Medical, personal & education > Sports & gym
+  /amino z/i → Medical, personal & education > Sports & gym
+  /glow up|galaxy nail|orchid massage|coastal aesthetic|the body shop|mecca brands/i → Medical, personal & education > Hair & beauty
+  /lskd|cotton on body|decjuba|bonds sunshine|forever new/i → Medical, personal & education > Clothing & shoes
+  /myer|david jones|target|kmart/i → Medical, personal & education > Shopping
+  /rebel sport|city beach|surf stitch|the iconic/i → Medical, personal & education > Clothing & shoes
+  /terry white|chemist|pharmacy|livelife pharmacy|chemist warehouse/i → Medical, personal & education > Medicines & pharmacy
+  /specsavers/i → Medical, personal & education > Glasses & eye care
+  /suncoast health|dietitian|hayley mary/i → Medical, personal & education > Doctors & medical
+
+Children:
+  /sunny sloths/i → Children > Toys
+
+Income:
+  /salary|payroll|employer/i → Income > Your take-home pay
+
+Renovations:
+  /architect|draftsman|building designer|town planner|interior design/i → Renovations > Planning & design
+```
+
+---
+
+## 7. CSV Import
+
+### Supported formats
+1. **ANZ with header** — columns: Date, Description (or "Original Description"), Amount
+2. **ANZ without header** — col 0 = date (DD/MM/YYYY), col 1 = amount, col 2 = description
+3. **Macquarie Bank** — separate Debit/Credit columns (debits = expenses negative, credits = income positive)
+
+### Detection
+If first cell matches date pattern `^\d{1,2}[\/\-]\d{1,2}[\/\-]\d{2,4}$` → headerless format. Otherwise parse first row as header.
+
+### Amount format
+Amounts may be quoted strings: `"-62.14"` — strip quotes and parse as float.
+
+### Duplicate prevention
+Key = `${date}|${amount}|${description}` — skip if already exists in loaded transactions.
+
+### On upload flow
+1. Parse CSV → new transactions
+2. Apply rules (custom first, then built-in)
+3. Show count of new transactions loaded in status bar
+4. Batch remaining uncategorised to AI (50 per batch)
+5. Show "Categorising N transactions with AI..." status
+6. Update transactions as AI results come back
+
+---
+
+## 8. Feature Details by Tab
+
+### 8.1 Transactions Tab
+
+Filters: category pills, subcategory pills, month dropdown, source dropdown, All/Personal/Business 3-way toggle, clear filters button, live transaction count.
+
+Table: checkbox, date, description (+💼 badge), amount (green if positive), category pill, subcategory, source (toggle), actions.
+
+Row backgrounds: uncategorised = warning, business = distinct, selected = accent.
+
+Per-row (view mode): 💼 toggle, Edit button, ↺ re-run rules button (only if categorised).
+
+Per-row (edit mode): category dropdown, subcategory dropdown, Learn button (saves + creates rule from first 3 words), Done button, Delete button.
+
+Bulk bar (shown when rows selected): category dropdown, subcategory dropdown, Apply to N, Clear selection, 🗑 Delete N.
+
+Header: Export CSV, 💼 Export Business (when flagged transactions exist), AI Review (N) (when uncategorised exist), Clear all, Upload CSV.
+
+**CSV export must use data URI, not createObjectURL** (CSP restriction in sandboxed environments).
+
+**No window.confirm** — use inline confirmation state instead.
+
+### 8.2 Summary Tab
+
+Month selector pills at top (All months + each month).
+
+Position card: Over/Under budget, Income actual/budget, Expenses actual/budget, Net, % of income progress bar.
+
+Income card (success colour): total budget vs actual, expandable subcategories, subcategories clickable to show transactions. Positive amounts in drilldown = green with "-$" prefix and "(refund/reimbursement)" label.
+
+Expense category cards (one per standard category, excludes project categories): budget, actual, vs budget %, expandable subcategories with drilldown.
+
+Projects & Capital Expenditure card (warning/gold colour): shown separately at bottom, amber styling, subcategories clickable for drilldown.
+
+Uncategorised warning banner.
+
+### 8.3 Budget Tab
+
+Monthly position card (income/expenses/net).
+
+Update from actuals button — sets budgets to monthly average of loaded transaction data.
+
+Category sections (excludes project categories): per subcategory row with rename (✏️), delete (🗑 hover-only), frequency dropdown, amount input. onKeyDown stopPropagation on inputs to prevent delete key triggering delete button. onChange: if NaN, return (don't save). Reset button on modified rows. Add subcategory at bottom.
+
+Delete modal: shows affected transaction count, transfer-to dropdown before deletion. Tombstone value is -1 (NOT 0).
+
+Deleted subcategories section at bottom with Restore buttons.
+
+Projects & Capital Expenditure section (amber): lump-sum budget input per project, progress bar, per-subcategory budget line items with individual inputs and "X spent" display.
+
+### 8.4 Cashflow Tab
+
+Monthly trend line chart (Income/Expenses/Net — needs 2+ months).
+Category actuals vs budget horizontal bar chart (red = over).
+Top overspend subcategories.
+Budget flow Sankey diagram.
+
+### 8.5 Rules Tab
+
+Test a transaction: input, shows all matching rules in priority order, winner highlighted. Each result badge (Custom/Built-in) is clickable — jumps to that rule in the table with edit mode pre-opened.
+
+Add rule: pattern input, ? help button (pattern syntax modal), category, subcategory, Add.
+
+Re-apply all rules: runs rules on all transactions. If match: update + clear _manual. If no match: keep existing category, just clear _manual. Shows feedback count.
+
+Custom rules table with inline editing.
+
+Built-in rules (collapsible) with Edit button — saves as custom override.
+
+Pattern help modal: simple keyword, OR (|), wildcard (.*) examples.
+
+### 8.6 AI Review Tab
+
+Triggered by AI Review button in header.
+Sends uncategorised transactions to Claude API (batches of 20) with web_search tool enabled.
+Results stream in with: date, description, amount, suggested category/subcategory, reason.
+Per-result: ✓ Confirm, ✗ Reject, category/subcategory override dropdowns.
+Bulk: Confirm all, Apply & close.
+
+---
+
+## 9. Critical Technical Requirements
+
+These caused significant bugs in the current version:
+
+1. **No IIFEs in JSX** — Babel rejects `(() => {})()` inside JSX. Compute all values above the return statement.
+
+2. **No window.confirm** — Blocked in sandboxed environments. Use inline UI for confirmations.
+
+3. **CSV export must use data URIs** — `data:text/csv;charset=utf-8,` + `encodeURIComponent(csv)`. NOT `URL.createObjectURL`.
+
+4. **Custom rules must always win** — Array passed to applyRules must be `[...customRules, ...BUILTIN_RULES]`.
+
+5. **Whitespace normalisation before matching** — `.replace(/\s+/g, " ").trim()` on both description and string patterns.
+
+6. **Stale closure on customRules** — Use `useRef`: `customRulesRef.current = customRules` synced on every render. Use `customRulesRef.current` in event handlers and rule application.
+
+7. **Tombstone is -1, not 0** — Zero is valid. -1 means deleted subcategory.
+
+8. **Re-apply preserves existing categories** — Only update when a rule matches. Never clear a category when no rule matches.
+
+9. **Debounced transaction saves** — 800ms debounce, save only 8 essential fields: `_id, date, amount, description, category, subcategory, file, _manual`.
+
+10. **Load order** — Load both transactions and custom rules, THEN re-run rules on transactions. Otherwise rules will be empty when transactions are re-processed.
+
+---
+
+## 10. v0 Prompt
+
+```
+Design a mobile-first personal budget tracking app for a household (two shared users).
+Part of the Transformotion platform — a professional business tools suite.
+
+App name: Budget Tracker
+Platform: Transformotion (apps.transformotion.com.au)
+
+Colour palette (use exactly):
+- Background: #0D1B2A
+- Card/surface: #141720
+- Accent teal: #00C4B3
+- Secondary gold: #E8A838
+- Success: #22c87a
+- Danger: #f05656
+- Warning: #f0a030
+- Primary text: #e8eaf0
+- Muted text: #6b7280
+
+Dark theme only. Mobile-first — show 375px view first, then 1280px desktop.
+Premium fintech aesthetic — consistent with a dark-themed stock analyser on the same platform.
+The two apps should feel like siblings.
+
+The app has 6 tabs: Transactions, Summary, Budget, Cashflow, Rules, Review.
+
+Key screens to design:
+
+1. Transactions — filterable list. Filters: category pills, month dropdown,
+   source dropdown, All/Personal/Business toggle. Rows show date, description
+   (💼 badge for business), amount (green positive, red negative), category pill,
+   subcategory, actions. Uncategorised rows have warning background. Bulk selection.
+
+2. Summary — monthly financial summary. Month selector pills. Position card
+   (income vs expenses vs net, coloured status). Expandable category cards
+   (budget vs actual vs % variance). Each category → subcategories → transactions.
+   Separate amber Projects section for below-the-line capital spend.
+
+3. Budget — set budget amounts. Category sections with subcategory rows: name,
+   frequency selector (weekly/fortnightly/monthly/quarterly/annually), amount input.
+   Separate Projects section with lump-sum budget inputs and progress bars.
+
+4. Cashflow — monthly trend line chart, category bar chart (actuals vs budget),
+   top overspend chart, Sankey budget flow diagram.
+
+5. Rules — test input at top to debug which rules match a description.
+   Custom rules table. Collapsible built-in rules section.
+
+6. Review — AI review queue. Uncategorised transactions with AI suggestions,
+   confirm/reject/override per row, confirm all, apply & close.
+
+Design constraints:
+- Mobile: bottom tab navigation
+- Desktop: sidebar or top nav
+- Financial numbers must be very legible — large, clear colour coding
+- Make your own UX decisions — do not copy any existing layout
+- Use realistic Australian household budget placeholder data
+- Surprise me with the design
+```
+
+---
+
+*End of PRD — v1.0*


### PR DESCRIPTION
## Summary

- Removes stale `v0-designs` git remote
- Removes empty root-level `budget-tracker/` and `stock-analyser/` folders left from earlier contract reorganisation
- Moves audit documents (`architecture-audit.md`, `budget-tracker-prd.md`) from repo root into `docs/`
- Adds generated-artefact patterns to `.gitignore` (`tsconfig.tsbuildinfo`, `next-env.d.ts`)
- Adds `.claude/` to `.gitignore` (Claude Code per-machine local settings)
- Adds `STABILISATION_FREEZE.md` declaring scope freeze during Phases 1–4
- Adds `apps/stock-analyser/MIGRATION_INVARIANTS.md` preserving 7 historical incidents and 9 additional invariants from the monolithic repo, to be encoded as tests during Phase 4 migration

Phase 0 of the stabilisation plan. No code or enforcement changes in this commit.

## Test plan

- [ ] CI passes (no code changes — expect fast green)
- [ ] `docs/` directory present with both audit files
- [ ] `STABILISATION_FREEZE.md` present at repo root
- [ ] `apps/stock-analyser/MIGRATION_INVARIANTS.md` present
- [ ] `.gitignore` contains `tsconfig.tsbuildinfo`, `next-env.d.ts`, `.claude/` entries

🤖 Generated with [Claude Code](https://claude.ai/claude-code)