### PR TITLE
ci: verify deployed artefact after deploy

### DIFF
--- a/.github/workflows/deploy-budget-tracker.yml
+++ b/.github/workflows/deploy-budget-tracker.yml
@@ -24,6 +24,7 @@ jobs:
       NEXT_PUBLIC_COGNITO_CLIENT_ID: ${{ vars.NEXT_PUBLIC_COGNITO_CLIENT_ID }}
       NEXT_PUBLIC_COGNITO_REGION: ${{ vars.NEXT_PUBLIC_COGNITO_REGION }}
       NEXT_PUBLIC_USE_MOCK_DATA: ${{ vars.NEXT_PUBLIC_USE_MOCK_DATA }}
+      NEXT_PUBLIC_COMMIT_HASH: ${{ github.sha }}
     steps:
       - uses: actions/checkout@v4
 
@@ -32,3 +33,13 @@ jobs:
 
       - name: Placeholder
         run: echo "Budget Tracker deployment workflow — not yet active. Add deploy steps when app scaffolding is complete."
+
+      # When Issue #17 wires up the real deploy, add this final step after S3 sync and
+      # CloudFront invalidation — the job-level env block already provides all vars:
+      #
+      # - name: Verify deployment
+      #   run: |
+      #     bash scripts/ci/verify-deploy.sh \
+      #       "${{ vars.NEXT_PUBLIC_BUDGET_TRACKER_APP_URL }}" \
+      #       apps/budget-tracker/.env.example \
+      #       "${{ github.sha }}"

--- a/.github/workflows/deploy-stock-analyser.yml
+++ b/.github/workflows/deploy-stock-analyser.yml
@@ -46,6 +46,7 @@ jobs:
       NEXT_PUBLIC_APP_URL: ${{ vars.NEXT_PUBLIC_APP_URL }}
       NEXT_PUBLIC_BUDGET_API_URL: ${{ vars.NEXT_PUBLIC_BUDGET_API_URL }}
       NEXT_PUBLIC_USE_MOCK_DATA: ${{ vars.NEXT_PUBLIC_USE_MOCK_DATA }}
+      NEXT_PUBLIC_COMMIT_HASH: ${{ github.sha }}
     steps:
       - uses: actions/checkout@v4
 
@@ -83,6 +84,13 @@ jobs:
       - name: Invalidate CloudFront
         run: aws cloudfront create-invalidation --distribution-id E1128DYYBLMWYK --paths "/*"
 
+      - name: Verify deployment
+        run: |
+          bash scripts/ci/verify-deploy.sh \
+            "${{ vars.NEXT_PUBLIC_APP_URL }}" \
+            apps/stock-analyser/.env.example \
+            "${{ github.sha }}"
+
   deploy-prod:
     name: Stock Analyser → Prod
     runs-on: ubuntu-latest
@@ -99,6 +107,7 @@ jobs:
       NEXT_PUBLIC_APP_URL: ${{ vars.NEXT_PUBLIC_APP_URL }}
       NEXT_PUBLIC_BUDGET_API_URL: ${{ vars.NEXT_PUBLIC_BUDGET_API_URL }}
       NEXT_PUBLIC_USE_MOCK_DATA: ${{ vars.NEXT_PUBLIC_USE_MOCK_DATA }}
+      NEXT_PUBLIC_COMMIT_HASH: ${{ github.sha }}
     steps:
       - uses: actions/checkout@v4
 
@@ -135,3 +144,10 @@ jobs:
 
       - name: Invalidate CloudFront
         run: aws cloudfront create-invalidation --distribution-id ${{ vars.CLOUDFRONT_DISTRIBUTION_ID_PROD }} --paths "/*"
+
+      - name: Verify deployment
+        run: |
+          bash scripts/ci/verify-deploy.sh \
+            "${{ vars.NEXT_PUBLIC_APP_URL }}" \
+            apps/stock-analyser/.env.example \
+            "${{ github.sha }}"

--- a/STABILISATION_FREEZE.md
+++ b/STABILISATION_FREEZE.md
@@ -2,7 +2,7 @@
 
 **Status:** ACTIVE
 **Started:** 2026-04-20
