### PR TITLE
fix(cognito): restore custom:active_account schema declaration (cannot be deleted)

### DIFF
--- a/docs/architecture/auth.md
+++ b/docs/architecture/auth.md
@@ -30,15 +30,14 @@ See [cdk.md](./cdk.md) for CDK stack names. See [data.md](./data.md) for account
 
 ### Custom attributes
 
-Only one custom attribute is used on the Cognito user record:
+The Cognito user pool declares these custom attributes:
 
-| Attribute | Type | Purpose |
-|---|---|---|
-| `custom:accounts` | String (max 2048) | Comma-separated account IDs the user belongs to (all apps combined). Maintained by the Lambdas that modify account membership; read by the pre-token Lambda. Not consulted directly by frontend or API handlers. |
+| Attribute | Type | Status | Purpose |
+|---|---|---|---|
+| `custom:accounts` | String (max 2048) | Active | Comma-separated account IDs the user belongs to (all apps combined). Maintained by the Lambdas that modify account membership; read by the pre-token Lambda. Not consulted directly by frontend or API handlers. |
+| `custom:active_account` | String (max 36) | Declared but unused | Historical attribute; no longer written or read by any code. Cannot be removed from the schema — Cognito does not permit removal of existing user pool schema attributes. Remains declared but inert. |
 
 **Active account is not a Cognito attribute.** Which account a user is currently viewing in an app is browser-local UI state, persisted in localStorage per-app. API requests include the `accountId` as a request parameter. The auth middleware validates the parameter against the token's `accounts` claim and rejects requests where the caller is not a member of the stated account.
-
-> **Migration note:** The currently deployed user pool has `custom:active_account` (singular UUID). This attribute is removed entirely in sub-phase 7e-prep-1.
 
 ### Token lifetime
 

--- a/docs/sub-phase-7e-plan.md
+++ b/docs/sub-phase-7e-plan.md
@@ -52,7 +52,7 @@
 Create new Cognito groups in `AuthStack` alongside existing groups:
 - `site-admin`, `stock-app-access`, `budget-app-access`
 
-Remove the `custom:active_account` custom attribute from the user pool (it is not migrated to a plural form — active account selection moves to client-side localStorage).
+Deprecate `custom:active_account`: Cognito does not permit removing schema attributes once declared in a live user pool, so the attribute remains in the CDK schema as a no-op declaration. No code writes or reads it; Steve's user value has been cleared. The attribute is removed from all app client `readAttributes`/`writeAttributes` lists (this change IS permitted by Cognito).
 
 **Old groups are NOT removed in this step** — they coexist during migration.
 
@@ -61,10 +61,9 @@ After deploy: manually add Steve to `site-admin`, `stock-app-access`, `budget-ap
 **Verification:** Steve signs in; `cognito:groups` claim includes both `admin` (old) and `site-admin` (new).
 
 **Observations during execution:**
-- Pre-flight found Steve had `custom:active_account` set to `6f28aaa4-9393-40b0-ad14-fe3ed5e325d4`. Cleared via `AdminDeleteUserAttributes`.
-- Cognito does NOT allow deleting existing schema attributes from a live user pool ("Existing schema attributes cannot be modified or deleted."). First deploy attempt failed with `UPDATE_FAILED`. Fixed by retaining `active_account` in the CDK schema as a deprecated no-op declaration.
-- `custom:active_account` removed from all three app client `readAttributes`/`writeAttributes` — this change IS allowed and deployed successfully.
-- `admin` group precedence bumped from 1 → 2 so `site-admin` can take precedence 1. No functional impact.
+- Pre-flight found Steve had `custom:active_account` set to `6f28aaa4-9393-40b0-ad14-fe3ed5e325d4`. Cleared via `AdminDeleteUserAttributes` before deploy.
+- Initial deploy attempt (PR #51 merge) failed: CDK attempted to delete the `custom:active_account` schema attribute, which Cognito rejected with "Existing schema attributes cannot be modified or deleted." The stack rolled back cleanly (`UPDATE_ROLLBACK_COMPLETE`); no production impact. New groups were also rolled back.
+- PR #52 corrected the approach: `active_account` is retained in the CDK schema as a deprecated no-op; only the app client attribute lists are changed (permitted). `admin` group precedence bumped 1 → 2 so `site-admin` takes 1.
 
 ### 7e-prep-2 — Lambda-layer: dual-gate authorization
 

--- a/docs/sub-phase-7e-plan.md
+++ b/docs/sub-phase-7e-plan.md
@@ -36,7 +36,7 @@
 | Component | Current | Target |
 |---|---|---|
 | Cognito groups | `admin`, `stock-app`, `budget-app`, `transformotion`, `family` | `site-admin`, `stock-app-access`, `budget-app-access` |
-| Custom attributes | `custom:active_account` (UUID), `custom:accounts` | Remove `custom:active_account`; keep `custom:accounts` (now JSON-stringified map) |
+| Custom attributes | `custom:active_account` (UUID), `custom:accounts` | `custom:active_account` retained as deprecated no-op (Cognito does not permit schema attribute deletion); keep `custom:accounts` (now JSON-stringified map) |
 | Pre-token Lambda | None | Injects `apps`, `site_admin`, `accounts` claims + reconciles group membership |
 | Auth middleware | `requireGroup(auth, ...groups)` | + `requireSiteAdmin`, `requireAppAccess`, `requireAccountAccess`, `requireAccountOwner` helpers |
 | Lambda authorization | `requireGroup` call sites | `requireAppAccess` + `requireAccountAccess` (+ `requireAccountOwner` for ownership ops) |
@@ -61,9 +61,10 @@ After deploy: manually add Steve to `site-admin`, `stock-app-access`, `budget-ap
 **Verification:** Steve signs in; `cognito:groups` claim includes both `admin` (old) and `site-admin` (new).
 
 **Observations during execution:**
