### PR TITLE
fix(infra): unblock platform deploy + add Storage to workflow

### DIFF
--- a/.github/workflows/deploy-platform.yml
+++ b/.github/workflows/deploy-platform.yml
@@ -60,7 +60,7 @@ jobs:
 
       - name: CDK Deploy — Platform stacks (dev)
         working-directory: infrastructure
-        run: pnpm exec cdk deploy 'TransformotionDev-Network' 'TransformotionDev-Auth' 'TransformotionDev-AuthApi' 'TransformotionDev-PlatformTables' 'TransformotionDev-Api' --require-approval never
+        run: pnpm exec cdk deploy 'TransformotionDev-Storage' 'TransformotionDev-Network' 'TransformotionDev-Auth' 'TransformotionDev-AuthApi' 'TransformotionDev-PlatformTables' 'TransformotionDev-Api' --require-approval never
 
   deploy-prod:
     name: Platform → Prod
@@ -93,4 +93,4 @@ jobs:
 
       - name: CDK Deploy — Platform stacks (prod)
         working-directory: infrastructure
-        run: pnpm exec cdk deploy 'TransformotionProd-Network' 'TransformotionProd-Auth' 'TransformotionProd-AuthApi' 'TransformotionProd-PlatformTables' 'TransformotionProd-Api' --require-approval never
+        run: pnpm exec cdk deploy 'TransformotionProd-Storage' 'TransformotionProd-Network' 'TransformotionProd-Auth' 'TransformotionProd-AuthApi' 'TransformotionProd-PlatformTables' 'TransformotionProd-Api' --require-approval never

--- a/infrastructure/bin/app.ts
+++ b/infrastructure/bin/app.ts
@@ -62,7 +62,7 @@ new PlatformTablesStack(app, 'TransformotionDev-PlatformTables', {
   description: 'Transformotion Apps — Dev platform DynamoDB tables (users, accounts, invitations)',
 });
 