-**Last updated:** 2026-04-21 (sub-phase 2b: CI hard-fail env var enforcement wired)
+**Last updated:** 2026-04-21 (sub-phase 3: deploy verification wired)
 **Expected end:** Once Phase 1 (foundations) and Phase 2
 (executable contracts) are complete, the freeze on stabilisation
 work lifts. The Phase 4 stock analyser migration begins under
@@ -61,14 +61,26 @@ Sub-phases:
    listing missing vars and ready-to-paste `gh variable set` commands.
    `deploy-platform.yml` excluded — CDK-only, no frontend env vars.
 
-   The forcing function is now active: the next deploy to dev will
-   fail because `NEXT_PUBLIC_COGNITO_DOMAIN` and `NEXT_PUBLIC_APP_URL`
-   are missing and the Claude URL vars are stale. Phase 3.5 (verified
-   redeploy) becomes the immediate next task after sub-phase 3.
-3. **Deploy verification** — every deploy workflow ends by confirming
-   the deploy actually succeeded and the deployed version matches
-   the commit that triggered it. CI says "deployed" only when it
-   can prove it.
+   **2c (complete):** Structural refactor — every deploy job now
+   declares its env block once at the job level. All steps inherit.
+   Divergence between the check step and the build step (the bug class
+   caught by PR #26) is structurally impossible. No variables added or
+   removed; purely a reorganisation.
+
+3. **Deploy verification** (complete) — `scripts/ci/verify-deploy.sh`
+   added. After S3 sync and CloudFront invalidation, the final step in
+   `deploy-stock-analyser.yml` (dev + prod) confirms:
+   (1) the deployed URL responds HTTP 200 and all JS chunks are
+   reachable; (2) the commit hash that triggered the deploy is present
+   in the deployed bundle (injected via `NEXT_PUBLIC_COMMIT_HASH`,
+   rendered as a `data-commit` attribute on the `<html>` element in
+   each app's root layout via `lib/build-info.ts`); (3) every
+   `[REQUIRED]` `NEXT_PUBLIC_*` variable's value appears as a string
+   literal in the deployed bundle. Hard-fails on any check failure.
+   A new `[BUILD-INJECTED]` tag was added to the `.env.example`
+   tagging convention for CI-injected values; `check-required-env-vars.sh`
+   does not match this tag (verified). When CI reports "deployed", it
+   now has cryptographic evidence.
 4. **Lint enforcement** — ESLint flat config migration, real
    workspace lint scripts, boundary rules enforced in CI.
    eslint-plugin-boundaries flat-config compatibility resolved.

--- a/apps/budget-tracker/.env.example
+++ b/apps/budget-tracker/.env.example
@@ -43,8 +43,15 @@
 #   [PLANNED]  — declared but not yet read by app code. Reserved for
 #                upcoming use. Sub-phase 2b skips these.
 #
+#   [BUILD-INJECTED] — value is injected by the deploy workflow at build
+#                time (e.g. commit hash, build timestamp). Not set by
+#                humans. Sub-phase 2b does NOT check these — their
+#                presence is the deploy workflow's responsibility, not the
+#                operator's. Sub-phase 3 verifies they appear in the
+#                deployed bundle.
+#
 # When adding a new variable, choose its tag deliberately and update
-# the deploy workflow's env block if [REQUIRED].
+# the deploy workflow's env block if [REQUIRED] or [BUILD-INJECTED].
 # ─────────────────────────────────────────────────────────────────────────────
 
 # ── Platform API ─────────────────────────────────────────────────────────────
@@ -140,6 +147,15 @@ NEXT_PUBLIC_AUTH_PROVIDER=cognito
 # wired up (Phase 4 or later), promote to [REQUIRED]. Until then,
 # absence has no runtime effect.
 NEXT_PUBLIC_AI_PROVIDER=anthropic
+
+# ── Build-injected ────────────────────────────────────────────────────────────
+
+# [BUILD-INJECTED]
+# The git commit hash that produced this build. Injected by the deploy
+# workflow from ${{ github.sha }}. Used by sub-phase 3's deploy-verification
+# step to confirm the deployed bundle matches the commit that triggered the
+# deploy. Empty in local development (defaults to 'dev' in lib/build-info.ts).
+NEXT_PUBLIC_COMMIT_HASH=
 
 # ── Lambda-only variables (DO NOT add to workflow env: block) ─────────────────
 # These are set by CDK on the Lambda function environment directly.

--- a/apps/budget-tracker/app/layout.tsx
+++ b/apps/budget-tracker/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata, Viewport } from 'next'
 import { Inter, Geist_Mono } from 'next/font/google'
+import { BUILD_COMMIT_HASH } from '@/lib/build-info'
 import './globals.css'
 
 const inter = Inter({
@@ -36,7 +37,7 @@ export default function RootLayout({
   children,
 }: Readonly<{ children: React.ReactNode }>) {
   return (
-    <html lang="en" className={`${inter.variable} ${geistMono.variable} bg-background`}>
+    <html lang="en" data-commit={BUILD_COMMIT_HASH} className={`${inter.variable} ${geistMono.variable} bg-background`}>
       <body className="font-sans antialiased min-h-screen bg-background text-foreground">
         {children}
       </body>

--- a/apps/budget-tracker/lib/build-info.ts
+++ b/apps/budget-tracker/lib/build-info.ts
@@ -1,0 +1,1 @@
+export const BUILD_COMMIT_HASH = process.env.NEXT_PUBLIC_COMMIT_HASH ?? 'dev';

--- a/apps/stock-analyser/.env.example
+++ b/apps/stock-analyser/.env.example
@@ -38,8 +38,15 @@
 #   [PLANNED]  — declared but not yet read by app code. Reserved for
 #                upcoming use. Sub-phase 2b skips these.
 #
+#   [BUILD-INJECTED] — value is injected by the deploy workflow at build
+#                time (e.g. commit hash, build timestamp). Not set by
+#                humans. Sub-phase 2b does NOT check these — their
+#                presence is the deploy workflow's responsibility, not the
+#                operator's. Sub-phase 3 verifies they appear in the
+#                deployed bundle.
+#
 # When adding a new variable, choose its tag deliberately and update
-# the deploy workflow's env block if [REQUIRED].
+# the deploy workflow's env block if [REQUIRED] or [BUILD-INJECTED].
 # ─────────────────────────────────────────────────────────────────────────────
 
 # ── Platform API ─────────────────────────────────────────────────────────────
@@ -174,6 +181,15 @@ NEXT_PUBLIC_AUTH_PROVIDER=cognito
 # wired up (Phase 4 or later), promote to [REQUIRED]. Until then,
 # absence has no runtime effect.
 NEXT_PUBLIC_AI_PROVIDER=anthropic
+
+# ── Build-injected ────────────────────────────────────────────────────────────
+
+# [BUILD-INJECTED]
+# The git commit hash that produced this build. Injected by the deploy
+# workflow from ${{ github.sha }}. Used by sub-phase 3's deploy-verification
+# step to confirm the deployed bundle matches the commit that triggered the
+# deploy. Empty in local development (defaults to 'dev' in lib/build-info.ts).
+NEXT_PUBLIC_COMMIT_HASH=
 
 # ── Lambda-only variables (DO NOT add to workflow env: block) ─────────────────
 # These are set by CDK on the Lambda function environment directly.

--- a/apps/stock-analyser/app/layout.tsx
+++ b/apps/stock-analyser/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata, Viewport } from 'next'
 import { Inter, Geist_Mono, Bebas_Neue } from 'next/font/google'
 import { Analytics } from '@vercel/analytics/next'
 import { AmplifyProvider } from '@/components/providers/amplify-provider'
+import { BUILD_COMMIT_HASH } from '@/lib/build-info'
 import './globals.css'
 
 const inter = Inter({ 
@@ -56,7 +57,7 @@ export default function RootLayout({
   children: React.ReactNode
 }>) {
   return (
-    <html lang="en" className={`${inter.variable} ${geistMono.variable} ${bebasNeue.variable} bg-background`}>
+    <html lang="en" data-commit={BUILD_COMMIT_HASH} className={`${inter.variable} ${geistMono.variable} ${bebasNeue.variable} bg-background`}>
       <body className="font-sans antialiased min-h-screen bg-background text-foreground">
         <AmplifyProvider>
           {children}

--- a/apps/stock-analyser/lib/build-info.ts
+++ b/apps/stock-analyser/lib/build-info.ts
@@ -1,0 +1,1 @@
+export const BUILD_COMMIT_HASH = process.env.NEXT_PUBLIC_COMMIT_HASH ?? 'dev';

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -41,8 +41,15 @@
 #   [PLANNED]  — declared but not yet read by app code. Reserved for
 #                upcoming use. Sub-phase 2b skips these.
 #
+#   [BUILD-INJECTED] — value is injected by the deploy workflow at build
+#                time (e.g. commit hash, build timestamp). Not set by
+#                humans. Sub-phase 2b does NOT check these — their
+#                presence is the deploy workflow's responsibility, not the
+#                operator's. Sub-phase 3 verifies they appear in the
+#                deployed bundle.
+#
 # When adding a new variable, choose its tag deliberately and update
-# the deploy workflow's env block if [REQUIRED].
+# the deploy workflow's env block if [REQUIRED] or [BUILD-INJECTED].
 # ─────────────────────────────────────────────────────────────────────────────
 
 # ── App navigation URLs ───────────────────────────────────────────────────────
@@ -67,3 +74,12 @@ NEXT_PUBLIC_STOCK_URL=https://dev.apps.transformotion.com.au
 #            is complete and the Budget Tracker has its own deployment,
 #            this will point to its own URL.
 NEXT_PUBLIC_BUDGET_URL=https://dev.apps.transformotion.com.au/budget-tracker
+
+# ── Build-injected ────────────────────────────────────────────────────────────
+
+# [BUILD-INJECTED]
+# The git commit hash that produced this build. Injected by the deploy
+# workflow from ${{ github.sha }}. Used by sub-phase 3's deploy-verification
+# step to confirm the deployed bundle matches the commit that triggered the
+# deploy. Empty in local development (defaults to 'dev' in lib/build-info.ts).
+NEXT_PUBLIC_COMMIT_HASH=

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata, Viewport } from 'next'
 import { Inter, Geist_Mono, Bebas_Neue } from 'next/font/google'
 import { Analytics } from '@vercel/analytics/next'
+import { BUILD_COMMIT_HASH } from '@/lib/build-info'
 import './globals.css'
 
 const inter = Inter({
@@ -38,6 +39,7 @@ export default function RootLayout({
   return (
     <html
       lang="en"
+      data-commit={BUILD_COMMIT_HASH}
       className={`${inter.variable} ${geistMono.variable} ${bebasNeue.variable} bg-background`}
     >
       <body className="font-sans antialiased min-h-screen bg-background text-foreground">

--- a/apps/web/lib/build-info.ts
+++ b/apps/web/lib/build-info.ts
@@ -1,0 +1,1 @@
+export const BUILD_COMMIT_HASH = process.env.NEXT_PUBLIC_COMMIT_HASH ?? 'dev';

--- a/scripts/ci/verify-deploy.sh
+++ b/scripts/ci/verify-deploy.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+# scripts/ci/verify-deploy.sh
+#
+# Post-deploy verification: confirms the deployed frontend artefact
+# matches the commit that triggered the deploy, that every [REQUIRED]
+# NEXT_PUBLIC_* variable was substituted at build time, and that the
+# deployed URL is reachable.
+#
+# Usage:
+#   scripts/ci/verify-deploy.sh <deployed-url> <path-to-.env.example> <expected-commit-hash>
+#
+# The [REQUIRED] var substitution check (check 3) reads each var's value
+# from the current shell environment. In CI the job-level env block
+# provides all NEXT_PUBLIC_* vars automatically. Locally, export them
+# before running this script.
+#
+# Exits 0 if all checks pass; 1 with a detailed report otherwise.
+
+set -euo pipefail
+
+DEPLOYED_URL="${1:?first arg must be deployed URL (e.g. https://dev.apps.transformotion.com.au)}"
+ENV_EXAMPLE="${2:?second arg must be path to .env.example}"
+EXPECTED_HASH="${3:?third arg must be expected commit hash}"
+
+# Strip trailing slash from URL if present.
+DEPLOYED_URL="${DEPLOYED_URL%/}"
+
+if [[ ! -f "$ENV_EXAMPLE" ]]; then
+  echo "ERROR: $ENV_EXAMPLE does not exist" >&2
+  exit 1
+fi
+
+echo "Verifying deployment at $DEPLOYED_URL..."
+echo "Expected commit hash: $EXPECTED_HASH"
+echo
+
+# ── Check 1: root document returns 200 ────────────────────────────────────────
+echo "[1/3] Probing root document..."
+root_code=$(curl -s -o /dev/null -w "%{http_code}" "$DEPLOYED_URL/")
+if [[ "$root_code" != "200" ]]; then
+  echo "FAIL: root document returned HTTP $root_code (expected 200)" >&2
+  exit 1
+fi
+echo "      OK: root returns 200"
+echo
+
+# Fetch root HTML once; extract chunk paths.
+root_html=$(curl -s "$DEPLOYED_URL/")
+chunk_paths=$(echo "$root_html" | grep -oE '_next/static/chunks/[^"]+\.js' | sort -u)
+if [[ -z "$chunk_paths" ]]; then
+  echo "FAIL: no JS chunks found in root HTML" >&2
+  exit 1
+fi
+chunk_count=$(echo "$chunk_paths" | wc -l | tr -d ' ')
+echo "[info] Found $chunk_count JS chunks in root HTML"
+echo
+
+# Fetch all chunks once; verify each is reachable; concatenate contents.
+all_chunks=""
+while IFS= read -r chunk; do
+  chunk_code=$(curl -s -o /dev/null -w "%{http_code}" "$DEPLOYED_URL/$chunk")
+  if [[ "$chunk_code" != "200" ]]; then
+    echo "FAIL: chunk $chunk returned HTTP $chunk_code (expected 200)" >&2
+    exit 1
+  fi
+  all_chunks="${all_chunks}$(curl -s "$DEPLOYED_URL/$chunk")"
+done <<< "$chunk_paths"
+echo "[info] All $chunk_count chunks reachable"
+echo
+
+# ── Check 2: commit hash present in the deployed artefact ─────────────────────
+echo "[2/3] Checking commit hash presence..."
+if echo "${root_html}${all_chunks}" | grep -qF "$EXPECTED_HASH"; then
+  echo "      OK: commit hash $EXPECTED_HASH found in deployed artefact"
+else
+  cat >&2 <<EOF
+
+FAIL: commit hash $EXPECTED_HASH NOT found in deployed artefact.
+
+This means the deployed bundle does not match the commit that triggered
+the deploy. Possible causes:
+  - NEXT_PUBLIC_COMMIT_HASH was not set during the build step
+  - lib/build-info.ts is not imported into the bundle (tree-shaken)
+  - S3 sync did not upload the new bundle (a dry-run or partial upload)
+  - CloudFront is serving stale cached content (invalidation failed or
+    the CDN TTL has not expired yet — retry after a few minutes)
+
+EOF
+  exit 1
+fi
+echo
+
+# ── Check 3: every [REQUIRED] NEXT_PUBLIC_* var was substituted ───────────────
+echo "[3/3] Checking [REQUIRED] var substitution in bundle..."
+
+required_vars=()
+current_tag=""
+while IFS= read -r line; do
+  if [[ "$line" =~ ^[[:space:]]*#[[:space:]]+\[REQUIRED\][[:space:]]*$ ]]; then
+    current_tag="REQUIRED"
+  elif [[ "$line" =~ ^[[:space:]]*#[[:space:]]+\[OPTIONAL\][[:space:]]*$ ]]; then
+    current_tag="OPTIONAL"
+  elif [[ "$line" =~ ^[[:space:]]*#[[:space:]]+\[PLANNED\][[:space:]]*$ ]]; then
+    current_tag="PLANNED"
+  elif [[ "$line" =~ ^[[:space:]]*#[[:space:]]+\[BUILD-INJECTED\][[:space:]]*$ ]]; then
+    current_tag="BUILD-INJECTED"
+  elif [[ "$line" =~ ^[A-Z_][A-Z0-9_]*= ]]; then
+    if [[ "$current_tag" == "REQUIRED" && "$line" =~ ^NEXT_PUBLIC_ ]]; then
+      varname="${line%%=*}"
+      required_vars+=("$varname")
+    fi
+    current_tag=""
+  elif [[ -z "$line" ]]; then
+    current_tag=""
+  fi
+done < "$ENV_EXAMPLE"
+
+echo "      Checking ${#required_vars[@]} [REQUIRED] NEXT_PUBLIC_* vars for build-time substitution"
+
+missing_substitution=()
+skipped_vars=()
+for var in "${required_vars[@]}"; do
+  value="${!var:-}"
+  if [[ -z "$value" ]]; then
+    skipped_vars+=("$var")
+    continue
+  fi
+  if echo "$all_chunks" | grep -qF "$value"; then
+    :
+  else
+    missing_substitution+=("$var")
+  fi
+done
+
+if [[ ${#skipped_vars[@]} -gt 0 ]]; then
+  echo "      WARN: ${#skipped_vars[@]} var(s) not set in script env — substitution not verified:" >&2
+  for var in "${skipped_vars[@]}"; do
+    echo "        - $var" >&2
+  done
+fi
+
+if [[ ${#missing_substitution[@]} -gt 0 ]]; then
+  cat >&2 <<EOF
+
+FAIL: ${#missing_substitution[@]} [REQUIRED] var(s) have values that do NOT appear
+in the deployed bundle as string literals:
+
+EOF
+  for var in "${missing_substitution[@]}"; do
+    echo "  - $var" >&2
+  done
+  cat >&2 <<EOF
+
+This means the build step did not substitute these vars into the bundle.
+The job-level env block may be missing variables, or the variable was
+added to .env.example as [REQUIRED] without being added to the workflow.
+(See PR #26 — this is the build-block-drift class of bug.)
+
+EOF
+  exit 1
+fi
+
+echo "      OK: all checked [REQUIRED] var values found in bundle"
+echo
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+echo "=============================================="
+echo "DEPLOY VERIFICATION PASSED"
+echo "  URL:     $DEPLOYED_URL"
+echo "  Commit:  $EXPECTED_HASH"
+echo "  Chunks:  $chunk_count"
+echo "  REQUIRED vars substituted: ${#required_vars[@]}"
+echo "=============================================="


### PR DESCRIPTION
Phase 1 sub-phase 3.

Closes the final gap in the deployment infrastructure: CI verifies the deployed artefact matches the commit that triggered the deploy, that every [REQUIRED] NEXT_PUBLIC_* variable was substituted at build time, and that the deployed URL is live. When CI reports "deployed", it now has cryptographic evidence.

## What

**`scripts/ci/verify-deploy.sh`** — new post-deploy verification runner. Three checks:
1. Root URL returns HTTP 200; all referenced JS chunks are reachable
2. Commit hash from `${{ github.sha }}` appears in the deployed bundle
3. Every `[REQUIRED]` `NEXT_PUBLIC_*` variable's value appears as a string literal in the deployed JS chunks

Hard-fails on any check failure, consistent with sub-phase 2b's forcing-function pattern.

**`lib/build-info.ts`** (new in each app) — exports `BUILD_COMMIT_HASH = process.env.NEXT_PUBLIC_COMMIT_HASH ?? 'dev'`. Each app's `layout.tsx` imports it and surfaces the value as `data-commit` on the `<html>` element, guaranteeing it's inlined as a string literal in the static bundle.

**Workflow changes:**
- `NEXT_PUBLIC_COMMIT_HASH: ${{ github.sha }}` added to job-level env blocks in both `deploy-dev` and `deploy-prod` (inherits to build step automatically, per sub-phase 2c)
- `Verify deployment` step added as the final step in both jobs
- `deploy-budget-tracker.yml`: `NEXT_PUBLIC_COMMIT_HASH` added; verification step stubbed in a comment for Issue #17's implementer

**`.env.example` convention** — new `[BUILD-INJECTED]` tag added to all three apps' tagging convention headers, and `NEXT_PUBLIC_COMMIT_HASH` added in a new "── Build-injected ──" section. `check-required-env-vars.sh`'s strict `[REQUIRED]`-only regex does not match this tag (verified).

## Why

PR #26 demonstrated that a deploy can exit 0 while silently serving a broken bundle (`undefined` baked in for missing vars). Sub-phase 3 closes this by making the deployment infrastructure self-verifying: every deploy now proves it uploaded the right bundle with the right values before reporting success.

## Local smoke test (pre-PR)

Run against the current dev deploy (pre-sub-phase-3 bundle, no hash injected):
- Check 1 (liveness): ✓ root 200, all 9 chunks reachable
- Check 2 (commit hash): ✗ hash absent — expected, since the current deploy predates this sub-phase. Proves the check detects a mismatch.

Refs: PR #25, PR #26, PR #27, Issue #18.