### PR TITLE
feat(7e): account bootstrap + -v2 rename + orphan table resolution

### DIFF
--- a/apps/stock-analyser/CLAUDE.md
+++ b/apps/stock-analyser/CLAUDE.md
@@ -33,7 +33,7 @@ React + TypeScript + Tailwind CSS.
 
 | Stack | Contents |
 |---|---|
-| `Transformotion{Stage}-StockAnalyserTables` | `stock-analyser.portfolio-{stage}-v2`, `stock-analyser.watchlist-{stage}-v2` |
+| `Transformotion{Stage}-StockAnalyserTables` | `stock-analyser.portfolio-{stage}`, `stock-analyser.watchlist-{stage}`, `stock-analyser.analysis-cache-{stage}` |
 | `Transformotion{Stage}-StockAnalyserApi` | All Stock Analyser Lambda functions + routes on the platform API Gateway |
 
 Source: `infrastructure/lib/stock-analyser/`
@@ -53,10 +53,11 @@ All Stock Analyser Lambdas share the platform API Gateway and Cognito JWT author
 
 | Table | PK | SK | Purpose |
 |---|---|---|---|
-| `stock-analyser.portfolio-{stage}-v2` | `accountId` | — | Portfolio holdings per account |
-| `stock-analyser.watchlist-{stage}-v2` | `accountId` | — | Watchlist items per account |
+| `stock-analyser.portfolio-{stage}` | `accountId` | `ticker` | Portfolio holdings per account |
+| `stock-analyser.watchlist-{stage}` | `accountId` | `ticker` | Watchlist items per account |
+| `stock-analyser.analysis-cache-{stage}` | `accountId` | `cacheKey` | Claude analysis cache (TTL: expiresAt) |
 
-Analysis cache (`platform.analysis-cache-{stage}`) is a platform table shared with other apps — accessed via `transformotion-claude-proxy-{stage}`, not directly.
+Analysis cache is accessed via both `transformotion-claude-proxy-{stage}` (write, for the async job pattern) and `transformotion-analysis-cache-{stage}` (read/delete, for polling and cache management).
 
 ## Authorization requirement
 

--- a/docs/architecture/cdk.md
+++ b/docs/architecture/cdk.md
@@ -42,7 +42,7 @@ Deployed by `deploy-stock-analyser.yml`. Source in `infrastructure/lib/stock-ana
 
 | Stack name | Class | Contents |
 |---|---|---|
-| `Transformotion{Stage}-StockAnalyserTables` | `StockAnalyserTablesStack` | `stock-analyser.portfolio-{stage}-v2`, `stock-analyser.watchlist-{stage}-v2`, `stock-analyser.analysis-cache-{stage}` |
+| `Transformotion{Stage}-StockAnalyserTables` | `StockAnalyserTablesStack` | `stock-analyser.portfolio-{stage}`, `stock-analyser.watchlist-{stage}`, `stock-analyser.analysis-cache-{stage}` |
 | `Transformotion{Stage}-StockAnalyserApi` | `StockAnalyserApiStack` | Stock Analyser Lambda functions + routes on the shared platform API Gateway |
 
 ### Budget Tracker stacks
@@ -108,13 +108,13 @@ Deployed by `deploy-budget-tracker.yml`. Source in `infrastructure/lib/budget-tr
 
 ## Cross-stack dependencies
 
-Stacks receive constructs via `props` in `bin/app.ts`. There are no `Fn::ImportValue` CloudFormation cross-stack references after the sub-phase 7b.5-alpha fix.
+Stacks receive constructs via `props` in `bin/app.ts`. Cross-stack references generate `Fn::ImportValue` in CloudFormation templates.
 
 | Consumer stack | Receives from | Props |
 |---|---|---|
 | `AuthApiStack` | `AuthStack` | `userPoolId` (string — avoids construct reference) |
 | `PlatformApiStack` | `AuthStack` | `userPool` (construct) |