-const devStockAnalyserTables = new StockAnalyserTablesStack(app, 'TransformotionDev-StockAnalyserTables', {
+new StockAnalyserTablesStack(app, 'TransformotionDev-StockAnalyserTables', {
   env,
   stage:       'dev',
   description: 'Transformotion Apps — Dev Stock Analyser DynamoDB tables',
@@ -70,10 +70,9 @@ const devStockAnalyserTables = new StockAnalyserTablesStack(app, 'Transformotion
 
 const devPlatformApi = new PlatformApiStack(app, 'TransformotionDev-Api', {
   env,
-  stage:              'dev',
-  description:        'Transformotion Apps — Dev platform API (shared routes for all apps)',
-  userPool:           devAuth.userPool,
-  analysisCacheTable: devStockAnalyserTables.analysisCacheTable,
+  stage:       'dev',
+  description: 'Transformotion Apps — Dev platform API (shared routes for all apps)',
+  userPool:    devAuth.userPool,
 });
 
 new StockAnalyserApiStack(app, 'TransformotionDev-StockAnalyserApi', {
@@ -132,7 +131,7 @@ new PlatformTablesStack(app, 'TransformotionProd-PlatformTables', {
   description: 'Transformotion Apps — Prod platform DynamoDB tables (users, accounts, invitations)',
 });
 
-const prodStockAnalyserTables = new StockAnalyserTablesStack(app, 'TransformotionProd-StockAnalyserTables', {
+new StockAnalyserTablesStack(app, 'TransformotionProd-StockAnalyserTables', {
   env,
   stage:       'prod',
   description: 'Transformotion Apps — Prod Stock Analyser DynamoDB tables',
@@ -140,10 +139,9 @@ const prodStockAnalyserTables = new StockAnalyserTablesStack(app, 'Transformotio
 
 const prodPlatformApi = new PlatformApiStack(app, 'TransformotionProd-Api', {
   env,
-  stage:              'prod',
-  description:        'Transformotion Apps — Prod platform API (shared routes for all apps)',
-  userPool:           prodAuth.userPool,
-  analysisCacheTable: prodStockAnalyserTables.analysisCacheTable,
+  stage:       'prod',
+  description: 'Transformotion Apps — Prod platform API (shared routes for all apps)',
+  userPool:    prodAuth.userPool,
 });
 
 new StockAnalyserApiStack(app, 'TransformotionProd-StockAnalyserApi', {

--- a/infrastructure/lib/platform/platform-api-stack.ts
+++ b/infrastructure/lib/platform/platform-api-stack.ts
@@ -13,8 +13,6 @@ export interface PlatformApiStackProps extends cdk.StackProps {
   stage: 'dev' | 'prod';
   /** Imported from AuthStack */
   userPool: cognito.IUserPool;
-  /** Imported from PlatformTablesStack */
-  analysisCacheTable: dynamodb.ITable;
 }
 
 /**
@@ -48,7 +46,7 @@ export class PlatformApiStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props: PlatformApiStackProps) {
     super(scope, id, props);
 
-    const { stage, userPool, analysisCacheTable } = props;
+    const { stage, userPool } = props;
 
     // ── REST API ─────────────────────────────────────────────────────────────
     this.api = new apigateway.RestApi(this, 'Api', {
@@ -141,6 +139,16 @@ export class PlatformApiStack extends cdk.Stack {
     // ── /api/claude — Shared Anthropic proxy (used by all apps) ──────────────
     const anthropicSecret = secretsmanager.Secret.fromSecretNameV2(
       this, 'AnthropicApiKey', `${stage}/anthropic/api-key`,
+    );
+
+    // UNBLOCK-WORKAROUND: look up analysis-cache by name instead of receiving
+    // it as a cross-stack construct prop. This breaks the Fn::ImportValue chain
+    // that was blocking PlatformTables from dropping its old analysis-cache
+    // export (StockAnalyserTables is stuck in REVIEW_IN_PROGRESS and cannot be
+    // deployed as a CDK dependency). Revert to a prop when StockAnalyserTables
+    // is healthy (account bootstrap phase).
+    const analysisCacheTable = dynamodb.Table.fromTableName(
+      this, 'AnalysisCacheTable', `stock-analyser.analysis-cache-${stage}`,
     );
 
     const claudeProxyFn = new lambdaNodejs.NodejsFunction(this, 'ClaudeProxyFn', {


### PR DESCRIPTION
Unblocks the broken platform deploy pipeline in two parts:

**1. PlatformApi uses `fromTableName` for analysis-cache.** Breaks the cross-stack `Fn::ImportValue` dependency on `StockAnalyserTables` (stuck `REVIEW_IN_PROGRESS`). Safe because analysis-cache has no GSIs. Marked `UNBLOCK-WORKAROUND` in source; reverted during account bootstrap.

**2. Storage stacks added to `deploy-platform.yml`.** PR #58's Storage stacks were never in the workflow.

After this merges and deploys, PR #57 and PR #58 finally actualise:
- `platform.analysis-cache-dev` destroyed
- `stock-analyser.analysis-cache-dev` created (already exists — no-op)
- `budget-tracker.accounts-dev` destroyed
- `transformotion-backups-959516291617` S3 bucket created

The orphan-tables issue is deferred to account bootstrap.

## cdk diffs

**PlatformTables:**
```
[-] AWS::DynamoDB::Table AnalysisCacheTable (destroy — 0 rows)
[-] Output AnalysisCacheTableArn
[-] Output ExportsOutputFnGetAtt...AnalysisCacheTable...
[-] Output ExportsOutputRef...AnalysisCacheTable...
```

**Api (ClaudeProxyFn only):**
```
[~] IAM Policy: Fn::ImportValue (PlatformTables export) → arn:...:table/stock-analyser.analysis-cache-dev (literal)
[~] Lambda env CACHE_TABLE: Fn::ImportValue → "stock-analyser.analysis-cache-dev" (literal)
```

**StockAnalyserTables:** template-only diff (stack still stuck REVIEW_IN_PROGRESS — not in deploy path, no impact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)