### PR TITLE
docs(env): tag .env.example vars with REQUIRED/OPTIONAL/PLANNED

### DIFF
--- a/apps/budget-tracker/.env.example
+++ b/apps/budget-tracker/.env.example
@@ -1,4 +1,4 @@
-# Budget Tracker — required environment variables
+# Budget Tracker — environment variables
 #
 # This file is the single source of truth for what environment variables
 # the Budget Tracker app needs to function. It is checked into git and
@@ -15,87 +15,111 @@
 # pass every [REQUIRED] variable listed here.
 #
 # Sub-phase 2b of the stabilisation plan adds a CI step that reads this
-# file and asserts every variable listed exists as a non-empty GitHub
+# file and asserts every [REQUIRED] variable exists as a non-empty GitHub
 # Actions environment variable before the build runs.
 # See STABILISATION_FREEZE.md → Phase 1 → sub-phase 2.
+
+# ── Tagging convention ────────────────────────────────────────────────────────
+# Each variable below is tagged [REQUIRED], [OPTIONAL], or [PLANNED]
+# in its preceding comment block:
 #
-# Variables marked [REQUIRED] cause broken functionality if absent or empty.
-# Variables marked [OPTIONAL] have a sensible fallback noted inline.
-# Variables marked [LAMBDA ONLY] are used only by backend Lambda functions
-# and are NOT part of the Next.js build.
+#   [REQUIRED] — must be set in the GitHub Actions environment for
+#                deploy to succeed; CI sub-phase 2b enforces this.
+#   [OPTIONAL] — has a default in code; setting it is optional.
+#   [PLANNED]  — declared but not yet consumed by app code.
+#
+# When adding a new variable, choose its tag deliberately and update
+# the deploy workflow's env: block if [REQUIRED].
+# ─────────────────────────────────────────────────────────────────────────────
 
 # ── Platform API ─────────────────────────────────────────────────────────────
 
-# [REQUIRED] Base URL of the shared platform API Gateway.
+# [REQUIRED]
+# Base URL of the shared platform API Gateway.
 # Used for platform routes (auth session, accounts).
 # Source: CloudFormation output ApiUrl on TransformotionDev-Api (dev) or
 #         TransformotionProd-Api (prod).
 NEXT_PUBLIC_API_URL=https://your-platform-api-id.execute-api.ap-southeast-2.amazonaws.com/dev
 
-# [REQUIRED] Claude proxy endpoint. AI features in the Budget Tracker
-# invoke this for AI categorisation via the shared backend proxy Lambda.
+# [REQUIRED]
+# Claude proxy endpoint. AI features in the Budget Tracker (AI
+# categorisation) invoke this via the shared backend proxy Lambda.
 # Source: <NEXT_PUBLIC_API_URL>/api/claude
 NEXT_PUBLIC_CLAUDE_API_URL=https://your-platform-api-id.execute-api.ap-southeast-2.amazonaws.com/dev/api/claude
 
-# [REQUIRED] Analysis-cache endpoint. Used for long-poll job status.
+# [REQUIRED]
+# Analysis-cache endpoint. Used for long-poll job status.
 # Source: <NEXT_PUBLIC_API_URL>/analysis-cache
 NEXT_PUBLIC_CLAUDE_CACHE_URL=https://your-platform-api-id.execute-api.ap-southeast-2.amazonaws.com/dev/analysis-cache
 
 # ── Cognito authentication ────────────────────────────────────────────────────
 
-# [REQUIRED] AWS Cognito User Pool ID. Shared across all apps.
+# [REQUIRED]
+# AWS Cognito User Pool ID. Shared across all apps.
 # Source: CloudFormation output UserPoolId on TransformotionDev-Auth.
 NEXT_PUBLIC_COGNITO_USER_POOL_ID=ap-southeast-2_XXXXXXXXX
 
