### PR TITLE
fix(auth): remove legacy group fallback, add viewer role — PR #63 audit findings

### DIFF
--- a/docs/architecture/auth.md
+++ b/docs/architecture/auth.md
@@ -320,12 +320,15 @@ requireAppAccess(auth, appSlug)
 // Throws 403 unless auth.apps includes appSlug OR auth.siteAdmin === true.
 // Use at the top of every handler scoped to a specific app.
 
+requireAnyAppAccess(auth, appSlugs)
+// Throws 403 unless auth.apps includes at least one of appSlugs OR auth.siteAdmin === true.
+// Use only in platform handlers that serve multiple apps (currently: claude-proxy).
+
 requireAccountAccess(auth, appSlug, accountId, minRole?)
 // Throws 403 unless the caller is a member of accountId for appSlug
 // with role >= minRole (or is site-admin).
-// Role hierarchy: owner > manager > member > viewer.
-// Without minRole, any membership role suffices.
-// Use before any DynamoDB query for account-scoped data.
+// Role hierarchy (ascending): viewer < member < manager < owner.
+// Default minRole is 'member'. Use before any DynamoDB query for account-scoped data.
 
 requireAccountOwner(auth, appSlug, accountId)
 // Throws 403 unless caller is the owner of accountId for appSlug
