### PR TITLE
ci(env): hard-fail deploys missing [REQUIRED] env vars

### DIFF
--- a/.github/workflows/deploy-budget-tracker.yml
+++ b/.github/workflows/deploy-budget-tracker.yml
@@ -15,6 +15,20 @@ jobs:
   placeholder:
     name: Budget Tracker (not yet deployed)
     runs-on: ubuntu-latest
+    environment: dev
     steps:
+      - uses: actions/checkout@v4
+
+      - name: Check required env vars are set
+        env:
+          NEXT_PUBLIC_API_URL: ${{ vars.NEXT_PUBLIC_API_URL }}
+          NEXT_PUBLIC_CLAUDE_API_URL: ${{ vars.NEXT_PUBLIC_CLAUDE_API_URL }}
+          NEXT_PUBLIC_CLAUDE_CACHE_URL: ${{ vars.NEXT_PUBLIC_CLAUDE_CACHE_URL }}
+          NEXT_PUBLIC_COGNITO_USER_POOL_ID: ${{ vars.NEXT_PUBLIC_COGNITO_USER_POOL_ID }}
+          NEXT_PUBLIC_COGNITO_CLIENT_ID: ${{ vars.NEXT_PUBLIC_COGNITO_CLIENT_ID }}
+          NEXT_PUBLIC_COGNITO_REGION: ${{ vars.NEXT_PUBLIC_COGNITO_REGION }}
+          NEXT_PUBLIC_USE_MOCK_DATA: ${{ vars.NEXT_PUBLIC_USE_MOCK_DATA }}
+        run: bash scripts/ci/check-required-env-vars.sh apps/budget-tracker/.env.example dev
+
       - name: Placeholder
         run: echo "Budget Tracker deployment workflow — not yet active. Add deploy steps when app scaffolding is complete."

--- a/.github/workflows/deploy-stock-analyser.yml
+++ b/.github/workflows/deploy-stock-analyser.yml
@@ -38,6 +38,20 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Check required env vars are set
+        env:
+          NEXT_PUBLIC_API_URL: ${{ vars.NEXT_PUBLIC_API_URL }}
+          NEXT_PUBLIC_CLAUDE_API_URL: ${{ vars.NEXT_PUBLIC_CLAUDE_API_URL }}
+          NEXT_PUBLIC_CLAUDE_CACHE_URL: ${{ vars.NEXT_PUBLIC_CLAUDE_CACHE_URL }}
+          NEXT_PUBLIC_COGNITO_USER_POOL_ID: ${{ vars.NEXT_PUBLIC_COGNITO_USER_POOL_ID }}
+          NEXT_PUBLIC_COGNITO_CLIENT_ID: ${{ vars.NEXT_PUBLIC_COGNITO_CLIENT_ID }}
+          NEXT_PUBLIC_COGNITO_REGION: ${{ vars.NEXT_PUBLIC_COGNITO_REGION }}
+          NEXT_PUBLIC_COGNITO_DOMAIN: ${{ vars.NEXT_PUBLIC_COGNITO_DOMAIN }}
+          NEXT_PUBLIC_APP_URL: ${{ vars.NEXT_PUBLIC_APP_URL }}
+          NEXT_PUBLIC_BUDGET_API_URL: ${{ vars.NEXT_PUBLIC_BUDGET_API_URL }}
+          NEXT_PUBLIC_USE_MOCK_DATA: ${{ vars.NEXT_PUBLIC_USE_MOCK_DATA }}
+        run: bash scripts/ci/check-required-env-vars.sh apps/stock-analyser/.env.example dev
+
       - uses: actions/setup-node@v4
         with:
           node-version: '22'
@@ -85,6 +99,20 @@ jobs:
     environment: prod
     steps:
       - uses: actions/checkout@v4
