### PR TITLE
docs(env): reclassify mock-mode defaults as REQUIRED

### DIFF
--- a/apps/budget-tracker/.env.example
+++ b/apps/budget-tracker/.env.example
@@ -93,23 +93,34 @@ NEXT_PUBLIC_COGNITO_REGION=ap-southeast-2
 
 # ── Feature flags ─────────────────────────────────────────────────────────────
 
-# [OPTIONAL]
-# Set to 'false' to use real API calls. Defaults to true (mock mode) if
-# absent or empty. Always set explicitly in deployed environments.
+# [REQUIRED]
+# Selects real vs mock data mode. Defaults to true (mock mode) in code
+# as a holdover from the v0 prototype phase. A deployed build with this
+# var unset silently uses mock data instead of real API calls — the app
+# appears to work while serving fake responses. Must be set to 'false'
+# in all deployed environments. (See Issue #18 for plan to flip the
+# default in code to production-safe false.)
 NEXT_PUBLIC_USE_MOCK_DATA=false
 
 # ── Optional tuning ───────────────────────────────────────────────────────────
 
-# [OPTIONAL]
-# Auth provider selection. Default: 'mock'. The Budget Tracker auth
-# service is currently a mock stub. This var will become meaningful once
-# Cognito is fully wired into the BT auth flow (Issue #17).
-# NEXT_PUBLIC_AUTH_PROVIDER=cognito
+# [REQUIRED]
+# Selects the auth provider. Defaults to 'mock' in code as a holdover
+# from the v0 prototype phase. The Budget Tracker auth service is
+# currently a mock stub (Issue #17), but a deployed build with this
+# unset would remain in mock auth mode even once that stub is replaced.
+# Must be set to 'cognito' in all deployed environments. (See Issue #18
+# for plan to flip the default in code to production-safe 'cognito'.)
+NEXT_PUBLIC_AUTH_PROVIDER=cognito
 
-# [OPTIONAL]
-# AI provider. Default: 'mock'. Set to 'anthropic' to use real Anthropic
-# calls via the Claude proxy Lambda.
-# NEXT_PUBLIC_AI_PROVIDER=anthropic
+# [REQUIRED]
+# Selects the AI service provider. Defaults to 'mock' in code as a
+# holdover from the v0 prototype phase. A deployed build with this var
+# unset silently returns mock AI responses instead of calling Anthropic
+# — AI categorisation appears to work while serving fake results. Must
+# be set to 'anthropic' in all deployed environments. (See Issue #18
+# for plan to flip the default in code to production-safe 'anthropic'.)
+NEXT_PUBLIC_AI_PROVIDER=anthropic
 
 # [OPTIONAL]
 # AI model for Anthropic calls. Default: 'claude-3-sonnet'.

--- a/apps/stock-analyser/.env.example
+++ b/apps/stock-analyser/.env.example
@@ -114,25 +114,36 @@ NEXT_PUBLIC_BUDGET_API_URL=https://your-budget-api-id.execute-api.ap-southeast-2
 
 # ── Feature flags ─────────────────────────────────────────────────────────────
 
-# [OPTIONAL]
-# Set to 'false' to use real API calls. Defaults to true (mock mode) if
-# absent or empty. Always set explicitly in deployed environments.
+# [REQUIRED]
+# Selects real vs mock data mode. Defaults to true (mock mode) in code
+# as a holdover from the v0 prototype phase. A deployed build with this
+# var unset silently uses mock data instead of real API calls — the app
+# appears to work while serving fake responses. Must be set to 'false'
+# in all deployed environments. (See Issue #18 for plan to flip the
+# default in code to production-safe false.)
 NEXT_PUBLIC_USE_MOCK_DATA=false
 
 # ── Optional tuning ───────────────────────────────────────────────────────────
 # These have sensible defaults and are not required in deployed environments.
 # Uncomment and set only if you need non-default behaviour.
 
-# [OPTIONAL]
-# Auth provider selection. Default: 'mock'. The switch is currently
-# vestigial — the app always uses Cognito regardless of this value.
-# Included for completeness; will be removed or wired up in a future cleanup.
-# NEXT_PUBLIC_AUTH_PROVIDER=cognito
+# [REQUIRED]
+# Selects the auth provider. Defaults to 'mock' in code as a holdover
+# from the v0 prototype phase. The switch is currently vestigial — the
+# app always uses Cognito regardless — but a deployed build with this
+# unset would expose the mock-mode path if the vestigial switch is ever
+# wired up. Must be set to 'cognito' in all deployed environments.
+# (See Issue #18 for plan to flip the default and remove the mock path.)
+NEXT_PUBLIC_AUTH_PROVIDER=cognito
 
-# [OPTIONAL]
-# AI provider. Default: 'mock'. Set to 'anthropic' to use real Anthropic
-# calls via the Claude proxy Lambda.
-# NEXT_PUBLIC_AI_PROVIDER=anthropic
+# [REQUIRED]
+# Selects the AI service provider. Defaults to 'mock' in code as a
+# holdover from the v0 prototype phase. A deployed build with this var
+# unset silently returns mock AI responses instead of calling Anthropic
+# — AI features appear to work while serving fake data. Must be set to
+# 'anthropic' in all deployed environments. (See Issue #18 for plan to
+# flip the default in code to production-safe 'anthropic'.)
+NEXT_PUBLIC_AI_PROVIDER=anthropic
 
 # [OPTIONAL]
 # AI model for Anthropic calls. Default: 'claude-3-sonnet'.


### PR DESCRIPTION
Sub-phase 2a follow-up #3.

Promotes USE_MOCK_DATA, AI_PROVIDER, AUTH_PROVIDER to [REQUIRED] in stock-analyser and budget-tracker .env.example files. Their code defaults are v0-era mock-mode fallbacks; a deployed build silently falling back to mock behaviour is the exact failure mode the production-correctness rule (PR #22) was designed to catch.

Companion code fix (flip defaults to production values, return vars to OPTIONAL) deferred to Phase 4; tracked on Issue #18.

Refs: PR #22, Issue #18.