### PR TITLE
docs(env): inventory and document required env vars per app

### DIFF
--- a/STABILISATION_FREEZE.md
+++ b/STABILISATION_FREEZE.md
@@ -2,7 +2,7 @@
 
 **Status:** ACTIVE
 **Started:** 2026-04-20
-**Last updated:** 2026-04-21
+**Last updated:** 2026-04-21 (sub-phase 2a: env var inventory and .env.example files)
 **Expected end:** Once Phase 1 (foundations) and Phase 2
 (executable contracts) are complete, the freeze on stabilisation
 work lifts. The Phase 4 stock analyser migration begins under
@@ -44,6 +44,20 @@ Sub-phases:
    required env vars across all apps and environments. `.env.example`
    checked in. CI verifies all required vars exist before deploying.
    Drift between local, GitHub Actions, and AWS becomes impossible.
+
+   **2a (complete):** `.env.example` files added to all three app
+   workspaces (stock-analyser, budget-tracker, web), each listing every
+   required variable with descriptive comments and placeholder values.
+   Inventory also surfaced two previously undocumented missing vars:
+   `NEXT_PUBLIC_COGNITO_DOMAIN` and `NEXT_PUBLIC_APP_URL` (required by
+   Amplify OAuth, absent from CI).
+
+   **2b enforcement note.** When sub-phase 2b lands, the CI env var
+   check is configured to hard-fail. This binds the env var fix (Phase
+   3.5) to a forcing function: no further deploys succeed until the
+   target environment's variables match the schema documented in each
+   app's `.env.example`. The "fix the dev environment's vars" task
+   becomes structurally unavoidable rather than schedulable.
 3. **Deploy verification** — every deploy workflow ends by confirming
    the deploy actually succeeded and the deployed version matches
    the commit that triggered it. CI says "deployed" only when it