-- Pre-flight found Steve had `custom:active_account` set to `6f28aaa4-9393-40b0-ad14-fe3ed5e325d4`. Cleared via `AdminDeleteUserAttributes` before CDK removes the schema entry.
+- Pre-flight found Steve had `custom:active_account` set to `6f28aaa4-9393-40b0-ad14-fe3ed5e325d4`. Cleared via `AdminDeleteUserAttributes`.
+- Cognito does NOT allow deleting existing schema attributes from a live user pool ("Existing schema attributes cannot be modified or deleted."). First deploy attempt failed with `UPDATE_FAILED`. Fixed by retaining `active_account` in the CDK schema as a deprecated no-op declaration.
+- `custom:active_account` removed from all three app client `readAttributes`/`writeAttributes` — this change IS allowed and deployed successfully.
 - `admin` group precedence bumped from 1 → 2 so `site-admin` can take precedence 1. No functional impact.
-- `custom:active_account` was also listed in all three app client `readAttributes`/`writeAttributes` — removed from those too.
 
 ### 7e-prep-2 — Lambda-layer: dual-gate authorization
 

--- a/infrastructure/lib/platform/auth-stack.ts
+++ b/infrastructure/lib/platform/auth-stack.ts
@@ -31,7 +31,10 @@ export interface AuthStackProps extends cdk.StackProps {
  *     family         — family members (basic access, assigned per invitation)
  *
  * Custom attributes (stored on the Cognito user object):
- *   custom:accounts — JSON-stringified map of appSlug → [{accountId, role}]
+ *   custom:active_account — DEPRECATED. Retained because Cognito does not permit
+ *                           deleting existing schema attributes from a live user pool.
+ *                           Will never be set. Active account is client-side UI state.
+ *   custom:accounts       — JSON-stringified map of appSlug → [{accountId, role}]
  *
  * Social IDPs (Google, Facebook, Microsoft) are wired here with Secrets Manager
  * references. Secrets are created with generated placeholder values. Populate real
@@ -69,9 +72,14 @@ export class AuthStack extends cdk.Stack {
         familyName: { required: false, mutable: true },
       },
 
-      // Custom attributes for account-based multi-tenancy
+      // Custom attributes for account-based multi-tenancy.
+      // NOTE: active_account is deprecated (active account is now client-side UI state).
+      // Cognito does not permit deleting existing schema attributes from a live user pool
+      // ("Existing schema attributes cannot be modified or deleted."). Retained as a
+      // no-op declaration; will never be set again.
       customAttributes: {
-        accounts: new cognito.StringAttribute({ mutable: true, maxLen: 2048 }),
+        active_account: new cognito.StringAttribute({ mutable: true, maxLen: 36 }),
+        accounts:       new cognito.StringAttribute({ mutable: true, maxLen: 2048 }),
       },
 
       // Password policy


### PR DESCRIPTION
Fixes the failed deploy from PR #51.

**Root cause:** Cognito does not permit deleting existing schema attributes from a live user pool. The previous deploy attempt failed with:
```
Invalid request provided: Existing schema attributes cannot be modified or deleted.
```

**Fix:** Restores `active_account` to the CDK `customAttributes` block as a deprecated no-op declaration — it satisfies the CloudFormation schema contract without ever being set.

**What still deploys from PR #51's intent:**
- Three new groups (`site-admin`, `stock-app-access`, `budget-app-access`) ✓
- `custom:active_account` removed from all three app client `readAttributes`/`writeAttributes` ✓ (this IS permitted)
- `admin` group precedence 1 → 2 ✓

**Updated cdk diff (no UserPool schema change):**
```
[+] AWS::Cognito::UserPoolGroup Group-site-admin
[+] AWS::Cognito::UserPoolGroup Group-stock-app-access
[+] AWS::Cognito::UserPoolGroup Group-budget-app-access
[~] UserPool/LaunchpadAppClient — removes custom:active_account from read+write
[~] UserPool/StockAnalyserAppClient — removes custom:active_account from read+write
[~] UserPool/BudgetTrackerAppClient — removes custom:active_account from read+write
[~] Group-admin — precedence 1 → 2
```