### PR TITLE
feat(authz): 7e-prep-2 — dual-gate Lambda handlers for old and new Cognito groups

### DIFF
--- a/apps/budget-tracker/functions/budget-ai/src/index.ts
+++ b/apps/budget-tracker/functions/budget-ai/src/index.ts
@@ -194,7 +194,7 @@ async function csvAnalysis(
 
 // ── Handler ───────────────────────────────────────────────────────────────────
 export const handler = withAuth(async ({ auth, account, event }) => {
-  requireGroup(auth, 'budget-app', 'admin');
+  requireGroup(auth, 'budget-app', 'budget-app-access', 'admin', 'site-admin');
   const resource = event.resource ?? '';
 
   if (resource === '/api/budget/v1/ai/categorise')    return categorise(auth, account.accountId, event);

--- a/apps/budget-tracker/functions/budget-export/src/index.ts
+++ b/apps/budget-tracker/functions/budget-export/src/index.ts
@@ -14,7 +14,7 @@ function toIso(ddmmyyyy: string): string {
 
 // GET /api/budget/v1/business-export
 export const handler = withAuth(async ({ auth, account, event }) => {
-  requireGroup(auth, 'budget-app', 'admin');
+  requireGroup(auth, 'budget-app', 'budget-app-access', 'admin', 'site-admin');
   const { accountId } = account;
 
   const from = getQueryParam(event, 'from', false);

--- a/apps/budget-tracker/functions/budget-migrate/src/index.ts
+++ b/apps/budget-tracker/functions/budget-migrate/src/index.ts
@@ -68,7 +68,7 @@ async function batchWrite(table: string, items: Record<string, unknown>[]) {
 
 // POST /api/budget/v1/migrate-from-localstorage
 export const handler = withAuth(async ({ auth, account, event }) => {
-  requireGroup(auth, 'budget-app', 'admin');
+  requireGroup(auth, 'budget-app', 'budget-app-access', 'admin', 'site-admin');
   const { accountId } = account;
 
   const { transactions, rules, settings } = parseBody<{

--- a/apps/budget-tracker/functions/budget-rules/src/index.ts
+++ b/apps/budget-tracker/functions/budget-rules/src/index.ts
@@ -92,7 +92,7 @@ async function deleteRule(accountId: string, ruleId: string) {
 
 // ── Handler ───────────────────────────────────────────────────────────────────
 export const handler = withAuth(async ({ auth, account, event }) => {
-  requireGroup(auth, 'budget-app', 'admin');
+  requireGroup(auth, 'budget-app', 'budget-app-access', 'admin', 'site-admin');
   const { accountId } = account;
   const method = event.httpMethod;
   const resource = event.resource ?? '';

--- a/apps/budget-tracker/functions/budget-settings/src/index.ts
+++ b/apps/budget-tracker/functions/budget-settings/src/index.ts
@@ -67,7 +67,7 @@ async function updateSettings(event: Parameters<typeof parseBody>[0], accountId:
 }
 
 export const handler = withAuth(async ({ auth, account, event }) => {
-  requireGroup(auth, 'budget-app', 'admin');
+  requireGroup(auth, 'budget-app', 'budget-app-access', 'admin', 'site-admin');
   const { accountId } = account;
   if (event.httpMethod === 'GET')   return getSettings(accountId);
   if (event.httpMethod === 'PATCH') return updateSettings(event, accountId);

--- a/apps/budget-tracker/functions/budget-transactions/src/index.ts
+++ b/apps/budget-tracker/functions/budget-transactions/src/index.ts
@@ -175,7 +175,7 @@ async function deleteTransaction(accountId: string, transactionId: string) {
 
 // ── Handler ───────────────────────────────────────────────────────────────────
 export const handler = withAuth(async ({ auth, account, event }) => {
-  requireGroup(auth, 'budget-app', 'admin');
+  requireGroup(auth, 'budget-app', 'budget-app-access', 'admin', 'site-admin');
   const { accountId } = account;
   const method   = event.httpMethod;
   const resource = event.resource ?? '';

--- a/apps/stock-analyser/functions/analysis-cache/src/index.ts
+++ b/apps/stock-analyser/functions/analysis-cache/src/index.ts
@@ -77,7 +77,7 @@ function resolveWriteAccountId(cacheKey: string, fallbackAccountId: string, clie
 }
 
 export const handler = withAuth(async ({ auth, account, event }) => {
-  requireGroup(auth, 'stock-app', 'admin');
+  requireGroup(auth, 'stock-app', 'stock-app-access', 'admin', 'site-admin');
   const { accountId } = account;
   // URL-decode the key so clients can send MARKET%23Global and the DDB key is MARKET#Global.
   const cacheKey = decodeURIComponent(getPathParam(event, 'key'));

--- a/apps/stock-analyser/functions/portfolio/src/index.ts
+++ b/apps/stock-analyser/functions/portfolio/src/index.ts
@@ -18,7 +18,7 @@ const ddb = DynamoDBDocumentClient.from(new DynamoDBClient({}));
 const TABLE = process.env.PORTFOLIO_TABLE!;
 
 export const handler = withAuth(async ({ auth, account, event }) => {
-  requireGroup(auth, 'stock-app', 'admin');
+  requireGroup(auth, 'stock-app', 'stock-app-access', 'admin', 'site-admin');
   const { accountId } = account;
 
   // ── GET /portfolio ────────────────────────────────────────────────────────

--- a/apps/stock-analyser/functions/watchlist/src/index.ts
+++ b/apps/stock-analyser/functions/watchlist/src/index.ts
@@ -18,7 +18,7 @@ const ddb = DynamoDBDocumentClient.from(new DynamoDBClient({}));
 const TABLE = process.env.WATCHLIST_TABLE!;
 
 export const handler = withAuth(async ({ auth, account, event }) => {
-  requireGroup(auth, 'stock-app', 'admin');
+  requireGroup(auth, 'stock-app', 'stock-app-access', 'admin', 'site-admin');
   const { accountId } = account;
 
   // ── GET /watchlist ────────────────────────────────────────────────────────

--- a/docs/sub-phase-7e-plan.md
+++ b/docs/sub-phase-7e-plan.md
@@ -1,6 +1,6 @@
 # Sub-phase 7e — Auth and permissions migration plan
 
-**Status:** In progress — 7e-prep-1 merged (pending deploy)  
+**Status:** In progress — 7e-prep-2 dual-gate Lambda handlers (PR open, awaiting review)  
 **Target architecture:** [/docs/architecture/auth.md](/docs/architecture/auth.md)  
 **Ephemeral document:** deleted at 7e-cleanup once the migration is complete and `auth.md` is verified against deployed reality.
 
@@ -47,7 +47,7 @@
 
 ## Sub-sub-phases
 
-### 7e-prep-1 — CDK: new group structure (additive) ✓ merged — pending deploy + post-deploy step
+### 7e-prep-1 — CDK: new group structure (additive) ✓ complete
 
 Create new Cognito groups in `AuthStack` alongside existing groups:
 - `site-admin`, `stock-app-access`, `budget-app-access`
@@ -65,7 +65,7 @@ After deploy: manually add Steve to `site-admin`, `stock-app-access`, `budget-ap
 - Initial deploy attempt (PR #51 merge) failed: CDK attempted to delete the `custom:active_account` schema attribute, which Cognito rejected with "Existing schema attributes cannot be modified or deleted." The stack rolled back cleanly (`UPDATE_ROLLBACK_COMPLETE`); no production impact. New groups were also rolled back.
 - PR #52 corrected the approach: `active_account` is retained in the CDK schema as a deprecated no-op; only the app client attribute lists are changed (permitted). `admin` group precedence bumped 1 → 2 so `site-admin` takes 1.
 
-### 7e-prep-2 — Lambda-layer: dual-gate authorization
+### 7e-prep-2 — Lambda-layer: dual-gate authorization ⟳ in progress (PR open, awaiting review)
 
 Update `requireGroup` calls in Lambda handlers to accept both old and new group names. Transitional — allows the migration to proceed without locking out existing access.
 
@@ -80,6 +80,11 @@ Search codebase for `requireGroup` before starting; expect call sites in:
 Pattern for stock handlers: `requireGroup(auth, 'stock-app', 'admin', 'stock-app-access', 'site-admin')` — temporarily broad.  
 Pattern for budget handlers: `requireGroup(auth, 'budget-app', 'admin', 'budget-app-access', 'site-admin')`.  
 Pattern for claude-proxy: `requireGroup(auth, 'stock-app', 'budget-app', 'admin', 'stock-app-access', 'budget-app-access', 'site-admin')`.
+
+**Observations during execution:**
+- Pre-flight scanned for all `requireGroup` call sites. The string `'admin'` also appears in TypeScript type definitions (`role: 'owner' | 'admin' | 'member'`) in frontend/package files — these are account role types, not Cognito group checks; no dual-gating needed there.
+- 10 handlers updated: 3 Stock Analyser (`portfolio`, `watchlist`, `analysis-cache`), 6 Budget Tracker (`transactions`, `settings`, `rules`, `migrate`, `export`, `ai`), 1 shared (`claude-proxy`).
+- Pre-existing test failures on Windows (`vitest` not found) confirmed unrelated to this change.
 
 ### 7e-pretoken — Pre-token generation Lambda
 

--- a/functions/claude-proxy/src/index.ts
+++ b/functions/claude-proxy/src/index.ts
@@ -267,7 +267,7 @@ async function executeAsyncJob(job: AsyncJobEvent): Promise<void> {
 // ── API Gateway handler (Cognito-authenticated) ───────────────────────────────
 
 const apiGatewayHandler = withAuth(async ({ auth, account, event }) => {
-  requireGroup(auth, 'stock-app', 'budget-app', 'admin');
+  requireGroup(auth, 'stock-app', 'stock-app-access', 'budget-app', 'budget-app-access', 'admin', 'site-admin');
   const {
     prompt,
     system,


### PR DESCRIPTION
## Summary

Transitional bridge for the 7e auth migration. All 10 Lambda handlers now accept **both** the legacy Cognito group names (`admin`, `stock-app`, `budget-app`) and the new names (`site-admin`, `stock-app-access`, `budget-app-access`) in their `requireGroup` calls.

- 3 Stock Analyser handlers: `portfolio`, `watchlist`, `analysis-cache`
- 6 Budget Tracker handlers: `transactions`, `settings`, `rules`, `migrate`, `export`, `ai`
- 1 shared handler: `claude-proxy`

No logic changes — only the group name lists in `requireGroup` are widened.

Also updates `docs/sub-phase-7e-plan.md` to mark 7e-prep-1 complete, 7e-prep-2 in-progress, and adds execution observations.

## Why

Users assigned to the new groups (`site-admin`, `stock-app-access`, `budget-app-access`) after 7e-prep-1 would currently be locked out — old handlers only accepted the legacy names. This change eliminates the lockout without removing the legacy group checks (those remain until 7e-cleanup).

## Test plan

- [ ] CI passes
- [ ] Sign in as a user in only the new groups (`site-admin`, `stock-app-access`, `budget-app-access`) — all Stock Analyser and Budget Tracker API calls succeed
- [ ] Sign in as a user in only the legacy groups (`admin`, `stock-app`, `budget-app`) — all calls still succeed (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)