### PR TITLE
docs(env): refine REQUIRED/OPTIONAL rule, reclassify web app URL vars

### DIFF
--- a/apps/budget-tracker/.env.example
+++ b/apps/budget-tracker/.env.example
@@ -23,13 +23,28 @@
 # Each variable below is tagged [REQUIRED], [OPTIONAL], or [PLANNED]
 # in its preceding comment block:
 #
-#   [REQUIRED] — must be set in the GitHub Actions environment for
-#                deploy to succeed; CI sub-phase 2b enforces this.
-#   [OPTIONAL] — has a default in code; setting it is optional.
-#   [PLANNED]  — declared but not yet consumed by app code.
+#   [REQUIRED] — the app would behave incorrectly in production if this
+#                var is missing. CI sub-phase 2b enforces presence of
+#                every [REQUIRED] var in the target GitHub Actions
+#                environment before a deploy proceeds.
+#
+#                A var is [REQUIRED] regardless of whether code has a
+#                fallback. Dev-only fallbacks (localhost URLs, debug
+#                stubs, mock responses) do NOT make a var optional —
+#                they only make local development convenient. The test
+#                is: "would the deployed app behave correctly with this
+#                var missing?" If no, [REQUIRED].
+#
+#   [OPTIONAL] — has a sensible production default in code; absence
+#                does not break or degrade production behaviour.
+#                Examples: feature flags off by default, log levels,
+#                poll intervals.
+#
+#   [PLANNED]  — declared but not yet read by app code. Reserved for
+#                upcoming use. Sub-phase 2b skips these.
 #
 # When adding a new variable, choose its tag deliberately and update
-# the deploy workflow's env: block if [REQUIRED].
+# the deploy workflow's env block if [REQUIRED].
 # ─────────────────────────────────────────────────────────────────────────────
 
 # ── Platform API ─────────────────────────────────────────────────────────────

--- a/apps/stock-analyser/.env.example
+++ b/apps/stock-analyser/.env.example
@@ -18,13 +18,28 @@
 # Each variable below is tagged [REQUIRED], [OPTIONAL], or [PLANNED]
 # in its preceding comment block:
 #
-#   [REQUIRED] — must be set in the GitHub Actions environment for
-#                deploy to succeed; CI sub-phase 2b enforces this.
-#   [OPTIONAL] — has a default in code; setting it is optional.
-#   [PLANNED]  — declared but not yet consumed by app code.
+#   [REQUIRED] — the app would behave incorrectly in production if this
+#                var is missing. CI sub-phase 2b enforces presence of
+#                every [REQUIRED] var in the target GitHub Actions
+#                environment before a deploy proceeds.
+#
+#                A var is [REQUIRED] regardless of whether code has a
+#                fallback. Dev-only fallbacks (localhost URLs, debug
+#                stubs, mock responses) do NOT make a var optional —
+#                they only make local development convenient. The test
+#                is: "would the deployed app behave correctly with this
+#                var missing?" If no, [REQUIRED].
+#
+#   [OPTIONAL] — has a sensible production default in code; absence
+#                does not break or degrade production behaviour.
+#                Examples: feature flags off by default, log levels,
+#                poll intervals.
+#
+#   [PLANNED]  — declared but not yet read by app code. Reserved for
+#                upcoming use. Sub-phase 2b skips these.
 #
 # When adding a new variable, choose its tag deliberately and update
-# the deploy workflow's env: block if [REQUIRED].
+# the deploy workflow's env block if [REQUIRED].
 # ─────────────────────────────────────────────────────────────────────────────
 
 # ── Platform API ─────────────────────────────────────────────────────────────

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -21,32 +21,49 @@
 # Each variable below is tagged [REQUIRED], [OPTIONAL], or [PLANNED]
 # in its preceding comment block:
 #
-#   [REQUIRED] — must be set in the GitHub Actions environment for
-#                deploy to succeed; CI sub-phase 2b enforces this.
-#   [OPTIONAL] — has a default in code; setting it is optional.
-#   [PLANNED]  — declared but not yet consumed by app code.
+#   [REQUIRED] — the app would behave incorrectly in production if this
+#                var is missing. CI sub-phase 2b enforces presence of
+#                every [REQUIRED] var in the target GitHub Actions
+#                environment before a deploy proceeds.
+#
+#                A var is [REQUIRED] regardless of whether code has a
+#                fallback. Dev-only fallbacks (localhost URLs, debug
+#                stubs, mock responses) do NOT make a var optional —
+#                they only make local development convenient. The test
+#                is: "would the deployed app behave correctly with this
+#                var missing?" If no, [REQUIRED].
+#
+#   [OPTIONAL] — has a sensible production default in code; absence
+#                does not break or degrade production behaviour.
+#                Examples: feature flags off by default, log levels,
+#                poll intervals.
+#
+#   [PLANNED]  — declared but not yet read by app code. Reserved for
+#                upcoming use. Sub-phase 2b skips these.
 #
 # When adding a new variable, choose its tag deliberately and update
-# the deploy workflow's env: block if [REQUIRED].
+# the deploy workflow's env block if [REQUIRED].
 # ─────────────────────────────────────────────────────────────────────────────
 
 # ── App navigation URLs ───────────────────────────────────────────────────────
 
-# [OPTIONAL]
-# Public URL of the Stock Analyser app. The launchpad tile navigates
-# the user here on launch. Defaults to http://localhost:3000 if absent.
+# [REQUIRED]
+# URL of the deployed Stock Analyser app. The launchpad's Stock Analyser
+# tile navigates here. Falls back to http://localhost:3000 in code for
+# local dev convenience only — a deployed launchpad with this var unset
+# would point users at localhost and break tile navigation.
 # For dev:   https://dev.apps.transformotion.com.au
 # For prod:  https://apps.transformotion.com.au
-# For local: http://localhost:3000
 NEXT_PUBLIC_STOCK_URL=https://dev.apps.transformotion.com.au
 
-# [OPTIONAL]
-# Public URL of the Budget Tracker app. The launchpad tile navigates
-# the user here on launch. Defaults to http://localhost:3002 if absent.
+# [REQUIRED]
+# URL of the deployed Budget Tracker app. The launchpad's Budget Tracker
+# tile navigates here. Falls back to http://localhost:3002 in code for
+# local dev convenience only — a deployed launchpad with this var unset
+# would point users at localhost and break tile navigation.
 # For dev:   the Budget Tracker is currently embedded inside the Stock
 #            Analyser app at <NEXT_PUBLIC_STOCK_URL>/budget-tracker
 #            (see Issue #17 for the consolidation plan). Once Issue #17
 #            is complete and the Budget Tracker has its own deployment,
 #            this will point to its own URL.
-# For local: http://localhost:3002
 NEXT_PUBLIC_BUDGET_URL=https://dev.apps.transformotion.com.au/budget-tracker


### PR DESCRIPTION
Sub-phase 2a follow-up #2.

Tightens the REQUIRED/OPTIONAL tagging rule to be based on production behaviour, not on whether code has a fallback. Reclassifies two web app vars whose localhost fallbacks are dev-only.

Refs: PR #21, Issue #18.