### PR TITLE
docs: architecture documentation set + 7e migration plan

### DIFF
--- a/MONOREPO.md
+++ b/MONOREPO.md
@@ -5,7 +5,7 @@
 ```
 transformotion-apps/
 ├── apps/
-│   ├── stock-analyser/           # Stock Analyser Next.js app
+│   ├── stock-analyser/           # Stock Analyser Next.js app — basePath /stock-signal
 │   │   ├── app/                  # Next.js App Router pages
 │   │   ├── components/           # React components
 │   │   ├── contracts/            # Stock Analyser interface contracts
@@ -17,9 +17,11 @@ transformotion-apps/
 │   │   ├── lib/                  # Domain logic, services, adaptors
 │   │   ├── stores/               # Zustand stores
 │   │   └── package.json          # @transformotion/stock-analyser
-│   └── budget-tracker/           # Budget Tracker app (scaffolding TBD)
-│       ├── contracts/            # Budget Tracker interface contracts
-│       └── package.json          # @transformotion/budget-tracker
+│   ├── budget-tracker/           # Budget Tracker app — basePath /budget-tracker
+│   │   ├── functions/            # Budget Tracker Lambda source
+│   │   └── package.json          # @transformotion/budget-tracker
+│   └── launchpad/                # Launchpad shell app — serves /, /sign-in/, /launchpad/
+│       └── package.json          # @transformotion/launchpad (planned — not yet deployed)
 │
 ├── packages/                      # Shared code — imported by any app
 │   ├── auth-client/               # Auth interface types (@transformotion/auth-client)
@@ -30,15 +32,18 @@ transformotion-apps/
 │
 ├── infrastructure/                 # AWS CDK — all environments
 │   ├── lib/
-│   │   ├── platform/              # Shared platform stacks (Cognito, S3/CF, API GW, tables)
+│   │   ├── platform/              # Platform stacks (Cognito, S3/CF, API GW, tables)
 │   │   │   ├── auth-stack.ts
 │   │   │   ├── auth-api-stack.ts
 │   │   │   ├── network-stack.ts
 │   │   │   ├── platform-api-stack.ts
 │   │   │   └── platform-tables-stack.ts
-│   │   └── stock-analyser/        # Stock Analyser-specific stacks
-│   │       ├── stock-analyser-api-stack.ts
-│   │       └── stock-analyser-tables-stack.ts
+│   │   ├── stock-analyser/        # Stock Analyser-specific stacks
+│   │   │   ├── stock-analyser-api-stack.ts
+│   │   │   └── stock-analyser-tables-stack.ts
+│   │   └── budget-tracker/        # Budget Tracker-specific stacks
+│   │       ├── budget-tracker-api-stack.ts
+│   │       └── budget-tracker-tables-stack.ts
 │   └── bin/app.ts                 # CDK app entry — instantiates all stacks
 │
 ├── functions/                      # Platform Lambda source (shared across apps)
@@ -47,7 +52,8 @@ transformotion-apps/
 │   ├── accounts/
 │   ├── invitations/
 │   ├── forgot-provider/
-│   └── claude-proxy/
+│   ├── claude-proxy/
+│   └── pre-token-generation/      # Cognito pre-token trigger (added in sub-phase 7e)
 │
 ├── contracts/                      # Cross-app contracts only (auth, platform)
 ├── .github/
@@ -99,10 +105,12 @@ Push-triggered, path-filtered per app:
 |---|---|
 | `apps/stock-analyser/**` | `deploy-stock-analyser.yml` |
 | `infrastructure/lib/stock-analyser/**` | `deploy-stock-analyser.yml` |
-| `apps/budget-tracker/**` | `deploy-budget-tracker.yml` (placeholder) |
+| `apps/budget-tracker/**` | `deploy-budget-tracker.yml` |
+| `infrastructure/lib/budget-tracker/**` | `deploy-budget-tracker.yml` |
 | `infrastructure/lib/platform/**` | `deploy-platform.yml` |
+| `infrastructure/bin/**` | `deploy-platform.yml` |
 | `functions/**` | `deploy-platform.yml` |
-| `packages/**` | `deploy-stock-analyser.yml` (and BT when active) |
+| `packages/**` | `deploy-stock-analyser.yml` + `deploy-budget-tracker.yml` |
 
 Changes to one app never trigger the other app's deployment.
 

--- a/STABILISATION_FREEZE.md
+++ b/STABILISATION_FREEZE.md
@@ -2,7 +2,7 @@
 
 **Status:** ACTIVE
 **Started:** 2026-04-20
-**Last updated:** 2026-04-24 (sub-phase 7e-docs: architecture document set created at docs/architecture/; per-app CLAUDE.md files added; discipline rule established)
+**Last updated:** 2026-04-24 (sub-phase 7e-docs amendment: auth model revised — 3-group Dimension A, single-owner invariant, 4 auth helpers, detailed invitation and revocation flows; sub-phase-7e-plan.md updated to match)
 **Expected end:** Once Phase 1 (foundations) and Phase 2
 (executable contracts) are complete, the freeze on stabilisation
 work lifts. The Phase 4 stock analyser migration begins under
@@ -212,14 +212,18 @@ Sub-phases:
    - Diff and reconcile remaining 4 diverged files (`builtin-rules.ts`,
      `types.ts`, `review-tab.tsx`, one more).
 
-   **Sub-phase 7e — `apps/launchpad`: real Cognito session + group-based tile hiding.**
-   Wire real Cognito auth into `apps/launchpad` launchpad (replace `MOCK_USER`).
-   Add `getGroups(): Promise<string[]>` to `packages/auth-client` (reads
-   `cognito:groups` claim from ID token). Change tile navigation from
-   full-origin env-var URLs to path-relative (`/stock-signal/`,
-   `/budget-tracker/`). Declare `NEXT_PUBLIC_BUDGET_URL` / `NEXT_PUBLIC_STOCK_URL`
-   in `apps/launchpad/.env.example`. Deploy `apps/launchpad` to the S3 root (replacing
-   launchpad/sign-in routes that currently come from `apps/stock-analyser`).
+   **Sub-phase 7e — Auth and permissions migration.**
+   Full auth model migration — see [docs/sub-phase-7e-plan.md](./docs/sub-phase-7e-plan.md)
+   for the detailed execution plan. Named sub-sub-phases in order:
+   `7e-prep-1` (new Cognito groups), `7e-prep-2` (dual-gate handlers),
+   `7e-pretoken` (pre-token-generation Lambda with invariant reconciliation),
+   `7e-auth-middleware-extend` (4 new auth helpers), `7e-lambda-authorization-migration`
+   (migrate all call sites), `7e-invitation-api` (full invitation model with two
+   entry points and transactional redemption), `7e-invitation-ui` (launchpad admin
+   + in-app invite forms), `7e-signup-reconciliation` (reconcile-invitation Lambda),
+   `7e-launchpad-tiles` (wire real Cognito session, replace `MOCK_USER`),
+   `7e-forgot-provider-fix` (federated-user lookup via `ListUsersCommand`),
+   `7e-cleanup` (remove old groups, delete `requireGroup`).
 
    **Sub-phase 7f — API Gateway rollback (optional).**
    Refactor `BudgetTrackerApiStack` to consume the platform API Gateway via

--- a/STABILISATION_FREEZE.md
+++ b/STABILISATION_FREEZE.md
@@ -2,11 +2,19 @@
 
 **Status:** ACTIVE
 **Started:** 2026-04-20
-**Last updated:** 2026-04-23 (sub-phases 5–6 complete; sub-phase 7a diagnostic complete; sub-phase 7 plan anchored; Issue #37 opened; preamble.4 Cognito gating verified; three-client permission model anchored; 7b.5-beta authz gap closed; Issue #42 opened; sub-phase 6 follow-up: infra excluded from pre-commit typecheck; sub-phase 7b.5-alpha three-client Cognito model complete — merged, deployed, verified)
+**Last updated:** 2026-04-24 (sub-phase 7e-docs: architecture document set created at docs/architecture/; per-app CLAUDE.md files added; discipline rule established)
 **Expected end:** Once Phase 1 (foundations) and Phase 2
 (executable contracts) are complete, the freeze on stabilisation
 work lifts. The Phase 4 stock analyser migration begins under
 normal feature-development cadence on the new foundation.
+
+## Architectural discipline
+
+All architectural invariants are documented in [docs/architecture/](./docs/architecture/). **Any PR changing what those documents describe must update the relevant document in the same PR.** Architecture documents are the source of truth; code conforms to them, not the other way around.
+
+The discipline rule applies from sub-phase 7e-docs forward. Pre-existing architectural decisions have been migrated to `docs/architecture/` as part of that sub-phase.
+
+---
 
 ## What this means
 
@@ -311,6 +319,8 @@ With the foundation stable, decide and document how (or whether)
 v0 fits back into the development cycle. Decision deferred until
 Phase 4 completes.
 
+> **Note on architectural content in this document.** Architectural decisions previously recorded inline (Cognito model, URL model, tile visibility, etc.) have been migrated to `docs/architecture/`. This document is now scoped to project plan, phase status, and process discipline. Historical decision context is preserved in git history and in the architecture documents.
+
 ## Platform permission invariants (Cognito)
 
 These are platform-level architectural invariants. Changes to any of
@@ -441,3 +451,5 @@ reasoning.
 
 This file is updated as scope evolves. Every update increments the
 "Last updated" date and records the change in the commit message.
+
+This document will be archived to `docs/history/` when stabilisation is complete.

--- a/apps/budget-tracker/CLAUDE.md
+++ b/apps/budget-tracker/CLAUDE.md
@@ -1,0 +1,179 @@
+# Budget Tracker — Claude Code operating guide
+
+Read this file before any Budget Tracker work. Read the root `CLAUDE.md` for branching strategy.
+
+## Overview
+
+Next.js app at `apps/budget-tracker/`. Static export deployed to S3/CloudFront.  
+Serves at `{host}/budget-tracker/*`.  
+React + TypeScript + Tailwind CSS + shadcn/ui.
+
+## Quick reference
+
+| What | Value |
+|---|---|
+| basePath | `/budget-tracker` |
+| Local dev port | `3002` |
+| Deploy workflow | `.github/workflows/deploy-budget-tracker.yml` |
+| Cognito client var | `NEXT_PUBLIC_BUDGET_TRACKER_COGNITO_CLIENT_ID` |
+| S3 prefix | `budget-tracker/` in `transformotion-web-{stage}-959516291617` |
+
+## Architecture references
+
+| Topic | Document |
+|---|---|
+| Auth model, groups, tokens, middleware | [/docs/architecture/auth.md](/docs/architecture/auth.md) |
+| DynamoDB table schemas | [/docs/architecture/data.md](/docs/architecture/data.md) |
+| CDK stacks, Lambda names | [/docs/architecture/cdk.md](/docs/architecture/cdk.md) |
+| URL routing, CloudFront, deploy triggers | [/docs/architecture/urls-and-deploy.md](/docs/architecture/urls-and-deploy.md) |
+| Data models and types | [/contracts/budget-tracker/data-models.md](/contracts/budget-tracker/data-models.md) |
+| API contracts | [/contracts/budget-tracker/api-contracts.md](/contracts/budget-tracker/api-contracts.md) |
+| State management and adaptor pattern | [/contracts/budget-tracker/state-management.md](/contracts/budget-tracker/state-management.md) |
+| AWS infrastructure reference | [/contracts/budget-tracker/aws-infrastructure.md](/contracts/budget-tracker/aws-infrastructure.md) |
+
+## CDK stacks owned
+
+| Stack | Contents |
+|---|---|
+| `Transformotion{Stage}-BudgetTrackerTables` | `budget-tracker.accounts`, `budget-tracker.transactions`, `budget-tracker.rules`, `budget-tracker.settings` |
+| `Transformotion{Stage}-BudgetTrackerApi` | All Budget Tracker Lambda functions + its own API Gateway |
+
+Source: `infrastructure/lib/budget-tracker/`
+
+> Note: Budget Tracker has its own API Gateway (`budget-tracker-api-{stage}`) rather than sharing the platform gateway. This is a known architectural divergence tracked as sub-phase 7f.
+
+## Lambda functions
+
+| Lambda | Routes |
+|---|---|
+| `budget-transactions-handler-{stage}` | `GET/POST/PATCH/DELETE /api/budget/v1/transactions` |
+| `budget-rules-handler-{stage}` | `GET/POST/PATCH/DELETE /api/budget/v1/rules` |
+| `budget-settings-handler-{stage}` | `GET/PATCH /api/budget/v1/settings` |
+| `budget-ai-categorise-handler-{stage}` | `POST /api/budget/v1/ai/categorise` |
+| `budget-ai-review-handler-{stage}` | `POST /api/budget/v1/ai/review` |
+| `budget-ai-csv-analysis-handler-{stage}` | `POST /api/budget/v1/ai/csv-analysis` |
+| `budget-export-handler-{stage}` | `GET /api/budget/v1/business-export` |
+| `budget-migrate-handler-{stage}` | `POST /api/budget/v1/migrate-from-localstorage` |
+
+## DynamoDB tables
+
+| Table | PK | SK | Purpose |
+|---|---|---|---|
+| `budget-tracker.accounts-{stage}` | `accountId` | — | Budget Tracker account container |
+| `budget-tracker.transactions-{stage}` | `accountId` | `transactionId` | Transactions; GSI: `accountId-dateIso-index` |
+| `budget-tracker.rules-{stage}` | `accountId` | `ruleId` | Custom categorisation rules |
+| `budget-tracker.settings-{stage}` | `accountId` | `settingKey` | Per-account settings (key-value) |
+
+## Authorization requirement
+
+All Lambda handlers must call:
+
+```typescript
+requireAppAccess(auth, 'budget-tracker')
+requireAccountAccess(auth, 'budget-tracker', accountId)
+```
+
+Do not call `requireGroup` directly. See [auth.md](/docs/architecture/auth.md) for the middleware helpers.
+
+## Adaptor pattern — mandatory constraint
+
+Budget Tracker UI uses the adaptor pattern. **Components never call APIs, DynamoDB, or localStorage directly.** The data flow is:
+
+```
+Component
+  → Zustand store action
+  → Repository interface method   ← defined in contracts/state-management.md
+  → stub adaptor (dev/v0) OR aws-adaptor (production)
+```
+
+The three Zustand stores:
+- `useBudgetStore` — transactions, rules, settings, categorisation actions
+- `useAiStore` — AI review queue and CSV analysis
+- `useAuthStore` — current user and sign-in/out
+
+Repository interfaces are defined in `contracts/budget-tracker/state-management.md`. **Do not add methods to a repository without updating the contract file first.**
+
+### Forbidden patterns
+
+- `fetch()` in components or store actions
+- `localStorage` reads/writes outside `lib/repositories/`
+- Types not in `contracts/budget-tracker/data-models.md`
+- `window.confirm` — use inline confirmation UI instead
+- IIFEs inside JSX — compute values above the return statement
+- `URL.createObjectURL` for CSV export — use data URI instead
+- AI prompt text in client-side code — prompts run server-side only
+- Imports from `apps/stock-analyser/`
+
+## Data types
+
+All types that cross the UI/backend boundary are defined in [contracts/budget-tracker/data-models.md](/contracts/budget-tracker/data-models.md). Key types:
+- `Transaction` — atomic unit; `_manual` flag prevents rules from overwriting
+- `CustomRule` — keyword or regex pattern, case-insensitive
+- `BudgetSettings` — per-account, stored key-by-key in DynamoDB
+- `BuiltinRule` — compiled into codebase, not user-editable, not stored in DynamoDB
+
+## Exclusion rules (apply everywhere)
+
+A transaction is **excluded from personal P&L** if any of these are true:
+1. `subcategory === "Transfer"`
+2. `_business === true`
+3. `category` is in `PROJECT_CATEGORIES` (default: `["Renovations"]`)
+4. `subcategory` is in `PROJECT_SUBCATEGORIES` (default: `["Capital purchases"]`)
+
+These exclusions must be consistent across Summary totals, Budget view, Cashflow charts, and the Sankey diagram. Excluded transactions remain visible in the Transactions tab.
+
+## Rules engine
+
+Custom rules override built-in rules. Most recent custom rule wins if multiple match. Process order:
+
+1. If `_manual === true`: return existing category unchanged
+2. Iterate custom rules in reverse (most recent first) — case-insensitive match
+3. Iterate built-in rules
+4. Return `{ category: "", subcategory: "" }` if no match
+
+**Critical ordering:** Never run the rules engine before custom rules are loaded. Load order: auth → settings → rules → transactions → run rules.
+
+## Testing
+
+Domain logic lives in `packages/budget-domain/` — pure TypeScript, no AWS dependencies. Run tests with:
+
+```bash
+cd packages/budget-domain
+pnpm test
+```
+
+Real export fixture: `migration-artifacts/budget-tracker/budget-tracker-export-2026-04-18.json` (726 transactions).
+
+Key invariants to preserve in tests:
+1. `Transaction._id` is always a UUID string
+2. `buildBudgetVsActual()` numMonths matches the transaction date range
+3. `isExcludedFromCashflow()` always excludes Transfer, `_business`, project categories
+4. `buildMonthlyTrend()` net = income − expenses (exact equality)
+5. Migration endpoint strips legacy `_id` before writing to DynamoDB
+6. `getSubcategoryMonthlyBudget()` returns 0 for tombstoned subcategories (override = -1)
+
+## v0 origins
+
+The Budget Tracker UI was originally built with v0 using the adaptor pattern described in `handover/v0-prompt.md`. When continuing UI work in v0:
+- Read `handover/v0-prompt.md` for v0-specific operating conventions
+- The stub adaptors (in-memory + localStorage) live in the v0 repo (`transformotion-apps-b8`)
+- The real AWS adaptors live here
+
+## Local development
+
+```bash
+pnpm --filter @transformotion/budget-tracker dev
+# Runs on http://localhost:3002
+```
+
+Environment: copy `apps/budget-tracker/.env.example` to `.env.local` and fill in values. Set `NEXT_PUBLIC_USE_MOCK_DATA=true` to use stub adaptors without real AWS.
+
+## Environment variables (relevant subset)
+
+| Variable | Purpose |
+|---|---|
+| `NEXT_PUBLIC_BUDGET_TRACKER_COGNITO_CLIENT_ID` | Cognito app client for this app |
+| `NEXT_PUBLIC_COGNITO_USER_POOL_ID` | Shared Cognito user pool ID |
+| `NEXT_PUBLIC_COGNITO_DOMAIN` | Hosted UI domain |
+| `NEXT_PUBLIC_USE_MOCK_DATA` | `true` = stub adaptors, `false` = real AWS |
+| `NEXT_PUBLIC_API_BASE_URL` | Budget Tracker API base URL |

--- a/apps/budget-tracker/CLAUDE.md
+++ b/apps/budget-tracker/CLAUDE.md
@@ -66,14 +66,17 @@ Source: `infrastructure/lib/budget-tracker/`
 
 ## Authorization requirement
 
-All Lambda handlers must call:
+All Lambda handlers use helpers from `packages/lambda-middleware`. The four available helpers and when to apply each:
 
 ```typescript
-requireAppAccess(auth, 'budget-tracker')
-requireAccountAccess(auth, 'budget-tracker', accountId)
+requireSiteAdmin(auth)                                             // platform admin ops only
+requireAppAccess(auth, 'budget-tracker')                          // entry-point check (every handler)
+requireAccountAccess(auth, 'budget-tracker', accountId)           // standard read/write ops
+requireAccountAccess(auth, 'budget-tracker', accountId, 'manager') // elevated ops (bulk delete, settings wipe, etc.)
+requireAccountOwner(auth, 'budget-tracker', accountId)            // ownership-transfer ops
 ```
 
-Do not call `requireGroup` directly. See [auth.md](/docs/architecture/auth.md) for the middleware helpers.
+Call `requireAppAccess` at the top of every handler, then `requireAccountAccess` (or `requireAccountOwner`) before each DynamoDB operation. Do not call `requireGroup` directly. See [auth.md](/docs/architecture/auth.md) for full middleware helper documentation.
 
 ## Adaptor pattern — mandatory constraint
 

--- a/apps/stock-analyser/CLAUDE.md
+++ b/apps/stock-analyser/CLAUDE.md
@@ -60,14 +60,17 @@ Analysis cache (`platform.analysis-cache-{stage}`) is a platform table shared wi
 
 ## Authorization requirement
 
-All Lambda handlers must call:
+All Lambda handlers use helpers from `packages/lambda-middleware`. The four available helpers and when to apply each:
 
 ```typescript
-requireAppAccess(auth, 'stock-signal')
-requireAccountAccess(auth, 'stock-signal', accountId)
+requireSiteAdmin(auth)                                           // platform admin ops only
+requireAppAccess(auth, 'stock-signal')                          // entry-point check (every handler)
+requireAccountAccess(auth, 'stock-signal', accountId)           // standard read/write ops
+requireAccountAccess(auth, 'stock-signal', accountId, 'manager') // elevated ops (bulk delete, etc.)
+requireAccountOwner(auth, 'stock-signal', accountId)            // ownership-transfer ops
 ```
 
-Do not call `requireGroup` directly. See [auth.md](/docs/architecture/auth.md) for the middleware helpers.
+Call `requireAppAccess` at the top of every handler, then `requireAccountAccess` (or `requireAccountOwner`) before each DynamoDB operation. Do not call `requireGroup` directly. See [auth.md](/docs/architecture/auth.md) for full middleware helper documentation.
 
 ## Service layer and data contracts
 

--- a/apps/stock-analyser/CLAUDE.md
+++ b/apps/stock-analyser/CLAUDE.md
@@ -1,0 +1,139 @@
+# Stock Analyser — Claude Code operating guide
+
+Read this file before any Stock Analyser work. Read the root `CLAUDE.md` for branching strategy.
+
+## Overview
+
+Next.js app at `apps/stock-analyser/`. Static export deployed to S3/CloudFront.  
+Serves at `{host}/stock-signal/*`.  
+React + TypeScript + Tailwind CSS.
+
+## Quick reference
+
+| What | Value |
+|---|---|
+| basePath | `/stock-signal` |
+| Local dev port | `3000` |
+| Deploy workflow | `.github/workflows/deploy-stock-analyser.yml` |
+| Cognito client var | `NEXT_PUBLIC_STOCK_ANALYSER_COGNITO_CLIENT_ID` |
+| S3 prefix | `stock-signal/` in `transformotion-web-{stage}-959516291617` |
+
+## Architecture references
+
+| Topic | Document |
+|---|---|
+| Auth model, groups, tokens, middleware | [/docs/architecture/auth.md](/docs/architecture/auth.md) |
+| DynamoDB table schemas | [/docs/architecture/data.md](/docs/architecture/data.md) |
+| CDK stacks, Lambda names | [/docs/architecture/cdk.md](/docs/architecture/cdk.md) |
+| URL routing, CloudFront, deploy triggers | [/docs/architecture/urls-and-deploy.md](/docs/architecture/urls-and-deploy.md) |
+| Stock Analyser API contracts and types | [apps/stock-analyser/contracts/DATA_CONTRACTS.md](./contracts/DATA_CONTRACTS.md) |
+| Migration invariants from HTML version | [apps/stock-analyser/MIGRATION_INVARIANTS.md](./MIGRATION_INVARIANTS.md) |
+
+## CDK stacks owned
+
+| Stack | Contents |
+|---|---|
+| `Transformotion{Stage}-StockAnalyserTables` | `stock-analyser.portfolio-{stage}-v2`, `stock-analyser.watchlist-{stage}-v2` |
+| `Transformotion{Stage}-StockAnalyserApi` | All Stock Analyser Lambda functions + routes on the platform API Gateway |
+
+Source: `infrastructure/lib/stock-analyser/`
+
+## Lambda functions
+
+All Stock Analyser Lambdas share the platform API Gateway and Cognito JWT authoriser.
+
+| Lambda | Source | Routes |
+|---|---|---|
+| `transformotion-portfolio-{stage}` | `apps/stock-analyser/functions/portfolio` | `GET/POST/PATCH/DELETE /api/portfolio` |
+| `transformotion-watchlist-{stage}` | `apps/stock-analyser/functions/watchlist` | `GET/POST/PATCH/DELETE /api/watchlist` |
+| `transformotion-analysis-cache-{stage}` | `apps/stock-analyser/functions/analysis-cache` | `GET /api/analysis-cache/*` |
+| `transformotion-cycle-check-{stage}` | `apps/stock-analyser/functions/cycle-check` | EventBridge scheduled (no HTTP route) |
+
+## DynamoDB tables
+
+| Table | PK | SK | Purpose |
+|---|---|---|---|
+| `stock-analyser.portfolio-{stage}-v2` | `accountId` | — | Portfolio holdings per account |
+| `stock-analyser.watchlist-{stage}-v2` | `accountId` | — | Watchlist items per account |
+
+Analysis cache (`platform.analysis-cache-{stage}`) is a platform table shared with other apps — accessed via `transformotion-claude-proxy-{stage}`, not directly.
+
+## Authorization requirement
+
+All Lambda handlers must call:
+
+```typescript
+requireAppAccess(auth, 'stock-signal')
+requireAccountAccess(auth, 'stock-signal', accountId)
+```
+
+Do not call `requireGroup` directly. See [auth.md](/docs/architecture/auth.md) for the middleware helpers.
+
+## Service layer and data contracts
+
+The app uses a service-adaptor pattern: components call service methods → service handles mock vs real internally. Components never check `NEXT_PUBLIC_USE_MOCK_DATA` directly.
+
+Key service methods defined in [contracts/DATA_CONTRACTS.md](./contracts/DATA_CONTRACTS.md):
+- `portfolioService.getHoldings()` / `saveHoldings()` / `enrichHoldings()`
+- `watchlistService.getItems()` / `saveItems()`
+- `useClaude()` hook — POST to `/api/claude` + async polling pattern
+
+### Claude AI pattern
+
+The `useClaude<T>()` hook handles the full async request/poll cycle:
+1. POST to `/api/claude` with prompt → returns `jobId`
+2. Poll `/analysis-cache/job-{jobId}` until complete
+3. Return typed result
+
+See `apps/stock-analyser/docs/claude-ai-pattern.md` for usage examples and configuration.
+
+### Cache key conventions
+
+| Data | Cache key format | TTL |
+|---|---|---|
+| Market Analysis | `MARKET#{geography}` | 24h |
+| Recommendations | `RECS#{market}` | 24h |
+| ETFs | `ETFS#{category}` | 48h |
+| Metals | `METALS#all` | 2h |
+| Stock Analysis | `ANALYSIS#{ticker}` | 8h |
+| Market Cycle | `CYCLE#{geography}` | 8h |
+
+## Migration invariants (Phase 4)
+
+When the monolithic `stock-signal-analyser.html` is migrated into this app (Phase 4), all 16 invariants in [MIGRATION_INVARIANTS.md](./MIGRATION_INVARIANTS.md) must be covered by automated tests. Do not declare Phase 4 complete until every invariant has a failing-then-passing test.
+
+Key invariants:
+1. Signal normalisation: `rawSig.trim().toUpperCase().startsWith('BUY')`
+2. `computeLiveCycle` works without a DOM container
+3. `isLive()` always exists and returns a boolean
+4. Watchlist refresh uses `Promise.all` (not serial awaits)
+5. Ticker matching by position before exact string equality
+6. JSON parsing uses depth-tracking parser (not `JSON.parse`)
+7. Prompts include "no emoji, JSON only"
+
+## Local development
+
+```bash
+pnpm --filter @transformotion/stock-analyser dev
+# Runs on http://localhost:3000
+```
+
+Environment: copy `apps/stock-analyser/.env.example` to `.env.local` and fill in values.
+
+Required env vars marked `[REQUIRED]` in `.env.example` must be set before the dev server will function correctly.
+
+## Environment variables (relevant subset)
+
+| Variable | Purpose |
+|---|---|
+| `NEXT_PUBLIC_STOCK_ANALYSER_COGNITO_CLIENT_ID` | Cognito app client for this app |
+| `NEXT_PUBLIC_COGNITO_USER_POOL_ID` | Shared Cognito user pool ID |
+| `NEXT_PUBLIC_COGNITO_DOMAIN` | Hosted UI domain |
+| `NEXT_PUBLIC_USE_MOCK_DATA` | `true` = mock services, `false` = real AWS |
+| `NEXT_PUBLIC_API_BASE_URL` | Platform API base URL |
+
+## Known constraints
+
+- The app currently contains Budget Tracker UI components at `components/budget-tracker/` and `app/budget-tracker/`. These are scheduled for deletion in sub-phase 7h, after `apps/budget-tracker` is live at `/budget-tracker/`.
+- The launchpad and sign-in routes (`app/launchpad/`, `app/sign-in/`) are also in this app pending sub-phase 7e deploying `apps/launchpad`.
+- `eslint-plugin-boundaries` enforces no cross-app imports — do not import from `apps/budget-tracker/`.

--- a/contracts/budget-tracker/aws-infrastructure.md
+++ b/contracts/budget-tracker/aws-infrastructure.md
@@ -7,11 +7,11 @@
 ```
 User browser
     ↓
-CloudFront (apps.transformotion.com.au/budget)
+CloudFront (apps.transformotion.com.au/budget-tracker)
     ↓
-S3 (React SPA — shared with other Transformotion apps)
+S3 (Next.js static export — shared bucket, budget-tracker/ prefix)
     ↓
-API Gateway (REST API — /api/budget/v1/*)
+API Gateway (budget-tracker-api-{stage} — /api/budget/v1/*)
     ↓
 Lambda Functions
     ↓
@@ -23,16 +23,27 @@ Lambda Functions
 
 ## Cognito
 
-**Uses the existing shared User Pool** (`transformotion-users`). Budget Tracker does not create its own.
+**Shares the platform Cognito User Pool** (`transformotion-{stage}`). Budget Tracker does not create its own user pool.
 
-- Required group for access: `budget-app`
-- App client: `budget-tracker-client` (new — scoped to this app's allowed OAuth flows)
-- JWT claims used by backend:
-  - `sub` — userId
-  - `cognito:username`
-  - `cognito:groups` — must include `budget-app`
-  - `email`
-- `accountId` is NOT in the JWT — it is looked up server-side in the `accounts` table (see below)
+Budget Tracker has a **dedicated app client**: `BudgetTrackerAppClient` — one of three distinct app clients in the three-client model introduced in sub-phase 7b.5-alpha.
+
+- **Dev client ID:** `291vbglkino4h7b9t39krg9c69`
+- **Env var:** `NEXT_PUBLIC_BUDGET_TRACKER_COGNITO_CLIENT_ID`
+- **Supported IDPs:** Cognito only (no social sign-in on this client — social sign-in happens at the launchpad and propagates via SSO)
+- **Callback URL:** `{host}/budget-tracker/callback`
+- **Logout URL:** `{host}/sign-in`
+
+Required group for access (target — sub-phase 7e): `budget-app-user` or `budget-app-admin` or `site-admin`  
+Current group (deployed): `budget-app` or `admin`
+
+JWT claims used by Lambda handlers:
+- `sub` — userId
+- `cognito:groups` — app access authorization (transitional; replaced by `apps` claim after 7e)
+- `email`
+- `apps` — structured app access claim (available after 7e pre-token Lambda is deployed)
+- `accounts` — per-app membership claim (available after 7e pre-token Lambda is deployed)
+
+For the complete auth model see [/docs/architecture/auth.md](/docs/architecture/auth.md).
 
 ## DynamoDB tables
 

--- a/contracts/budget-tracker/aws-infrastructure.md
+++ b/contracts/budget-tracker/aws-infrastructure.md
@@ -33,7 +33,7 @@ Budget Tracker has a **dedicated app client**: `BudgetTrackerAppClient` — one 
 - **Callback URL:** `{host}/budget-tracker/callback`
 - **Logout URL:** `{host}/sign-in`
 
-Required group for access (target — sub-phase 7e): `budget-app-user` or `budget-app-admin` or `site-admin`  
+Required group for access (target — sub-phase 7e): `budget-app-access` or `site-admin`  
 Current group (deployed): `budget-app` or `admin`
 
 JWT claims used by Lambda handlers:

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,0 +1,32 @@
+# Architecture documents
+
+These documents describe the architectural invariants of the Transformotion platform. They are the source of truth for how the system is structured, how its parts interact, and what constraints bind new work.
+
+## The discipline
+
+**Any pull request that changes what is described here must update the corresponding document in the same PR.** Code conforms to these documents; these documents are not retrofitted to describe whatever code happened to land.
+
+If during implementation a document is discovered to be wrong or incomplete, work pauses and the document is corrected before proceeding. Architectural drift is prevented by this rule, not by individual vigilance.
+
+## Documents
+
+- **[auth.md](./auth.md)** — Authentication and permissions. Cognito pool, app clients, identity providers, token shape, two-dimensional permission model (app access + account membership), pre-token generation Lambda, invitation flow, revocation.
+
+- **[data.md](./data.md)** — Data model. DynamoDB table conventions, per-app vs platform-scoped tables, account-scoping invariant, PK/SK patterns, GSI conventions.
+
+- **[urls-and-deploy.md](./urls-and-deploy.md)** — URL routing, CloudFront distribution, S3 layout, deploy triggers, Next.js basePath per app.
+
+- **[cdk.md](./cdk.md)** — CDK stack topology, cross-stack references, deploy ordering, env var enforcement.
+
+## Companion documents elsewhere in the repo
+
+- **[MONOREPO.md](/MONOREPO.md)** — Workspace structure, import boundaries, build/deploy triggers.
+- **[contracts/](/contracts/)** — Per-app data and API contracts (living documentation adjacent to each app's code).
+- **[apps/stock-analyser/CLAUDE.md](/apps/stock-analyser/CLAUDE.md)** — Stock Analyser operating guide for agents.
+- **[apps/budget-tracker/CLAUDE.md](/apps/budget-tracker/CLAUDE.md)** — Budget Tracker operating guide for agents.
+
+## What is NOT in these documents
+
+- Project status, phase plans, or work schedules — see `STABILISATION_FREEZE.md`.
+- Migration plans for specific sub-phases — ephemeral documents like `docs/sub-phase-7e-plan.md` exist for the duration of their work, then are deleted.
+- Implementation details that change frequently — live in code or in per-app CLAUDE.md.

--- a/docs/architecture/auth.md
+++ b/docs/architecture/auth.md
@@ -1,0 +1,343 @@
+# Authentication and permissions
+
+## Overview
+
+The platform uses AWS Cognito as the single source of identity. Authentication is handled at the Cognito Hosted UI layer; authorization operates in two independent dimensions: **app access** (via Cognito groups) and **account membership** (via DynamoDB records). These two dimensions are orthogonal — a user must satisfy both to perform a data operation.
+
+A pre-token generation Lambda injects structured claims into every issued token. API handlers and the launchpad consume these claims rather than raw group strings. This means authorization logic is centralised in the token, not duplicated across handlers.
+
+Social identity providers (Google, Facebook, Microsoft) are wired at the Cognito layer. Social sign-in happens only at the launchpad; subsequent app access uses the shared Hosted UI domain session cookie.
+
+See [cdk.md](./cdk.md) for CDK stack names. See [data.md](./data.md) for account and membership table schemas.
+
+---
+
+## Cognito user pool
+
+- **Pool name:** `transformotion-{stage}` (dev / prod)
+- **Region:** `ap-southeast-2`
+- **Account ID:** `959516291617`
+- **Username:** Cognito-generated UUID (`sub`) — not email
+- **Sign-in alias:** email address
+- **Email:** required; auto-verified
+
+### Password policy
+
+- Minimum 8 characters
+- Requires uppercase, lowercase, digits
+- Symbols not required
+- Temporary password validity: 7 days
+
+### Custom attributes
+
+| Attribute | Type | Purpose |
+|---|---|---|
+| `custom:accounts` | String (max 2048) | Comma-separated UUIDs of all accounts the user belongs to (all apps combined) |
+| `custom:active_accounts` | String (max 2048) | JSON map of per-app active account: `{"stock-signal":"uuid","budget-tracker":"uuid"}` |
+
+> **Migration note:** The deployed attribute is currently `custom:active_account` (singular, UUID only). The target `custom:active_accounts` (plural, per-app JSON map) is introduced in sub-phase 7e. The migration plan is in `docs/sub-phase-7e-plan.md`.
+
+### Token lifetime
+
+| Token | Validity |
+|---|---|
+| Access token | 1 hour |
+| ID token | 1 hour |
+| Refresh token | 30 days |
+
+### MFA
+
+Optional TOTP. Users may enrol if they wish; it is not required.
+
+### Account recovery
+
+Email only.
+
+### Lambda triggers
+
+| Trigger | Function | Purpose |
+|---|---|---|
+| Pre-token generation | `transformotion-pre-token-generation-{stage}` | Injects `apps`, `site_admin`, `accounts` custom claims — see below |
+
+---
+
+## App clients
+
+Three distinct Cognito app clients, one per deployable app. All share the same user pool; SSO works via the shared Hosted UI domain session cookie.
+
+| Client | Serving path | Identity providers | CDK logical ID |
+|---|---|---|---|
+| `LaunchpadAppClient` | `/`, `/sign-in/*`, `/launchpad/*` | Cognito, Google, Facebook, Microsoft | `LaunchpadAppClient` in `AuthStack` |
+| `StockAnalyserAppClient` | `/stock-signal/*` | Cognito only | `StockAnalyserAppClient` in `AuthStack` |
+| `BudgetTrackerAppClient` | `/budget-tracker/*` | Cognito only | `BudgetTrackerAppClient` in `AuthStack` |
+
+Social sign-in is enabled on the launchpad client only. Per-app clients are Cognito-only because social identity sessions established at the launchpad propagate via SSO.
+
+**Dev client IDs** (set in GitHub `dev` environment variables after each auth stack deploy):
+
+| Variable | Client |
+|---|---|
+| `NEXT_PUBLIC_LAUNCHPAD_COGNITO_CLIENT_ID` | LaunchpadAppClient |
+| `NEXT_PUBLIC_STOCK_ANALYSER_COGNITO_CLIENT_ID` | StockAnalyserAppClient |
+| `NEXT_PUBLIC_BUDGET_TRACKER_COGNITO_CLIENT_ID` | BudgetTrackerAppClient |
+
+**Callback URL convention:** `{host}/{app-slug}/callback`
+**Logout URL convention:** `{host}/sign-in`
+
+For current client IDs, read from CloudFormation outputs:
+
+```bash
+aws cloudformation describe-stacks \
+  --stack-name TransformotionDev-Auth \
+  --query "Stacks[0].Outputs[?OutputKey=='BudgetTrackerAppClientId'].OutputValue"
+```
+
+---
+
+## Hosted UI domain
+
+```
+transformotion-{account}-{stage}.auth.ap-southeast-2.amazoncognito.com
+```
+
+For dev: `transformotion-959516291617-dev.auth.ap-southeast-2.amazoncognito.com`
+
+The Hosted UI domain provides the OAuth 2.0 / PKCE flow endpoint for all three app clients and is the redirect target for all social IDPs.
+
+---
+
+## Social identity providers
+
+Google, Facebook, and Microsoft IDPs are registered **manually in the Cognito console** (not managed by CloudFormation, because they were configured before CDK). The `AuthStack` creates Secrets Manager entries to hold credentials and references them via dynamic `{{resolve:secretsmanager:...}}` syntax.
+
+Apple Sign-In has placeholder secrets but is not yet active.
+
+All social IDP callback URIs point to:
+```
+https://transformotion-959516291617-{stage}.auth.ap-southeast-2.amazoncognito.com/oauth2/idpresponse
+```
+
+For setup instructions see `docs/social-idp-setup.md`.
+
+---
+
+## Permission model — two dimensions
+
+### Dimension A: App access (Cognito groups)
+
+Groups determine which apps a user can access and at what capability level.
+
+| Group | App | Grants |
+|---|---|---|
+| `stock-app-view` | Stock Signal | Read-only: view portfolio, watchlist, analysis results |
+| `stock-app-user` | Stock Signal | Full use: add/edit/delete holdings, trigger analysis |
+| `stock-app-admin` | Stock Signal | Full use + can invite others to Stock Signal |
+| `budget-app-view` | Budget Tracker | Read-only: view transactions, budget, cashflow |
+| `budget-app-user` | Budget Tracker | Full use: import, categorise, set budgets |
+| `budget-app-admin` | Budget Tracker | Full use + can invite others to Budget Tracker |
+| `site-admin` | All apps | Platform-wide admin; can invite to any app; implicit admin-level in all apps |
+
+Rules:
+- A user is in at most one `{app}-{level}` group per app.
+- `site-admin` is orthogonal to app groups. A `site-admin` user does not need `stock-app-admin` to access Stock Signal at admin level.
+- A user with no group for a given app cannot access that app, even if they have a valid Cognito session.
+
+> **Migration note:** The currently deployed groups are `admin`, `stock-app`, `budget-app`, `transformotion`, `family`. The target groups above are introduced in sub-phase 7e. During migration, both old and new groups coexist; handlers accept both. Old groups are removed at 7e-cleanup.
+
+### Dimension B: Account membership (DynamoDB)
+
+Accounts are per-app data containers. Each app has its own set of accounts; a user's "Stock Signal account" and "Budget Tracker account" are independent.
+
+Account membership is stored in `platform.account-members-{stage}` (PK: `accountId`, SK: `userId`) with a `role` attribute:
+
+| Role | Capability |
+|---|---|
+| `owner` | Created the account; can transfer ownership; can delete |
+| `manager` | Can manage members (add/remove/change role); cannot delete the account |
+| `member` | Read and write the account's data |
+| `viewer` | Read-only |
+
+A user can be `owner` of their own accounts and any role in others' accounts. Multiple memberships per app are permitted (e.g. owner of personal account + member of a shared household account).
+
+---
+
+## Pre-token generation Lambda
+
+**Function name:** `transformotion-pre-token-generation-{stage}`
+
+**Trigger:** Cognito pre-token-generation — invoked on every token issuance (sign-in and token refresh).
+
+**Responsibilities:**
+
+1. Read the user's Cognito groups from the trigger event
+2. Map groups to a structured `apps` claim:
+   - `stock-app-view/user/admin` → `apps["stock-signal"] = "view" | "user" | "admin"`
+   - `budget-app-view/user/admin` → `apps["budget-tracker"] = "view" | "user" | "admin"`
+   - `site-admin` → sets `site_admin: true` AND populates all-app entries at `admin` level
+3. Query `platform.account-members-{stage}` for the user's memberships, shape into `accounts` claim
+4. Inject via `event.response.claimsAndScopeOverrideDetails`
+
+**On failure:** The Lambda returns the event unchanged; the token is issued without custom claims. All API handlers fail closed — absent claims means no access.
+
+---
+
+## Claim shape in ID tokens
+
+The pre-token generation Lambda adds three custom claims. These are consumed by the launchpad and API handlers.
+
+```json
+{
+  "apps": {
+    "stock-signal": "view | user | admin",
+    "budget-tracker": "view | user | admin"
+  },
+  "site_admin": true,
+  "accounts": {
+    "stock-signal": [
+      { "accountId": "uuid", "role": "owner | manager | member | viewer" }
+    ],
+    "budget-tracker": [
+      { "accountId": "uuid", "role": "owner | manager | member | viewer" }
+    ]
+  }
+}
+```
+
+Plus standard Cognito claims (`sub`, `email`, `cognito:groups`) and the custom attributes `custom:accounts` and `custom:active_accounts`.
+
+---
+
+## Three-state tile model
+
+The launchpad renders app tiles based on two conditions:
+
+| User has app in `apps` claim | App is deployed | Tile state |
+|---|---|---|
+| Yes | Yes | Active — clickable link to app |
+| Yes | No | Visible, greyed out, "Coming Soon" label |
+| No | Any | Not rendered |
+
+App deployment state is statically known to the launchpad (hardcoded list of deployed app slugs). The `apps` claim controls visibility; deployment state controls interactivity.
+
+---
+
+## Auth middleware (`packages/lambda-middleware`)
+
+All API Lambda handlers use `withAuth` to validate the Cognito JWT from the `Authorization: Bearer` header. The middleware exposes:
+
+| Property | Type | Source |
+|---|---|---|
+| `auth.userId` | `string` | Cognito `sub` |
+| `auth.email` | `string` | `email` claim |
+| `auth.apps` | `Record<string, 'view'\|'user'\|'admin'>` | `apps` custom claim |
+| `auth.siteAdmin` | `boolean` | `site_admin` custom claim |
+| `auth.accounts` | `Record<string, Array<{accountId, role}>>` | `accounts` custom claim |
+
+**Authorization helpers** (use these instead of `requireGroup`):
+
+```typescript
+requireAppAccess(auth, 'stock-signal')
+// Throws 403 if caller doesn't have 'stock-signal' in auth.apps
+// and is not site_admin
+
+requireAppAccess(auth, 'stock-signal', 'admin')
+// Also requires role === 'admin'
+
+requireAccountAccess(auth, 'stock-signal', accountId)
+// Throws 403 if caller is not a member of accountId for stock-signal
+// and is not site_admin
+
+requireAccountAccess(auth, 'budget-tracker', accountId, 'manager')
+// Also requires role in ['owner', 'manager'] (manager-or-above check)
+```
+
+Handlers do not call `requireGroup` directly. The claim-based helpers replace it.
+
+---
+
+## Invitation flow
+
+Invitations are admin-initiated and carry full preconfiguration of the invitee's access.
+
+### Invitation record (`platform.invitations-{stage}`)
+
+```typescript
+{
+  invitationId:         string       // UUID (PK)
+  email:                string       // normalised lowercase
+  invitedBy:            string       // userId of the inviting admin
+  createdAt:            string       // ISO 8601
+  expiresAt:            number       // epoch-seconds (TTL attribute — 7 days)
+  status:               'pending' | 'redeemed' | 'expired'
+  perApp: {
+    [appSlug: string]: {
+      groupRole: 'view' | 'user' | 'admin'
+      accountMembership:
+        | { type: 'new-personal-account'; accountName?: string }
+        | { type: 'join-existing'; accountId: string; accountRole: 'manager' | 'member' | 'viewer' }
+    }
+  }
+}
+```
+
+### Who can create invitations
+
+| Caller | Can invite to |
+|---|---|
+| `site-admin` | Any app, any account |
+| `{app}-admin` | Their app only; `join-existing` accounts must be ones they own or manage |
+| Account `owner` or `manager` | Can add a user to their account with `join-existing` (no new Cognito group granted) |
+
+### Redemption flow
+
+1. Admin creates invitation via `POST /accounts/{accountId}/invitations`
+2. SES email is sent containing a redemption link: `{host}/sign-in?invitation=<token>`
+3. Invitee clicks the link; the launchpad preserves the token in the OAuth `state` parameter through the Cognito Hosted UI flow
+4. On callback, the launchpad POSTs the token to `POST /auth/reconcile-invitation` along with the user's session
+5. The reconciliation Lambda validates the token, looks up the invitation, and for each app in `perApp`:
+   - Adds the user to the appropriate Cognito group (`{app}-{groupRole}`)
+   - Creates a new account (`new-personal-account`) OR adds the user to an existing account (`join-existing`)
+   - Sets `custom:active_accounts[appSlug]` to the resolved accountId
+6. Marks the invitation as `redeemed`
+
+**Same email, different identity provider:** invitation redemption is not dependent on the social IDP's email matching the invitation's email. The OAuth state carries the invitation token; the reconciliation Lambda matches on the authenticated session, not email.
+
+---
+
+## Revocation
+
+When access is revoked (group removal or account membership deletion):
+
+1. Remove the relevant row from `platform.account-members-{stage}` and/or remove the user from their Cognito group
+2. Call `AdminUserGlobalSignOut(username)` — invalidates all refresh tokens immediately
+3. Existing access tokens remain valid until natural expiry (up to 1 hour). This staleness window is accepted.
+4. On the user's next token refresh, Cognito invokes the pre-token generation Lambda, which reads updated state and issues a token without the revoked access
+
+**Full disable:** `AdminDisableUser` blocks sign-in immediately on the next token refresh. Active tokens remain valid until expiry.
+
+No per-request DynamoDB lookup is performed for revocation; the system relies on claim-based authorization with an accepted 1-hour staleness window.
+
+---
+
+## Forgot-provider flow
+
+Users who do not remember which identity provider they signed up with can request a reminder.
+
+**Endpoint:** `POST /auth/lookup-provider` (public — no JWT required)
+
+The Lambda `transformotion-forgot-provider-{stage}` (in `AuthApiStack`):
+1. Rate-limits by IP/email
+2. Calls `AdminGetUser(Username: email)` on the Cognito user pool
+3. Reads the `identities` attribute to detect which IDP was used
+4. Sends an SES email to the user naming the sign-in method and a link
+
+**Known limitation:** For federated users whose Cognito `username` is `Google_{sub}` (not email), the `AdminGetUser(email)` lookup fails silently — no email is sent to those users. Tracked in the Stabilisation backlog for fix.
+
+---
+
+## Out of scope (future)
+
+- OAuth resource server custom scopes as an alternative or complement to group-based checks — tracked as Issue #42.
+- Capability-level permissions within an app beyond `view/user/admin`.
+- Multi-owner accounts.
+- Per-browser-session active account (alternative to `custom:active_accounts`).

--- a/docs/architecture/auth.md
+++ b/docs/architecture/auth.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The platform uses AWS Cognito as the single source of identity. Authentication is handled at the Cognito Hosted UI layer; authorization operates in two independent dimensions: **app access** (via Cognito groups) and **account membership** (via DynamoDB records). These two dimensions are orthogonal — a user must satisfy both to perform a data operation.
+The platform uses AWS Cognito as the single source of identity. Authentication is handled at the Cognito Hosted UI layer; authorization operates in two independent dimensions: **app access** (via Cognito groups) and **account membership** (via DynamoDB records). Dimension A is the ceiling — it determines whether a user can access an app at all. Dimension B determines what they can do within a specific account's data.
 
 A pre-token generation Lambda injects structured claims into every issued token. API handlers and the launchpad consume these claims rather than raw group strings. This means authorization logic is centralised in the token, not duplicated across handlers.
 
@@ -30,12 +30,15 @@ See [cdk.md](./cdk.md) for CDK stack names. See [data.md](./data.md) for account
 
 ### Custom attributes
 
+Only one custom attribute is used on the Cognito user record:
+
 | Attribute | Type | Purpose |
 |---|---|---|
-| `custom:accounts` | String (max 2048) | Comma-separated UUIDs of all accounts the user belongs to (all apps combined) |
-| `custom:active_accounts` | String (max 2048) | JSON map of per-app active account: `{"stock-signal":"uuid","budget-tracker":"uuid"}` |
+| `custom:accounts` | String (max 2048) | Comma-separated account IDs the user belongs to (all apps combined). Maintained by the Lambdas that modify account membership; read by the pre-token Lambda. Not consulted directly by frontend or API handlers. |
 
-> **Migration note:** The deployed attribute is currently `custom:active_account` (singular, UUID only). The target `custom:active_accounts` (plural, per-app JSON map) is introduced in sub-phase 7e. The migration plan is in `docs/sub-phase-7e-plan.md`.
+**Active account is not a Cognito attribute.** Which account a user is currently viewing in an app is browser-local UI state, persisted in localStorage per-app. API requests include the `accountId` as a request parameter. The auth middleware validates the parameter against the token's `accounts` claim and rejects requests where the caller is not a member of the stated account.
+
+> **Migration note:** The currently deployed user pool has `custom:active_account` (singular UUID). This attribute is removed entirely in sub-phase 7e-prep-1.
 
 ### Token lifetime
 
@@ -125,85 +128,156 @@ For setup instructions see `docs/social-idp-setup.md`.
 
 ### Dimension A: App access (Cognito groups)
 
-Groups determine which apps a user can access and at what capability level.
+Three Cognito groups control app access:
 
-| Group | App | Grants |
-|---|---|---|
-| `stock-app-view` | Stock Signal | Read-only: view portfolio, watchlist, analysis results |
-| `stock-app-user` | Stock Signal | Full use: add/edit/delete holdings, trigger analysis |
-| `stock-app-admin` | Stock Signal | Full use + can invite others to Stock Signal |
-| `budget-app-view` | Budget Tracker | Read-only: view transactions, budget, cashflow |
-| `budget-app-user` | Budget Tracker | Full use: import, categorise, set budgets |
-| `budget-app-admin` | Budget Tracker | Full use + can invite others to Budget Tracker |
-| `site-admin` | All apps | Platform-wide admin; can invite to any app; implicit admin-level in all apps |
+| Group | Grants |
+|---|---|
+| `stock-app-access` | User has access to Stock Signal |
+| `budget-app-access` | User has access to Budget Tracker |
+| `site-admin` | Platform-wide admin: can invite anyone to any app; implicit access to all apps at owner level on all accounts |
 
-Rules:
-- A user is in at most one `{app}-{level}` group per app.
-- `site-admin` is orthogonal to app groups. A `site-admin` user does not need `stock-app-admin` to access Stock Signal at admin level.
-- A user with no group for a given app cannot access that app, even if they have a valid Cognito session.
+**Single-tier app access is deliberate.** Capability-level within an app (who can read, write, invite, delete) is expressed entirely by Dimension B (account roles). A user either has access to an app or they do not; *what they can do* within the app is determined by which accounts they belong to and in what role.
 
-> **Migration note:** The currently deployed groups are `admin`, `stock-app`, `budget-app`, `transformotion`, `family`. The target groups above are introduced in sub-phase 7e. During migration, both old and new groups coexist; handlers accept both. Old groups are removed at 7e-cleanup.
+**App-access groups are derived from account membership.** The pre-token Lambda enforces the invariant: a user is in `stock-app-access` iff they have at least one Stock Signal account. Same pattern for `budget-app-access`. If the two diverge (e.g., due to manual manipulation or a bug), the pre-token Lambda reconciles by trusting account membership as the authoritative source and updating group membership to match.
+
+**`site-admin` is first-class and explicit.** It is not derived from any other state; it is an explicit Cognito group grant and represents platform-level administrative authority.
+
+> **Migration note:** Currently deployed groups are `admin`, `stock-app`, `budget-app`, `transformotion`, `family`. Target groups (`stock-app-access`, `budget-app-access`, `site-admin`) are introduced in sub-phase 7e-prep-1. During migration both old and new groups coexist; handlers accept either. Old groups (and `transformotion`, `family` which reference features not in current scope) are removed at 7e-cleanup.
 
 ### Dimension B: Account membership (DynamoDB)
 
-Accounts are per-app data containers. Each app has its own set of accounts; a user's "Stock Signal account" and "Budget Tracker account" are independent.
+Accounts are per-app data containers. Each app has its own set of accounts; a user's "Stock Signal account" and "Budget Tracker account" are independent records with independent IDs and independent membership lists.
 
 Account membership is stored in `platform.account-members-{stage}` (PK: `accountId`, SK: `userId`) with a `role` attribute:
 
-| Role | Capability |
-|---|---|
-| `owner` | Created the account; can transfer ownership; can delete |
-| `manager` | Can manage members (add/remove/change role); cannot delete the account |
-| `member` | Read and write the account's data |
-| `viewer` | Read-only |
+| Role | Capability | Allowed multiplicity per account |
+|---|---|---|
+| `owner` | Full control: read, write, invite others, remove any member, delete the account, transfer ownership | Exactly one |
+| `manager` | Full use + can invite; can remove non-owner members (cannot remove the owner or other managers) | Any number |
+| `member` | Read and write the account's data | Any number |
+| `viewer` | Read-only | Any number |
 
-A user can be `owner` of their own accounts and any role in others' accounts. Multiple memberships per app are permitted (e.g. owner of personal account + member of a shared household account).
+**Single-owner invariant.** Every account has exactly one owner at all times. Operations that would remove or demote the owner are rejected unless ownership is transferred to another user atomically in the same operation. Site-admin can override to reassign ownership administratively.
+
+**Ownership transfer.** The current owner can transfer ownership to any other member or manager of the account. The previous owner becomes a manager; they can choose to remove themselves afterwards. The account retains exactly one owner throughout.
+
+**Role hierarchy** (for `requireAccountAccess` minRole checks):
+`owner > manager > member > viewer`. A check for `minRole: 'manager'` succeeds for `owner` and `manager`; fails for `member` and `viewer`.
+
+### Conflict resolution between dimensions
+
+Dimensions A and B describe different axes and can express potentially conflicting states (e.g., user has app-access but is `viewer` on all accounts; user lacks app-access but somehow has a `member` row).
+
+The resolution rule is: **Dimension A is the ceiling.**
+
+- If a user lacks app-access for Stock Signal (Dimension A), they cannot perform any operation in Stock Signal, regardless of any Dimension B roles they might have on Stock Signal accounts.
+- If a user has app-access for Stock Signal (Dimension A), their capability within a specific Stock Signal account is determined entirely by Dimension B (their role on that account).
+- Dimension B can only restrict, never grant beyond Dimension A.
+
+In practice: Dimension A governs *whether the user can use the app at all*. Dimension B governs *what operations they can perform on a specific account's data*.
+
+**`site-admin` bypasses both dimensions.** A site-admin user can perform any operation on any app's data on any account, even without explicit app-access group or account membership. Every authorization helper checks site-admin first as an override.
 
 ---
 
 ## Pre-token generation Lambda
 
-**Function name:** `transformotion-pre-token-generation-{stage}`
-
-**Trigger:** Cognito pre-token-generation — invoked on every token issuance (sign-in and token refresh).
+**Function:** `transformotion-pre-token-generation-{stage}`
+**Trigger:** Cognito pre-token-generation — invoked on every token issuance (sign-in and refresh).
 
 **Responsibilities:**
 
-1. Read the user's Cognito groups from the trigger event
-2. Map groups to a structured `apps` claim:
-   - `stock-app-view/user/admin` → `apps["stock-signal"] = "view" | "user" | "admin"`
-   - `budget-app-view/user/admin` → `apps["budget-tracker"] = "view" | "user" | "admin"`
-   - `site-admin` → sets `site_admin: true` AND populates all-app entries at `admin` level
-3. Query `platform.account-members-{stage}` for the user's memberships, shape into `accounts` claim
-4. Inject via `event.response.claimsAndScopeOverrideDetails`
+1. Read the user's Cognito groups from the event (`event.request.groupConfiguration.groupsToOverride`).
+2. Query `platform.account-members-{stage}` for all rows where `userId = <event.userName>` — returns all of the user's account memberships across all apps.
+3. **Reconcile the app-access invariant.** For each app slug (`stock-signal`, `budget-tracker`):
+   - If user has any accounts for the app but is not in `<app>-access`: call `AdminAddUserToGroup`, update the in-memory group list for claim construction.
+   - If user is in `<app>-access` but has no accounts: call `AdminRemoveUserFromGroup`, update the in-memory list.
+   - `site-admin` membership overrides the "no accounts" removal — site-admin keeps all access regardless of account memberships.
+4. Build the `apps` claim: JSON-stringified array of app slugs the user has access to (derived from reconciled groups plus site-admin override).
+5. Build the `accounts` claim: JSON-stringified map of app slug to `[{accountId, role}]`, grouped from the membership query results.
+6. Build `site_admin`: the string `"true"` or `"false"` (Cognito requires claim values to be strings).
+7. Set `event.response.claimsAndScopeOverrideDetails.accessTokenGeneration.claimsToAddOrOverride` with the three claims.
+8. Also set the same on `idTokenGeneration.claimsToAddOrOverride` so both tokens carry the claims.
 
-**On failure:** The Lambda returns the event unchanged; the token is issued without custom claims. All API handlers fail closed — absent claims means no access.
+**On failure:** Return the event unchanged. Cognito issues tokens without custom claims. Consumers (launchpad, API handlers) fail closed — empty or missing `apps`/`accounts` means the user has no access.
+
+**Latency budget:** One DynamoDB query per token issuance plus zero-to-two `AdminAddUserToGroup` / `AdminRemoveUserFromGroup` calls in the reconciliation step. Invoked only on sign-in and token refresh (roughly every hour per active user, not every API call). Cost and latency are negligible at family-platform scale.
 
 ---
 
-## Claim shape in ID tokens
+## Claim shape
 
-The pre-token generation Lambda adds three custom claims. These are consumed by the launchpad and API handlers.
+The pre-token generation Lambda injects three custom claims on every token issuance:
 
 ```json
 {
-  "apps": {
-    "stock-signal": "view | user | admin",
-    "budget-tracker": "view | user | admin"
-  },
-  "site_admin": true,
-  "accounts": {
-    "stock-signal": [
-      { "accountId": "uuid", "role": "owner | manager | member | viewer" }
-    ],
-    "budget-tracker": [
-      { "accountId": "uuid", "role": "owner | manager | member | viewer" }
-    ]
-  }
+  "apps": "[\"stock-signal\",\"budget-tracker\"]",
+  "site_admin": "false",
+  "accounts": "{\"stock-signal\":[{\"accountId\":\"uuid-1\",\"role\":\"owner\"}],\"budget-tracker\":[{\"accountId\":\"uuid-2\",\"role\":\"manager\"}]}"
 }
 ```
 
-Plus standard Cognito claims (`sub`, `email`, `cognito:groups`) and the custom attributes `custom:accounts` and `custom:active_accounts`.
+The values are JSON-stringified strings (Cognito requires claim values to be primitive strings). Frontend and auth middleware parse the stringified JSON back into objects on receipt.
+
+Logical shape after parsing:
+
+```
+apps:       string[]                                     — app slugs the user can access
+site_admin: boolean
+accounts:   Record<appSlug, Array<{accountId, role}>>   — per-app membership list
+```
+
+Plus the standard Cognito claims (`sub`, `email`, `cognito:groups`, token lifetime fields) and the custom attribute `custom:accounts`.
+
+**Launchpad renders tiles by inspecting the `apps` claim.**
+**API handlers enforce per-account authorization by inspecting `accounts`.**
+
+---
+
+## Token creation flow (end-to-end)
+
+How a user gets from "not signed in" to "making authenticated API calls":
+
+**Step 1 — Sign-in initiation.** The launchpad app redirects the user's browser to the Cognito Hosted UI:
+
+```
+https://transformotion-959516291617-{stage}.auth.ap-southeast-2.amazoncognito.com/login
+  ?client_id=<LaunchpadAppClientId>
+  &response_type=code
+  &scope=openid+email+profile
+  &redirect_uri=https://dev.apps.transformotion.com.au/sign-in/callback
+  &state=<random-nonce-or-invitation-token>
+```
+
+The `state` parameter is arbitrary data the app preserves through the auth flow; Cognito echoes it back unchanged.
+
+**Step 2 — User authenticates.** The Hosted UI presents the sign-in page. The user either:
+- Enters email + password → Cognito verifies credentials, or
+- Clicks a federated IDP button → redirects to Google / Facebook / Microsoft → returns with user attributes → Cognito creates or updates the federated user record
+
+**Step 3 — Pre-token Lambda fires.** Cognito invokes the pre-token-generation Lambda synchronously. The Lambda runs the reconciliation and claim-building logic described above and returns the enriched event.
+
+**Step 4 — Cognito issues tokens.** Cognito constructs three JWTs signed with its RSA key:
+- **ID token** — identity + custom claims; used by the frontend to know who is signed in
+- **Access token** — identity + custom claims; sent as `Authorization: Bearer <token>` on API calls
+- **Refresh token** — opaque string; used to obtain new access and ID tokens when they expire
+
+**Step 5 — Redirect with code.** Cognito redirects the browser to the callback URL:
+```
+https://dev.apps.transformotion.com.au/sign-in/callback?code=<auth-code>&state=<original-state>
+```
+
+**Step 6 — Code-for-token exchange.** The launchpad's callback handler POSTs the authorization code to Cognito's token endpoint (`/oauth2/token`) with the app client ID. Cognito returns the three tokens as JSON.
+
+**Step 7 — Token storage.** The launchpad stores tokens client-side:
+- Access and ID tokens: in-memory (application state)
+- Refresh token: handled via the Cognito Hosted UI session cookie set on the Cognito domain
+
+The Hosted UI session cookie is what enables SSO across the three app clients — when the user navigates from the launchpad to Stock Signal, the Stock Signal client's auth flow finds the existing session cookie and silently re-authenticates without re-prompting.
+
+**Step 8 — API calls.** When the frontend calls a Lambda-backed API, it includes the access token in the `Authorization: Bearer <token>` header. API Gateway's Cognito authorizer validates the JWT signature against Cognito's public keys and confirms the token has not expired. The auth middleware in the Lambda handler parses the custom claims (`apps`, `accounts`, `site_admin`) and constructs the `auth` object for the handler to use.
+
+**Step 9 — Token refresh.** Every hour (default access token lifetime), the frontend detects the token is about to expire and calls the refresh endpoint. Cognito invokes the pre-token Lambda again and issues new access + ID tokens. The fresh token reflects any changes to the user's groups or account memberships since the last issuance (up to the 1-hour staleness window).
 
 ---
 
@@ -223,99 +297,231 @@ App deployment state is statically known to the launchpad (hardcoded list of dep
 
 ## Auth middleware (`packages/lambda-middleware`)
 
-All API Lambda handlers use `withAuth` to validate the Cognito JWT from the `Authorization: Bearer` header. The middleware exposes:
+All API Lambda handlers use `withAuth` to validate the Cognito JWT from the `Authorization: Bearer` header. The middleware parses the custom claims (JSON-stringified → objects) and exposes:
 
 | Property | Type | Source |
 |---|---|---|
 | `auth.userId` | `string` | Cognito `sub` |
 | `auth.email` | `string` | `email` claim |
-| `auth.apps` | `Record<string, 'view'\|'user'\|'admin'>` | `apps` custom claim |
-| `auth.siteAdmin` | `boolean` | `site_admin` custom claim |
-| `auth.accounts` | `Record<string, Array<{accountId, role}>>` | `accounts` custom claim |
+| `auth.apps` | `string[]` | `apps` custom claim (parsed from JSON string) |
+| `auth.siteAdmin` | `boolean` | `site_admin` custom claim (parsed from `"true"`/`"false"`) |
+| `auth.accounts` | `Record<string, Array<{accountId: string, role: string}>>` | `accounts` custom claim (parsed from JSON string) |
 
-**Authorization helpers** (use these instead of `requireGroup`):
+### Authorization helpers
+
+The following helpers are provided by `packages/lambda-middleware`. Handlers use these instead of inspecting the `auth` object directly.
 
 ```typescript
-requireAppAccess(auth, 'stock-signal')
-// Throws 403 if caller doesn't have 'stock-signal' in auth.apps
-// and is not site_admin
+requireSiteAdmin(auth)
+// Throws 403 unless auth.siteAdmin === true.
+// Use for platform-wide operations (cross-app invitations,
+// user disable/delete, cross-account admin).
 
-requireAppAccess(auth, 'stock-signal', 'admin')
-// Also requires role === 'admin'
+requireAppAccess(auth, appSlug)
+// Throws 403 unless auth.apps includes appSlug OR auth.siteAdmin === true.
+// Use at the top of every handler scoped to a specific app.
 
-requireAccountAccess(auth, 'stock-signal', accountId)
-// Throws 403 if caller is not a member of accountId for stock-signal
-// and is not site_admin
+requireAccountAccess(auth, appSlug, accountId, minRole?)
+// Throws 403 unless the caller is a member of accountId for appSlug
+// with role >= minRole (or is site-admin).
+// Role hierarchy: owner > manager > member > viewer.
+// Without minRole, any membership role suffices.
+// Use before any DynamoDB query for account-scoped data.
 
-requireAccountAccess(auth, 'budget-tracker', accountId, 'manager')
-// Also requires role in ['owner', 'manager'] (manager-or-above check)
+requireAccountOwner(auth, appSlug, accountId)
+// Throws 403 unless caller is the owner of accountId for appSlug
+// (or is site-admin).
+// Use for account deletion, ownership transfer, and similar
+// operations only the owner can perform.
 ```
 
-Handlers do not call `requireGroup` directly. The claim-based helpers replace it.
+All helpers check site-admin first as an override. A site-admin caller passes all authorization checks regardless of explicit app-access group or account membership.
+
+Handlers do NOT call `requireGroup` (the old pattern) for new work. `requireGroup` remains during the 7e migration for transitional purposes and is removed at 7e-cleanup.
 
 ---
 
-## Invitation flow
+## Invitations
 
-Invitations are admin-initiated and carry full preconfiguration of the invitee's access.
+Invitations grant platform access to new or existing users with preconfigured app access and account memberships. Two entry points reflect the two scenarios in which invitations are issued.
 
-### Invitation record (`platform.invitations-{stage}`)
+### Invitation entry points
 
-```typescript
-{
-  invitationId:         string       // UUID (PK)
-  email:                string       // normalised lowercase
-  invitedBy:            string       // userId of the inviting admin
-  createdAt:            string       // ISO 8601
-  expiresAt:            number       // epoch-seconds (TTL attribute — 7 days)
-  status:               'pending' | 'redeemed' | 'expired'
-  perApp: {
-    [appSlug: string]: {
-      groupRole: 'view' | 'user' | 'admin'
-      accountMembership:
-        | { type: 'new-personal-account'; accountName?: string }
-        | { type: 'join-existing'; accountId: string; accountRole: 'manager' | 'member' | 'viewer' }
-    }
-  }
-}
+**Launchpad invitation UI (site-admin only).** Used to onboard a new person to the platform with granular control across multiple apps. Site-admin selects:
+- Which apps to grant access to (any or all)
+- For each app: create a new personal account, or join an existing account with a specified role
+
+Endpoint: `POST /admin/invitations`. Authorization: `requireSiteAdmin`.
+
+**In-app invitation UI (site-admin or account owner/manager).** Available inside each app's UI. Used to share an account or add someone to an app when the inviter has authority for that specific app. The invitation is scoped to the current app; multi-app invitations are not possible from this entry point.
+
+Endpoint: `POST /apps/{appSlug}/invitations`. Authorization: `requireSiteAdmin` OR caller is `owner`/`manager` of at least one account in `appSlug` AND (for the specific accounts named in the invitation) is `owner`/`manager` of each.
+
+### Invitation data model
+
+Table: `platform.invitations-{stage}`.
+
+```
+invitationId       UUID (PK)
+email              normalised lowercase
+invitedBy          userId of the inviter
+createdAt          ISO 8601 timestamp
+expiresAt          epoch-seconds (7 days default; used by DynamoDB TTL
+                   for eventual cleanup, but records persist for audit)
+status             'pending' | 'redeemed' | 'cancelled' | 'expired'
+redeemedAt         ISO 8601 (set on redemption)
+cancelledAt        ISO 8601 (set on cancellation)
+perApp             map of app slug → {
+                     accountMembership: one of:
+                       { type: 'new-personal-account',
+                         accountName?: string }
+                       | { type: 'join-existing',
+                           accountId: string,
+                           role: 'manager' | 'member' | 'viewer' }
+                   }
 ```
 
-### Who can create invitations
+Variant rules:
+- `new-personal-account`: invitee becomes `owner` of the new account (always — not configurable)
+- `join-existing`: role must be `manager`, `member`, or `viewer`, never `owner` (would violate the single-owner invariant)
 
-| Caller | Can invite to |
-|---|---|
-| `site-admin` | Any app, any account |
-| `{app}-admin` | Their app only; `join-existing` accounts must be ones they own or manage |
-| Account `owner` or `manager` | Can add a user to their account with `join-existing` (no new Cognito group granted) |
+GSIs:
+- `email-index` (PK: `email`) — check pending invitations for a given email address
+- `status-index` (PK: `status`) — admin queries like "list all pending invitations"
 
-### Redemption flow
+Status lifecycle: `pending` → `redeemed` | `cancelled` | `expired`. Records persist after status transition for audit purposes. Hard deletion via DynamoDB TTL applies after `expiresAt` + retention period.
 
-1. Admin creates invitation via `POST /accounts/{accountId}/invitations`
-2. SES email is sent containing a redemption link: `{host}/sign-in?invitation=<token>`
-3. Invitee clicks the link; the launchpad preserves the token in the OAuth `state` parameter through the Cognito Hosted UI flow
-4. On callback, the launchpad POSTs the token to `POST /auth/reconcile-invitation` along with the user's session
-5. The reconciliation Lambda validates the token, looks up the invitation, and for each app in `perApp`:
-   - Adds the user to the appropriate Cognito group (`{app}-{groupRole}`)
-   - Creates a new account (`new-personal-account`) OR adds the user to an existing account (`join-existing`)
-   - Sets `custom:active_accounts[appSlug]` to the resolved accountId
-6. Marks the invitation as `redeemed`
+### Invitation creation authorization
 
-**Same email, different identity provider:** invitation redemption is not dependent on the social IDP's email matching the invitation's email. The OAuth state carries the invitation token; the reconciliation Lambda matches on the authenticated session, not email.
+For site-admin (from either entry point): no restrictions. Can grant access to any app, with any combination of new accounts and joins.
+
+For account owner/manager (in-app entry point only): the invitation must satisfy BOTH:
+- The caller is `owner` or `manager` of at least one account in the target app
+- If `accountMembership.type === 'join-existing'`: the caller is `owner` or `manager` of the specified `accountId`
+
+This means: Kieran (owner of a Stock Signal account) can invite Ella to his Stock Signal account as a member, or create a new Stock Signal personal account for her as owner. He cannot invite her to Budget Tracker unless he also owns or manages a Budget Tracker account.
+
+### Invitation creation flow
+
+1. Admin fills out the invitation form in the launchpad or in-app UI.
+2. Frontend POSTs to the appropriate creation endpoint.
+3. The invitation Lambda (`invitations-create`):
+   a. Authorizes the caller per the rules above.
+   b. Generates an invitation ID (crypto-random UUID) — this is the invitation's single-use token.
+   c. Writes the record to `platform.invitations-{stage}` with `status: 'pending'`.
+   d. Composes the invitation email: "You've been invited to Transformotion. Click here to accept: `{link}`" where `link = https://{host}/sign-in?invitation=<invitationId>`.
+   e. Sends the email via SES (`SendEmailCommand`) using a template.
+   f. Returns 201 with the invitation ID.
+4. SES handles delivery. The email arrives in the invitee's inbox.
+
+### Invitation redemption flow
+
+1. Invitee clicks the link. Browser opens `https://{host}/sign-in?invitation=<invitationId>`.
+2. The launchpad sign-in page reads the `invitation` URL parameter and encodes it into the OAuth `state` parameter when redirecting to Cognito Hosted UI.
+3. Invitee signs up or signs in with their preferred method (email/password, Google, Facebook, Microsoft).
+   - Cognito creates or reuses their user record.
+   - Pre-token Lambda fires. User has no accounts yet → token issued with empty `apps` and `accounts`.
+4. Cognito redirects back with the authorization code and the preserved `state` (containing the invitation ID).
+5. Launchpad callback handler:
+   a. Exchanges code for tokens.
+   b. Decodes the OAuth state, recovers the invitation ID.
+   c. POSTs `{invitationId}` to `POST /auth/reconcile-invitation` with the invitee's `Authorization` header.
+6. The reconciliation Lambda (`invitations-reconcile`):
+   a. Validates caller has a valid JWT (`withAuth`). No other authorization checks — the invitation itself is the authority.
+   b. Looks up the invitation by `invitationId` in `platform.invitations-{stage}`.
+   c. Validates:
+      - `status === 'pending'`
+      - Current time < `expiresAt`
+      - Invitation `email` matches caller's Cognito email (case-insensitive) — prevents a different user from redeeming a link they intercepted
+   d. Executes the grant **transactionally** (DynamoDB `TransactWriteItems`) across all `perApp` entries:
+      - For `new-personal-account`: create a new account record in `platform.accounts-{stage}`, add the user to `platform.account-members-{stage}` as `owner`.
+      - For `join-existing`: verify the accountId exists, add the user to `platform.account-members-{stage}` with the specified role.
+      - Update the user's `custom:accounts` attribute via `AdminUpdateUserAttributes` to include the new account IDs.
+      - Mark the invitation as `status: 'redeemed'`, set `redeemedAt`.
+   e. If any part fails, the transaction rolls back; the invitation stays `pending` and the caller receives an error. No partial grants.
+   f. Returns 200 with the redeemed invitation summary.
+7. The frontend receives success and forces a token refresh. The next token from Cognito invokes the pre-token Lambda, which reads the now-updated account memberships and injects the full `apps` and `accounts` claims.
+8. The invitee is returned to the launchpad with their granted tiles visible and clickable.
+
+### Invitation listing and management
+
+**`GET /admin/invitations`** — site-admin only. Lists all invitations across all apps. Filterable by status.
+
+**`GET /apps/{appSlug}/invitations`** — in-app listing. Returns invitations where `perApp[appSlug]` is defined AND the caller is site-admin OR the caller is `owner`/`manager` of the target account in `perApp[appSlug]`. Display is filtered to show only the `appSlug` portion of each invitation's `perApp` map.
+
+**Cancellation:** `DELETE /invitations/{invitationId}`. Authorization: site-admin, or the original inviter (`invitedBy` matches caller). Sets `status: 'cancelled'`, `cancelledAt`. Does not delete the record (audit trail preserved).
+
+**Expiration:** A scheduled Lambda runs daily, queries via `status-index` for `status = 'pending'` records where `expiresAt < now()`, and updates each to `status: 'expired'`.
+
+### Security properties
+
+- **Authentication required for redemption.** Caller must have a valid Cognito JWT.
+- **Email match enforced.** The invitation's email must match the redeemer's Cognito email (case-insensitive). Prevents an intercepted link being redeemed by a different user.
+- **Single-use token.** Once status is not `pending`, the invitation cannot be redeemed again.
+- **Time-bounded.** Default 7-day expiry.
+- **Random token.** The invitation ID is a cryptographically random UUID, not guessable.
+- **Rate limiting.** Apply on `POST /auth/reconcile-invitation` by caller `userId` — suggested 5 attempts per 15 minutes — to prevent brute-force against random invitation IDs.
+
+**Known limitation — federated email mismatch.** If the invitation is sent to `steve@gmail.com` and Steve signs in with Apple (which uses `steve@privaterelay.appleid.com`), the email match fails and redemption is rejected. The invitation email body should include a hint: "Sign in using the email address this invitation was sent to (`{email}`)."
 
 ---
 
-## Revocation
+## Revocation flows
 
-When access is revoked (group removal or account membership deletion):
+Three revocation scenarios, each with a specific entry point.
 
-1. Remove the relevant row from `platform.account-members-{stage}` and/or remove the user from their Cognito group
-2. Call `AdminUserGlobalSignOut(username)` — invalidates all refresh tokens immediately
-3. Existing access tokens remain valid until natural expiry (up to 1 hour). This staleness window is accepted.
-4. On the user's next token refresh, Cognito invokes the pre-token generation Lambda, which reads updated state and issues a token without the revoked access
+### Scenario A: Removing a user from an account
 
-**Full disable:** `AdminDisableUser` blocks sign-in immediately on the next token refresh. Active tokens remain valid until expiry.
+An account owner or manager removes someone from a specific account.
 
-No per-request DynamoDB lookup is performed for revocation; the system relies on claim-based authorization with an accepted 1-hour staleness window.
+Endpoint: `DELETE /accounts/{accountId}/members/{userId}`. Lambda: `account-members-remove`.
+
+Authorization:
+- `requireAccountAccess(auth, appSlug, accountId, minRole: 'manager')`
+- If the target `userId` is the `owner` of the account: reject. Ownership must be transferred first.
+- If the caller is a `manager` (not owner) and the target is also a `manager`: reject. Managers cannot remove other managers; only the owner can.
+- Self-removal (caller and target are the same user): allowed if the target is not the owner.
+
+Steps:
+1. Validate authorization per the rules above.
+2. Delete the row in `platform.account-members-{stage}` for `(accountId, userId)`.
+3. Update the target user's `custom:accounts` attribute to remove `accountId`.
+4. Call `AdminUserGlobalSignOut` on the target user — refresh tokens invalidated immediately.
+
+After this: the target user's existing access token remains valid until expiry (up to 1 hour). On their next token refresh, the pre-token Lambda reads the updated memberships and issues a token without the removed account. If this was the user's last account in a given app, the invariant reconciliation in the pre-token Lambda automatically removes them from that app's `-access` group.
+
+### Scenario B: Disabling a user
+
+Site-admin temporarily disables a user (suspected compromise, temporary hold).
+
+Endpoint: `POST /admin/users/{userId}/disable`. Lambda: `admin-users-disable`.
+
+Authorization: `requireSiteAdmin`.
+
+Steps:
+1. Call `AdminDisableUser` on the Cognito user — prevents future sign-ins.
+2. Call `AdminUserGlobalSignOut` — invalidates refresh tokens.
+3. Account-members records are NOT deleted (the disable is temporary and reversible).
+
+After this: the user cannot sign in at all. Existing access tokens remain valid for up to 1 hour.
+
+Reverse: `POST /admin/users/{userId}/enable`.
+
+### Scenario C: Deleting a user
+
+Site-admin permanently removes a user from the platform.
+
+Endpoint: `DELETE /admin/users/{userId}`. Lambda: `admin-users-delete`.
+
+Authorization: `requireSiteAdmin`.
+
+**Account-ownership constraint.** Before deletion, query `platform.account-members-{stage}` for rows where `userId = <target>` AND `role = 'owner'`. If any exist: reject with 409 Conflict, listing the affected accounts with ownership-transfer instructions. The caller must transfer each account's ownership to another user before retrying the delete.
+
+If no ownership rows remain: proceed:
+1. Delete all membership rows from `platform.account-members-{stage}` where `userId = <target>`.
+2. Call `AdminDeleteUser` on the Cognito user.
+
+After this: the user record is gone from Cognito. Existing access tokens remain valid for up to 1 hour, then expire naturally.
 
 ---
 
@@ -327,11 +533,11 @@ Users who do not remember which identity provider they signed up with can reques
 
 The Lambda `transformotion-forgot-provider-{stage}` (in `AuthApiStack`):
 1. Rate-limits by IP/email
-2. Calls `AdminGetUser(Username: email)` on the Cognito user pool
+2. Queries Cognito via `ListUsersCommand` with filter `email = "<email>"` (works for both native users and federated users regardless of Cognito username format)
 3. Reads the `identities` attribute to detect which IDP was used
 4. Sends an SES email to the user naming the sign-in method and a link
 
-**Known limitation:** For federated users whose Cognito `username` is `Google_{sub}` (not email), the `AdminGetUser(email)` lookup fails silently — no email is sent to those users. Tracked in the Stabilisation backlog for fix.
+**Known limitation:** For federated users, `AdminGetUser(Username=email)` fails because their Cognito username is `Google_{sub}` (not email). The fix using `ListUsersCommand` resolves this. See sub-phase `7e-forgot-provider-fix` in `docs/sub-phase-7e-plan.md`.
 
 ---
 

--- a/docs/architecture/cdk.md
+++ b/docs/architecture/cdk.md
@@ -1,0 +1,174 @@
+# CDK stack topology
+
+## Overview
+
+AWS CDK in TypeScript at `infrastructure/`. All stacks are defined in `infrastructure/bin/app.ts`. Each environment (`dev`, `prod`) has its own set of stacks; stacks are never shared across environments.
+
+Account ID: `959516291617`  
+Region: `ap-southeast-2`
+
+Stacks are deployed by GitHub Actions workflows — see [urls-and-deploy.md](./urls-and-deploy.md) for workflow triggers.
+
+---
+
+## Stack inventory
+
+### Platform stacks
+
+Deployed by `deploy-platform.yml`. Source in `infrastructure/lib/platform/`.
+
+| Stack name | Class | Contents |
+|---|---|---|
+| `Transformotion{Stage}-Network` | `NetworkStack` | S3 bucket `transformotion-web-{stage}-959516291617`, CloudFront distribution, ACM cert wiring |
+| `Transformotion{Stage}-Auth` | `AuthStack` | Cognito user pool, three app clients, Cognito groups, Secrets Manager entries for social IDP credentials, Hosted UI domain |
+| `Transformotion{Stage}-AuthApi` | `AuthApiStack` | `transformotion-forgot-provider-{stage}` Lambda + its own API Gateway (public — no JWT required on `/auth/lookup-provider`) |
+| `Transformotion{Stage}-PlatformTables` | `PlatformTablesStack` | `platform.users`, `platform.accounts`, `platform.account-members`, `platform.invitations`, `platform.analysis-cache` DynamoDB tables |
+| `Transformotion{Stage}-Api` | `PlatformApiStack` | Shared REST API Gateway (`transformotion-api-{stage}`), Cognito JWT authoriser, platform Lambda functions (see below) |
+
+### Stock Analyser stacks
+
+Deployed by `deploy-stock-analyser.yml`. Source in `infrastructure/lib/stock-analyser/`.
+
+| Stack name | Class | Contents |
+|---|---|---|
+| `Transformotion{Stage}-StockAnalyserTables` | `StockAnalyserTablesStack` | `stock-analyser.portfolio-{stage}-v2`, `stock-analyser.watchlist-{stage}-v2` |
+| `Transformotion{Stage}-StockAnalyserApi` | `StockAnalyserApiStack` | Stock Analyser Lambda functions + routes on the shared platform API Gateway |
+
+### Budget Tracker stacks
+
+Deployed by `deploy-budget-tracker.yml`. Source in `infrastructure/lib/budget-tracker/`.
+
+| Stack name | Class | Contents |
+|---|---|---|
+| `Transformotion{Stage}-BudgetTrackerTables` | `BudgetTrackerTablesStack` | `budget-tracker.accounts`, `budget-tracker.transactions`, `budget-tracker.rules`, `budget-tracker.settings` |
+| `Transformotion{Stage}-BudgetTrackerApi` | `BudgetTrackerApiStack` | Budget Tracker Lambda functions + its own API Gateway (`budget-tracker-api-{stage}`) |
+
+> **Note:** Budget Tracker has its own API Gateway rather than sharing the platform gateway. This is an architectural divergence from the intended model. It is functional and not blocking; consolidation to the platform gateway is tracked as sub-phase 7f (optional).
+
+---
+
+## Lambda functions
+
+### Platform API Lambda functions (`Transformotion{Stage}-Api`)
+
+| Function name | Handler | Routes |
+|---|---|---|
+| `transformotion-first-login-{stage}` | `functions/first-login` | `POST /auth/setup`, `POST /auth/switch` |
+| `transformotion-user-{stage}` | `functions/user` | `GET /api/user/profile`, `PUT /api/user/preferences` |
+| `transformotion-claude-proxy-{stage}` | `functions/claude-proxy` | `POST /api/claude` |
+| `transformotion-accounts-{stage}` | `functions/accounts` | `POST /accounts`, `GET/PUT/DELETE /accounts/{id}`, `GET /accounts/{id}/members`, `DELETE /accounts/{id}/members/{userId}` |
+| `transformotion-invitations-{stage}` | `functions/invitations` | `POST /accounts/{id}/invitations` |
+
+### Auth API Lambda functions (`Transformotion{Stage}-AuthApi`)
+
+| Function name | Handler | Routes |
+|---|---|---|
+| `transformotion-forgot-provider-{stage}` | `functions/forgot-provider` | `POST /auth/lookup-provider` (public) |
+
+### Pre-token generation Lambda (`Transformotion{Stage}-Auth`)
+
+| Function name | Handler | Trigger |
+|---|---|---|
+| `transformotion-pre-token-generation-{stage}` | `functions/pre-token-generation` | Cognito pre-token-generation trigger |
+
+### Stock Analyser Lambda functions (`Transformotion{Stage}-StockAnalyserApi`)
+
+| Function name | Handler | Routes |
+|---|---|---|
+| `transformotion-portfolio-{stage}` | `apps/stock-analyser/functions/portfolio` | `GET/POST/PATCH/DELETE /api/portfolio` |
+| `transformotion-watchlist-{stage}` | `apps/stock-analyser/functions/watchlist` | `GET/POST/PATCH/DELETE /api/watchlist` |
+| `transformotion-analysis-cache-{stage}` | `apps/stock-analyser/functions/analysis-cache` | `GET /api/analysis-cache/*` |
+| `transformotion-cycle-check-{stage}` | `apps/stock-analyser/functions/cycle-check` | EventBridge scheduled (no API Gateway route) |
+
+### Budget Tracker Lambda functions (`Transformotion{Stage}-BudgetTrackerApi`)
+
+| Function name | Handler | Routes |
+|---|---|---|
+| `budget-transactions-handler-{stage}` | Budget Tracker transactions Lambda | `GET/POST/PATCH/DELETE /api/budget/v1/transactions` |
+| `budget-rules-handler-{stage}` | Budget Tracker rules Lambda | `GET/POST/PATCH/DELETE /api/budget/v1/rules` |
+| `budget-settings-handler-{stage}` | Budget Tracker settings Lambda | `GET/PATCH /api/budget/v1/settings` |
+| `budget-ai-categorise-handler-{stage}` | Budget Tracker AI Lambda | `POST /api/budget/v1/ai/categorise` |
+| `budget-ai-review-handler-{stage}` | Budget Tracker AI Lambda | `POST /api/budget/v1/ai/review` |
+| `budget-ai-csv-analysis-handler-{stage}` | Budget Tracker AI Lambda | `POST /api/budget/v1/ai/csv-analysis` |
+| `budget-export-handler-{stage}` | Budget Tracker export Lambda | `GET /api/budget/v1/business-export` |
+| `budget-migrate-handler-{stage}` | Budget Tracker migrate Lambda | `POST /api/budget/v1/migrate-from-localstorage` |
+
+---
+
+## Cross-stack dependencies
+
+Stacks receive constructs via `props` in `bin/app.ts`. There are no `Fn::ImportValue` CloudFormation cross-stack references after the sub-phase 7b.5-alpha fix.
+
+| Consumer stack | Receives from | Props |
+|---|---|---|
+| `AuthApiStack` | `AuthStack` | `userPoolId` (string — avoids construct reference) |
+| `PlatformApiStack` | `AuthStack` | `userPool` (construct) |
+| `PlatformApiStack` | `PlatformTablesStack` | `analysisCacheTable` (construct) |
+| `StockAnalyserApiStack` | `PlatformApiStack` | `api` and `authoriser` (constructs) |
+| `BudgetTrackerApiStack` | `AuthStack` | `userPool` (construct — for its own authoriser) |
+
+---
+
+## Deploy ordering
+
+`deploy-platform.yml` sequences its CDK steps explicitly to avoid CloudFormation dependency conflicts:
+
+1. **Step 1 — BudgetTrackerTables first** — deploys `TransformotionDev-BudgetTrackerTables` in isolation. This must complete before Auth deploys, because BudgetTrackerTables previously imported an Auth export that needed to be released first.
+2. **Step 2 — Remaining platform stacks** — deploys `Network`, `Auth`, `AuthApi`, `PlatformTables`, `Api` together. CDK runs independent stacks in parallel within this step.
+
+This two-step ordering is preserved even now that the `Fn::ImportValue` is gone, as a guard against future cross-stack changes inadvertently re-introducing the dependency.
+
+---
+
+## Stack naming convention
+
+All stacks follow the pattern `Transformotion{Stage}-{Name}` where `Stage` is `Dev` or `Prod` (capitalised).
+
+CDK logical IDs within stacks use PascalCase resource names. Renaming a logical ID forces CloudFormation to replace the resource — avoid unless intentional.
+
+---
+
+## Environment variables injected into Lambda functions
+
+Common environment variables available to all Lambda functions:
+
+| Variable | Value |
+|---|---|
+| `REGION` | `ap-southeast-2` (via CDK `this.region`) |
+| `AWS_REGION` | Set automatically by Lambda runtime |
+
+Platform Lambda environment variables:
+
+| Variable | Lambda | Value |
+|---|---|---|
+| `ACCOUNTS_TABLE` | first-login, accounts, invitations | `platform.accounts-{stage}` |
+| `ACCOUNT_MEMBERS_TABLE` | first-login, accounts | `platform.account-members-{stage}` |
+| `INVITATIONS_TABLE` | invitations | `platform.invitations-{stage}` |
+| `USERS_TABLE` | user | `platform.users-{stage}` |
+| `CACHE_TABLE` | claude-proxy | `platform.analysis-cache-{stage}` |
+| `ANTHROPIC_SECRET_NAME` | claude-proxy | `{stage}/anthropic/api-key` (Secrets Manager) |
+| `USER_POOL_ID` | first-login | Cognito user pool ID |
+
+---
+
+## Removal policies
+
+| Stage | Tables / User Pool | Other resources |
+|---|---|---|
+| `dev` | `DESTROY` (data not permanent) | `DESTROY` with `autoDeleteObjects` on S3 |
+| `prod` | `RETAIN` (data is permanent) | `RETAIN` on user pool, Secrets Manager entries |
+
+Secrets Manager entries for social IDP credentials are always `RETAIN` in both environments (credentials should not be destroyed if the stack is torn down).
+
+---
+
+## Adding a new app's CDK stacks
+
+When a new app is added to the platform:
+
+1. Create `infrastructure/lib/{app-name}/{app-name}-tables-stack.ts` — DynamoDB tables
+2. Create `infrastructure/lib/{app-name}/{app-name}-api-stack.ts` — Lambda functions, routes added to the shared platform API Gateway (`api` and `authoriser` props from `PlatformApiStack`)
+3. Register both stacks in `infrastructure/bin/app.ts` for both `dev` and `prod`
+4. Update `deploy-platform.yml` if tables need to deploy before other stacks
+5. Add a Cognito app client for the new app in `auth-stack.ts`
+6. Update `docs/architecture/cdk.md` (this file) with the new stacks

--- a/docs/architecture/data.md
+++ b/docs/architecture/data.md
@@ -1,0 +1,235 @@
+# Data model
+
+## Overview
+
+DynamoDB is the canonical datastore for all platform and app data. Tables are divided into two scopes:
+
+- **Platform tables** — shared infrastructure, used by the platform API and available to all apps. Managed by `PlatformTablesStack`.
+- **Per-app tables** — owned exclusively by one app. Managed by that app's `TablesStack`.
+
+All records in per-app data tables are keyed by `accountId`. The account-scoping invariant (see below) means no handler may read another user's data.
+
+See [auth.md](./auth.md) for the account membership model. See [cdk.md](./cdk.md) for stack names.
+
+---
+
+## Table naming convention
+
+```
+{scope}.{entity}-{stage}
+```
+
+- `scope` is either `platform` (cross-app) or an app slug (`stock-analyser`, `budget-tracker`)
+- `stage` is `dev` or `prod`
+
+Examples: `platform.accounts-dev`, `budget-tracker.transactions-prod`, `stock-analyser.portfolio-dev-v2`
+
+---
+
+## Platform tables
+
+Managed by `TransformotionDev-PlatformTables` / `TransformotionProd-PlatformTables`.
+
+### `platform.users-{stage}`
+
+User preferences, stored per Cognito `sub`.
+
+| Attribute | Type | Notes |
+|---|---|---|
+| `userId` (PK) | String | Cognito `sub` |
+| `defaultMode` | String | UI preference |
+| `notificationsEnabled` | Boolean | |
+| `cycleAlertThreshold` | Number | Stock Analyser alert threshold |
+| `lastAnalysedTicker` | String | Most recently analysed ticker |
+
+Served by `transformotion-user-{stage}` Lambda (`GET /api/user/profile`, `PUT /api/user/preferences`).
+
+### `platform.accounts-{stage}`
+
+Account container records, shared across all apps.
+
+| Attribute | Type | Notes |
+|---|---|---|
+| `accountId` (PK) | String | UUID |
+| `name` | String | Human-readable account name |
+| `appSlug` | String | Which app this account belongs to (`stock-signal`, `budget-tracker`) |
+| `createdAt` | String | ISO 8601 |
+| `ownerId` | String | userId of the account creator |
+
+Served by `transformotion-accounts-{stage}` Lambda.
+
+### `platform.account-members-{stage}`
+
+Membership records: which users belong to which accounts, and in what role.
+
+| Attribute | Type | Notes |
+|---|---|---|
+| `accountId` (PK) | String | |
+| `userId` (SK) | String | Cognito `sub` |
+| `role` | String | `owner \| manager \| member \| viewer` |
+| `email` | String | Denormalised for display |
+| `joinedAt` | String | ISO 8601 |
+
+**GSI:** `userId-index` (PK: `userId`) — look up all accounts a given user belongs to.
+
+Read by the pre-token generation Lambda to build the `accounts` claim. Also read by account membership handlers.
+
+### `platform.invitations-{stage}`
+
+Pending, redeemed, and expired invitations.
+
+| Attribute | Type | Notes |
+|---|---|---|
+| `invitationId` (PK) | String | UUID |
+| `email` | String | Normalised lowercase |
+| `invitedBy` | String | userId of the inviting admin |
+| `createdAt` | String | ISO 8601 |
+| `expiresAt` | Number | Epoch-seconds (TTL attribute — 7 days) |
+| `status` | String | `pending \| redeemed \| expired` |
+| `perApp` | Map | Per-app access configuration — see [auth.md](./auth.md) for shape |
+
+**GSI:** `email-index` (PK: `email`) — look up pending invitations for a newly registered user.
+
+Served by `transformotion-invitations-{stage}` Lambda.
+
+### `platform.analysis-cache-{stage}`
+
+Shared Claude AI response cache, used by the `transformotion-claude-proxy-{stage}` Lambda across all apps.
+
+| Attribute | Type | Notes |
+|---|---|---|
+| `accountId` (PK) | String | |
+| `cacheKey` (SK) | String | Namespaced cache key (e.g. `MARKET#ASX`, `ANALYSIS#CBA.AX`) |
+| `result` | Map | Cached response |
+| `expiresAt` | Number | Epoch-seconds (TTL attribute) |
+
+---
+
+## Per-app tables
+
+### Stock Analyser
+
+Managed by `TransformotionDev-StockAnalyserTables` / `TransformotionProd-StockAnalyserTables`.
+
+#### `stock-analyser.portfolio-{stage}-v2`
+
+| Attribute | Type | Notes |
+|---|---|---|
+| `accountId` (PK) | String | |
+| `holdings` | List | Serialised `PortfolioHolding[]` |
+
+#### `stock-analyser.watchlist-{stage}-v2`
+
+| Attribute | Type | Notes |
+|---|---|---|
+| `accountId` (PK) | String | |
+| `items` | List | Serialised `WatchlistItem[]` |
+
+For full type definitions see [apps/stock-analyser/contracts/DATA_CONTRACTS.md](/apps/stock-analyser/contracts/DATA_CONTRACTS.md).
+
+### Budget Tracker
+
+Managed by `TransformotionDev-BudgetTrackerTables` / `TransformotionProd-BudgetTrackerTables`.
+
+#### `budget-tracker.accounts-{stage}`
+
+Budget-Tracker-specific account container. Stores account name and members list as a nested attribute.
+
+| Attribute | Type | Notes |
+|---|---|---|
+| `accountId` (PK) | String | UUID |
+| `name` | String | Household name |
+| `members` | List | `[{ userId, role, email, joinedAt }]` |
+| `createdAt` | String | ISO 8601 |
+
+> **Duplication note:** This table partially overlaps with `platform.accounts` and `platform.account-members`. Consolidation to the platform tables is deferred to a future cleanup phase.
+
+#### `budget-tracker.transactions-{stage}`
+
+| Attribute | Type | Notes |
+|---|---|---|
+| `accountId` (PK) | String | |
+| `transactionId` (SK) | String | UUID |
+| `date` | String | DD/MM/YYYY (preserved for display) |
+| `dateIso` | String | YYYY-MM-DD (for range queries) |
+| `amount` | String | Signed — preserved as imported to avoid floating-point issues |
+| `description` | String | Original description from CSV |
+| `category` | String | |
+| `subcategory` | String | |
+| `file` | String | Source CSV filename |
+| `_manual` | Boolean | `true` = user manually categorised; rules engine will not overwrite |
+| `_business` | Boolean | `true` = excluded from personal P&L |
+
+**GSI:** `accountId-dateIso-index` (PK: `accountId`, SK: `dateIso`) — efficient date-range queries.
+
+#### `budget-tracker.rules-{stage}`
+
+| Attribute | Type | Notes |
+|---|---|---|
+| `accountId` (PK) | String | |
+| `ruleId` (SK) | String | UUID |
+| `match` | String | Keyword or regex pattern, case-insensitive |
+| `category` | String | |
+| `subcategory` | String | |
+| `learned` | Boolean | `true` = created via "Learn" button; `false` = manually authored |
+| `createdAt` | String | ISO 8601 |
+
+#### `budget-tracker.settings-{stage}`
+
+Key-value store — each settings field is its own DynamoDB item.
+
+| Attribute | Type | Notes |
+|---|---|---|
+| `accountId` (PK) | String | |
+| `settingKey` (SK) | String | `budgetOverrides`, `budgetFreqs`, `customCategories`, `projectBudgets`, `deletedSubs`, `csvFormatMappings`, and others |
+| `value` | Map or List | Shape depends on `settingKey` — see [contracts/budget-tracker/data-models.md](/contracts/budget-tracker/data-models.md) |
+
+For full type definitions see [contracts/budget-tracker/data-models.md](/contracts/budget-tracker/data-models.md).
+
+---
+
+## The account-scoping invariant
+
+**Every record in a per-app data table must be keyed by `accountId`. Every handler that reads or writes per-app data must verify the caller's membership in that account before touching DynamoDB.**
+
+Handlers enforce this by calling:
+
+```typescript
+requireAccountAccess(auth, 'stock-signal', accountId)
+// or
+requireAccountAccess(auth, 'budget-tracker', accountId, 'member')
+```
+
+before any DynamoDB operation. The `accountId` used in DynamoDB operations is always the one already verified against the caller's `accounts` claim — never trusted directly from a query parameter without verification.
+
+This invariant means: even if a user knows another account's UUID, they cannot read or write its data. Authorization is enforced at the handler layer, not at DynamoDB's IAM level (LeadingKeys conditions are aspirational — see Issue #42 for platform Lambda IAM hardening).
+
+---
+
+## Account relationships example
+
+Steve creates a Budget Tracker account (`steve-bt-uuid`). He invites Liz. The resulting records:
+
+```
+platform.accounts-dev:
+  accountId=steve-bt-uuid  name="Moodie Family"  appSlug=budget-tracker  ownerId=steve-sub
+
+platform.account-members-dev:
+  accountId=steve-bt-uuid  userId=steve-sub   role=owner
+  accountId=steve-bt-uuid  userId=liz-sub     role=member
+```
+
+When Liz signs in, the pre-token Lambda queries `userId-index` for `liz-sub`, finds both rows (Liz's own account + Steve's), and builds:
+
+```json
+{
+  "accounts": {
+    "budget-tracker": [
+      { "accountId": "liz-bt-uuid",   "role": "owner"  },
+      { "accountId": "steve-bt-uuid", "role": "member" }
+    ]
+  }
+}
+```
+
+Liz's active account (`custom:active_accounts["budget-tracker"]`) determines which data she sees by default. She can switch accounts via `POST /auth/switch`.

--- a/docs/architecture/urls-and-deploy.md
+++ b/docs/architecture/urls-and-deploy.md
@@ -1,0 +1,163 @@
+# URL routing and deployment
+
+## URL model
+
+Path-based, single CloudFront distribution serving all apps at:
+- **Dev:** `dev.apps.transformotion.com.au`
+- **Prod:** `apps.transformotion.com.au`
+
+| Path prefix | App | Notes |
+|---|---|---|
+| `/` | apps/launchpad | Root redirects to `/launchpad/` (authenticated) or `/sign-in/` (unauthenticated) |
+| `/sign-in/*` | apps/launchpad | Sign-in and OAuth callback routes |
+| `/launchpad/*` | apps/launchpad | Authenticated launchpad UI, app tile navigation |
+| `/stock-signal/*` | apps/stock-analyser | Stock Signal Analyser |
+| `/budget-tracker/*` | apps/budget-tracker | Budget Tracker |
+
+---
+
+## Next.js basePath per app
+
+Each app's `next.config.mjs` sets `basePath` to match its serving path:
+
+| App | basePath | Static export path |
+|---|---|---|
+| `apps/launchpad` | *(none — serves at root)* | `out/` |
+| `apps/stock-analyser` | `/stock-signal` | `out/stock-signal/` |
+| `apps/budget-tracker` | `/budget-tracker` | `out/budget-tracker/` |
+
+All apps use `output: 'export'` (Next.js static export) and `trailingSlash: true`.
+
+---
+
+## S3 bucket layout
+
+Single S3 bucket: `transformotion-web-{stage}-959516291617`
+
+Target layout after all apps are deployed:
+
+```
+bucket/
+  index.html                        ← launchpad root
+  _next/                            ← launchpad assets
+  sign-in/
+    index.html
+    ...
+  launchpad/
+    index.html
+    ...
+  stock-signal/
+    index.html
+    _next/                          ← stock-analyser assets
+    ...
+  budget-tracker/
+    index.html
+    _next/                          ← budget-tracker assets
+    ...
+```
+
+Deploy workflows sync to their respective prefix only. No deploy syncs the bucket root with `--delete` across the entire bucket — that would wipe other apps' artefacts.
+
+Correct S3 sync pattern per app:
+```bash
+# Stock Analyser
+aws s3 sync apps/stock-analyser/out/stock-signal s3://${BUCKET}/stock-signal --delete
+
+# Budget Tracker
+aws s3 sync apps/budget-tracker/out/budget-tracker s3://${BUCKET}/budget-tracker --delete
+
+# Launchpad (syncs root, must NOT use --delete on full bucket)
+aws s3 sync apps/launchpad/out s3://${BUCKET}/ --delete --exclude "stock-signal/*" --exclude "budget-tracker/*"
+```
+
+---
+
+## CloudFront distribution
+
+Single distribution (`TransformotionDev-Network` / `TransformotionProd-Network`), configured in `NetworkStack`.
+
+- **Origin:** S3 bucket with Origin Access Control
+- **Default root object:** `index.html`
+- **HTTPS:** redirect all HTTP to HTTPS
+- **Error responses:** 403 and 404 serve `/index.html` (SPA fallback)
+- **Caching:** `CachingOptimized` policy (default behavior)
+- **Compression:** enabled
+
+> **Current limitation:** The CloudFront distribution has a single default behavior with no path-based behaviors. The 403/404 error fallback serves `/index.html` (the launchpad). This means direct navigation to `/stock-signal/some-route` will correctly load the stock-analyser SPA at `/stock-signal/index.html` only if the error response for 403 is updated to be path-aware, OR if S3 serves the correct `index.html` for the path prefix.
+>
+> The target architecture has path-based CloudFront behaviors routing `/stock-signal/*` and `/budget-tracker/*` to their respective S3 path prefixes with per-prefix SPA fallbacks. This CDK change is part of sub-phase 7b/7g.
+
+---
+
+## Deploy triggers
+
+Each app has its own path-filtered GitHub Actions deploy workflow. Workflows fire on push to `develop` (dev deploy) or `main` (prod deploy).
+
+| Workflow | Trigger paths | What it deploys |
+|---|---|---|
+| `deploy-stock-analyser.yml` | `apps/stock-analyser/**`, `infrastructure/lib/stock-analyser/**`, `packages/**` | `TransformotionDev-StockAnalyserApi` CDK stack + S3 sync to `stock-signal/` |
+| `deploy-budget-tracker.yml` | `apps/budget-tracker/**`, `infrastructure/lib/budget-tracker/**`, `packages/**` | `TransformotionDev-BudgetTrackerTables` + `BudgetTrackerApi` CDK stacks + S3 sync to `budget-tracker/` |
+| `deploy-platform.yml` | `infrastructure/lib/platform/**`, `infrastructure/bin/**`, `functions/**` | All platform CDK stacks |
+
+> **Note:** `deploy-platform.yml` does not trigger on `apps/**` changes, and app workflows do not trigger on `functions/**` changes. If you add a new Lambda to a platform stack and want it deployed with the app, ensure it is in `functions/` (not `apps/*/functions/`).
+
+Changes to one app's paths never trigger another app's deployment.
+
+---
+
+## Environment variables
+
+Per-app deploys require these variables set in the GitHub environment (`dev` or `prod`):
+
+### Shared across apps
+
+| Variable | Value |
+|---|---|
+| `NEXT_PUBLIC_COGNITO_USER_POOL_ID` | Cognito user pool ID (e.g. `ap-southeast-2_7QhxUvefw`) |
+| `NEXT_PUBLIC_COGNITO_DOMAIN` | Hosted UI domain (e.g. `transformotion-959516291617-dev.auth.ap-southeast-2.amazoncognito.com`) |
+| `NEXT_PUBLIC_APP_URL` | App root URL (e.g. `https://dev.apps.transformotion.com.au`) |
+| `NEXT_PUBLIC_API_BASE_URL` | Platform API base URL |
+
+### Per-app client IDs
+
+| Variable | Client |
+|---|---|
+| `NEXT_PUBLIC_LAUNCHPAD_COGNITO_CLIENT_ID` | LaunchpadAppClient |
+| `NEXT_PUBLIC_STOCK_ANALYSER_COGNITO_CLIENT_ID` | StockAnalyserAppClient |
+| `NEXT_PUBLIC_BUDGET_TRACKER_COGNITO_CLIENT_ID` | BudgetTrackerAppClient |
+
+Client IDs are synced from CloudFormation outputs after each auth stack deploy by running:
+```bash
+bash scripts/ci/sync-cognito-client-ids.sh dev
+```
+
+### Build-injected
+
+| Variable | Source |
+|---|---|
+| `NEXT_PUBLIC_COMMIT_HASH` | Set by CI to `${{ github.sha }}` |
+
+The deploy verification script (`scripts/ci/verify-deploy.sh`) checks that the commit hash appears in the deployed bundle.
+
+---
+
+## API Gateway URLs
+
+| Gateway | Purpose | Name |
+|---|---|---|
+| `transformotion-api-{stage}` | Platform + Stock Analyser routes | `TransformotionDev-Api` stack output |
+| `budget-tracker-api-{stage}` | Budget Tracker routes (own gateway) | `TransformotionDev-BudgetTrackerApi` stack output |
+
+> The Budget Tracker has its own API Gateway rather than sharing the platform gateway. This is a known architectural divergence (tracked in the Stabilisation backlog as sub-phase 7f). The separate gateway is functional; consolidation is optional.
+
+---
+
+## Cognito OAuth callback flow
+
+1. App redirects to Cognito Hosted UI with `client_id`, `redirect_uri`, `state`, `code_challenge`
+2. User authenticates (email/password or social IDP)
+3. Cognito redirects to `{redirect_uri}?code=...&state=...`
+4. App exchanges `code` for tokens at the Hosted UI token endpoint
+5. ID token contains standard claims + custom claims injected by pre-token Lambda
+
+`redirect_uri` must exactly match one of the configured callback URLs for the app client. Mismatches cause `redirect_mismatch` errors from Cognito.

