### PR TITLE
fix(budget): sync DEFAULT_SETTINGS and SETTING_KEYS with BudgetSettings contract

### DIFF
--- a/apps/budget-tracker/functions/budget-settings/src/index.ts
+++ b/apps/budget-tracker/functions/budget-settings/src/index.ts
@@ -6,17 +6,30 @@ import type { BudgetSettings } from '@transformotion/budget-domain';
 const ddb = DynamoDBDocumentClient.from(new DynamoDBClient({}));
 const TABLE = process.env.SETTINGS_TABLE!;
 
+// DEFAULT_SETTINGS and SETTING_KEYS below must stay in sync with
+// BudgetSettings in contracts/budget-tracker/data-models.md.
+// Drift here causes GET/PATCH to silently drop fields.
+// Phase 2 will replace this with Zod-validated schemas.
 const SETTING_KEYS: Array<keyof Omit<BudgetSettings, 'accountId'>> = [
   'budgetOverrides', 'budgetFreqs', 'customCategories',
-  'projectBudgets', 'deletedSubs', 'csvFormatMappings',
+  'deletedSubs', 'projectBudgets', 'projectTasks',
+  'customTopCategories', 'customProjectCategories',
+  'deletedCategories', 'deletedProjectCategories',
+  'disabledProjectCategories', 'csvFormatMappings',
 ];
 
 const DEFAULT_SETTINGS: Omit<BudgetSettings, 'accountId'> = {
   budgetOverrides: {},
   budgetFreqs: {},
   customCategories: {},
-  projectBudgets: {},
   deletedSubs: [],
+  projectBudgets: {},
+  projectTasks: {},
+  customTopCategories: [],
+  customProjectCategories: [],
+  deletedCategories: [],
+  deletedProjectCategories: [],
+  disabledProjectCategories: [],
   csvFormatMappings: {},
 };
 


### PR DESCRIPTION
Fixes pre-existing TypeScript drift on develop (blocking Phase 0 PR #12).

## Problem

`apps/budget-tracker/functions/budget-settings/src/index.ts` had DEFAULT_SETTINGS and SETTING_KEYS at 6 fields, while the canonical `BudgetSettings` contract in `contracts/budget-tracker/data-models.md` defines 12. Introduced in fa5898e when the contract was expanded without updating this Lambda.

## Impact

- CI typecheck failure on every PR touching anything that triggers `turbo typecheck`
- Runtime: GET and PATCH handlers silently drop 6 fields because they aren't in SETTING_KEYS

## Fix

Mechanical contract-conformance. Added the 6 missing fields to both DEFAULT_SETTINGS (with contract-matching empty defaults) and SETTING_KEYS. No design changes. No other files touched.

## Out of scope

- The `csvFormatMappings` optional-vs-required inconsistency (harmless, separate)
- Replacing markdown contracts with executable schemas (Phase 2)
- Adding runtime validation (Phase 2)

## Verification

- `pnpm --filter @transformotion/fn-budget-settings typecheck` passes
- `pnpm turbo typecheck` passes (full monorepo, 28/28 successful)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)