### PR TITLE
fix(ci): deploy PlatformTables after Api to release Fn::ImportValue

### DIFF
--- a/.github/workflows/deploy-platform.yml
+++ b/.github/workflows/deploy-platform.yml
@@ -60,7 +60,11 @@ jobs:
 
       - name: CDK Deploy — Platform stacks (dev)
         working-directory: infrastructure
-        run: pnpm exec cdk deploy 'TransformotionDev-Storage' 'TransformotionDev-Network' 'TransformotionDev-Auth' 'TransformotionDev-AuthApi' 'TransformotionDev-PlatformTables' 'TransformotionDev-Api' --require-approval never
+        run: pnpm exec cdk deploy 'TransformotionDev-Storage' 'TransformotionDev-Network' 'TransformotionDev-Auth' 'TransformotionDev-AuthApi' 'TransformotionDev-Api' --require-approval never
+
+      - name: CDK Deploy — PlatformTables (must follow Api to release Fn::ImportValue)
+        working-directory: infrastructure
+        run: pnpm exec cdk deploy 'TransformotionDev-PlatformTables' --require-approval never
 
   deploy-prod:
     name: Platform → Prod
@@ -93,4 +97,8 @@ jobs:
 
       - name: CDK Deploy — Platform stacks (prod)
         working-directory: infrastructure
-        run: pnpm exec cdk deploy 'TransformotionProd-Storage' 'TransformotionProd-Network' 'TransformotionProd-Auth' 'TransformotionProd-AuthApi' 'TransformotionProd-PlatformTables' 'TransformotionProd-Api' --require-approval never
+        run: pnpm exec cdk deploy 'TransformotionProd-Storage' 'TransformotionProd-Network' 'TransformotionProd-Auth' 'TransformotionProd-AuthApi' 'TransformotionProd-Api' --require-approval never
+
+      - name: CDK Deploy — PlatformTables (must follow Api to release Fn::ImportValue)
+        working-directory: infrastructure
+        run: pnpm exec cdk deploy 'TransformotionProd-PlatformTables' --require-approval never


### PR DESCRIPTION
## Problem

`deploy-platform.yml` deploys `PlatformTables` and `Api` in the same CDK command. Without a CDK-level construct dependency between them, CDK may deploy `PlatformTables` before `Api`'s template is updated. CloudFormation then blocks the export deletion:

```
Cannot delete export TransformotionDev-PlatformTables:ExportsOutputRefAnalysisCacheTable...
as it is in use by TransformotionDev-Api
```

This happened across PRs #57 and #59 — the code changes were correct, but the deploy ordering meant CloudFormation always saw the `Fn::ImportValue` still active in the *currently-deployed* `Api` template when `PlatformTables` tried to drop the export.

## Fix

Split `PlatformTables` into its own sequential step **after** the main platform step (which includes `Api`). This guarantees `Api`'s template is deployed first, releasing the `Fn::ImportValue`, before `PlatformTables` attempts to drop the export.

Same pattern as the pre-existing `BudgetTrackerTables` pre-step.

## Deploy sequence (dev)

1. `BudgetTrackerTables` (pre-existing step — releases BT cross-stack import)
2. `Storage`, `Network`, `Auth`, `AuthApi`, `Api` (parallel within CDK)
3. `PlatformTables` (new step — safe to drop analysis-cache export now that Api is updated)

## Expected outcome after merge

- `platform.analysis-cache-dev` table destroyed (export released)
- `budget-tracker.accounts-dev` table destroyed (orphan cleaned up)
- `transformotion-backups-959516291617` S3 bucket created
- `claude-proxy` Lambda env var confirmed pointing to `stock-analyser.analysis-cache-dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)