--- a/docs/sub-phase-7e-plan.md
+++ b/docs/sub-phase-7e-plan.md
@@ -35,12 +35,12 @@
 
 | Component | Current | Target |
 |---|---|---|
-| Cognito groups | `admin`, `stock-app`, `budget-app`, `transformotion`, `family` | `site-admin`, `stock-app-view/user/admin`, `budget-app-view/user/admin` |
-| Custom attributes | `custom:active_account` (UUID), `custom:accounts` | `custom:active_accounts` (per-app JSON map), `custom:accounts` |
-| Pre-token Lambda | None | Injects `apps`, `site_admin`, `accounts` claims |
-| Auth middleware | `requireGroup(auth, ...groups)` | + `requireAppAccess`, `requireAccountAccess` helpers |
-| Lambda authorization | `requireGroup` call sites | `requireAppAccess` + `requireAccountAccess` |
-| Invitation Lambda | Creates record, no email, no `perApp` | Full `perApp` model, SES email, reconciliation on redemption |
+| Cognito groups | `admin`, `stock-app`, `budget-app`, `transformotion`, `family` | `site-admin`, `stock-app-access`, `budget-app-access` |
+| Custom attributes | `custom:active_account` (UUID), `custom:accounts` | Remove `custom:active_account`; keep `custom:accounts` (now JSON-stringified map) |
+| Pre-token Lambda | None | Injects `apps`, `site_admin`, `accounts` claims + reconciles group membership |
+| Auth middleware | `requireGroup(auth, ...groups)` | + `requireSiteAdmin`, `requireAppAccess`, `requireAccountAccess`, `requireAccountOwner` helpers |
+| Lambda authorization | `requireGroup` call sites | `requireAppAccess` + `requireAccountAccess` (+ `requireAccountOwner` for ownership ops) |
+| Invitation Lambda | Creates record, no email, no `perApp` | Full `perApp` model, two entry points, SES email, transactional redemption |
 | Launchpad tiles | `MOCK_USER` | Reads `apps` claim; three-state tile model |
 
 ---
