### PR TITLE
fix(verify-deploy): resolve pipefail/SIGPIPE false negative

### DIFF
--- a/scripts/ci/verify-deploy.sh
+++ b/scripts/ci/verify-deploy.sh
@@ -70,7 +70,11 @@ echo
 
 # ── Check 2: commit hash present in the deployed artefact ─────────────────────
 echo "[2/3] Checking commit hash presence..."
-if echo "${root_html}${all_chunks}" | grep -qF "$EXPECTED_HASH"; then
+# Run in a subshell with pipefail disabled: when grep -q finds a match early it
+# exits 0 and closes the pipe, causing echo/printf to receive SIGPIPE (exit 141).
+# With pipefail the pipeline would return 141 even on a successful match.
+# Disabling pipefail in a subshell makes the pipeline return grep's exit code.
+if (set +o pipefail; printf '%s%s' "${root_html}" "${all_chunks}" 2>/dev/null | grep -qF "$EXPECTED_HASH"); then
   echo "      OK: commit hash $EXPECTED_HASH found in deployed artefact"
 else
   cat >&2 <<EOF
@@ -125,7 +129,7 @@ for var in "${required_vars[@]}"; do
     skipped_vars+=("$var")
     continue
   fi
-  if echo "$all_chunks" | grep -qF "$value"; then
+  if (set +o pipefail; printf '%s' "${all_chunks}" 2>/dev/null | grep -qF "$value"); then
     :
   else
     missing_substitution+=("$var")
@@ -160,7 +164,8 @@ EOF
   exit 1
 fi
 
-echo "      OK: all checked [REQUIRED] var values found in bundle"
+checked=$((${#required_vars[@]} - ${#skipped_vars[@]}))
+echo "      OK: $checked var(s) checked, 0 missing substitution (${#skipped_vars[@]} skipped — not in env)"
 echo
 
 # ── Summary ───────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Fixes a bug in `scripts/ci/verify-deploy.sh` introduced in PR #28 that caused verification to always fail with exit code 1, even when the deploy was correct.

## Root cause

`set -euo pipefail` interacts with `grep -q` in a pipeline:

1. `grep -qF` exits as soon as it finds a match (by design, for performance)
2. When the match is found early (the hash is in the 9KB HTML, the first content in the pipe), grep exits 0 immediately and closes the read end of the pipe
3. The writer (`printf`/`echo`) is still writing the remaining ~900KB of JS chunks and receives SIGPIPE (exit 141)
4. With `pipefail`, the pipeline's exit code is 141 (the leftmost non-zero exit code), not grep's 0
5. The `if` condition evaluates FALSE — the script reports FAIL even though the hash was found

The same pattern affects check 3 (REQUIRED var substitution).

## Fix

Wrap each `grep-in-pipe` check in a subshell with `pipefail` disabled:

```bash
if (set +o pipefail; printf '%s%s' "${root_html}" "${all_chunks}" 2>/dev/null | grep -qF "$EXPECTED_HASH"); then
```

The subshell's exit code is grep's exit code (0 = match, 1 = no match). `2>/dev/null` suppresses the "write error: Broken pipe" stderr noise from the writer.

## Verified locally

Script now passes against the PR #28 deploy:
```
[1/3] OK: root returns 200
[2/3] OK: commit hash 3929f7ab... found in deployed artefact
[3/3] OK: 10 var(s) checked, 0 missing substitution
DEPLOY VERIFICATION PASSED
```

Refs: PR #28.