-# [REQUIRED] Cognito app client ID for the Budget Tracker app.
+# [REQUIRED]
+# Cognito app client ID for the Budget Tracker app.
 # IMPORTANT: This is a different client ID from the Stock Analyser app.
 #   Budget Tracker client: BTAppClientId on TransformotionDev-BudgetTrackerTables
 #   Stock Analyser client: UserPoolClientId on TransformotionDev-Auth
-# The deploy-budget-tracker.yml workflow must NOT reuse the same
-# NEXT_PUBLIC_COGNITO_CLIENT_ID GitHub Actions variable as deploy-stock-analyser.yml.
-# Use a separate GitHub environment or a distinct variable name when wiring
-# up the Budget Tracker pipeline (see Issue #17).
+# When the Budget Tracker deploy workflow is wired up (Issue #17), it must
+# NOT reuse the same NEXT_PUBLIC_COGNITO_CLIENT_ID GitHub Actions variable
+# value as the Stock Analyser. Use a separate GitHub environment or a
+# distinct variable name. Different client IDs do NOT break SSO — SSO works
+# because both clients share the same User Pool and Hosted UI domain.
+# See Issue #17 comment for the full SSO precursor explanation.
 NEXT_PUBLIC_COGNITO_CLIENT_ID=your-budget-tracker-cognito-client-id
 
-# [REQUIRED] AWS region where Cognito is deployed.
+# [REQUIRED]
+# AWS region where Cognito is deployed.
 NEXT_PUBLIC_COGNITO_REGION=ap-southeast-2
 
 # ── Feature flags ─────────────────────────────────────────────────────────────
 
-# [REQUIRED] Set to 'false' to use real API calls. Defaults to true (mock
-# mode) if absent — always set explicitly in deployed environments.
+# [OPTIONAL]
+# Set to 'false' to use real API calls. Defaults to true (mock mode) if
+# absent or empty. Always set explicitly in deployed environments.
 NEXT_PUBLIC_USE_MOCK_DATA=false
 
 # ── Optional tuning ───────────────────────────────────────────────────────────
 
-# [OPTIONAL] Auth provider selection. Default: 'mock'.
-# The Budget Tracker auth service is currently a mock stub. This var will
-# become meaningful once Cognito is fully wired into the BT auth flow.
+# [OPTIONAL]
+# Auth provider selection. Default: 'mock'. The Budget Tracker auth
+# service is currently a mock stub. This var will become meaningful once
+# Cognito is fully wired into the BT auth flow (Issue #17).
 # NEXT_PUBLIC_AUTH_PROVIDER=cognito
 
-# [OPTIONAL] AI provider. Default: 'mock'. Set to 'anthropic' to use real
-# Anthropic calls via the Claude proxy Lambda.
+# [OPTIONAL]
+# AI provider. Default: 'mock'. Set to 'anthropic' to use real Anthropic
+# calls via the Claude proxy Lambda.
 # NEXT_PUBLIC_AI_PROVIDER=anthropic
 
-# [OPTIONAL] AI model for Anthropic calls. Default: 'claude-3-sonnet'.
+# [OPTIONAL]
+# AI model for Anthropic calls. Default: 'claude-3-sonnet'.
 # NEXT_PUBLIC_AI_MODEL=claude-3-sonnet
 
-# [OPTIONAL] Claude proxy polling interval in ms. Default: 2500.
+# [OPTIONAL]
+# Claude proxy polling interval in ms. Default: 2500.
 # NEXT_PUBLIC_CLAUDE_POLL_INTERVAL=2500
 
-# [OPTIONAL] Max time to poll for a Claude response in ms. Default: 500000.
+# [OPTIONAL]
+# Max time to poll for a Claude response in ms. Default: 500000.
 # NEXT_PUBLIC_CLAUDE_MAX_POLL_TIME=500000
 
-# [OPTIONAL] Log level. Default: 'info'. Options: debug|info|warn|error.
+# [OPTIONAL]
+# Log level. Default: 'info'. Options: debug|info|warn|error.
 # NEXT_PUBLIC_LOG_LEVEL=info
 