+
+      - name: Check required env vars are set
+        env:
+          NEXT_PUBLIC_API_URL: ${{ vars.NEXT_PUBLIC_API_URL }}
+          NEXT_PUBLIC_CLAUDE_API_URL: ${{ vars.NEXT_PUBLIC_CLAUDE_API_URL }}
+          NEXT_PUBLIC_CLAUDE_CACHE_URL: ${{ vars.NEXT_PUBLIC_CLAUDE_CACHE_URL }}
+          NEXT_PUBLIC_COGNITO_USER_POOL_ID: ${{ vars.NEXT_PUBLIC_COGNITO_USER_POOL_ID }}
+          NEXT_PUBLIC_COGNITO_CLIENT_ID: ${{ vars.NEXT_PUBLIC_COGNITO_CLIENT_ID }}
+          NEXT_PUBLIC_COGNITO_REGION: ${{ vars.NEXT_PUBLIC_COGNITO_REGION }}
+          NEXT_PUBLIC_COGNITO_DOMAIN: ${{ vars.NEXT_PUBLIC_COGNITO_DOMAIN }}
+          NEXT_PUBLIC_APP_URL: ${{ vars.NEXT_PUBLIC_APP_URL }}
+          NEXT_PUBLIC_BUDGET_API_URL: ${{ vars.NEXT_PUBLIC_BUDGET_API_URL }}
+          NEXT_PUBLIC_USE_MOCK_DATA: ${{ vars.NEXT_PUBLIC_USE_MOCK_DATA }}
+        run: bash scripts/ci/check-required-env-vars.sh apps/stock-analyser/.env.example prod
 
       - uses: actions/setup-node@v4
         with:

--- a/STABILISATION_FREEZE.md
+++ b/STABILISATION_FREEZE.md
@@ -2,7 +2,7 @@
 
 **Status:** ACTIVE
 **Started:** 2026-04-20
-**Last updated:** 2026-04-21 (sub-phase 2a: env var inventory and .env.example files)
+**Last updated:** 2026-04-21 (sub-phase 2b: CI hard-fail env var enforcement wired)
 **Expected end:** Once Phase 1 (foundations) and Phase 2
 (executable contracts) are complete, the freeze on stabilisation
 work lifts. The Phase 4 stock analyser migration begins under
@@ -52,12 +52,19 @@ Sub-phases:
    `NEXT_PUBLIC_COGNITO_DOMAIN` and `NEXT_PUBLIC_APP_URL` (required by
    Amplify OAuth, absent from CI).
 
-   **2b enforcement note.** When sub-phase 2b lands, the CI env var
-   check is configured to hard-fail. This binds the env var fix (Phase
-   3.5) to a forcing function: no further deploys succeed until the
-   target environment's variables match the schema documented in each
-   app's `.env.example`. The "fix the dev environment's vars" task
-   becomes structurally unavoidable rather than schedulable.
+   **2b (complete):** `scripts/ci/check-required-env-vars.sh` added.
+   Parses each app's `.env.example` for `[REQUIRED]` tags and asserts
+   every required variable is set and non-empty in the target GitHub
+   Actions environment before any install, build, or deploy step runs.
+   Wired into `deploy-stock-analyser.yml` (dev + prod jobs) and
+   `deploy-budget-tracker.yml`. Exits 1 with an actionable error
+   listing missing vars and ready-to-paste `gh variable set` commands.
+   `deploy-platform.yml` excluded — CDK-only, no frontend env vars.
+
+   The forcing function is now active: the next deploy to dev will
+   fail because `NEXT_PUBLIC_COGNITO_DOMAIN` and `NEXT_PUBLIC_APP_URL`
+   are missing and the Claude URL vars are stale. Phase 3.5 (verified
+   redeploy) becomes the immediate next task after sub-phase 3.
 3. **Deploy verification** — every deploy workflow ends by confirming
    the deploy actually succeeded and the deployed version matches
    the commit that triggered it. CI says "deployed" only when it