@@ -49,14 +49,14 @@
 
 ### 7e-prep-1 — CDK: new group structure (additive)
 
-Create new three-tier Cognito groups in `AuthStack` alongside existing groups:
-- `site-admin`, `stock-app-view`, `stock-app-user`, `stock-app-admin`, `budget-app-view`, `budget-app-user`, `budget-app-admin`
+Create new Cognito groups in `AuthStack` alongside existing groups:
+- `site-admin`, `stock-app-access`, `budget-app-access`
 
-Also add the new `custom:active_accounts` custom attribute to the user pool (string, mutable, maxLen 2048).
+Remove the `custom:active_account` custom attribute from the user pool (it is not migrated to a plural form — active account selection moves to client-side localStorage).
 
 **Old groups are NOT removed in this step** — they coexist during migration.
 
-After deploy: manually add Steve to `site-admin`, `stock-app-admin`, `budget-app-admin`.
+After deploy: manually add Steve to `site-admin`, `stock-app-access`, `budget-app-access`.
 
 **Verification:** Steve signs in; `cognito:groups` claim includes both `admin` (old) and `site-admin` (new).
 
@@ -64,7 +64,7 @@ After deploy: manually add Steve to `site-admin`, `stock-app-admin`, `budget-app
 
 Update `requireGroup` calls in Lambda handlers to accept both old and new group names. Transitional — allows the migration to proceed without locking out existing access.
 
-Files affected (10+ call sites — search codebase for `requireGroup` before starting):
+Search codebase for `requireGroup` before starting; expect call sites in:
 - `apps/stock-analyser/functions/portfolio`
 - `apps/stock-analyser/functions/watchlist`
 - `apps/stock-analyser/functions/analysis-cache`
@@ -72,24 +72,31 @@ Files affected (10+ call sites — search codebase for `requireGroup` before sta
 - All Budget Tracker Lambda handlers
 - Platform Lambdas once they receive auth gating (Issue #42)
 
-Pattern: `requireGroup(auth, 'stock-app', 'admin', 'stock-app-user', 'stock-app-admin', 'site-admin')` — temporarily broad.
+Pattern for stock handlers: `requireGroup(auth, 'stock-app', 'admin', 'stock-app-access', 'site-admin')` — temporarily broad.  
+Pattern for budget handlers: `requireGroup(auth, 'budget-app', 'admin', 'budget-app-access', 'site-admin')`.  
+Pattern for claude-proxy: `requireGroup(auth, 'stock-app', 'budget-app', 'admin', 'stock-app-access', 'budget-app-access', 'site-admin')`.
 
 ### 7e-pretoken — Pre-token generation Lambda
 
 Write and deploy `functions/pre-token-generation`. Register as Cognito pre-token-generation trigger in `AuthStack`.
 
-Responsibilities per [auth.md](/docs/architecture/auth.md#pre-token-generation-lambda).
+Responsibilities per [auth.md](/docs/architecture/auth.md#pre-token-generation-lambda). Key points:
+- Reads `platform.account-members` to derive authoritative app access from account membership
+- Calls `AdminAddUserToGroup` / `AdminRemoveUserFromGroup` to reconcile Cognito group membership with account membership (accounts are the authoritative source)
+- Injects claims: `apps` (JSON-stringified `string[]`), `site_admin` (string `"true"`/`"false"`), `accounts` (JSON-stringified map of appSlug → `[{accountId, role}]`)
 
-**Verification:** Steve signs in; ID token decoded (`jwt.io`) shows `apps`, `site_admin`, `accounts` custom claims.
+**Verification:** Steve signs in; ID token decoded at `jwt.io` shows `custom:apps`, `custom:site_admin`, `custom:accounts` with correct JSON values.
 
 ### 7e-auth-middleware-extend
 
 Extend `packages/lambda-middleware` to parse the new claims and expose authorization helpers:
-- `auth.apps` — from `apps` custom claim
-- `auth.siteAdmin` — from `site_admin` claim
-- `auth.accounts` — from `accounts` claim
-- `requireAppAccess(auth, appSlug, minRole?)` helper
+- `auth.apps` — from `apps` custom claim; parsed type is `string[]`
+- `auth.siteAdmin` — from `site_admin` claim; parsed as boolean
+- `auth.accounts` — from `accounts` custom claim; parsed type is `Record<appSlug, Array<{accountId: string, role: string}>>`
+- `requireSiteAdmin(auth)` helper
+- `requireAppAccess(auth, appSlug)` helper — no role parameter (Dimension A is binary)
 - `requireAccountAccess(auth, appSlug, accountId, minRole?)` helper
+- `requireAccountOwner(auth, appSlug, accountId)` helper
 
 Keep existing `auth.groups` and `requireGroup` for the transitional period.
 
@@ -97,33 +104,47 @@ This sub-sub-phase is independent of `7e-pretoken` and can run in parallel.
 
 ### 7e-lambda-authorization-migration
 
-Replace `requireGroup` calls with `requireAppAccess` + `requireAccountAccess` across all Lambda handlers.
+Replace `requireGroup` calls with the appropriate helper across all Lambda handlers:
+- Entry-point check (app access): `requireAppAccess(auth, appSlug)` — no role parameter
+- Account-scoped operations (read/write): `requireAccountAccess(auth, appSlug, accountId)` — no minRole for standard reads/writes
+- Elevated operations (e.g. bulk delete, settings wipe): `requireAccountAccess(auth, appSlug, accountId, 'manager')` with minRole
+- Ownership operations (transfer, account deletion): `requireAccountOwner(auth, appSlug, accountId)`
+- Admin-only platform ops: `requireSiteAdmin(auth)`
 
-For account-scoped handlers: add `requireAccountAccess` before every DynamoDB query.
+For account-scoped handlers: call `requireAccountAccess` before every DynamoDB query, not just at the handler entry point.
 
 This sub-sub-phase depends on `7e-auth-middleware-extend` completing first.
 
 ### 7e-invitation-api
 
 Significantly extend `functions/invitations` to implement the full invitation model from [auth.md](/docs/architecture/auth.md#invitation-flow):
-- Add `perApp` field to invitation records
-- Authorization: `site-admin` or `{app}-admin` with scope validation
-- SES email delivery with redemption link
-- Handle `new-personal-account` and `join-existing` account membership types
+- Two creation endpoints: `POST /admin/invitations` (site-admin only, cross-app) and `POST /apps/{appSlug}/invitations` (scoped to caller's app access)
+- Two listing endpoints matching the same scope split
+- Cancellation endpoint: `DELETE /invitations/{invitationId}`
+- `perApp` field on invitation records: map of appSlug → `{ accountType: 'new-personal-account' | 'join-existing', accountId?, role }` — no `groupRole` field (Dimension A is binary; group membership is derived from account membership by the pre-token Lambda)
+- Add `status-index` GSI to `platform.invitations` table (partition key `status`, sort key `expiresAt`) for expiry scan
+- Scheduled Lambda to mark expired invitations `expired` (EventBridge rule, daily)
+- SES email delivery with redemption link containing signed token
+- Transactional redemption via `DynamoDBClient.send(TransactWriteItemsCommand)`: mark invitation `redeemed`, create/update account membership records, update `custom:accounts` attribute, add user to Cognito groups — all or nothing
 
 ### 7e-invitation-ui
 
-Launchpad admin UI for creating invitations. Shows a matrix of apps × capability levels × account assignment. Input form scoped to caller's permissions (an `{app}-admin` only sees their app).
+Two UI entry points for creating invitations:
+1. **Launchpad admin panel** (`site-admin` only): cross-app invitation form covering all apps and all `perApp` assignment options
+2. **In-app invite UI** (per-app, for users with `manager` or `owner` role in an account): scoped to the current app; can only invite to accounts the caller owns or manages
+
+Both UIs call the corresponding creation endpoint (`/admin/invitations` or `/apps/{appSlug}/invitations`). The in-app form is added to Stock Analyser and Budget Tracker settings/members screens as appropriate.
 
 ### 7e-signup-reconciliation
 
 New Lambda `functions/reconcile-invitation` serving `POST /auth/reconcile-invitation`.
 
-Reads `invitation=<token>` from the OAuth callback, validates the invitation, and for each app in `perApp`:
-1. Adds user to the Cognito group (`AdminAddUserToGroup`)
-2. Creates account (`new-personal-account`) or adds to existing (`join-existing`)
-3. Sets `custom:active_accounts[appSlug]`
-4. Marks invitation `redeemed`
+Reads `invitation=<token>` from the OAuth callback (passed as query parameter by the Launchpad callback handler), validates the invitation, and executes a single `TransactWriteItemsCommand` that:
+1. Creates account record (`new-personal-account`) or writes membership record (`join-existing`) for each app in `perApp`
+2. Updates `custom:accounts` attribute via `AdminUpdateUserAttributes` (JSON-stringified map)
+3. Marks invitation status `redeemed`
+
+Group membership (Cognito groups) is NOT set here — the pre-token Lambda derives groups from account membership on next token issue. No `AdminAddUserToGroup` call in reconciliation.
 
 ### 7e-launchpad-tiles
 
@@ -136,18 +157,18 @@ Wire real Cognito session into `apps/launchpad` — replace `MOCK_USER`:
 
 Fix federated-user lookup bug in `functions/forgot-provider`:
 - `AdminGetUser(Username: email)` fails for users whose Cognito username is `Google_{sub}`
-- Fix: also query `ListUsers` with filter `email = "{email}"` as a fallback
+- Fix: replace `AdminGetUser` with `ListUsersCommand` filtered by `email = "{email}"` — this works for both native and federated users
 - Track fix against the Stabilisation backlog issue
 
 ### 7e-cleanup
 
 After all the above sub-sub-phases are verified in dev and deployed to prod:
 
-1. Remove old Cognito groups (`admin`, `stock-app`, `budget-app`, `transformotion`, `family`) from `AuthStack`
-2. Remove old group names from `requireGroup` transitional calls — or delete `requireGroup` if no consumers remain
-3. Remove `auth.groups` from middleware if no remaining consumers
+1. Remove old Cognito groups (`admin`, `stock-app`, `budget-app`, `transformotion`, `family`) from `AuthStack` — 5 groups total
+2. Delete `requireGroup` entirely from `packages/lambda-middleware` — all call sites should have been migrated in `7e-lambda-authorization-migration`
+3. Remove `auth.groups` from the parsed auth context if no consumers remain
 4. Verify `docs/architecture/auth.md` matches deployed reality: walk through each section and confirm it reflects the live system
-5. Update `docs/architecture/data.md` to confirm `custom:active_accounts` custom attribute is live
+5. Confirm `docs/architecture/data.md` accurately reflects all deployed tables and GSIs (including `status-index` on `platform.invitations`)
 6. Delete this file (`docs/sub-phase-7e-plan.md`)
 
 ---

--- a/docs/sub-phase-7e-plan.md
+++ b/docs/sub-phase-7e-plan.md
@@ -1,0 +1,180 @@
+# Sub-phase 7e — Auth and permissions migration plan
+
+**Status:** Planning  
+**Target architecture:** [/docs/architecture/auth.md](/docs/architecture/auth.md)  
+**Ephemeral document:** deleted at 7e-cleanup once the migration is complete and `auth.md` is verified against deployed reality.
+
+---
+
+## Current state (as of 2026-04-24)
+
+**Deployed groups:** `admin`, `stock-app`, `budget-app`, `transformotion`, `family`
+
+**App clients (deployed — three-client model, sub-phase 7b.5-alpha):**
+- `LaunchpadAppClient` — social IDPs
+- `StockAnalyserAppClient` — Cognito only
+- `BudgetTrackerAppClient` — Cognito only
+
+**Pre-token generation Lambda:** Absent. `UserPool.LambdaConfig` is null. No custom claims are injected.
+
+**Auth middleware (`packages/lambda-middleware`):** Supports `requireGroup(auth, ...groups)` — flat string equality check against `cognito:groups`.
+
+**Authorization state per app:**
+- Stock Analyser: `requireGroup(auth, 'stock-app', 'admin')` — Lambda-layer gating only
+- Budget Tracker: `requireGroup(auth, 'budget-app', 'admin')` — Lambda-layer gating only
+- Platform Lambdas (accounts, user, invitations, first-login): ungated (tracked as Issue #42)
+- Claude proxy: `requireGroup(auth, 'stock-app', 'budget-app', 'admin')`
+
+**Custom attributes:** `custom:active_account` (singular UUID), `custom:accounts` (comma-separated UUIDs)
+
+**Invitation flow:** `functions/invitations` creates pending invitation records but does not send email, does not include `perApp` field, does not trigger group assignment or account creation on redemption.
+
+---
+
+## Target state delta (current → target)
+
+| Component | Current | Target |
+|---|---|---|
+| Cognito groups | `admin`, `stock-app`, `budget-app`, `transformotion`, `family` | `site-admin`, `stock-app-view/user/admin`, `budget-app-view/user/admin` |
+| Custom attributes | `custom:active_account` (UUID), `custom:accounts` | `custom:active_accounts` (per-app JSON map), `custom:accounts` |
+| Pre-token Lambda | None | Injects `apps`, `site_admin`, `accounts` claims |
+| Auth middleware | `requireGroup(auth, ...groups)` | + `requireAppAccess`, `requireAccountAccess` helpers |
+| Lambda authorization | `requireGroup` call sites | `requireAppAccess` + `requireAccountAccess` |
+| Invitation Lambda | Creates record, no email, no `perApp` | Full `perApp` model, SES email, reconciliation on redemption |
+| Launchpad tiles | `MOCK_USER` | Reads `apps` claim; three-state tile model |
+
+---
+
+## Sub-sub-phases
+
+### 7e-prep-1 — CDK: new group structure (additive)
+
+Create new three-tier Cognito groups in `AuthStack` alongside existing groups:
+- `site-admin`, `stock-app-view`, `stock-app-user`, `stock-app-admin`, `budget-app-view`, `budget-app-user`, `budget-app-admin`
+
+Also add the new `custom:active_accounts` custom attribute to the user pool (string, mutable, maxLen 2048).
+
+**Old groups are NOT removed in this step** — they coexist during migration.
+
+After deploy: manually add Steve to `site-admin`, `stock-app-admin`, `budget-app-admin`.
+
+**Verification:** Steve signs in; `cognito:groups` claim includes both `admin` (old) and `site-admin` (new).
+
+### 7e-prep-2 — Lambda-layer: dual-gate authorization
+
+Update `requireGroup` calls in Lambda handlers to accept both old and new group names. Transitional — allows the migration to proceed without locking out existing access.
+
+Files affected (10+ call sites — search codebase for `requireGroup` before starting):
+- `apps/stock-analyser/functions/portfolio`
+- `apps/stock-analyser/functions/watchlist`
+- `apps/stock-analyser/functions/analysis-cache`
+- `functions/claude-proxy`
+- All Budget Tracker Lambda handlers
+- Platform Lambdas once they receive auth gating (Issue #42)
+
+Pattern: `requireGroup(auth, 'stock-app', 'admin', 'stock-app-user', 'stock-app-admin', 'site-admin')` — temporarily broad.
+
+### 7e-pretoken — Pre-token generation Lambda
+
+Write and deploy `functions/pre-token-generation`. Register as Cognito pre-token-generation trigger in `AuthStack`.
+
+Responsibilities per [auth.md](/docs/architecture/auth.md#pre-token-generation-lambda).
+
+**Verification:** Steve signs in; ID token decoded (`jwt.io`) shows `apps`, `site_admin`, `accounts` custom claims.
+
+### 7e-auth-middleware-extend
+
+Extend `packages/lambda-middleware` to parse the new claims and expose authorization helpers:
+- `auth.apps` — from `apps` custom claim
+- `auth.siteAdmin` — from `site_admin` claim
+- `auth.accounts` — from `accounts` claim
+- `requireAppAccess(auth, appSlug, minRole?)` helper
+- `requireAccountAccess(auth, appSlug, accountId, minRole?)` helper
+
+Keep existing `auth.groups` and `requireGroup` for the transitional period.
+
+This sub-sub-phase is independent of `7e-pretoken` and can run in parallel.
+
+### 7e-lambda-authorization-migration
+
+Replace `requireGroup` calls with `requireAppAccess` + `requireAccountAccess` across all Lambda handlers.
+
+For account-scoped handlers: add `requireAccountAccess` before every DynamoDB query.
+
+This sub-sub-phase depends on `7e-auth-middleware-extend` completing first.
+
+### 7e-invitation-api
+
+Significantly extend `functions/invitations` to implement the full invitation model from [auth.md](/docs/architecture/auth.md#invitation-flow):
+- Add `perApp` field to invitation records
+- Authorization: `site-admin` or `{app}-admin` with scope validation
+- SES email delivery with redemption link
+- Handle `new-personal-account` and `join-existing` account membership types
+
+### 7e-invitation-ui
+
+Launchpad admin UI for creating invitations. Shows a matrix of apps × capability levels × account assignment. Input form scoped to caller's permissions (an `{app}-admin` only sees their app).
+
+### 7e-signup-reconciliation
+
+New Lambda `functions/reconcile-invitation` serving `POST /auth/reconcile-invitation`.
+
+Reads `invitation=<token>` from the OAuth callback, validates the invitation, and for each app in `perApp`:
+1. Adds user to the Cognito group (`AdminAddUserToGroup`)
+2. Creates account (`new-personal-account`) or adds to existing (`join-existing`)
+3. Sets `custom:active_accounts[appSlug]`
+4. Marks invitation `redeemed`
+
+### 7e-launchpad-tiles
+
+Wire real Cognito session into `apps/launchpad` — replace `MOCK_USER`:
+- `packages/auth-client` `getAppAccess()` reads `apps` claim from ID token
+- Launchpad renders tiles per three-state model (see [auth.md](/docs/architecture/auth.md#three-state-tile-model))
+- Tile navigation uses path-relative links (`/stock-signal/`, `/budget-tracker/`)
+
+### 7e-forgot-provider-fix
+
+Fix federated-user lookup bug in `functions/forgot-provider`:
+- `AdminGetUser(Username: email)` fails for users whose Cognito username is `Google_{sub}`
+- Fix: also query `ListUsers` with filter `email = "{email}"` as a fallback
+- Track fix against the Stabilisation backlog issue
+
+### 7e-cleanup
+
+After all the above sub-sub-phases are verified in dev and deployed to prod:
+
+1. Remove old Cognito groups (`admin`, `stock-app`, `budget-app`, `transformotion`, `family`) from `AuthStack`
+2. Remove old group names from `requireGroup` transitional calls — or delete `requireGroup` if no consumers remain
+3. Remove `auth.groups` from middleware if no remaining consumers
+4. Verify `docs/architecture/auth.md` matches deployed reality: walk through each section and confirm it reflects the live system
+5. Update `docs/architecture/data.md` to confirm `custom:active_accounts` custom attribute is live
+6. Delete this file (`docs/sub-phase-7e-plan.md`)
+
+---
+
+## Ordering constraints
+
+```
+7e-prep-1
+  ↓
+7e-prep-2
+  ↓
+7e-pretoken ─────────────────┐
+7e-auth-middleware-extend ───┴─→ 7e-lambda-authorization-migration
+                                   ↓
+                             7e-invitation-api
+                                   ↓
+                             7e-invitation-ui + 7e-signup-reconciliation (parallel)
+                                   ↓
+                             7e-launchpad-tiles
+                                   ↓
+                             7e-forgot-provider-fix (any time, independent)
+                                   ↓
+                             7e-cleanup
+```
+
+---
+
+## Open decisions
+
+None at this point. All architectural decisions are captured in [auth.md](/docs/architecture/auth.md). Decisions that arise during execution must update `auth.md` before the implementing PR is written.


### PR DESCRIPTION
## Summary

- Creates `docs/architecture/` with five permanent documents: `README.md` (index + discipline rule), `auth.md`, `data.md`, `urls-and-deploy.md`, `cdk.md`
- Adds `apps/stock-analyser/CLAUDE.md` and `apps/budget-tracker/CLAUDE.md` — both missing and referenced by root `CLAUDE.md`
- Adds `docs/sub-phase-7e-plan.md` — ephemeral migration plan for the 7e auth refactor
- Updates `MONOREPO.md`, `contracts/budget-tracker/aws-infrastructure.md`, `STABILISATION_FREEZE.md`

## Why this PR

The 7e-docs audit (`docs/sub-phase-7e-docs-audit.md` on `claude-code/phase-1-7e-docs-audit`) identified four missing target documents, one live Cognito conflict in the budget-tracker contracts, and missing CDK stacks in MONOREPO.md. This PR addresses items 1–5 from the recommended writing PR scope.

## The discipline

Established by `docs/architecture/README.md`: any PR changing what the architecture documents describe must update the corresponding document in the same PR.

## Factual verification

All facts drawn from reading the deployed CDK stacks directly (infrastructure/bin/app.ts, infrastructure/lib/**/*). Cognito dev client IDs drawn from live CloudFormation outputs (synced 2026-04-24 by sync-cognito-client-ids.sh).

## Not in this PR

- Deletions of stale files — separate housekeeping PR
- `docs/onboarding.md` — blocked on 7e architecture decisions
- `docs/architecture/README.md` points to `apps/launchpad/CLAUDE.md` — that app doesn't exist yet

## Test plan

- [ ] Read each new document and confirm no content contradicts deployed infrastructure
- [ ] Confirm `docs/architecture/auth.md` target state is consistent with `docs/sub-phase-7e-plan.md` current state delta
- [ ] Confirm both per-app CLAUDE.md files reference the correct CDK stack names from `infrastructure/bin/app.ts`
- [ ] CI passes (no code changes — lint/typecheck should be clean)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)