### PR TITLE
fix(infra): enforce table namespace — move analysis-cache to stock-analyser, drop budget-tracker.accounts

### DIFF
--- a/docs/architecture/data.md
+++ b/docs/architecture/data.md
@@ -24,6 +24,8 @@ See [auth.md](./auth.md) for the account membership model. See [cdk.md](./cdk.md
 
 Examples: `platform.accounts-dev`, `budget-tracker.transactions-prod`, `stock-analyser.portfolio-dev-v2`
 
+**Enforcement rule:** App-specific tables must never use the `platform.` prefix. If a table is only read or written by one app's Lambdas, it belongs in that app's scope (e.g. `stock-analyser.*`, `budget-tracker.*`) and in that app's `TablesStack`.
+
 ---
 
 ## Platform tables
@@ -92,17 +94,6 @@ Pending, redeemed, and expired invitations.
 
 Served by `transformotion-invitations-{stage}` Lambda.
 
-### `platform.analysis-cache-{stage}`
-
-Shared Claude AI response cache, used by the `transformotion-claude-proxy-{stage}` Lambda across all apps.
-
-| Attribute | Type | Notes |
-|---|---|---|
-| `accountId` (PK) | String | |
-| `cacheKey` (SK) | String | Namespaced cache key (e.g. `MARKET#ASX`, `ANALYSIS#CBA.AX`) |
-| `result` | Map | Cached response |
-| `expiresAt` | Number | Epoch-seconds (TTL attribute) |
-
 ---
 
 ## Per-app tables
@@ -125,24 +116,24 @@ Managed by `TransformotionDev-StockAnalyserTables` / `TransformotionProd-StockAn
 | `accountId` (PK) | String | |
 | `items` | List | Serialised `WatchlistItem[]` |
 
+#### `stock-analyser.analysis-cache-{stage}`
+
+Cache of Claude AI analysis results, keyed per account.
+
+| Attribute | Type | Notes |
+|---|---|---|
+| `accountId` (PK) | String | |
+| `cacheKey` (SK) | String | Namespaced cache key (e.g. `MARKET#ASX`, `ANALYSIS#CBA.AX`) |
+| `result` | Map | Cached response |
+| `expiresAt` | Number | Epoch-seconds (TTL attribute) |
+
+Served by `transformotion-analysis-cache-{stage}` Lambda (`GET/PUT/DELETE /analysis-cache/{key}`).
+
 For full type definitions see [apps/stock-analyser/contracts/DATA_CONTRACTS.md](/apps/stock-analyser/contracts/DATA_CONTRACTS.md).
 
 ### Budget Tracker
 
 Managed by `TransformotionDev-BudgetTrackerTables` / `TransformotionProd-BudgetTrackerTables`.
-
-#### `budget-tracker.accounts-{stage}`
-
-Budget-Tracker-specific account container. Stores account name and members list as a nested attribute.
-
-| Attribute | Type | Notes |
-|---|---|---|
-| `accountId` (PK) | String | UUID |
-| `name` | String | Household name |
-| `members` | List | `[{ userId, role, email, joinedAt }]` |
-| `createdAt` | String | ISO 8601 |
-
-> **Duplication note:** This table partially overlaps with `platform.accounts` and `platform.account-members`. Consolidation to the platform tables is deferred to a future cleanup phase.
 
 #### `budget-tracker.transactions-{stage}`
 

--- a/infrastructure/bin/app.ts
+++ b/infrastructure/bin/app.ts
@@ -49,10 +49,16 @@ new AuthApiStack(app, 'TransformotionDev-AuthApi', {
   appUrl:      'https://dev.apps.transformotion.com.au',
 });
 
-const devPlatformTables = new PlatformTablesStack(app, 'TransformotionDev-PlatformTables', {
+new PlatformTablesStack(app, 'TransformotionDev-PlatformTables', {
   env,
   stage:       'dev',
-  description: 'Transformotion Apps — Dev platform DynamoDB tables (users, accounts, invitations, analysis-cache)',
+  description: 'Transformotion Apps — Dev platform DynamoDB tables (users, accounts, invitations)',
+});
+
+const devStockAnalyserTables = new StockAnalyserTablesStack(app, 'TransformotionDev-StockAnalyserTables', {
+  env,
+  stage:       'dev',
+  description: 'Transformotion Apps — Dev Stock Analyser DynamoDB tables',
 });
 
 const devPlatformApi = new PlatformApiStack(app, 'TransformotionDev-Api', {
@@ -60,13 +66,7 @@ const devPlatformApi = new PlatformApiStack(app, 'TransformotionDev-Api', {
   stage:              'dev',
   description:        'Transformotion Apps — Dev platform API (shared routes for all apps)',
   userPool:           devAuth.userPool,
-  analysisCacheTable: devPlatformTables.analysisCacheTable,
-});
-
-new StockAnalyserTablesStack(app, 'TransformotionDev-StockAnalyserTables', {
-  env,
-  stage:       'dev',
-  description: 'Transformotion Apps — Dev Stock Analyser DynamoDB tables',
+  analysisCacheTable: devStockAnalyserTables.analysisCacheTable,
 });
 
 new StockAnalyserApiStack(app, 'TransformotionDev-StockAnalyserApi', {
@@ -113,10 +113,16 @@ new AuthApiStack(app, 'TransformotionProd-AuthApi', {
   appUrl:      'https://apps.transformotion.com.au',
 });
 
-const prodPlatformTables = new PlatformTablesStack(app, 'TransformotionProd-PlatformTables', {
+new PlatformTablesStack(app, 'TransformotionProd-PlatformTables', {
   env,
   stage:       'prod',
-  description: 'Transformotion Apps — Prod platform DynamoDB tables',
+  description: 'Transformotion Apps — Prod platform DynamoDB tables (users, accounts, invitations)',
+});
+
+const prodStockAnalyserTables = new StockAnalyserTablesStack(app, 'TransformotionProd-StockAnalyserTables', {
+  env,
+  stage:       'prod',
+  description: 'Transformotion Apps — Prod Stock Analyser DynamoDB tables',
 });
 
 const prodPlatformApi = new PlatformApiStack(app, 'TransformotionProd-Api', {
@@ -124,13 +130,7 @@ const prodPlatformApi = new PlatformApiStack(app, 'TransformotionProd-Api', {
   stage:              'prod',
   description:        'Transformotion Apps — Prod platform API (shared routes for all apps)',
   userPool:           prodAuth.userPool,
-  analysisCacheTable: prodPlatformTables.analysisCacheTable,
-});
-
-new StockAnalyserTablesStack(app, 'TransformotionProd-StockAnalyserTables', {
-  env,
-  stage:       'prod',
-  description: 'Transformotion Apps — Prod Stock Analyser DynamoDB tables',
+  analysisCacheTable: prodStockAnalyserTables.analysisCacheTable,
 });
 
 new StockAnalyserApiStack(app, 'TransformotionProd-StockAnalyserApi', {

--- a/infrastructure/lib/budget-tracker/budget-tracker-tables-stack.ts
+++ b/infrastructure/lib/budget-tracker/budget-tracker-tables-stack.ts
@@ -10,7 +10,6 @@ export interface BudgetTrackerTablesStackProps extends cdk.StackProps {
  * BudgetTrackerTablesStack — DynamoDB tables for Budget Tracker.
  *
  * Tables (all prefixed budget-tracker.):
- *   budget-tracker.accounts      PK: accountId
  *   budget-tracker.transactions  PK: accountId  SK: transactionId
  *                                GSI: accountId-dateIso-index (PK: accountId, SK: dateIso)
  *   budget-tracker.rules         PK: accountId  SK: ruleId
@@ -24,7 +23,6 @@ export class BudgetTrackerTablesStack extends cdk.Stack {
   public readonly transactionsTable: dynamodb.Table;
   public readonly rulesTable:        dynamodb.Table;
   public readonly settingsTable:     dynamodb.Table;
-  public readonly accountsTable:     dynamodb.Table;
 
   constructor(scope: Construct, id: string, props: BudgetTrackerTablesStackProps) {
     super(scope, id, props);
@@ -36,14 +34,6 @@ export class BudgetTrackerTablesStack extends cdk.Stack {
     // Apply per-app tags to every resource in this stack
     cdk.Tags.of(this).add('app',         'budget-tracker');
     cdk.Tags.of(this).add('environment', stage);
-
-    // ── budget-tracker.accounts ───────────────────────────────────────────────
-    this.accountsTable = new dynamodb.Table(this, 'AccountsTable', {
-      tableName:     `budget-tracker.accounts-${stage}`,
-      partitionKey:  { name: 'accountId', type: dynamodb.AttributeType.STRING },
-      billingMode:   dynamodb.BillingMode.PAY_PER_REQUEST,
-      removalPolicy: removal,
-    });
 
     // ── budget-tracker.transactions ───────────────────────────────────────────
     this.transactionsTable = new dynamodb.Table(this, 'TransactionsTable', {
@@ -83,7 +73,6 @@ export class BudgetTrackerTablesStack extends cdk.Stack {
     const out = (id: string, value: string, description: string) =>
       new cdk.CfnOutput(this, id, { value, description, exportName: `Transformotion-${stage}-${id}` });
 
-    out('BTAccountsTableArn',     this.accountsTable.tableArn,     'budget-tracker.accounts table ARN');
     out('BTTransactionsTableArn', this.transactionsTable.tableArn, 'budget-tracker.transactions table ARN');
     out('BTRulesTableArn',        this.rulesTable.tableArn,        'budget-tracker.rules table ARN');
     out('BTSettingsTableArn',     this.settingsTable.tableArn,     'budget-tracker.settings table ARN');

--- a/infrastructure/lib/platform/platform-tables-stack.ts
+++ b/infrastructure/lib/platform/platform-tables-stack.ts
@@ -14,8 +14,6 @@ export interface PlatformTablesStackProps extends cdk.StackProps {
  *   platform.accounts        PK: accountId
  *   platform.account-members PK: accountId  SK: userId
  *   platform.invitations     PK: invitationId   TTL: expiresAt
- *   platform.analysis-cache  PK: accountId  SK: cacheKey   TTL: expiresAt
- *     (used by the shared claude-proxy Lambda — all apps share one cache)
  *
  * Per-app tables live in their own app stacks (see apps/<app>/infrastructure/).
  */
@@ -24,7 +22,6 @@ export class PlatformTablesStack extends cdk.Stack {
   public readonly accountsTable:       dynamodb.Table;
   public readonly accountMembersTable: dynamodb.Table;
   public readonly invitationsTable:    dynamodb.Table;
-  public readonly analysisCacheTable:  dynamodb.Table;
 
   constructor(scope: Construct, id: string, props: PlatformTablesStackProps) {
     super(scope, id, props);
@@ -83,18 +80,6 @@ export class PlatformTablesStack extends cdk.Stack {
       projectionType: dynamodb.ProjectionType.ALL,
     });
 
-    // ── platform.analysis-cache ───────────────────────────────────────────
-    // Shared by the claude-proxy Lambda across all apps.
-    // PK: accountId  SK: cacheKey   TTL: expiresAt (epoch seconds)
-    this.analysisCacheTable = new dynamodb.Table(this, 'AnalysisCacheTable', {
-      tableName:     `platform.analysis-cache-${stage}`,
-      partitionKey:  { name: 'accountId', type: dynamodb.AttributeType.STRING },
-      sortKey:       { name: 'cacheKey',  type: dynamodb.AttributeType.STRING },
-      billingMode:   dynamodb.BillingMode.PAY_PER_REQUEST,
-      timeToLiveAttribute: 'expiresAt',
-      removalPolicy: removal,
-    });
-
     // ── Outputs ───────────────────────────────────────────────────────────
     const out = (id: string, table: dynamodb.Table, hint: string) => {
       new cdk.CfnOutput(this, id, {
@@ -108,6 +93,5 @@ export class PlatformTablesStack extends cdk.Stack {
     out('AccountsTableArn',       this.accountsTable,       'platform.accounts table ARN');
     out('AccountMembersTableArn', this.accountMembersTable, 'platform.account-members table ARN');
     out('InvitationsTableArn',    this.invitationsTable,    'platform.invitations table ARN');
-    out('AnalysisCacheTableArn',  this.analysisCacheTable,  'platform.analysis-cache table ARN');
   }
 }

--- a/infrastructure/lib/stock-analyser/stock-analyser-api-stack.ts
+++ b/infrastructure/lib/stock-analyser/stock-analyser-api-stack.ts
@@ -89,13 +89,12 @@ export class StockAnalyserApiStack extends cdk.Stack {
       runtime:      lambda.Runtime.NODEJS_20_X,
       timeout:      cdk.Duration.seconds(15),
       memorySize:   256,
-      environment:  { CACHE_TABLE: `platform.analysis-cache-${stage}` },
+      environment:  { CACHE_TABLE: `stock-analyser.analysis-cache-${stage}` },
       bundling:     { externalModules: ['@aws-sdk/*'], minify: true, sourceMap: false, forceDockerBundling: false },
     });
 
-    // Grant cache Lambda access to the platform analysis-cache table
     const analysisCacheTable = dynamodb.Table.fromTableName(
-      this, 'AnalysisCacheTable', `platform.analysis-cache-${stage}`,
+      this, 'AnalysisCacheTable', `stock-analyser.analysis-cache-${stage}`,
     );
     analysisCacheTable.grantReadWriteData(cacheFn);
 

--- a/infrastructure/lib/stock-analyser/stock-analyser-tables-stack.ts
+++ b/infrastructure/lib/stock-analyser/stock-analyser-tables-stack.ts
@@ -10,12 +10,14 @@ export interface StockAnalyserTablesStackProps extends cdk.StackProps {
  * StockAnalyserTablesStack — DynamoDB tables owned by the Stock Analyser app.
  *
  * Tables:
- *   stock-analyser.portfolio  PK: accountId
- *   stock-analyser.watchlist  PK: accountId
+ *   stock-analyser.portfolio       PK: accountId  SK: ticker
+ *   stock-analyser.watchlist       PK: accountId  SK: ticker
+ *   stock-analyser.analysis-cache  PK: accountId  SK: cacheKey  TTL: expiresAt
  */
 export class StockAnalyserTablesStack extends cdk.Stack {
-  public readonly portfolioTable: dynamodb.Table;
-  public readonly watchlistTable: dynamodb.Table;
+  public readonly portfolioTable:     dynamodb.Table;
+  public readonly watchlistTable:     dynamodb.Table;
+  public readonly analysisCacheTable: dynamodb.Table;
 
   constructor(scope: Construct, id: string, props: StockAnalyserTablesStackProps) {
     super(scope, id, props);
@@ -40,6 +42,18 @@ export class StockAnalyserTablesStack extends cdk.Stack {
       removalPolicy: removal,
     });
 
+    // ── stock-analyser.analysis-cache ────────────────────────────────────
+    // Cache of Claude-generated analysis results, keyed by account + cache key.
+    // PK: accountId  SK: cacheKey  TTL: expiresAt (epoch seconds)
+    this.analysisCacheTable = new dynamodb.Table(this, 'AnalysisCacheTable', {
+      tableName:           `stock-analyser.analysis-cache-${stage}`,
+      partitionKey:        { name: 'accountId', type: dynamodb.AttributeType.STRING },
+      sortKey:             { name: 'cacheKey',  type: dynamodb.AttributeType.STRING },
+      billingMode:         dynamodb.BillingMode.PAY_PER_REQUEST,
+      timeToLiveAttribute: 'expiresAt',
+      removalPolicy:       removal,
+    });
+
     // ── Outputs ───────────────────────────────────────────────────────────
     const out = (id: string, table: dynamodb.Table, hint: string) => {
       new cdk.CfnOutput(this, id, {
@@ -49,7 +63,8 @@ export class StockAnalyserTablesStack extends cdk.Stack {
       });
     };
 
-    out('SAPortfolioTableArn', this.portfolioTable, 'stock-analyser.portfolio table ARN');
-    out('SAWatchlistTableArn', this.watchlistTable, 'stock-analyser.watchlist table ARN');
+    out('SAPortfolioTableArn',     this.portfolioTable,     'stock-analyser.portfolio table ARN');
+    out('SAWatchlistTableArn',     this.watchlistTable,     'stock-analyser.watchlist table ARN');
+    out('SAAnalysisCacheTableArn', this.analysisCacheTable, 'stock-analyser.analysis-cache table ARN');
   }
 }


### PR DESCRIPTION
## Summary

- **Rename `platform.analysis-cache-{stage}` → `stock-analyser.analysis-cache-{stage}`** — this table is exclusively owned by Stock Analyser Lambdas; using the `platform.` prefix violated the namespace convention. Moved from `PlatformTablesStack` to `StockAnalyserTablesStack` and updated CDK wiring in `app.ts`.
- **Remove `budget-tracker.accounts-{stage}`** from `BudgetTrackerTablesStack` — table was empty in both dev and prod, and its schema duplicated `platform.accounts` + `platform.account-members`.
- **Update `docs/architecture/data.md`** — add explicit namespace enforcement rule, remove stale `platform.analysis-cache` section, add correct `stock-analyser.analysis-cache` section under Stock Analyser, remove `budget-tracker.accounts` section.

## Test plan

- [ ] `cdk synth` passes for all affected stacks (verified locally)
- [ ] `tsc` build clean (verified locally)
- [ ] CI deploy to dev succeeds — `TransformotionDev-PlatformTables`, `TransformotionDev-StockAnalyserTables`, `TransformotionDev-BudgetTrackerTables`, `TransformotionDev-Api` stacks
- [ ] `stock-analyser.analysis-cache-dev` table exists in AWS after deploy (already exists from prior CDK run — no drift expected)
- [ ] No `platform.analysis-cache-dev` table created or referenced post-deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)