--- a/scripts/ci/check-required-env-vars.sh
+++ b/scripts/ci/check-required-env-vars.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# scripts/ci/check-required-env-vars.sh
+#
+# Asserts that every variable tagged [REQUIRED] in the supplied
+# .env.example file is set and non-empty in the current shell
+# environment.
+#
+# Usage:
+#   scripts/ci/check-required-env-vars.sh <path-to-.env.example> <environment-name>
+#
+# Environment name is used for error messages and to construct the
+# `gh variable set --env <name>` remediation commands.
+#
+# Exits 0 if all required vars are present; exits 1 with a detailed
+# report otherwise.
+
+set -euo pipefail
+
+ENV_EXAMPLE="${1:?first argument must be path to .env.example}"
+ENV_NAME="${2:?second argument must be environment name (e.g. dev, prod)}"
+
+if [[ ! -f "$ENV_EXAMPLE" ]]; then
+  echo "ERROR: $ENV_EXAMPLE does not exist" >&2
+  exit 1
+fi
+
+# Parse [REQUIRED] vars from the .env.example.
+#
+# Rule: a variable is REQUIRED if the line immediately before its
+# declaration (or one of the preceding comment-block lines) is a
+# standalone tag line of the form "# [REQUIRED]" (nothing after the
+# tag). We match strictly to avoid false positives from comment text
+# that mentions [REQUIRED] inline (e.g. "promote to [REQUIRED]").
+required_vars=()
+current_tag=""
+while IFS= read -r line; do
+  if [[ "$line" =~ ^[[:space:]]*#[[:space:]]+\[REQUIRED\][[:space:]]*$ ]]; then
+    current_tag="REQUIRED"
+  elif [[ "$line" =~ ^[[:space:]]*#[[:space:]]+\[OPTIONAL\][[:space:]]*$ ]]; then
+    current_tag="OPTIONAL"
+  elif [[ "$line" =~ ^[[:space:]]*#[[:space:]]+\[PLANNED\][[:space:]]*$ ]]; then
+    current_tag="PLANNED"
+  elif [[ "$line" =~ ^[A-Z_][A-Z0-9_]*= ]]; then
+    # Variable declaration line.
+    if [[ "$current_tag" == "REQUIRED" ]]; then
+      varname="${line%%=*}"
+      required_vars+=("$varname")
+    fi
+    current_tag=""  # Reset after consuming.
+  elif [[ -z "$line" ]]; then
+    # Blank line resets the tag context.
+    current_tag=""
+  fi
+  # Comment lines with other content don't reset the tag.
+done < "$ENV_EXAMPLE"
+
+if [[ ${#required_vars[@]} -eq 0 ]]; then
+  echo "No [REQUIRED] variables found in $ENV_EXAMPLE — nothing to check."
+  exit 0
+fi
+
+echo "Checking ${#required_vars[@]} [REQUIRED] variable(s) from $ENV_EXAMPLE against environment '$ENV_NAME'..."
+
+missing=()
+for var in "${required_vars[@]}"; do
+  # Indirect expansion: get the value of the var whose name is in $var.
+  value="${!var:-}"
+  if [[ -z "$value" ]]; then
+    missing+=("$var")
+  fi
+done
+
+if [[ ${#missing[@]} -eq 0 ]]; then
+  echo "OK: all ${#required_vars[@]} required variable(s) present and non-empty."
+  exit 0
+fi
+
+# Emit a detailed, actionable error.
+cat >&2 <<EOF
+
+==============================================================================
+ENV VAR CHECK FAILED
+
+$ENV_EXAMPLE declares ${#required_vars[@]} [REQUIRED] variables.
+${#missing[@]} of them are missing or empty in GitHub Actions environment '$ENV_NAME'.
+
+Missing variables:
+EOF
+
+for var in "${missing[@]}"; do
+  echo "  - $var" >&2
+done
+
+cat >&2 <<EOF
+
+To fix, set each missing variable in the '$ENV_NAME' environment:
+
+EOF
+
+for var in "${missing[@]}"; do
+  echo "  gh variable set $var --env $ENV_NAME --body '<value>'" >&2
+done
+
+cat >&2 <<EOF
+
+See $ENV_EXAMPLE for descriptions of what each variable should contain.
+
+Sub-phase 2b enforces that every [REQUIRED] variable is non-empty in the
+target environment before a deploy proceeds. This is a hard fail by
+design (see STABILISATION_FREEZE.md Phase 1 sub-phase 2b).
+==============================================================================
+EOF
+
+exit 1


### PR DESCRIPTION
Phase 1 sub-phase 2b — the forcing function.

Adds a reusable CI check that parses each app's .env.example for [REQUIRED] tags and asserts each required variable is set and non-empty in the target GitHub Actions environment. Any missing variable fails the deploy with an actionable error listing exactly what to set.

Wired into deploy-stock-analyser.yml (dev + prod jobs) and deploy-budget-tracker.yml. deploy-platform.yml excluded — CDK-only, no frontend env vars.

## Expected immediate effect

The next deploy to dev after this merges WILL FAIL. Dev is known to be missing:
- `NEXT_PUBLIC_COGNITO_DOMAIN`
- `NEXT_PUBLIC_APP_URL`

and has stale values (pointing at dead API ID `e1of4z34lj`) for:
- `NEXT_PUBLIC_CLAUDE_API_URL`
- `NEXT_PUBLIC_CLAUDE_CACHE_URL`

This is the intended forcing function: Phase 3.5's env var fix (tracked in Issue #18) becomes unavoidable immediately after merge. No future deploy will succeed until those vars are correct.

## Implementation note

The script uses a strict regex (`^[[:space:]]*#[[:space:]]+\[REQUIRED\][[:space:]]*$`) to match only standalone tag lines, not inline mentions of `[REQUIRED]` in comment text (e.g. "promote to [REQUIRED]"). This was caught during local smoke-testing.

Refs: Issue #18, PR #24.