-| `PlatformApiStack` | `PlatformTablesStack` | `analysisCacheTable` (construct) |
+| `PlatformApiStack` | `StockAnalyserTablesStack` | `analysisCacheTable` (construct) |
 | `StockAnalyserApiStack` | `PlatformApiStack` | `api` and `authoriser` (constructs) |
 | `BudgetTrackerApiStack` | `AuthStack` | `userPool` (construct — for its own authoriser) |
 
@@ -125,9 +125,10 @@ Stacks receive constructs via `props` in `bin/app.ts`. There are no `Fn::ImportV
 `deploy-platform.yml` sequences its CDK steps explicitly to avoid CloudFormation dependency conflicts:
 
 1. **Step 1 — BudgetTrackerTables first** — deploys `TransformotionDev-BudgetTrackerTables` in isolation. This must complete before Auth deploys, because BudgetTrackerTables previously imported an Auth export that needed to be released first.
-2. **Step 2 — Remaining platform stacks** — deploys `Network`, `Auth`, `AuthApi`, `PlatformTables`, `Api` together. CDK runs independent stacks in parallel within this step.
+2. **Step 2 — Main platform stacks** — deploys `Storage`, `Network`, `Auth`, `AuthApi`, `Api` together. CDK runs independent stacks in parallel within this step.
+3. **Step 3 — PlatformTables** — deploys `PlatformTables` alone, after `Api` has updated its template. This ordering ensures `Api` releases any `Fn::ImportValue` exports before `PlatformTables` attempts to drop them.
 
-This two-step ordering is preserved even now that the `Fn::ImportValue` is gone, as a guard against future cross-stack changes inadvertently re-introducing the dependency.
+The StockAnalyserTables deploy is triggered by `deploy-stock-analyser.yml`, not `deploy-platform.yml`. When a cross-stack prop flows from `StockAnalyserTables` → `PlatformApi`, that workflow must run first (or `PlatformApi` must use `fromTableName` as a temporary workaround — see data.md CDK constraints).
 
 ---
 

--- a/docs/architecture/data.md
+++ b/docs/architecture/data.md
@@ -22,7 +22,7 @@ See [auth.md](./auth.md) for the account membership model. See [cdk.md](./cdk.md
 - `scope` is either `platform` (cross-app) or an app slug (`stock-analyser`, `budget-tracker`)
 - `stage` is `dev` or `prod`
 
-Examples: `platform.accounts-dev`, `budget-tracker.transactions-prod`, `stock-analyser.portfolio-dev-v2`
+Examples: `platform.accounts-dev`, `budget-tracker.transactions-prod`, `stock-analyser.portfolio-dev`
 
 **Enforcement rule:** App-specific tables must never use the `platform.` prefix. If a table is only read or written by one app's Lambdas, it belongs in that app's scope (e.g. `stock-analyser.*`, `budget-tracker.*`) and in that app's `TablesStack`.
 
@@ -102,19 +102,23 @@ Served by `transformotion-invitations-{stage}` Lambda.
 
 Managed by `TransformotionDev-StockAnalyserTables` / `TransformotionProd-StockAnalyserTables`.
 
-#### `stock-analyser.portfolio-{stage}-v2`
+#### `stock-analyser.portfolio-{stage}`
 
 | Attribute | Type | Notes |
 |---|---|---|
 | `accountId` (PK) | String | |
-| `holdings` | List | Serialised `PortfolioHolding[]` |
+| `ticker` (SK) | String | |
+| `shares` | Number | |
+| `avgCost` | Number | |
+| `addedAt` | Number | Epoch ms |
+| `isGifted` | Boolean | |
 
-#### `stock-analyser.watchlist-{stage}-v2`
+#### `stock-analyser.watchlist-{stage}`
 
 | Attribute | Type | Notes |
 |---|---|---|
 | `accountId` (PK) | String | |
-| `items` | List | Serialised `WatchlistItem[]` |
+| `ticker` (SK) | String | |
 
 #### `stock-analyser.analysis-cache-{stage}`
 
@@ -224,3 +228,19 @@ When Liz signs in, the pre-token Lambda queries `userId-index` for `liz-sub`, fi
 ```
 
 Liz's active account (`custom:active_accounts["budget-tracker"]`) determines which data she sees by default. She can switch accounts via `POST /auth/switch`.