-# [OPTIONAL] Enable debug mode. Default: false.
+# [OPTIONAL]
+# Enable debug mode. Default: false.
 # NEXT_PUBLIC_DEBUG_MODE=false
 
 # ── Lambda-only variables (DO NOT add to workflow env: block) ─────────────────
 # These are set by CDK on the Lambda function environment directly.
-# They are listed here for documentation — they are NOT part of the
-# Next.js build and must never appear in the deploy workflow's env: block.
+# They are NOT part of the Next.js build and must never appear in the
+# deploy workflow's env: block.
 #
 # AWS_REGION                — Lambda runtime region (set by AWS runtime)
 # CLOUDWATCH_LOG_GROUP      — Lambda log group (set by CDK)

--- a/apps/stock-analyser/.env.example
+++ b/apps/stock-analyser/.env.example
@@ -1,4 +1,4 @@
-# Stock Analyser — required environment variables
+# Stock Analyser — environment variables
 #
 # This file is the single source of truth for what environment variables
 # the Stock Analyser app needs to function. It is checked into git and
@@ -10,44 +10,56 @@
 #   GitHub repo Settings → Environments → dev/prod variables.
 #
 # Sub-phase 2b of the stabilisation plan adds a CI step that reads this
-# file and asserts every variable listed exists as a non-empty GitHub
+# file and asserts every [REQUIRED] variable exists as a non-empty GitHub
 # Actions environment variable before the build runs.
 # See STABILISATION_FREEZE.md → Phase 1 → sub-phase 2.
+
+# ── Tagging convention ────────────────────────────────────────────────────────
+# Each variable below is tagged [REQUIRED], [OPTIONAL], or [PLANNED]
+# in its preceding comment block:
 #
-# Variables marked [REQUIRED] cause broken functionality if absent or empty.
-# Variables marked [OPTIONAL] have a sensible fallback noted inline.
-# Variables marked [LAMBDA ONLY] are used only by backend Lambda functions
-# and are NOT part of the Next.js build — do not add them to the workflow
-# env: block.
+#   [REQUIRED] — must be set in the GitHub Actions environment for
+#                deploy to succeed; CI sub-phase 2b enforces this.
+#   [OPTIONAL] — has a default in code; setting it is optional.
+#   [PLANNED]  — declared but not yet consumed by app code.
+#
+# When adding a new variable, choose its tag deliberately and update
+# the deploy workflow's env: block if [REQUIRED].
+# ─────────────────────────────────────────────────────────────────────────────
 
 # ── Platform API ─────────────────────────────────────────────────────────────
 
-# [REQUIRED] Base URL of the shared platform API Gateway.
+# [REQUIRED]
+# Base URL of the shared platform API Gateway.
 # All platform routes (auth session, accounts, portfolio, watchlist,
 # Claude proxy, analysis-cache) are sent here.
 # Source: CloudFormation output ApiUrl on TransformotionDev-Api (dev) or
 #         TransformotionProd-Api (prod).
 NEXT_PUBLIC_API_URL=https://your-platform-api-id.execute-api.ap-southeast-2.amazonaws.com/dev
 
-# [REQUIRED] Claude proxy endpoint. AI features in the Stock Analyser
-# invoke this to call Anthropic via the shared backend proxy Lambda.
+# [REQUIRED]
+# Claude proxy endpoint. AI features in the Stock Analyser invoke this
+# to call Anthropic via the shared backend proxy Lambda.
 # Path is /api/claude on the platform API — update both API ID and stage
 # whenever TransformotionDev-Api is recreated.
 # Source: <NEXT_PUBLIC_API_URL>/api/claude
 NEXT_PUBLIC_CLAUDE_API_URL=https://your-platform-api-id.execute-api.ap-southeast-2.amazonaws.com/dev/api/claude
 
