### PR TITLE
docs(env): reconcile AUTH_PROVIDER/AI_PROVIDER tags against auth diagnostic

### DIFF
--- a/apps/budget-tracker/.env.example
+++ b/apps/budget-tracker/.env.example
@@ -104,24 +104,6 @@ NEXT_PUBLIC_USE_MOCK_DATA=false
 
 # ── Optional tuning ───────────────────────────────────────────────────────────
 
-# [REQUIRED]
-# Selects the auth provider. Defaults to 'mock' in code as a holdover
-# from the v0 prototype phase. The Budget Tracker auth service is
-# currently a mock stub (Issue #17), but a deployed build with this
-# unset would remain in mock auth mode even once that stub is replaced.
-# Must be set to 'cognito' in all deployed environments. (See Issue #18
-# for plan to flip the default in code to production-safe 'cognito'.)
-NEXT_PUBLIC_AUTH_PROVIDER=cognito
-
-# [REQUIRED]
-# Selects the AI service provider. Defaults to 'mock' in code as a
-# holdover from the v0 prototype phase. A deployed build with this var
-# unset silently returns mock AI responses instead of calling Anthropic
-# — AI categorisation appears to work while serving fake results. Must
-# be set to 'anthropic' in all deployed environments. (See Issue #18
-# for plan to flip the default in code to production-safe 'anthropic'.)
-NEXT_PUBLIC_AI_PROVIDER=anthropic
-
 # [OPTIONAL]
 # AI model for Anthropic calls. Default: 'claude-3-sonnet'.
 # NEXT_PUBLIC_AI_MODEL=claude-3-sonnet
@@ -141,6 +123,23 @@ NEXT_PUBLIC_AI_PROVIDER=anthropic
 # [OPTIONAL]
 # Enable debug mode. Default: false.
 # NEXT_PUBLIC_DEBUG_MODE=false
+
+# ── Planned / not yet implemented ─────────────────────────────────────────────
+
+# [PLANNED]
+# Selects the auth provider. Declared in config/index.ts but the Budget
+# Tracker auth service is currently a mock stub (Issue #17). When the
+# Cognito integration is wired up, promote to [REQUIRED]. Until then,
+# absence has no runtime effect.
+NEXT_PUBLIC_AUTH_PROVIDER=cognito
+
+# [PLANNED]
+# Selects the AI service provider. Declared in config/index.ts but not
+# yet read by application code — AI categorisation branches on
+# NEXT_PUBLIC_USE_MOCK_DATA instead. When the provider abstraction is
+# wired up (Phase 4 or later), promote to [REQUIRED]. Until then,
+# absence has no runtime effect.
+NEXT_PUBLIC_AI_PROVIDER=anthropic
 
 # ── Lambda-only variables (DO NOT add to workflow env: block) ─────────────────
 # These are set by CDK on the Lambda function environment directly.

--- a/apps/stock-analyser/.env.example
+++ b/apps/stock-analyser/.env.example
@@ -127,24 +127,6 @@ NEXT_PUBLIC_USE_MOCK_DATA=false
 # These have sensible defaults and are not required in deployed environments.
 # Uncomment and set only if you need non-default behaviour.
 
-# [REQUIRED]
-# Selects the auth provider. Defaults to 'mock' in code as a holdover
-# from the v0 prototype phase. The switch is currently vestigial — the
-# app always uses Cognito regardless — but a deployed build with this
-# unset would expose the mock-mode path if the vestigial switch is ever
-# wired up. Must be set to 'cognito' in all deployed environments.
-# (See Issue #18 for plan to flip the default and remove the mock path.)
-NEXT_PUBLIC_AUTH_PROVIDER=cognito
-
-# [REQUIRED]
-# Selects the AI service provider. Defaults to 'mock' in code as a
-# holdover from the v0 prototype phase. A deployed build with this var
-# unset silently returns mock AI responses instead of calling Anthropic
-# — AI features appear to work while serving fake data. Must be set to
-# 'anthropic' in all deployed environments. (See Issue #18 for plan to
-# flip the default in code to production-safe 'anthropic'.)
-NEXT_PUBLIC_AI_PROVIDER=anthropic
-
 # [OPTIONAL]
 # AI model for Anthropic calls. Default: 'claude-3-sonnet'.
 # NEXT_PUBLIC_AI_MODEL=claude-3-sonnet
@@ -176,6 +158,22 @@ NEXT_PUBLIC_AI_PROVIDER=anthropic
 # integration is wired up.
 # Source: CloudFormation output on TransformotionDev-AuthApi.
 # NEXT_PUBLIC_AUTH_API_URL=https://your-auth-api-id.execute-api.ap-southeast-2.amazonaws.com/dev
+
+# [PLANNED]
+# Selects the auth provider. Declared in config/index.ts but not yet
+# read by application code — cognitoAuth is hardwired in the auth store
+# and API client regardless of this value. When the provider abstraction
+# is wired up (Phase 4 or later), promote to [REQUIRED]. Until then,
+# absence has no runtime effect.
+NEXT_PUBLIC_AUTH_PROVIDER=cognito
+
+# [PLANNED]
+# Selects the AI service provider. Declared in config/index.ts but not
+# yet read by application code — use-claude.ts branches on
+# NEXT_PUBLIC_USE_MOCK_DATA instead. When the provider abstraction is
+# wired up (Phase 4 or later), promote to [REQUIRED]. Until then,
+# absence has no runtime effect.
+NEXT_PUBLIC_AI_PROVIDER=anthropic
 
 # ── Lambda-only variables (DO NOT add to workflow env: block) ─────────────────
 # These are set by CDK on the Lambda function environment directly.


### PR DESCRIPTION
Sub-phase 2a follow-up #4.

The auth flow diagnostic revealed AUTH_PROVIDER and AI_PROVIDER are declared but not consumed by application code. PR #23 tagged them [REQUIRED] based on their default values looking mock-mode-like; the actual call path doesn't read them. Demoted to [PLANNED] so 2b's enforcement doesn't mandate vars that have no runtime effect.

Also tidies .env.example section headers so no section contradicts the tags within it. Captures three diagnostic findings on Issue #18 (sign-in loop candidate, 401 recovery UX, ID token design note).

Refs: PR #23, Issue #18.