--- a/apps/budget-tracker/.env.example
+++ b/apps/budget-tracker/.env.example
@@ -1,0 +1,105 @@
+# Budget Tracker — required environment variables
+#
+# This file is the single source of truth for what environment variables
+# the Budget Tracker app needs to function. It is checked into git and
+# is documentation only — it is NOT loaded at runtime.
+#
+# For local development: copy to .env.local and fill in real values.
+# For CI/CD: variable names here must match entries in
+#   .github/workflows/deploy-budget-tracker.yml (env: block, once active)
+#   AND GitHub repo Settings → Environments → dev/prod variables.
+#
+# NOTE: deploy-budget-tracker.yml is currently a no-op placeholder.
+# The deploy pipeline will be wired up as part of Issue #17 (Budget
+# Tracker consolidation). When it is, the workflow env: block must
+# pass every [REQUIRED] variable listed here.
+#
+# Sub-phase 2b of the stabilisation plan adds a CI step that reads this
+# file and asserts every variable listed exists as a non-empty GitHub
+# Actions environment variable before the build runs.
+# See STABILISATION_FREEZE.md → Phase 1 → sub-phase 2.
+#
+# Variables marked [REQUIRED] cause broken functionality if absent or empty.
+# Variables marked [OPTIONAL] have a sensible fallback noted inline.
+# Variables marked [LAMBDA ONLY] are used only by backend Lambda functions
+# and are NOT part of the Next.js build.
+
+# ── Platform API ─────────────────────────────────────────────────────────────
+
+# [REQUIRED] Base URL of the shared platform API Gateway.
+# Used for platform routes (auth session, accounts).
+# Source: CloudFormation output ApiUrl on TransformotionDev-Api (dev) or
+#         TransformotionProd-Api (prod).
+NEXT_PUBLIC_API_URL=https://your-platform-api-id.execute-api.ap-southeast-2.amazonaws.com/dev
+
+# [REQUIRED] Claude proxy endpoint. AI features in the Budget Tracker
+# invoke this for AI categorisation via the shared backend proxy Lambda.
+# Source: <NEXT_PUBLIC_API_URL>/api/claude
+NEXT_PUBLIC_CLAUDE_API_URL=https://your-platform-api-id.execute-api.ap-southeast-2.amazonaws.com/dev/api/claude
+
+# [REQUIRED] Analysis-cache endpoint. Used for long-poll job status.
+# Source: <NEXT_PUBLIC_API_URL>/analysis-cache
+NEXT_PUBLIC_CLAUDE_CACHE_URL=https://your-platform-api-id.execute-api.ap-southeast-2.amazonaws.com/dev/analysis-cache
+
+# ── Cognito authentication ────────────────────────────────────────────────────
+
+# [REQUIRED] AWS Cognito User Pool ID. Shared across all apps.
+# Source: CloudFormation output UserPoolId on TransformotionDev-Auth.
+NEXT_PUBLIC_COGNITO_USER_POOL_ID=ap-southeast-2_XXXXXXXXX
+
+# [REQUIRED] Cognito app client ID for the Budget Tracker app.
+# IMPORTANT: This is a different client ID from the Stock Analyser app.
+#   Budget Tracker client: BTAppClientId on TransformotionDev-BudgetTrackerTables
+#   Stock Analyser client: UserPoolClientId on TransformotionDev-Auth
+# The deploy-budget-tracker.yml workflow must NOT reuse the same
+# NEXT_PUBLIC_COGNITO_CLIENT_ID GitHub Actions variable as deploy-stock-analyser.yml.
+# Use a separate GitHub environment or a distinct variable name when wiring
+# up the Budget Tracker pipeline (see Issue #17).
+NEXT_PUBLIC_COGNITO_CLIENT_ID=your-budget-tracker-cognito-client-id
+
+# [REQUIRED] AWS region where Cognito is deployed.
+NEXT_PUBLIC_COGNITO_REGION=ap-southeast-2
+
+# ── Feature flags ─────────────────────────────────────────────────────────────
+
+# [REQUIRED] Set to 'false' to use real API calls. Defaults to true (mock
+# mode) if absent — always set explicitly in deployed environments.
+NEXT_PUBLIC_USE_MOCK_DATA=false
+
+# ── Optional tuning ───────────────────────────────────────────────────────────
+
+# [OPTIONAL] Auth provider selection. Default: 'mock'.
+# The Budget Tracker auth service is currently a mock stub. This var will
+# become meaningful once Cognito is fully wired into the BT auth flow.
+# NEXT_PUBLIC_AUTH_PROVIDER=cognito
+
+# [OPTIONAL] AI provider. Default: 'mock'. Set to 'anthropic' to use real
+# Anthropic calls via the Claude proxy Lambda.
+# NEXT_PUBLIC_AI_PROVIDER=anthropic
+
+# [OPTIONAL] AI model for Anthropic calls. Default: 'claude-3-sonnet'.
+# NEXT_PUBLIC_AI_MODEL=claude-3-sonnet
+
+# [OPTIONAL] Claude proxy polling interval in ms. Default: 2500.
+# NEXT_PUBLIC_CLAUDE_POLL_INTERVAL=2500
+
+# [OPTIONAL] Max time to poll for a Claude response in ms. Default: 500000.
+# NEXT_PUBLIC_CLAUDE_MAX_POLL_TIME=500000
+
+# [OPTIONAL] Log level. Default: 'info'. Options: debug|info|warn|error.
+# NEXT_PUBLIC_LOG_LEVEL=info
+
+# [OPTIONAL] Enable debug mode. Default: false.
+# NEXT_PUBLIC_DEBUG_MODE=false
+
+# ── Lambda-only variables (DO NOT add to workflow env: block) ─────────────────
+# These are set by CDK on the Lambda function environment directly.
+# They are listed here for documentation — they are NOT part of the
+# Next.js build and must never appear in the deploy workflow's env: block.
+#
+# AWS_REGION                — Lambda runtime region (set by AWS runtime)
+# CLOUDWATCH_LOG_GROUP      — Lambda log group (set by CDK)
+# SETTINGS_TABLE            — DynamoDB table name for budget settings
+# TRANSACTIONS_TABLE        — DynamoDB table name for transactions
+# RULES_TABLE               — DynamoDB table name for categorisation rules
+# CLAUDE_PROXY_FUNCTION_NAME — Lambda function name for direct Claude invocation