-# [REQUIRED] Analysis-cache endpoint. Persistent cache of AI analysis
-# results, used for long-poll job status.
+# [REQUIRED]
+# Analysis-cache endpoint. Persistent cache of AI analysis results,
+# used for long-poll job status.
 # Source: <NEXT_PUBLIC_API_URL>/analysis-cache
 NEXT_PUBLIC_CLAUDE_CACHE_URL=https://your-platform-api-id.execute-api.ap-southeast-2.amazonaws.com/dev/analysis-cache
 
 # ── Cognito authentication ────────────────────────────────────────────────────
 
-# [REQUIRED] AWS Cognito User Pool ID. Shared across all apps.
+# [REQUIRED]
+# AWS Cognito User Pool ID. Shared across all apps.
 # Source: CloudFormation output UserPoolId on TransformotionDev-Auth.
 NEXT_PUBLIC_COGNITO_USER_POOL_ID=ap-southeast-2_XXXXXXXXX
 
-# [REQUIRED] Cognito app client ID for the Stock Analyser / platform app.
+# [REQUIRED]
+# Cognito app client ID for the Stock Analyser / platform app.
 # NOTE: This value differs between apps. The Budget Tracker app uses a
 # separate client ID (BTAppClientId on TransformotionDev-BudgetTrackerTables).
 # When the Budget Tracker deploy workflow is wired up (Issue #17), it will
@@ -56,77 +68,93 @@ NEXT_PUBLIC_COGNITO_USER_POOL_ID=ap-southeast-2_XXXXXXXXX
 # Source: CloudFormation output UserPoolClientId on TransformotionDev-Auth.
 NEXT_PUBLIC_COGNITO_CLIENT_ID=your-cognito-client-id
 
-# [REQUIRED] AWS region where Cognito is deployed.
+# [REQUIRED]
+# AWS region where Cognito is deployed.
 NEXT_PUBLIC_COGNITO_REGION=ap-southeast-2
 
-# [REQUIRED] Cognito hosted UI domain. Used by Amplify to configure the
-# OAuth flow (social sign-in / sign-in-with-redirect). Without this,
-# signInWithRedirect() fails — basic email/password auth still works.
+# [REQUIRED]
+# Cognito Hosted UI domain. Used by Amplify to configure the OAuth flow
+# (signInWithRedirect). Without this, OAuth/social sign-in fails; basic
+# email/password auth still works but the SSO session cookie cannot be set.
+# Must be identical across all apps that share SSO — see Issue #17.
 # Source: CloudFormation output UserPoolDomain on TransformotionDev-Auth.
 # Format: <pool-name>-<account-id>-<stage>.auth.<region>.amazoncognito.com
 NEXT_PUBLIC_COGNITO_DOMAIN=your-pool-name.auth.ap-southeast-2.amazoncognito.com
 
-# [REQUIRED] The public URL of this app. Used by Amplify as the OAuth
-# redirect target (redirectSignIn, redirectSignOut).
-# For dev: https://dev.apps.transformotion.com.au
+# [REQUIRED]
+# The public URL of this app. Used by Amplify as the OAuth redirect target
+# (redirectSignIn, redirectSignOut). Must be registered as a permitted
+# callback URL on the Cognito app client in the AWS console.
+# For dev:   https://dev.apps.transformotion.com.au
 # For local: http://localhost:3000
 NEXT_PUBLIC_APP_URL=https://dev.apps.transformotion.com.au
 
 # ── Budget Tracker API ────────────────────────────────────────────────────────
 
-# [REQUIRED] Budget Tracker API Gateway base URL (currently a separate
-# API Gateway from the platform — architectural drift tracked in Issue #17).
+# [REQUIRED]
+# Budget Tracker API Gateway base URL (currently a separate API Gateway
+# from the platform — architectural drift tracked in Issue #17).
 # Source: CloudFormation output BudgetApiBase on TransformotionDev-BudgetTrackerApi.
 NEXT_PUBLIC_BUDGET_API_URL=https://your-budget-api-id.execute-api.ap-southeast-2.amazonaws.com/dev/api/budget/v1
 
 # ── Feature flags ─────────────────────────────────────────────────────────────
 