+
+---
+
+## CDK constraints to remember
+
+These CDK and CloudFormation constraints are not obvious and have cost real deploy failures. Noted here so future work doesn't rediscover them.
+
+**1. `Table.fromTableName()` doesn't know about GSIs.** When imported this way, `grantReadData()` only covers the table ARN, not the index ARN. For tables with GSIs that handlers query, use `Table.fromTableAttributes()` with explicit `globalIndexes` list. For tables without GSIs (or where the handler doesn't query the index), `fromTableName` is fine.
+
+**2. Cognito user pool schemas are append-only.** Custom attributes declared on a user pool cannot be removed. They can be abandoned (not written, not read) but remain declared forever. Plan custom attribute names and types carefully — they are permanent.
+
+**3. Removing CDK cross-stack dependencies doesn't reorder deploys.** If you move a resource between stacks or change how stacks reference each other, CDK no longer has a basis to sequence deploys. The workflow-level sequence (which stacks deploy first) may need explicit ordering, often via separate `cdk deploy` steps in CI. The `deploy-platform.yml` file has examples of this pattern (PlatformTables runs in its own step after Api releases its imports).
+
+**4. S3 buckets containing important data should NEVER have `autoDeleteObjects: true`.** This is a CDK convenience for ephemeral dev buckets. For backups buckets, use `removalPolicy: RETAIN` alone and allow manual deletion only.
+
+**5. `cdk import` requires CDK config to match deployed reality exactly.** If the deployed table has a sort key but the CDK construct doesn't declare it (or vice versa), the import changeset will fail. Run `aws dynamodb describe-table` before writing the CDK construct for any table being imported.

