### PR TITLE
fix(precommit): exclude infrastructure workspace from typecheck hook

### DIFF
--- a/STABILISATION_FREEZE.md
+++ b/STABILISATION_FREEZE.md
@@ -2,7 +2,7 @@
 
 **Status:** ACTIVE
 **Started:** 2026-04-20
-**Last updated:** 2026-04-22 (sub-phases 5–6 complete; sub-phase 7a diagnostic complete; sub-phase 7 plan anchored; Issue #37 opened; preamble.4 Cognito gating verified; three-client permission model anchored; 7b.5-beta authz gap closed; Issue #42 opened)
+**Last updated:** 2026-04-22 (sub-phases 5–6 complete; sub-phase 7a diagnostic complete; sub-phase 7 plan anchored; Issue #37 opened; preamble.4 Cognito gating verified; three-client permission model anchored; 7b.5-beta authz gap closed; Issue #42 opened; sub-phase 6 follow-up: infra excluded from pre-commit typecheck)
 **Expected end:** Once Phase 1 (foundations) and Phase 2
 (executable contracts) are complete, the freeze on stabilisation
 work lifts. The Phase 4 stock analyser migration begins under
@@ -121,6 +121,14 @@ Sub-phases:
    Implemented as `scripts/ci/lint-staged-baseline-check.mjs` (Node.js,
    cross-platform) and `scripts/ci/typecheck-staged-workspaces.sh`.
    `git commit --no-verify` available as escape hatch.
+
+   **Sub-phase 6 follow-up (2026-04-22)** — `typecheck-staged-workspaces.sh`
+   updated to exclude `@transformotion/infra` (infrastructure/) from
+   pre-commit typecheck. CDK typecheck is too slow (60–120s) for the
+   "fast feedback" goal of pre-commit hooks, and has been observed
+   hanging entirely. CI's `pnpm turbo typecheck` still covers
+   infrastructure, so no verification coverage is lost. A 60s per-
+   workspace timeout also added as belt-and-braces defence.
 7. **Budget Tracker consolidation** — see Issue #17. Executed as sub-phases
    7a–7h in order. See below for the full plan.
 

--- a/scripts/ci/typecheck-staged-workspaces.sh
+++ b/scripts/ci/typecheck-staged-workspaces.sh
@@ -6,6 +6,21 @@
 # (bypasses turbo to avoid build-chain overhead in the commit loop).
 #
 # lint-staged passes the list of changed files as $@.
+#
+# EXCLUSIONS
+# ----------
+# @transformotion/infra (infrastructure/) is excluded from pre-commit
+# typecheck. Running tsc --noEmit against AWS-CDK type definitions takes
+# 60-120s and has been observed hanging entirely — both conflict with
+# pre-commit's "fast feedback" goal. CI's pnpm turbo typecheck still covers
+# infrastructure, so no verification coverage is lost.
+# See: https://github.com/transformotion/transformotion-apps/pull/44
+#
+# TIMEOUT
+# -------
+# Each workspace typecheck is wrapped in a 60s timeout as belt-and-braces
+# defence. If any workspace exceeds this limit the hook fails with a clear
+# message rather than hanging indefinitely.
 
 set -euo pipefail
 
@@ -23,8 +38,20 @@ cwd="$(pwd)"
 normalised=()
 for f in "$@"; do
   case "$f" in
-    /*) normalised+=("${f#"$cwd/"}") ;;
-    *)  normalised+=("$f") ;;
+    /*)
+      # Unix absolute path (e.g. /c/Users/... from MSYS2/Git Bash lint-staged)
+      normalised+=("${f#"$cwd/"}") ;;
+    [A-Za-z]:*)
+      # Windows absolute path (e.g. C:\Users\... from lint-staged on Windows)
+      # Convert drive letter to POSIX mount point: C:\foo -> /c/foo -> relative
+      drive="${f:0:1}"
+      drive_lower="${drive,,}"
+      rest="${f:2}"
+      rest="${rest//\\//}"
+      unix_f="/${drive_lower}${rest}"
+      normalised+=("${unix_f#"$cwd/"}") ;;
+    *)
+      normalised+=("$f") ;;
   esac
 done
 set -- ${normalised[@]+"${normalised[@]}"}
@@ -55,12 +82,34 @@ if [[ ${#SEEN_WORKSPACES[@]} -eq 0 ]]; then
   exit 0
 fi
 
+# Workspaces excluded from pre-commit typecheck (see header comment).
+EXCLUDED_WORKSPACES=("@transformotion/infra")
+
 FAILED=0
 
 for name in "${!SEEN_WORKSPACES[@]}"; do
   ws_path="${SEEN_WORKSPACES[$name]}"
+
+  # Skip excluded workspaces — CI covers them.
+  excluded=0
+  for excl in "${EXCLUDED_WORKSPACES[@]}"; do
+    if [[ "$name" == "$excl" ]]; then
+      excluded=1
+      break
+    fi
+  done
+  if [[ $excluded -eq 1 ]]; then
+    echo "Skipping typecheck for $name ($ws_path) — excluded from pre-commit (CI covers this)."
+    continue
+  fi
+
   echo "Typechecking $name ($ws_path)..."
-  if ! pnpm --filter="$name" run typecheck 2>&1; then
+  typecheck_exit=0
+  timeout 60s pnpm --filter="$name" run typecheck 2>&1 || typecheck_exit=$?
+  if [[ $typecheck_exit -ne 0 ]]; then
+    if [[ $typecheck_exit -eq 124 ]]; then
+      echo >&2 "PRE-COMMIT FAIL: typecheck timed out after 60s for $name. Fix or use --no-verify."
+    fi
     FAILED=1
   fi
 done


### PR DESCRIPTION
Sub-phase 6 follow-up. Fixes the pre-commit hook hang on infrastructure workspace typecheck that's been forcing `--no-verify` on recent PRs (40, 43, and others).

## Root cause (found during smoke-testing)

Two separate path format issues in `typecheck-staged-workspaces.sh`:

1. **MSYS2/Git Bash absolute paths** (`/c/Users/...`) — fixed in PR #39
2. **Windows absolute paths** (`C:\Users\...`) — NEW: lint-staged on Windows passes these too; the `dirname` loop was getting stuck at `C:` (infinite loop) because `dirname "C:"` returns `C:` unchanged

Both are now handled in the path normalization block.

## Changes

- `@transformotion/infra` added to `EXCLUDED_WORKSPACES` array — skipped with a clear message; CI's `pnpm turbo typecheck` still covers it
- Windows-style absolute path normalization: `C:\Users\...` → `/c/Users/...` → relative path (same logic as the MSYS2 fix, extended to the `[A-Za-z]:\*` case)
- 60s `timeout` wrapper on each typecheck call as belt-and-braces defence

## Smoke-tested

- Infrastructure-only commit: hook completes in < 2s, prints "Skipping typecheck for @transformotion/infra"
- Non-infrastructure commit: hook completes in ~5s, runs budget-domain typecheck