-# [REQUIRED] Set to 'false' to use real API calls. Defaults to true (mock
-# mode) if absent — always set explicitly in deployed environments.
+# [OPTIONAL]
+# Set to 'false' to use real API calls. Defaults to true (mock mode) if
+# absent or empty. Always set explicitly in deployed environments.
 NEXT_PUBLIC_USE_MOCK_DATA=false
 
 # ── Optional tuning ───────────────────────────────────────────────────────────
 # These have sensible defaults and are not required in deployed environments.
 # Uncomment and set only if you need non-default behaviour.
 
-# [OPTIONAL] Auth provider selection. Default: 'mock'.
-# The switch is currently vestigial — the app always uses Cognito regardless.
+# [OPTIONAL]
+# Auth provider selection. Default: 'mock'. The switch is currently
+# vestigial — the app always uses Cognito regardless of this value.
 # Included for completeness; will be removed or wired up in a future cleanup.
 # NEXT_PUBLIC_AUTH_PROVIDER=cognito
 
-# [OPTIONAL] AI provider. Default: 'mock'. Set to 'anthropic' to use real
-# Anthropic calls via the Claude proxy Lambda.
+# [OPTIONAL]
+# AI provider. Default: 'mock'. Set to 'anthropic' to use real Anthropic
+# calls via the Claude proxy Lambda.
 # NEXT_PUBLIC_AI_PROVIDER=anthropic
 
-# [OPTIONAL] AI model for Anthropic calls. Default: 'claude-3-sonnet'.
+# [OPTIONAL]
+# AI model for Anthropic calls. Default: 'claude-3-sonnet'.
 # NEXT_PUBLIC_AI_MODEL=claude-3-sonnet
 
-# [OPTIONAL] Claude proxy polling interval in ms. Default: 2500.
+# [OPTIONAL]
+# Claude proxy polling interval in ms. Default: 2500.
 # NEXT_PUBLIC_CLAUDE_POLL_INTERVAL=2500
 
-# [OPTIONAL] Max time to poll for a Claude response in ms. Default: 500000.
+# [OPTIONAL]
+# Max time to poll for a Claude response in ms. Default: 500000.
 # NEXT_PUBLIC_CLAUDE_MAX_POLL_TIME=500000
 
-# [OPTIONAL] Log level. Default: 'info'. Options: debug|info|warn|error.
+# [OPTIONAL]
+# Log level. Default: 'info'. Options: debug|info|warn|error.
 # NEXT_PUBLIC_LOG_LEVEL=info
 
-# [OPTIONAL] Enable debug mode (verbose client-side logging). Default: false.
+# [OPTIONAL]
+# Enable debug mode (verbose client-side logging). Default: false.
 # NEXT_PUBLIC_DEBUG_MODE=false
 
 # ── Planned / not yet implemented ─────────────────────────────────────────────
 
-# [PLANNED] Auth API URL for the forgot-provider flow (tells users which
-# sign-in method they used). The Lambda (transformotion-forgot-provider-dev)
+# [PLANNED]
+# Auth API URL for the forgot-provider flow (tells users which sign-in
+# method they used). The Lambda (transformotion-forgot-provider-dev)
 # and API Gateway (TransformotionDev-AuthApi) exist in AWS, but the
-# frontend ForgotProviderModal does not yet call them — it is currently a
-# submit stub. This var will be required once that integration is wired up.
+# frontend ForgotProviderModal does not yet call them — it is currently
+# a submit stub. This var will graduate to [REQUIRED] once that
+# integration is wired up.
 # Source: CloudFormation output on TransformotionDev-AuthApi.
 # NEXT_PUBLIC_AUTH_API_URL=https://your-auth-api-id.execute-api.ap-southeast-2.amazonaws.com/dev
 
 # ── Lambda-only variables (DO NOT add to workflow env: block) ─────────────────
 # These are set by CDK on the Lambda function environment directly.