@@ -334,9 +337,48 @@ requireAccountOwner(auth, appSlug, accountId)
 // operations only the owner can perform.
 ```
 
-All helpers check site-admin first as an override. A site-admin caller passes all authorization checks regardless of explicit app-access group or account membership.
+All helpers check `auth.siteAdmin` first as an override. A site-admin caller passes all authorization checks regardless of app-access or account membership.
+
+**Fail-closed semantics.** When `auth.apps` or `auth.accounts` are absent or empty (e.g., due to a pre-token Lambda failure), helpers deny access rather than granting it. The pre-token Lambda documents this under "On failure" above.
 
 Handlers do NOT call `requireGroup` (the old pattern) for new work. `requireGroup` remains during the 7e migration for transitional purposes and is removed at 7e-cleanup.
+
+---
+
+## Handler authorization patterns
+
+Every Lambda handler follows this pattern. Deviations require a written justification in the handler's code.
+
+### Standard app-scoped handler
+
+```typescript
+export const handler = withAuth(async ({ auth, account, event }) => {
+  requireAppAccess(auth, 'app-slug');                         // (1) fail fast if user lacks app access
+  requireAccountAccess(auth, 'app-slug', account.accountId); // (2) verify account membership before any data access
+
+  // ... handler logic uses account.accountId for all DynamoDB keys
+});
+```
+
+### Multi-app platform handler (currently: claude-proxy only)
+
+```typescript
+export const handler = withAuth(async ({ auth, account, event }) => {
+  requireAnyAppAccess(auth, ['stock-signal', 'budget-tracker']); // user must have at least one app
+
+  // ... handler logic
+});
+```
+
+### Rules
+
+1. **`requireAppAccess` (or `requireAnyAppAccess`) is the first call in every handler**, before any business logic or DynamoDB access.
+2. **`requireAccountAccess` is called before every DynamoDB read or write** that operates on account-scoped data.
+3. **`accountId` always comes from request context** (`account.accountId`, which is sourced from the `X-Account-Id` request header). Never derive `accountId` from `auth.accounts` or any other JWT claim.
+4. **Elevated operations** (bulk delete, admin overrides) use `requireAccountAccess(auth, appSlug, accountId, 'manager')`.
+5. **Ownership-only operations** (account deletion, ownership transfer) use `requireAccountOwner`.
+6. **Platform-admin operations** (cross-app user management, user disable/delete) use `requireSiteAdmin`.
+7. **`requireGroup` must not appear in new handler code.** It is deprecated and will be removed at 7e-cleanup.
 
 ---
 

--- a/packages/lambda-middleware/src/auth.test.ts
+++ b/packages/lambda-middleware/src/auth.test.ts
@@ -96,19 +96,19 @@ describe('extractAuthClaims', () => {
 // ── requireSiteAdmin ──────────────────────────────────────────────────────────
 
 describe('requireSiteAdmin', () => {
-  it('passes for siteAdmin flag', () => {
+  it('passes when siteAdmin claim is true', () => {
     expect(() => requireSiteAdmin(makeClaims({ siteAdmin: true }))).not.toThrow();
   });
 
-  it('passes for legacy admin group', () => {
-    expect(() => requireSiteAdmin(makeClaims({ groups: ['admin'] }))).not.toThrow();
+  it('throws 403 when only legacy admin group is present', () => {
+    expect(() => requireSiteAdmin(makeClaims({ groups: ['admin'] }))).toThrow(HttpError);
   });
 
-  it('passes for legacy site-admin group', () => {
-    expect(() => requireSiteAdmin(makeClaims({ groups: ['site-admin'] }))).not.toThrow();
+  it('throws 403 when only legacy site-admin group is present', () => {
+    expect(() => requireSiteAdmin(makeClaims({ groups: ['site-admin'] }))).toThrow(HttpError);
   });
 
-  it('throws 403 for regular user', () => {
+  it('throws 403 for regular user with no claims', () => {
     expect(() => requireSiteAdmin(makeClaims())).toThrow(HttpError);
   });
 });
@@ -122,33 +122,21 @@ describe('requireAppAccess', () => {
     )).not.toThrow();
   });
 
-  it('passes via legacy budget-app group', () => {
-    expect(() => requireAppAccess(
-      makeClaims({ groups: ['budget-app'] }), 'budget-tracker',
-    )).not.toThrow();
-  });
-
-  it('passes via legacy budget-app-access group', () => {
-    expect(() => requireAppAccess(
-      makeClaims({ groups: ['budget-app-access'] }), 'budget-tracker',
-    )).not.toThrow();
-  });
-
-  it('passes via legacy stock-app group', () => {
-    expect(() => requireAppAccess(
-      makeClaims({ groups: ['stock-app'] }), 'stock-signal',
-    )).not.toThrow();
-  });
-
-  it('passes for site admin regardless of apps', () => {
+  it('passes when siteAdmin is true regardless of apps claim', () => {
     expect(() => requireAppAccess(makeClaims({ siteAdmin: true }), 'budget-tracker')).not.toThrow();
   });
 
-  it('throws 403 when user lacks access', () => {
+  it('throws 403 when apps claim is empty (fail closed — no group fallback)', () => {
+    expect(() => requireAppAccess(
+      makeClaims({ groups: ['budget-app'] }), 'budget-tracker',
+    )).toThrow(HttpError);
+  });
+
+  it('throws 403 when apps claim is empty', () => {
     expect(() => requireAppAccess(makeClaims(), 'budget-tracker')).toThrow(HttpError);
   });
 
-  it('throws 403 when user has access to different app only', () => {
+  it('throws 403 when user has access to a different app only', () => {
     expect(() => requireAppAccess(
       makeClaims({ apps: ['stock-signal'] }), 'budget-tracker',
     )).toThrow(HttpError);
@@ -164,10 +152,16 @@ describe('requireAnyAppAccess', () => {
     )).not.toThrow();
   });
 
-  it('passes via legacy group for either app', () => {
+  it('passes when siteAdmin is true', () => {
+    expect(() => requireAnyAppAccess(
+      makeClaims({ siteAdmin: true }), ['budget-tracker', 'stock-signal'],
+    )).not.toThrow();
+  });
+
+  it('throws 403 when user has neither app in apps claim (fail closed — no group fallback)', () => {
     expect(() => requireAnyAppAccess(
       makeClaims({ groups: ['stock-app'] }), ['budget-tracker', 'stock-signal'],
-    )).not.toThrow();
+    )).toThrow(HttpError);
   });
 
   it('throws 403 when user has neither app', () => {
@@ -183,6 +177,20 @@ describe('requireAccountAccess', () => {
       makeClaims({ accounts: { 'budget-tracker': [{ accountId: 'acc-1', role: 'member' }] } }),
       'budget-tracker', 'acc-1',
     )).not.toThrow();
+  });
+
+  it('passes when user has viewer access and viewer is required', () => {
+    expect(() => requireAccountAccess(
+      makeClaims({ accounts: { 'budget-tracker': [{ accountId: 'acc-1', role: 'viewer' }] } }),
+      'budget-tracker', 'acc-1', 'viewer',
+    )).not.toThrow();
+  });
+
+  it('throws 403 when user has viewer but member is required', () => {
+    expect(() => requireAccountAccess(
+      makeClaims({ accounts: { 'budget-tracker': [{ accountId: 'acc-1', role: 'viewer' }] } }),
+      'budget-tracker', 'acc-1', 'member',
+    )).toThrow(HttpError);
   });
 
   it('passes when user has manager access and member is required', () => {
@@ -213,10 +221,14 @@ describe('requireAccountAccess', () => {
     )).toThrow(HttpError);
   });
 
-  it('falls back to legacy groups when accounts claim is empty', () => {
+  it('throws 403 when accounts claim is empty (fail closed — no group fallback)', () => {
     expect(() => requireAccountAccess(
       makeClaims({ groups: ['budget-app'] }), 'budget-tracker', 'acc-1',
-    )).not.toThrow();
+    )).toThrow(HttpError);
+  });
+
+  it('throws 403 when accounts claim is empty', () => {
+    expect(() => requireAccountAccess(makeClaims(), 'budget-tracker', 'acc-1')).toThrow(HttpError);
   });
 
   it('passes for site admin', () => {
@@ -241,6 +253,10 @@ describe('requireAccountOwner', () => {
       makeClaims({ accounts: { 'budget-tracker': [{ accountId: 'acc-1', role: 'manager' }] } }),
       'budget-tracker', 'acc-1',
     )).toThrow(HttpError);
+  });
+
+  it('throws 403 when accounts claim is empty', () => {
+    expect(() => requireAccountOwner(makeClaims(), 'budget-tracker', 'acc-1')).toThrow(HttpError);
   });
 
   it('passes for site admin', () => {

--- a/packages/lambda-middleware/src/auth.ts
+++ b/packages/lambda-middleware/src/auth.ts
@@ -47,35 +47,15 @@ export function extractAuthClaims(event: APIGatewayProxyEvent): AuthClaims {
 }
 
 /**
- * Resolve the active account for this request.
- *
- * Precedence:
- *   1. `X-Account-Id` header — explicit override (e.g. admin switching accounts)
- *   2. `custom:active_account` JWT claim — the user's last-selected account
- *
- * Throws HttpError(400) if no account context can be resolved.
- * The frontend must ensure `custom:active_account` is set after first login
- * (handled in S2.8 first-login migration flow).
+ * Resolve the active account for this request from the `X-Account-Id` header.
+ * Throws HttpError(400) if the header is absent.
  */
-export function resolveAccountContext(
-  event: APIGatewayProxyEvent,
-  claims: Record<string, string>,
-): AccountContext {
-  // Header override takes precedence (trimmed, lowercased for safety)
+export function resolveAccountContext(event: APIGatewayProxyEvent): AccountContext {
   const headerAccountId = event.headers?.['x-account-id']?.trim();
   if (headerAccountId) {
     return { accountId: headerAccountId };
   }
-
-  // Fall back to the active account stored in the JWT custom attribute
-  const jwtAccountId = claims['custom:active_account']?.trim();
-  if (jwtAccountId) {
-    return { accountId: jwtAccountId };
-  }
-
-  throw badRequest(
-    'No active account context. Set X-Account-Id header or update custom:active_account on the user.',
-  );
+  throw badRequest('No active account context. Set X-Account-Id header.');
 }
 
 /**
@@ -96,19 +76,10 @@ export function requireGroup(claims: AuthClaims, ...groups: string[]): void {
   }
 }
 
-// ── Legacy group names used for fallback while pre-token Lambda is not yet live ──
-
-const APP_LEGACY_GROUPS: Record<AppName, string[]> = {
-  'budget-tracker': ['budget-app', 'budget-app-access'],
-  'stock-signal':   ['stock-app', 'stock-app-access'],
-};
-
-const ROLE_HIERARCHY: AccountRole[] = ['member', 'manager', 'owner'];
+const ROLE_HIERARCHY: AccountRole[] = ['viewer', 'member', 'manager', 'owner'];
 
 function isSuperUser(auth: AuthClaims): boolean {
-  return auth.siteAdmin
-    || auth.groups.includes('admin')
-    || auth.groups.includes('site-admin');
+  return auth.siteAdmin;
 }
 
 function hasRequiredRole(roles: string[], minRole: AccountRole): boolean {
@@ -126,44 +97,31 @@ export function requireSiteAdmin(auth: AuthClaims): void {
 
 /**
  * Throws HttpError(403) unless the user has been granted access to `app`.
- *
- * Checks (in order):
- *   1. site_admin / admin group → always passes
- *   2. `auth.apps` includes the app (new claims path)
- *   3. Legacy Cognito groups for the app (fallback while pre-token Lambda is not live)
+ * Passes if `auth.siteAdmin === true` or `auth.apps` includes `app`.
  */
 export function requireAppAccess(auth: AuthClaims, app: AppName): void {
   if (isSuperUser(auth)) return;
   if (auth.apps.includes(app)) return;
-  const legacyGroups = APP_LEGACY_GROUPS[app];
-  if (legacyGroups.some(g => auth.groups.includes(g))) return;
   throw forbidden(`Access to app '${app}' required`);
 }
 
 /**
  * Like requireAppAccess but accepts multiple apps — passes if the user has
  * access to ANY of them. Used by platform handlers that serve multiple apps
- * (e.g. the shared Claude proxy).
+ * (currently only claude-proxy).
  */
 export function requireAnyAppAccess(auth: AuthClaims, apps: AppName[]): void {
   if (isSuperUser(auth)) return;
-  for (const app of apps) {
-    if (auth.apps.includes(app)) return;
-    const legacyGroups = APP_LEGACY_GROUPS[app];
-    if (legacyGroups.some(g => auth.groups.includes(g))) return;
-  }
+  if (apps.some(app => auth.apps.includes(app))) return;
   throw forbidden(`Access to one of [${apps.join(', ')}] required`);
 }
 
 /**
  * Throws HttpError(403) unless the user has at least `minRole` access to
  * `accountId` within `app`.
- *
- * Checks (in order):
- *   1. site_admin / admin group → always passes
- *   2. `auth.accounts[app]` has a membership for `accountId` with role ≥ minRole (new claims path)
- *   3. Legacy: if accounts claim is entirely empty (pre-token Lambda not yet live),
- *      fall back to app-level group membership
+ * Passes if `auth.siteAdmin === true`, or `auth.accounts[app]` contains a
+ * membership for `accountId` with role ≥ minRole.
+ * Role hierarchy (ascending): viewer < member < manager < owner.
  */
 export function requireAccountAccess(
   auth: AuthClaims,
@@ -172,18 +130,9 @@ export function requireAccountAccess(
   minRole: AccountRole = 'member',
 ): void {
   if (isSuperUser(auth)) return;
-
-  const preTokenLive = Object.keys(auth.accounts).length > 0;
-  if (preTokenLive) {
-    const appAccounts = auth.accounts[app] ?? [];
-    const membership = appAccounts.find(m => m.accountId === accountId);
-    if (membership && hasRequiredRole([membership.role], minRole)) return;
-    throw forbidden(`Account access required (accountId: ${accountId}, minRole: ${minRole})`);
-  }
-
-  // Fallback: pre-token Lambda not live yet — use app-level group membership
-  const legacyGroups = APP_LEGACY_GROUPS[app];
-  if (legacyGroups.some(g => auth.groups.includes(g))) return;
+  const appAccounts = auth.accounts[app] ?? [];
+  const membership = appAccounts.find(m => m.accountId === accountId);
+  if (membership && hasRequiredRole([membership.role], minRole)) return;
   throw forbidden(`Account access required (accountId: ${accountId}, minRole: ${minRole})`);
 }
 

--- a/packages/lambda-middleware/src/middleware.ts
+++ b/packages/lambda-middleware/src/middleware.ts
@@ -8,7 +8,7 @@ import { errorResponse } from './response';
  * Wrap a protected Lambda handler with standard middleware:
  *
  *   1. Extract and validate Cognito JWT claims from the API Gateway event
- *   2. Resolve the active account (X-Account-Id header → JWT custom attribute)
+ *   2. Resolve the active account from the X-Account-Id request header
  *   3. Call the inner handler with the fully-typed LambdaContext
  *   4. Serialise LambdaResponse → APIGatewayProxyResult
  *   5. Catch HttpError throws → structured JSON error response
@@ -19,8 +19,8 @@ import { errorResponse } from './response';
  * import { withAuth } from '@transformotion/lambda-middleware';
  *
  * export const handler = withAuth(async ({ auth, account, event }) => {
- *   // auth.userId, auth.email, auth.groups
- *   // account.accountId
+ *   // auth.userId, auth.email, auth.apps, auth.accounts, auth.siteAdmin
+ *   // account.accountId — from X-Account-Id header
  *   return { statusCode: 200, body: { ok: true } };
  * });
  * ```