--- a/docs/sub-phase-7e-plan.md
+++ b/docs/sub-phase-7e-plan.md
@@ -86,6 +86,10 @@ Pattern for claude-proxy: `requireGroup(auth, 'stock-app', 'budget-app', 'admin'
 - 10 handlers updated: 3 Stock Analyser (`portfolio`, `watchlist`, `analysis-cache`), 6 Budget Tracker (`transactions`, `settings`, `rules`, `migrate`, `export`, `ai`), 1 shared (`claude-proxy`).
 - Pre-existing test failures on Windows (`vitest` not found) confirmed unrelated to this change.
 
+### 7e-account-bootstrap — Account bootstrap + -v2 table rename ✓ complete (2026-04-25)
+
+Brought orphan -v2 tables under CloudFormation management via `cdk import`. Created new per-app accounts (`stock-signal` accountId: `a03f9cd4`, `budget-tracker` accountId: `aed9dcdf`). Migrated 7 portfolio + 6 watchlist rows to new no-suffix tables with new accountIds. Rewrote 10 budget-tracker.settings rows. Deleted old shared account (6f28aaa4), debug account (fc2f6a09), cleared `custom:accounts`. Reverted UNBLOCK-WORKAROUND — PlatformApi now uses proper cross-stack prop for analysis-cache. -v2 tables destroyed.
+
 ### 7e-pretoken — Pre-token generation Lambda ⟳ in progress (PR open, awaiting review)
 
 Write and deploy `functions/pre-token-generation`. Register as Cognito pre-token-generation trigger in `AuthStack`.

--- a/infrastructure/bin/app.ts
+++ b/infrastructure/bin/app.ts
@@ -62,7 +62,7 @@ new PlatformTablesStack(app, 'TransformotionDev-PlatformTables', {
   description: 'Transformotion Apps — Dev platform DynamoDB tables (users, accounts, invitations)',
 });
 
-new StockAnalyserTablesStack(app, 'TransformotionDev-StockAnalyserTables', {
+const devStockAnalyserTables = new StockAnalyserTablesStack(app, 'TransformotionDev-StockAnalyserTables', {
   env,
   stage:       'dev',
   description: 'Transformotion Apps — Dev Stock Analyser DynamoDB tables',
@@ -70,9 +70,10 @@ new StockAnalyserTablesStack(app, 'TransformotionDev-StockAnalyserTables', {
 
 const devPlatformApi = new PlatformApiStack(app, 'TransformotionDev-Api', {
   env,
-  stage:       'dev',
-  description: 'Transformotion Apps — Dev platform API (shared routes for all apps)',
-  userPool:    devAuth.userPool,
+  stage:              'dev',
+  description:        'Transformotion Apps — Dev platform API (shared routes for all apps)',
+  userPool:           devAuth.userPool,
+  analysisCacheTable: devStockAnalyserTables.analysisCacheTable,
 });
 
 new StockAnalyserApiStack(app, 'TransformotionDev-StockAnalyserApi', {
@@ -131,7 +132,7 @@ new PlatformTablesStack(app, 'TransformotionProd-PlatformTables', {
   description: 'Transformotion Apps — Prod platform DynamoDB tables (users, accounts, invitations)',
 });
 
-new StockAnalyserTablesStack(app, 'TransformotionProd-StockAnalyserTables', {
+const prodStockAnalyserTables = new StockAnalyserTablesStack(app, 'TransformotionProd-StockAnalyserTables', {
   env,
   stage:       'prod',
   description: 'Transformotion Apps — Prod Stock Analyser DynamoDB tables',
@@ -139,9 +140,10 @@ new StockAnalyserTablesStack(app, 'TransformotionProd-StockAnalyserTables', {
 
 const prodPlatformApi = new PlatformApiStack(app, 'TransformotionProd-Api', {
   env,
-  stage:       'prod',
-  description: 'Transformotion Apps — Prod platform API (shared routes for all apps)',
-  userPool:    prodAuth.userPool,
+  stage:              'prod',
+  description:        'Transformotion Apps — Prod platform API (shared routes for all apps)',
+  userPool:           prodAuth.userPool,
+  analysisCacheTable: prodStockAnalyserTables.analysisCacheTable,
 });
 
 new StockAnalyserApiStack(app, 'TransformotionProd-StockAnalyserApi', {

--- a/infrastructure/lib/platform/platform-api-stack.ts
+++ b/infrastructure/lib/platform/platform-api-stack.ts
@@ -13,6 +13,8 @@ export interface PlatformApiStackProps extends cdk.StackProps {
   stage: 'dev' | 'prod';
   /** Imported from AuthStack */
   userPool: cognito.IUserPool;
+  /** Imported from StockAnalyserTablesStack */
+  analysisCacheTable: dynamodb.ITable;
 }
 
 /**
@@ -46,7 +48,7 @@ export class PlatformApiStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props: PlatformApiStackProps) {
     super(scope, id, props);
 
-    const { stage, userPool } = props;
+    const { stage, userPool, analysisCacheTable } = props;
 
     // ── REST API ─────────────────────────────────────────────────────────────
     this.api = new apigateway.RestApi(this, 'Api', {
@@ -141,15 +143,6 @@ export class PlatformApiStack extends cdk.Stack {
       this, 'AnthropicApiKey', `${stage}/anthropic/api-key`,
     );
 
-    // UNBLOCK-WORKAROUND: look up analysis-cache by name instead of receiving
-    // it as a cross-stack construct prop. This breaks the Fn::ImportValue chain
-    // that was blocking PlatformTables from dropping its old analysis-cache
-    // export (StockAnalyserTables is stuck in REVIEW_IN_PROGRESS and cannot be
-    // deployed as a CDK dependency). Revert to a prop when StockAnalyserTables
-    // is healthy (account bootstrap phase).
-    const analysisCacheTable = dynamodb.Table.fromTableName(
-      this, 'AnalysisCacheTable', `stock-analyser.analysis-cache-${stage}`,
-    );
 
     const claudeProxyFn = new lambdaNodejs.NodejsFunction(this, 'ClaudeProxyFn', {
       functionName: `transformotion-claude-proxy-${stage}`,

--- a/infrastructure/lib/stock-analyser/stock-analyser-api-stack.ts
+++ b/infrastructure/lib/stock-analyser/stock-analyser-api-stack.ts
@@ -37,7 +37,7 @@ export class StockAnalyserApiStack extends cdk.Stack {
 
     // ── /portfolio — Portfolio Lambda ─────────────────────────────────────
     const portfolioTable = dynamodb.Table.fromTableName(
-      this, 'PortfolioTable', `stock-analyser.portfolio-${stage}-v2`,
+      this, 'PortfolioTable', `stock-analyser.portfolio-${stage}`,
     );
 
     const portfolioFn = new lambdaNodejs.NodejsFunction(this, 'PortfolioFn', {
@@ -60,7 +60,7 @@ export class StockAnalyserApiStack extends cdk.Stack {
 
     // ── /watchlist — Watchlist Lambda ─────────────────────────────────────
     const watchlistTable = dynamodb.Table.fromTableName(
-      this, 'WatchlistTable', `stock-analyser.watchlist-${stage}-v2`,
+      this, 'WatchlistTable', `stock-analyser.watchlist-${stage}`,
     );
 
     const watchlistFn = new lambdaNodejs.NodejsFunction(this, 'WatchlistFn', {

--- a/infrastructure/lib/stock-analyser/stock-analyser-tables-stack.ts
+++ b/infrastructure/lib/stock-analyser/stock-analyser-tables-stack.ts
@@ -30,6 +30,7 @@ export class StockAnalyserTablesStack extends cdk.Stack {
     this.portfolioTable = new dynamodb.Table(this, 'PortfolioTable', {
       tableName:     `stock-analyser.portfolio-${stage}-v2`,
       partitionKey:  { name: 'accountId', type: dynamodb.AttributeType.STRING },
+      sortKey:       { name: 'ticker',    type: dynamodb.AttributeType.STRING },
       billingMode:   dynamodb.BillingMode.PAY_PER_REQUEST,
       removalPolicy: removal,
     });
@@ -38,6 +39,7 @@ export class StockAnalyserTablesStack extends cdk.Stack {
     this.watchlistTable = new dynamodb.Table(this, 'WatchlistTable', {
       tableName:     `stock-analyser.watchlist-${stage}-v2`,
       partitionKey:  { name: 'accountId', type: dynamodb.AttributeType.STRING },
+      sortKey:       { name: 'ticker',    type: dynamodb.AttributeType.STRING },
       billingMode:   dynamodb.BillingMode.PAY_PER_REQUEST,
       removalPolicy: removal,
     });

--- a/infrastructure/lib/stock-analyser/stock-analyser-tables-stack.ts
+++ b/infrastructure/lib/stock-analyser/stock-analyser-tables-stack.ts
@@ -15,8 +15,10 @@ export interface StockAnalyserTablesStackProps extends cdk.StackProps {
  *   stock-analyser.analysis-cache  PK: accountId  SK: cacheKey  TTL: expiresAt
  */
 export class StockAnalyserTablesStack extends cdk.Stack {
-  public readonly portfolioTable:     dynamodb.Table;
-  public readonly watchlistTable:     dynamodb.Table;
+  public readonly portfolioTable:    dynamodb.Table;
+  public readonly watchlistTable:    dynamodb.Table;
+  public readonly portfolioTableNew: dynamodb.Table;
+  public readonly watchlistTableNew: dynamodb.Table;
   public readonly analysisCacheTable: dynamodb.Table;
 
   constructor(scope: Construct, id: string, props: StockAnalyserTablesStackProps) {
@@ -44,6 +46,24 @@ export class StockAnalyserTablesStack extends cdk.Stack {
       removalPolicy: removal,
     });
 
+    // ── stock-analyser.portfolio (no suffix) — migration target ──────────
+    this.portfolioTableNew = new dynamodb.Table(this, 'PortfolioTableNew', {
+      tableName:     `stock-analyser.portfolio-${stage}`,
+      partitionKey:  { name: 'accountId', type: dynamodb.AttributeType.STRING },
+      sortKey:       { name: 'ticker',    type: dynamodb.AttributeType.STRING },
+      billingMode:   dynamodb.BillingMode.PAY_PER_REQUEST,
+      removalPolicy: cdk.RemovalPolicy.RETAIN,
+    });
+
+    // ── stock-analyser.watchlist (no suffix) — migration target ──────────
+    this.watchlistTableNew = new dynamodb.Table(this, 'WatchlistTableNew', {
+      tableName:     `stock-analyser.watchlist-${stage}`,
+      partitionKey:  { name: 'accountId', type: dynamodb.AttributeType.STRING },
+      sortKey:       { name: 'ticker',    type: dynamodb.AttributeType.STRING },
+      billingMode:   dynamodb.BillingMode.PAY_PER_REQUEST,
+      removalPolicy: cdk.RemovalPolicy.RETAIN,
+    });
+
     // ── stock-analyser.analysis-cache ────────────────────────────────────
     // Cache of Claude-generated analysis results, keyed by account + cache key.
     // PK: accountId  SK: cacheKey  TTL: expiresAt (epoch seconds)
@@ -65,8 +85,10 @@ export class StockAnalyserTablesStack extends cdk.Stack {
       });
     };
 
-    out('SAPortfolioTableArn',     this.portfolioTable,     'stock-analyser.portfolio table ARN');
-    out('SAWatchlistTableArn',     this.watchlistTable,     'stock-analyser.watchlist table ARN');
+    out('SAPortfolioTableArn',    this.portfolioTable,    'stock-analyser.portfolio-v2 table ARN (legacy)');
+    out('SAWatchlistTableArn',    this.watchlistTable,    'stock-analyser.watchlist-v2 table ARN (legacy)');
+    out('SAPortfolioNewTableArn', this.portfolioTableNew, 'stock-analyser.portfolio table ARN');
+    out('SAWatchlistNewTableArn', this.watchlistTableNew, 'stock-analyser.watchlist table ARN');
     out('SAAnalysisCacheTableArn', this.analysisCacheTable, 'stock-analyser.analysis-cache table ARN');
   }
 }

--- a/infrastructure/lib/stock-analyser/stock-analyser-tables-stack.ts
+++ b/infrastructure/lib/stock-analyser/stock-analyser-tables-stack.ts
@@ -15,10 +15,8 @@ export interface StockAnalyserTablesStackProps extends cdk.StackProps {
  *   stock-analyser.analysis-cache  PK: accountId  SK: cacheKey  TTL: expiresAt
  */
 export class StockAnalyserTablesStack extends cdk.Stack {
-  public readonly portfolioTable:    dynamodb.Table;
-  public readonly watchlistTable:    dynamodb.Table;
-  public readonly portfolioTableNew: dynamodb.Table;
-  public readonly watchlistTableNew: dynamodb.Table;
+  public readonly portfolioTableNew:  dynamodb.Table;
+  public readonly watchlistTableNew:  dynamodb.Table;
   public readonly analysisCacheTable: dynamodb.Table;
 
   constructor(scope: Construct, id: string, props: StockAnalyserTablesStackProps) {
@@ -29,24 +27,6 @@ export class StockAnalyserTablesStack extends cdk.Stack {
     const removal = isProd ? cdk.RemovalPolicy.RETAIN : cdk.RemovalPolicy.DESTROY;
 
     // ── stock-analyser.portfolio ──────────────────────────────────────────
-    this.portfolioTable = new dynamodb.Table(this, 'PortfolioTable', {
-      tableName:     `stock-analyser.portfolio-${stage}-v2`,
-      partitionKey:  { name: 'accountId', type: dynamodb.AttributeType.STRING },
-      sortKey:       { name: 'ticker',    type: dynamodb.AttributeType.STRING },
-      billingMode:   dynamodb.BillingMode.PAY_PER_REQUEST,
-      removalPolicy: removal,
-    });
-
-    // ── stock-analyser.watchlist ──────────────────────────────────────────
-    this.watchlistTable = new dynamodb.Table(this, 'WatchlistTable', {
-      tableName:     `stock-analyser.watchlist-${stage}-v2`,
-      partitionKey:  { name: 'accountId', type: dynamodb.AttributeType.STRING },
-      sortKey:       { name: 'ticker',    type: dynamodb.AttributeType.STRING },
-      billingMode:   dynamodb.BillingMode.PAY_PER_REQUEST,
-      removalPolicy: removal,
-    });
-
-    // ── stock-analyser.portfolio (no suffix) — migration target ──────────
     this.portfolioTableNew = new dynamodb.Table(this, 'PortfolioTableNew', {
       tableName:     `stock-analyser.portfolio-${stage}`,
       partitionKey:  { name: 'accountId', type: dynamodb.AttributeType.STRING },
@@ -55,7 +35,7 @@ export class StockAnalyserTablesStack extends cdk.Stack {
       removalPolicy: cdk.RemovalPolicy.RETAIN,
     });
 
-    // ── stock-analyser.watchlist (no suffix) — migration target ──────────
+    // ── stock-analyser.watchlist ──────────────────────────────────────────
     this.watchlistTableNew = new dynamodb.Table(this, 'WatchlistTableNew', {
       tableName:     `stock-analyser.watchlist-${stage}`,
       partitionKey:  { name: 'accountId', type: dynamodb.AttributeType.STRING },
@@ -85,10 +65,8 @@ export class StockAnalyserTablesStack extends cdk.Stack {
       });
     };
 
-    out('SAPortfolioTableArn',    this.portfolioTable,    'stock-analyser.portfolio-v2 table ARN (legacy)');
-    out('SAWatchlistTableArn',    this.watchlistTable,    'stock-analyser.watchlist-v2 table ARN (legacy)');
-    out('SAPortfolioNewTableArn', this.portfolioTableNew, 'stock-analyser.portfolio table ARN');
-    out('SAWatchlistNewTableArn', this.watchlistTableNew, 'stock-analyser.watchlist table ARN');
+    out('SAPortfolioNewTableArn',  this.portfolioTableNew,  'stock-analyser.portfolio table ARN');
+    out('SAWatchlistNewTableArn',  this.watchlistTableNew,  'stock-analyser.watchlist table ARN');
     out('SAAnalysisCacheTableArn', this.analysisCacheTable, 'stock-analyser.analysis-cache table ARN');
   }
 }


### PR DESCRIPTION
Substantial 7e-account-bootstrap migration PR.

**Stage 1 — Orphan table resolution.** Deleted stale REVIEW_IN_PROGRESS changeset. Added missing sort key (ticker) to CDK definitions to match deployed reality. Ran cdk import to bring stock-analyser.portfolio-dev-v2 and watchlist-dev-v2 under CloudFormation management. Created stock-analyser.analysis-cache-dev (was never deployed despite being in CDK code). Stack transitions from REVIEW_IN_PROGRESS to UPDATE_COMPLETE.

**Stage 2 — New tables created.** Added stock-analyser.portfolio-dev and watchlist-dev (no -v2 suffix) to CDK, deployed. All four tables coexist during migration.

**Stage 3 — Account bootstrap + data migration.** Generated two new per-app accountIds (stock-signal: `a03f9cd4`, budget-tracker: `aed9dcdf`). Wrote new platform.accounts and account-members rows. Migrated 7 portfolio + 6 watchlist rows to new tables with new accountId. Rewrote 10 budget-tracker.settings rows in place.

**Stage 4 — Handler cutover.** Stock Analyser handler env vars updated to new table names (no -v2). PlatformApi reverted from UNBLOCK-WORKAROUND (fromTableName) back to proper cross-stack construct prop for analysis-cache.

**Stage 5 — Cleanup.** Deleted old shared 6f28aaa4 account rows, debug test account (fc2f6a09), cleared custom:accounts Cognito attribute. -v2 tables destroyed.

**Stage 6 — Documentation.** data.md updated (no -v2, corrected key schema, CDK gotchas section added). cdk.md updated (cross-stack deps corrected, deploy ordering updated). stock-analyser/CLAUDE.md updated. sub-phase-7e-plan.md marks 7e-account-bootstrap complete.

Phase 0 backup at s3://transformotion-backups-959516291617/migration-backups/2026-04-25/ was preserved throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)