### PR TITLE
feat(cognito): add three-tier access groups + remove custom:active_account

### DIFF
--- a/docs/sub-phase-7e-plan.md
+++ b/docs/sub-phase-7e-plan.md
@@ -1,6 +1,6 @@
 # Sub-phase 7e — Auth and permissions migration plan
 
-**Status:** Planning  
+**Status:** In progress — 7e-prep-1 merged (pending deploy)  
 **Target architecture:** [/docs/architecture/auth.md](/docs/architecture/auth.md)  
 **Ephemeral document:** deleted at 7e-cleanup once the migration is complete and `auth.md` is verified against deployed reality.
 
@@ -47,7 +47,7 @@
 
 ## Sub-sub-phases
 
-### 7e-prep-1 — CDK: new group structure (additive)
+### 7e-prep-1 — CDK: new group structure (additive) ✓ merged — pending deploy + post-deploy step
 
 Create new Cognito groups in `AuthStack` alongside existing groups:
 - `site-admin`, `stock-app-access`, `budget-app-access`
@@ -59,6 +59,11 @@ Remove the `custom:active_account` custom attribute from the user pool (it is no
 After deploy: manually add Steve to `site-admin`, `stock-app-access`, `budget-app-access`.
 
 **Verification:** Steve signs in; `cognito:groups` claim includes both `admin` (old) and `site-admin` (new).
+
+**Observations during execution:**
+- Pre-flight found Steve had `custom:active_account` set to `6f28aaa4-9393-40b0-ad14-fe3ed5e325d4`. Cleared via `AdminDeleteUserAttributes` before CDK removes the schema entry.
+- `admin` group precedence bumped from 1 → 2 so `site-admin` can take precedence 1. No functional impact.
+- `custom:active_account` was also listed in all three app client `readAttributes`/`writeAttributes` — removed from those too.
 
 ### 7e-prep-2 — Lambda-layer: dual-gate authorization
 

--- a/infrastructure/lib/platform/auth-stack.ts
+++ b/infrastructure/lib/platform/auth-stack.ts
@@ -19,15 +19,19 @@ export interface AuthStackProps extends cdk.StackProps {
  * Hosted UI domain session cookie.
  *
  * Groups (control Launchpad rendering and Lambda authoriser):
- *   admin          — platform administrators, access to all apps
- *   stock-app      — Stock Signal Analyser
- *   budget-app     — Budget Tracker
- *   transformotion — Transformotion Framework
- *   family         — family members (basic access, assigned per invitation)
+ *   Target groups (7e-prep-1):
+ *     site-admin        — platform administrators
+ *     stock-app-access  — Stock Signal Analyser access
+ *     budget-app-access — Budget Tracker access
+ *   Legacy groups (removed at 7e-cleanup):
+ *     admin          — platform administrators, access to all apps
+ *     stock-app      — Stock Signal Analyser
+ *     budget-app     — Budget Tracker
+ *     transformotion — Transformotion Framework
+ *     family         — family members (basic access, assigned per invitation)
  *
  * Custom attributes (stored on the Cognito user object):
- *   custom:active_account — UUID of the user's currently active account
- *   custom:accounts       — comma-separated UUIDs of all accounts the user belongs to
+ *   custom:accounts — JSON-stringified map of appSlug → [{accountId, role}]
  *
  * Social IDPs (Google, Facebook, Microsoft) are wired here with Secrets Manager
  * references. Secrets are created with generated placeholder values. Populate real
@@ -65,10 +69,9 @@ export class AuthStack extends cdk.Stack {
         familyName: { required: false, mutable: true },
       },
 
-      // Custom attributes for account-based multi-tenancy (Section 9)
+      // Custom attributes for account-based multi-tenancy
       customAttributes: {
-        active_account: new cognito.StringAttribute({ mutable: true, maxLen: 36 }),
-        accounts:       new cognito.StringAttribute({ mutable: true, maxLen: 2048 }),
+        accounts: new cognito.StringAttribute({ mutable: true, maxLen: 2048 }),
       },
 
       // Password policy
@@ -201,7 +204,12 @@ export class AuthStack extends cdk.Stack {
 
     // ── Cognito Groups ─────────────────────────────────────────────────────
     const groups: Array<{ name: string; description: string; precedence: number }> = [
-      { name: 'admin',          description: 'Platform administrators — full access to all apps', precedence: 1  },
+      // Target groups (7e-prep-1) — accepted by handlers after 7e-prep-2 dual-gate
+      { name: 'site-admin',        description: 'Platform administrator',          precedence: 1  },
+      { name: 'stock-app-access',  description: 'User has access to Stock Signal', precedence: 50 },
+      { name: 'budget-app-access', description: 'User has access to Budget Tracker', precedence: 60 },
+      // Legacy groups — removed at 7e-cleanup
+      { name: 'admin',          description: 'Platform administrators — full access to all apps', precedence: 2  },
       { name: 'stock-app',      description: 'Stock Signal Analyser access',                       precedence: 10 },
       { name: 'budget-app',     description: 'Budget Tracker access',                              precedence: 20 },
       { name: 'transformotion', description: 'Transformotion Framework access',                    precedence: 30 },
@@ -291,10 +299,10 @@ export class AuthStack extends cdk.Stack {
       refreshTokenValidity: cdk.Duration.days(30),
       readAttributes: new cognito.ClientAttributes()
         .withStandardAttributes({ email: true, emailVerified: true, givenName: true, familyName: true })
-        .withCustomAttributes('active_account', 'accounts'),
+        .withCustomAttributes('accounts'),
       writeAttributes: new cognito.ClientAttributes()
         .withStandardAttributes({ email: true, givenName: true, familyName: true })
-        .withCustomAttributes('active_account', 'accounts'),
+        .withCustomAttributes('accounts'),
     });
   }
 }


### PR DESCRIPTION
Phase 1 sub-phase 7e-prep-1.

Creates the three new access groups per the target model in `docs/architecture/auth.md`: `stock-app-access`, `budget-app-access`, `site-admin`.

Removes the `custom:active_account` user pool attribute — active account is now client-side UI state per auth.md. Pre-flight found Steve had a value set (`6f28aaa4...`); cleared via `AdminDeleteUserAttributes` before this deploy.

Also removes `custom:active_account` from all three app client `readAttributes`/`writeAttributes`.

Old groups (`admin`, `stock-app`, `budget-app`, `transformotion`, `family`) unchanged. They remain functional until 7e-cleanup.

**Post-deploy manual step required.** After `deploy-platform.yml` completes on merge, Steve needs to be added to the three new groups:

```
aws cognito-idp admin-add-user-to-group --user-pool-id ap-southeast-2_7QhxUvefw --username f90ed478-4011-7052-def2-0d79e847ffd2 --group-name stock-app-access
aws cognito-idp admin-add-user-to-group --user-pool-id ap-southeast-2_7QhxUvefw --username f90ed478-4011-7052-def2-0d79e847ffd2 --group-name budget-app-access
aws cognito-idp admin-add-user-to-group --user-pool-id ap-southeast-2_7QhxUvefw --username f90ed478-4011-7052-def2-0d79e847ffd2 --group-name site-admin
```

Steve retains membership in `admin` through to 7e-cleanup.

**cdk diff:**

```
Stack TransformotionDev-Auth
Resources
[+] AWS::Cognito::UserPoolGroup Group-site-admin Groupsiteadmin
[+] AWS::Cognito::UserPoolGroup Group-stock-app-access Groupstockappaccess
[+] AWS::Cognito::UserPoolGroup Group-budget-app-access Groupbudgetappaccess
[~] AWS::Cognito::UserPool UserPool UserPool6BA7E5F2
 └─ [~] Schema
     └─ removes active_account attribute (custom:active_account — mutable string maxLen 36)
[~] AWS::Cognito::UserPoolClient UserPool/LaunchpadAppClient (read+write attributes)
[~] AWS::Cognito::UserPoolClient UserPool/StockAnalyserAppClient (read+write attributes)
[~] AWS::Cognito::UserPoolClient UserPool/BudgetTrackerAppClient (read+write attributes)
[~] AWS::Cognito::UserPoolGroup Group-admin
 └─ [~] Precedence 1 → 2 (site-admin takes 1)
```