### PR TITLE
fix(auth): harden auth store against stale persistence and double-init

### DIFF
--- a/apps/stock-analyser/stores/auth/use-auth-store.ts
+++ b/apps/stock-analyser/stores/auth/use-auth-store.ts
@@ -34,7 +34,7 @@ interface AuthState {
 
 export const useAuthStore = create<AuthState>()(
   persist(
-    (set) => ({
+    (set, get) => ({
       // Initial state
       user:            null,
       isAuthenticated: false,
@@ -44,6 +44,8 @@ export const useAuthStore = create<AuthState>()(
 
       // Check existing Cognito session on app load
       initialize: async () => {
+        const state = get()
+        if (state.isInitialized || state.isLoading) return
         set({ isLoading: true })
         try {
           const cognitoUser = await cognitoAuth.getCurrentUser()
@@ -114,10 +116,10 @@ export const useAuthStore = create<AuthState>()(
     }),
     {
       name: 'auth-store',
+      version: 1,  // bumped to discard old persisted isAuthenticated
       partialize: (state) => ({
-        // Only persist the user display info — Amplify manages the real session
-        user:            state.user,
-        isAuthenticated: state.isAuthenticated,
+        // Only persist display info — Cognito is the source of truth for auth state
+        user: state.user,
       }),
     }
   )


### PR DESCRIPTION
## Context

Rescued from a stashed working tree on the merged `feat/incorporate-web-launchpad` branch. The auth hardening was in progress when that branch was merged but was stashed rather than committed; it has been sitting in local git stash since.

## What changed

Three related changes in `apps/stock-analyser/stores/auth/use-auth-store.ts` that work together:

1. **Early-return guard in `initialize()`** — prevents concurrent init runs (React StrictMode, multiple component mounts). Without it, the store can enter inconsistent loading state.
2. **Remove `isAuthenticated` from persisted state** — Cognito is the source of truth. Persisting a boolean locally lets the UI trust a stale value.
3. **Bump store version to 1** — forces existing users' stale `isAuthenticated` values to be discarded on upgrade.

Item 3 is required for item 2 to actually help existing users; they are a unit.

## Why now

This is a bug fix, not a feature. It fits within the stabilisation freeze declared in `STABILISATION_FREEZE.md`.

## Risk

Users will be re-authenticated once on upgrade if Cognito's session is not independently valid. That is the intended behaviour — we are telling the store not to trust persisted `isAuthenticated` any more.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)