-# They are listed here for documentation — they are NOT part of the
-# Next.js build and must never appear in the deploy workflow's env: block.
+# They are NOT part of the Next.js build and must never appear in the
+# deploy workflow's env: block.
 #
 # AWS_REGION               — Lambda runtime region (set by AWS runtime)
 # CLOUDWATCH_LOG_GROUP     — Lambda log group (set by CDK)

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,4 +1,4 @@
-# Web (Launchpad) — required environment variables
+# Web (Launchpad) — environment variables
 #
 # This file is the single source of truth for what environment variables
 # the Web / Launchpad app needs to function. It is checked into git and
@@ -10,30 +10,43 @@
 # needs the public URLs of the apps it links to.
 #
 # NOTE: apps/web has no deploy workflow yet. When one is added, the
-# workflow env: block must pass the variables listed here.
+# workflow env: block must pass every [REQUIRED] variable listed here.
 #
 # Sub-phase 2b of the stabilisation plan adds a CI step that reads this
-# file and asserts every variable listed exists as a non-empty GitHub
+# file and asserts every [REQUIRED] variable exists as a non-empty GitHub
 # Actions environment variable before the build runs.
 # See STABILISATION_FREEZE.md → Phase 1 → sub-phase 2.
 
+# ── Tagging convention ────────────────────────────────────────────────────────
+# Each variable below is tagged [REQUIRED], [OPTIONAL], or [PLANNED]
+# in its preceding comment block:
+#
+#   [REQUIRED] — must be set in the GitHub Actions environment for
+#                deploy to succeed; CI sub-phase 2b enforces this.
+#   [OPTIONAL] — has a default in code; setting it is optional.
+#   [PLANNED]  — declared but not yet consumed by app code.
+#
+# When adding a new variable, choose its tag deliberately and update
+# the deploy workflow's env: block if [REQUIRED].
+# ─────────────────────────────────────────────────────────────────────────────
+
 # ── App navigation URLs ───────────────────────────────────────────────────────
 
-# [REQUIRED] Public URL of the Stock Analyser app. The launchpad tile
-# navigates the user here on launch.
+# [OPTIONAL]
+# Public URL of the Stock Analyser app. The launchpad tile navigates
+# the user here on launch. Defaults to http://localhost:3000 if absent.
 # For dev:   https://dev.apps.transformotion.com.au
 # For prod:  https://apps.transformotion.com.au
 # For local: http://localhost:3000
-# Fallback if absent: http://localhost:3000
 NEXT_PUBLIC_STOCK_URL=https://dev.apps.transformotion.com.au
 
-# [REQUIRED] Public URL of the Budget Tracker app. The launchpad tile
-# navigates the user here on launch.
+# [OPTIONAL]
+# Public URL of the Budget Tracker app. The launchpad tile navigates
+# the user here on launch. Defaults to http://localhost:3002 if absent.
 # For dev:   the Budget Tracker is currently embedded inside the Stock
-#            Analyser app at <NEXT_PUBLIC_STOCK_URL>/budget-tracker (see
-#            Issue #17 for the consolidation plan). Once Issue #17 is
-#            complete and the Budget Tracker has its own deployment, this
-#            will point to its own URL.
+#            Analyser app at <NEXT_PUBLIC_STOCK_URL>/budget-tracker
+#            (see Issue #17 for the consolidation plan). Once Issue #17
+#            is complete and the Budget Tracker has its own deployment,
+#            this will point to its own URL.
 # For local: http://localhost:3002
-# Fallback if absent: http://localhost:3002
 NEXT_PUBLIC_BUDGET_URL=https://dev.apps.transformotion.com.au/budget-tracker


### PR DESCRIPTION
Sub-phase 2a follow-up — establishes the tagging convention sub-phase 2b's CI check will parse.

No env values change. Pure documentation tightening.

Refs: PR #20, Issue #18.