@@ -29,8 +29,7 @@ export function withAuth(inner: ProtectedHandler) {
   return async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
     try {
       const auth    = extractAuthClaims(event);
-      const claims  = event.requestContext?.authorizer?.claims as Record<string, string>;
-      const account = resolveAccountContext(event, claims);
+      const account = resolveAccountContext(event);
 
       const result = await inner({ auth, account, event });
 

--- a/packages/lambda-middleware/src/types.ts
+++ b/packages/lambda-middleware/src/types.ts
@@ -12,7 +12,7 @@ export interface AuthClaims {
   email: string;
   /** Legacy Cognito groups (space-separated, still present for fallback). */
   groups: string[];
-  /** Apps the user has been granted access to, e.g. ['budget-tracker', 'stock-analyser']. */
+  /** Apps the user has been granted access to, e.g. ['budget-tracker', 'stock-signal']. */
   apps: string[];
   /**
    * Account memberships keyed by appSlug, value is an array of membership records.
@@ -27,16 +27,13 @@ export interface AuthClaims {
 /** App identifiers used across all auth helpers. */
 export type AppName = 'budget-tracker' | 'stock-signal';
 
-/** Account role levels (ordered ascending). */
-export type AccountRole = 'member' | 'manager' | 'owner';
+/** Account role levels (ordered ascending by capability). */
+export type AccountRole = 'viewer' | 'member' | 'manager' | 'owner';
 
 /**
  * Resolved account context for the request.
- * The active account is determined by (in order of precedence):
- *   1. `X-Account-Id` request header (explicit override, e.g. admin impersonation)
- *   2. The `custom:active_account` Cognito attribute on the JWT
- *
- * If neither is present the Lambda should return 400.
+ * The active account is determined from the `X-Account-Id` request header.
+ * If the header is absent the middleware throws 400.
  */
 export interface AccountContext {
   accountId: string;


### PR DESCRIPTION
## Summary

Fixes all 6 findings from the PR #63 auth middleware audit.

- **Fail-closed semantics** — removed all `cognito:groups` fallbacks from `requireSiteAdmin`, `requireAppAccess`, `requireAnyAppAccess`, `requireAccountAccess`; `isSuperUser()` now checks `auth.siteAdmin` only
- **`AccountRole` adds `'viewer'`** — role hierarchy is now `viewer < member < manager < owner`
- **`resolveAccountContext` simplified** — removed dead `custom:active_account` fallback; X-Account-Id header is the only source
- **`requireAnyAppAccess` documented** in `docs/architecture/auth.md` with fail-closed semantics paragraph
- **Handler authorization patterns section** added to auth.md
- **JSDoc typo fixed** — `apps` example `'stock-analyser'` → `'stock-signal'`

## Test plan

- [ ] 37 unit tests in `packages/lambda-middleware` pass (`pnpm --filter @transformotion/lambda-middleware test`)
- [ ] Typecheck passes across workspace
- [ ] All three deploy workflows succeed after merge to develop

## Before / after — fallback removal

| Helper | Before (PR #63) | After |
|---|---|---|
| `isSuperUser` | `siteAdmin \|\| groups.includes('admin') \|\| groups.includes('site-admin')` | `siteAdmin` only |
| `requireAppAccess` | falls back to `APP_LEGACY_GROUPS[app]` group check | fail closed — no group read |
| `requireAnyAppAccess` | falls back to legacy group check per app | fail closed — no group read |
| `requireAccountAccess` | falls back to `budget-app` / `stock-app` group | fail closed — no group read |
| `resolveAccountContext` | header → `custom:active_account` claim fallback | header only |

🤖 Generated with [Claude Code](https://claude.com/claude-code)