### PR TITLE
fix(cdk): pre-token Lambda GSI query permissions

### DIFF
--- a/infrastructure/lib/platform/auth-stack.ts
+++ b/infrastructure/lib/platform/auth-stack.ts
@@ -220,8 +220,11 @@ export class AuthStack extends cdk.Stack {
     // Injects `apps`, `site_admin`, `accounts` claims on every token issuance.
     // Enforces the app-access invariant by reconciling Cognito group membership
     // against account memberships in platform.account-members-{stage}.
-    const accountMembersTable = dynamodb.Table.fromTableName(
-      this, 'PreTokenAccountMembersTable', `platform.account-members-${stage}`,
+    const accountMembersTable = dynamodb.Table.fromTableAttributes(
+      this, 'PreTokenAccountMembersTable', {
+        tableName:     `platform.account-members-${stage}`,
+        globalIndexes: ['userId-index'],
+      },
     );
     const accountsTable = dynamodb.Table.fromTableName(
       this, 'PreTokenAccountsTable', `platform.accounts-${stage}`,


### PR DESCRIPTION
## Summary

- Pre-token Lambda was failing silently on every invocation — tokens had no custom claims
- Root cause: `Table.fromTableName()` returns an `ITable` that doesn't know about GSIs, so `grantReadData()` only generated a policy on the table ARN, not the index ARN
- Fix: use `Table.fromTableAttributes()` with an explicit `globalIndexes: ['userId-index']` list
- CDK diff shows only IAM policy change — `table/platform.account-members-dev/index/*` added to the two DynamoDB statement resources

## cdk diff (Auth stack only — one change)

```
IAM Statement Changes:
+ arn:...:table/platform.account-members-dev
  arn:...:table/platform.account-members-dev/index/*   Allow  dynamodb:Query (+ others)  PreTokenGenerationFn/ServiceRole
```

No Lambda replacements. No other resource changes.

## Audit note — separate bug exists

`budget-tracker-api-stack.ts` imports `budget-tracker.transactions-{stage}` via `fromTableName` but the `TransactionsFn` and `ExportFn` Lambdas query the `accountId-dateIso-index` GSI — same latent bug. Not fixed here per scope agreement. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)