### PR TITLE
fix(infra): suppress Cognito schema in CloudFormation to unblock UserPool updates

### DIFF
--- a/infrastructure/lib/platform/auth-stack.ts
+++ b/infrastructure/lib/platform/auth-stack.ts
@@ -115,6 +115,13 @@ export class AuthStack extends cdk.Stack {
       removalPolicy: isProd ? cdk.RemovalPolicy.RETAIN : cdk.RemovalPolicy.DESTROY,
     });
 
+    // Schema attributes cannot be modified or deleted once created in Cognito.
+    // CloudFormation's UpdateUserPool call includes Schema on every stack update,
+    // causing Cognito to reject with "Existing schema attributes cannot be modified
+    // or deleted." Removing Schema from the CloudFormation resource prevents this —
+    // the attributes remain live in Cognito from the initial deployment.
+    (this.userPool.node.defaultChild as cognito.CfnUserPool).addPropertyDeletionOverride('Schema');
+
     // ── User Pool Domain ───────────────────────────────────────────────────
     // Provides the Cognito Hosted UI endpoint for OAuth2/PKCE + social IDP flows.
     this.userPoolDomain = this.userPool.addDomain('UserPoolDomain', {


### PR DESCRIPTION
## Summary

- Adds `addPropertyDeletionOverride('Schema')` to the CDK `UserPool` construct in `auth-stack.ts`
- Prevents CloudFormation from including the `Schema` array when calling `UpdateUserPool`, which Cognito rejects with _"Existing schema attributes cannot be modified or deleted"_ even when the attributes are unchanged
- Unblocks PR #54 (pre-token generation Lambda + auth directory reorganisation), which failed deploy with this exact error on run 24869810875

## Why this happens

CDK synthesises `Schema` attributes into `AWS::Cognito::UserPool`. On any stack update (e.g. adding the pre-token trigger), CloudFormation calls `UpdateUserPool` with the full resource spec including `Schema`. Cognito rejects this even when the attributes are identical to what's deployed.

`addPropertyDeletionOverride('Schema')` removes `Schema` from the CloudFormation template. The attributes remain live in Cognito from the initial deployment — CloudFormation just stops trying to manage them.

## Test plan

- [ ] CI typecheck passes
- [ ] CDK Deploy — Platform stacks (dev) succeeds without Cognito schema error
- [ ] Auth stack deploys with pre-token trigger wired (from PR #54)

🤖 Generated with [Claude Code](https://claude.com/claude-code)