--- a/apps/stock-analyser/.env.example
+++ b/apps/stock-analyser/.env.example
@@ -1,0 +1,136 @@
+# Stock Analyser — required environment variables
+#
+# This file is the single source of truth for what environment variables
+# the Stock Analyser app needs to function. It is checked into git and
+# is documentation only — it is NOT loaded at runtime.
+#
+# For local development: copy to .env.local and fill in real values.
+# For CI/CD: variable names here must match entries in
+#   .github/workflows/deploy-stock-analyser.yml (env: block) AND
+#   GitHub repo Settings → Environments → dev/prod variables.
+#
+# Sub-phase 2b of the stabilisation plan adds a CI step that reads this
+# file and asserts every variable listed exists as a non-empty GitHub
+# Actions environment variable before the build runs.
+# See STABILISATION_FREEZE.md → Phase 1 → sub-phase 2.
+#
+# Variables marked [REQUIRED] cause broken functionality if absent or empty.
+# Variables marked [OPTIONAL] have a sensible fallback noted inline.
+# Variables marked [LAMBDA ONLY] are used only by backend Lambda functions
+# and are NOT part of the Next.js build — do not add them to the workflow
+# env: block.
+
+# ── Platform API ─────────────────────────────────────────────────────────────
+
+# [REQUIRED] Base URL of the shared platform API Gateway.
+# All platform routes (auth session, accounts, portfolio, watchlist,
+# Claude proxy, analysis-cache) are sent here.
+# Source: CloudFormation output ApiUrl on TransformotionDev-Api (dev) or
+#         TransformotionProd-Api (prod).
+NEXT_PUBLIC_API_URL=https://your-platform-api-id.execute-api.ap-southeast-2.amazonaws.com/dev
+
+# [REQUIRED] Claude proxy endpoint. AI features in the Stock Analyser
+# invoke this to call Anthropic via the shared backend proxy Lambda.
+# Path is /api/claude on the platform API — update both API ID and stage
+# whenever TransformotionDev-Api is recreated.
+# Source: <NEXT_PUBLIC_API_URL>/api/claude
+NEXT_PUBLIC_CLAUDE_API_URL=https://your-platform-api-id.execute-api.ap-southeast-2.amazonaws.com/dev/api/claude
+
+# [REQUIRED] Analysis-cache endpoint. Persistent cache of AI analysis
+# results, used for long-poll job status.
+# Source: <NEXT_PUBLIC_API_URL>/analysis-cache
+NEXT_PUBLIC_CLAUDE_CACHE_URL=https://your-platform-api-id.execute-api.ap-southeast-2.amazonaws.com/dev/analysis-cache
+
+# ── Cognito authentication ────────────────────────────────────────────────────
+
+# [REQUIRED] AWS Cognito User Pool ID. Shared across all apps.
+# Source: CloudFormation output UserPoolId on TransformotionDev-Auth.
+NEXT_PUBLIC_COGNITO_USER_POOL_ID=ap-southeast-2_XXXXXXXXX
+
+# [REQUIRED] Cognito app client ID for the Stock Analyser / platform app.
+# NOTE: This value differs between apps. The Budget Tracker app uses a
+# separate client ID (BTAppClientId on TransformotionDev-BudgetTrackerTables).
+# When the Budget Tracker deploy workflow is wired up (Issue #17), it will
+# need its own environment variable or a separate GitHub environment with
+# a different value for this key.
+# Source: CloudFormation output UserPoolClientId on TransformotionDev-Auth.
+NEXT_PUBLIC_COGNITO_CLIENT_ID=your-cognito-client-id
+
+# [REQUIRED] AWS region where Cognito is deployed.
+NEXT_PUBLIC_COGNITO_REGION=ap-southeast-2
+
+# [REQUIRED] Cognito hosted UI domain. Used by Amplify to configure the
+# OAuth flow (social sign-in / sign-in-with-redirect). Without this,
+# signInWithRedirect() fails — basic email/password auth still works.
+# Source: CloudFormation output UserPoolDomain on TransformotionDev-Auth.
+# Format: <pool-name>-<account-id>-<stage>.auth.<region>.amazoncognito.com
+NEXT_PUBLIC_COGNITO_DOMAIN=your-pool-name.auth.ap-southeast-2.amazoncognito.com
+
+# [REQUIRED] The public URL of this app. Used by Amplify as the OAuth
+# redirect target (redirectSignIn, redirectSignOut).
+# For dev: https://dev.apps.transformotion.com.au
+# For local: http://localhost:3000
+NEXT_PUBLIC_APP_URL=https://dev.apps.transformotion.com.au
+
+# ── Budget Tracker API ────────────────────────────────────────────────────────
+
+# [REQUIRED] Budget Tracker API Gateway base URL (currently a separate
+# API Gateway from the platform — architectural drift tracked in Issue #17).
+# Source: CloudFormation output BudgetApiBase on TransformotionDev-BudgetTrackerApi.
+NEXT_PUBLIC_BUDGET_API_URL=https://your-budget-api-id.execute-api.ap-southeast-2.amazonaws.com/dev/api/budget/v1
+
+# ── Feature flags ─────────────────────────────────────────────────────────────
+
+# [REQUIRED] Set to 'false' to use real API calls. Defaults to true (mock
+# mode) if absent — always set explicitly in deployed environments.
+NEXT_PUBLIC_USE_MOCK_DATA=false
+
+# ── Optional tuning ───────────────────────────────────────────────────────────
+# These have sensible defaults and are not required in deployed environments.
+# Uncomment and set only if you need non-default behaviour.
+
+# [OPTIONAL] Auth provider selection. Default: 'mock'.
+# The switch is currently vestigial — the app always uses Cognito regardless.
+# Included for completeness; will be removed or wired up in a future cleanup.
+# NEXT_PUBLIC_AUTH_PROVIDER=cognito
+
+# [OPTIONAL] AI provider. Default: 'mock'. Set to 'anthropic' to use real
+# Anthropic calls via the Claude proxy Lambda.
+# NEXT_PUBLIC_AI_PROVIDER=anthropic
+
+# [OPTIONAL] AI model for Anthropic calls. Default: 'claude-3-sonnet'.
+# NEXT_PUBLIC_AI_MODEL=claude-3-sonnet
+
+# [OPTIONAL] Claude proxy polling interval in ms. Default: 2500.
+# NEXT_PUBLIC_CLAUDE_POLL_INTERVAL=2500
+
+# [OPTIONAL] Max time to poll for a Claude response in ms. Default: 500000.
+# NEXT_PUBLIC_CLAUDE_MAX_POLL_TIME=500000
+
+# [OPTIONAL] Log level. Default: 'info'. Options: debug|info|warn|error.
+# NEXT_PUBLIC_LOG_LEVEL=info
+
+# [OPTIONAL] Enable debug mode (verbose client-side logging). Default: false.
+# NEXT_PUBLIC_DEBUG_MODE=false
+
+# ── Planned / not yet implemented ─────────────────────────────────────────────
+
+# [PLANNED] Auth API URL for the forgot-provider flow (tells users which
+# sign-in method they used). The Lambda (transformotion-forgot-provider-dev)
+# and API Gateway (TransformotionDev-AuthApi) exist in AWS, but the
+# frontend ForgotProviderModal does not yet call them — it is currently a
+# submit stub. This var will be required once that integration is wired up.
+# Source: CloudFormation output on TransformotionDev-AuthApi.
+# NEXT_PUBLIC_AUTH_API_URL=https://your-auth-api-id.execute-api.ap-southeast-2.amazonaws.com/dev
+
+# ── Lambda-only variables (DO NOT add to workflow env: block) ─────────────────
+# These are set by CDK on the Lambda function environment directly.
+# They are listed here for documentation — they are NOT part of the
+# Next.js build and must never appear in the deploy workflow's env: block.
+#
+# AWS_REGION               — Lambda runtime region (set by AWS runtime)
+# CLOUDWATCH_LOG_GROUP     — Lambda log group (set by CDK)
+# PORTFOLIO_TABLE          — DynamoDB table name for portfolio data
+# WATCHLIST_TABLE          — DynamoDB table name for watchlist data
+# CACHE_TABLE              — DynamoDB table name for analysis cache
+# ANTHROPIC_API_KEY        — Anthropic API key (set from Secrets Manager)

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,0 +1,39 @@
+# Web (Launchpad) — required environment variables
+#
+# This file is the single source of truth for what environment variables
+# the Web / Launchpad app needs to function. It is checked into git and
+# is documentation only — it is NOT loaded at runtime.
+#
+# apps/web is the platform launchpad — the sign-in and app-selection
+# shell that links to the Stock Analyser and Budget Tracker apps.
+# It does not make API calls or authenticate users directly; it only
+# needs the public URLs of the apps it links to.
+#
+# NOTE: apps/web has no deploy workflow yet. When one is added, the
+# workflow env: block must pass the variables listed here.
+#
+# Sub-phase 2b of the stabilisation plan adds a CI step that reads this
+# file and asserts every variable listed exists as a non-empty GitHub
+# Actions environment variable before the build runs.
+# See STABILISATION_FREEZE.md → Phase 1 → sub-phase 2.
+
+# ── App navigation URLs ───────────────────────────────────────────────────────
+
+# [REQUIRED] Public URL of the Stock Analyser app. The launchpad tile
+# navigates the user here on launch.
+# For dev:   https://dev.apps.transformotion.com.au
+# For prod:  https://apps.transformotion.com.au
+# For local: http://localhost:3000
+# Fallback if absent: http://localhost:3000
+NEXT_PUBLIC_STOCK_URL=https://dev.apps.transformotion.com.au
+
+# [REQUIRED] Public URL of the Budget Tracker app. The launchpad tile
+# navigates the user here on launch.
+# For dev:   the Budget Tracker is currently embedded inside the Stock
+#            Analyser app at <NEXT_PUBLIC_STOCK_URL>/budget-tracker (see
+#            Issue #17 for the consolidation plan). Once Issue #17 is
+#            complete and the Budget Tracker has its own deployment, this
+#            will point to its own URL.
+# For local: http://localhost:3002
+# Fallback if absent: http://localhost:3002
+NEXT_PUBLIC_BUDGET_URL=https://dev.apps.transformotion.com.au/budget-tracker


### PR DESCRIPTION
Phase 1 sub-phase 2a of the stabilisation plan — env var foundation, documentation layer.

## What

- Adds `.env.example` to `apps/stock-analyser/`, `apps/budget-tracker/`, `apps/web/` listing every required env var with descriptive comments and placeholder values
- Creates repo labels (enhancement, architecture, infrastructure); backfills onto Issues #16, #17, #18
- Documents the 2b enforcement-binding in STABILISATION_FREEZE.md (no deploys succeed after 2b lands until target env vars match the schema)

## What this is not

- No env var values change
- No deploys run differently
- No code logic changes
- Pure documentation + label hygiene

## What's next

Sub-phase 2b will add a CI step that reads each `.env.example` and asserts every variable listed exists as a non-empty GitHub Actions environment variable in the target environment. That check is configured to hard-fail, which forces the Phase 3.5 env var fix immediately upon merge.

Refs Issue #18.