### PR TITLE
ci: add handler authorization pattern checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,12 @@ jobs:
       - name: Lint baseline check (no new violations)
         run: bash scripts/ci/check-lint-baseline.sh
 
+      - name: No requireGroup in handlers (deprecated)
+        run: bash scripts/ci/check-no-new-require-group.sh
+
+      - name: Handler authorization pattern (DynamoDB → authz helper required)
+        run: bash scripts/ci/check-handler-authz-pattern.sh
+
       - name: Verify baseline didn't grow vs base branch
         run: |
           BASE="${{ github.base_ref }}"

--- a/docs/architecture/cdk.md
+++ b/docs/architecture/cdk.md
@@ -175,6 +175,40 @@ Secrets Manager entries for social IDP credentials are always `RETAIN` in both e
 
 ---
 
+## CI checks
+
+Two grep-based checks run in the `Typecheck & Lint` CI job on every PR. They enforce the handler authorization patterns described in [auth.md](./auth.md).
+
+### `check-no-new-require-group.sh`
+
+Fails if any handler file calls `requireGroup`. `requireGroup` is deprecated — all handlers were migrated to `requireAppAccess` / `requireAccountAccess` in sub-phase 7e. Zero usages is the expected baseline.
+
+Removal: delete this script when 7e-cleanup removes `requireGroup` from the middleware package entirely.
+
+### `check-handler-authz-pattern.sh`
+
+Fails if any handler file performs a DynamoDB operation (`PutItemCommand`, `GetItemCommand`, `QueryCommand`, `ScanCommand`, `UpdateItemCommand`, `DeleteItemCommand`, `TransactWriteCommand`, `BatchGetCommand`, `BatchWriteCommand`) without also calling at least one of `requireAppAccess`, `requireAnyAppAccess`, `requireAccountAccess`, `requireAccountOwner`, or `requireSiteAdmin`.
+
+This is a coarse file-level check — it confirms authorization helpers are present; it does not verify call ordering.
+
+### Checked paths
+
+Both checks cover the same scope:
+
+- `apps/*/functions/` — app-specific handlers (Budget Tracker, Stock Analyser)
+- `functions/claude-proxy/` — platform multi-app handler
+
+### Exempt paths
+
+| Path | Category | Reason |
+|---|---|---|
+| `functions/auth/pre-token-generation/` | auth-infrastructure | Cognito trigger (`PreTokenGenerationTriggerEvent`), not API Gateway — reads DynamoDB to build JWT claims, cannot consume them |
+| `functions/auth/forgot-provider/` | auth-infrastructure | Public endpoint (`withPublic`); DynamoDB used for rate-limiting only, no JWT context |
+| `functions/auth/account-provisioning/` | auth-infrastructure | First-login route (`withAuthOnly`); user is authenticated but has no app claims yet — `requireAppAccess` is inapplicable by design |
+| `functions/accounts/` | platform-infrastructure | Platform accounts API — manages the accounts table that the pre-token Lambda reads; does inline DynamoDB membership checks rather than consuming JWT claims (it IS the accounts system) |
+
+---
+
 ## Adding a new app's CDK stacks
 
 When a new app is added to the platform:

--- a/scripts/ci/check-handler-authz-pattern.sh
+++ b/scripts/ci/check-handler-authz-pattern.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# scripts/ci/check-handler-authz-pattern.sh
+#
+# Fails CI if any handler file in the checked paths performs a DynamoDB
+# operation without also calling at least one authorization helper.
+#
+# DynamoDB operations detected:
+#   PutItemCommand, GetItemCommand, QueryCommand, ScanCommand,
+#   UpdateItemCommand, DeleteItemCommand, TransactWriteCommand,
+#   BatchGetCommand, BatchWriteCommand
+#   (also matches the @aws-sdk/lib-dynamodb Document client variants)
+#
+# Authorization helpers that satisfy the check:
+#   requireAppAccess, requireAnyAppAccess, requireAccountAccess,
+#   requireAccountOwner, requireSiteAdmin
+#
+# This is a coarse file-level check — it confirms authorization helpers are
+# present in any file that performs DynamoDB work. It does not verify call
+# ordering or that every individual operation is guarded.
+#
+# Checked paths:
+#   apps/*/functions/   — app-specific handlers (Budget Tracker, Stock Analyser)
+#   functions/claude-proxy/  — platform multi-app handler
+#
+# Exempt (see docs/architecture/cdk.md — CI checks):
+#   functions/accounts/              platform-infrastructure: inline DynamoDB authz
+#   functions/auth/account-provisioning/  auth-infrastructure: withAuthOnly, no app claims
+#   functions/auth/forgot-provider/       auth-infrastructure: public endpoint
+#   functions/auth/pre-token-generation/  auth-infrastructure: Cognito trigger
+#
+# Usage: bash scripts/ci/check-handler-authz-pattern.sh
+# Exits 0 if all checked files pass; 1 if any violation found.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+SEARCH_PATHS=(
+  "$REPO_ROOT/apps"
+  "$REPO_ROOT/functions/claude-proxy"
+)
+
+DYNAMO_PATTERN='PutItemCommand|GetItemCommand|QueryCommand|ScanCommand|UpdateItemCommand|DeleteItemCommand|TransactWriteCommand|BatchGetCommand|BatchWriteCommand'
+AUTHZ_PATTERN='requireAppAccess|requireAnyAppAccess|requireAccountAccess|requireAccountOwner|requireSiteAdmin'
+
+echo "Checking handler authorization patterns..."
+
+VIOLATIONS=()
+
+for base in "${SEARCH_PATHS[@]}"; do
+  if [[ ! -d "$base" ]]; then
+    continue
+  fi
+  while IFS= read -r file; do
+    if grep -qE "$DYNAMO_PATTERN" "$file" 2>/dev/null; then
+      if ! grep -qE "$AUTHZ_PATTERN" "$file" 2>/dev/null; then
+        VIOLATIONS+=("$file")
+      fi
+    fi
+  done < <(find "$base" -name "*.ts" ! -name "*.d.ts" -not -path "*/node_modules/*" -not -path "*/__tests__/*" -not -name "*.test.ts" -not -name "*.spec.ts")
+done
+
+if [[ ${#VIOLATIONS[@]} -eq 0 ]]; then
+  echo "OK — all handlers with DynamoDB operations call an authorization helper."
+  exit 0
+fi
+
+echo ""
+echo "ERROR: The following handlers perform DynamoDB operations without calling"
+echo "an authorization helper (requireAppAccess, requireAnyAppAccess,"
+echo "requireAccountAccess, requireAccountOwner, or requireSiteAdmin)."
+echo ""
+echo "Violations:"
+for f in "${VIOLATIONS[@]}"; do
+  echo "  $f"
+done
+echo ""
+echo "See docs/architecture/auth.md — Handler authorization patterns."
+exit 1

--- a/scripts/ci/check-no-new-require-group.sh
+++ b/scripts/ci/check-no-new-require-group.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# scripts/ci/check-no-new-require-group.sh
+#
+# Fails CI if any handler under the checked paths calls requireGroup.
+# requireGroup is deprecated — all handlers were migrated to requireAppAccess /
+# requireAccountAccess in sub-phase 7e. Zero usages is the expected baseline.
+#
+# Checked paths:
+#   apps/*/functions/   — app-specific handlers (Budget Tracker, Stock Analyser)
+#   functions/claude-proxy/  — platform multi-app handler
+#
+# Exempt (see docs/architecture/cdk.md — CI checks):
+#   functions/accounts/              platform-infrastructure: inline DynamoDB authz
+#   functions/auth/account-provisioning/  auth-infrastructure: withAuthOnly, no app claims
+#   functions/auth/forgot-provider/       auth-infrastructure: public endpoint
+#   functions/auth/pre-token-generation/  auth-infrastructure: Cognito trigger
+#   functions/user/                        no DynamoDB operations
+#   functions/auth/invitations/            no DynamoDB operations
+#
+# When 7e-cleanup removes requireGroup from the middleware package entirely,
+# delete this script (it becomes redundant).
+#
+# Usage: bash scripts/ci/check-no-new-require-group.sh
+# Exits 0 if no violations; 1 if any found.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+SEARCH_PATHS=(
+  "$REPO_ROOT/apps"
+  "$REPO_ROOT/functions/claude-proxy"
+)
+
+echo "Checking for requireGroup usage in handler paths..."
+
+VIOLATIONS=()
+
+for base in "${SEARCH_PATHS[@]}"; do
+  if [[ ! -d "$base" ]]; then
+    continue
+  fi
+  while IFS= read -r file; do
+    if grep -qE '\brequireGroup\s*\(' "$file" 2>/dev/null; then
+      VIOLATIONS+=("$file")
+    fi
+  done < <(find "$base" -name "*.ts" ! -name "*.d.ts" -not -path "*/node_modules/*" -not -path "*/__tests__/*" -not -name "*.test.ts" -not -name "*.spec.ts")
+done
+
+if [[ ${#VIOLATIONS[@]} -eq 0 ]]; then
+  echo "OK — no requireGroup calls found."
+  exit 0
+fi
+
+echo ""
+echo "ERROR: requireGroup is deprecated. Migrate to requireAppAccess / requireAccountAccess."
+echo "Violations:"
+for f in "${VIOLATIONS[@]}"; do
+  echo "  $f"
+done
+exit 1


### PR DESCRIPTION
## Summary

Two grep-based CI checks that enforce handler authorization patterns on every PR going forward. Both run inside the existing `Typecheck & Lint` job.

- **`check-no-new-require-group.sh`** — fails if any handler under the checked paths calls `requireGroup` (deprecated since sub-phase 7e, zero usages now). Removed when 7e-cleanup deletes the helper from middleware.
- **`check-handler-authz-pattern.sh`** — fails if any handler file performs a DynamoDB operation without also calling `requireAppAccess`, `requireAnyAppAccess`, `requireAccountAccess`, `requireAccountOwner`, or `requireSiteAdmin`. Coarse file-level check — catches "forgot to authorize entirely."

## Scope

Both checks cover:
- `apps/*/functions/` — app-specific handlers (Budget Tracker, Stock Analyser)
- `functions/claude-proxy/` — platform multi-app handler

Exempt (documented in `docs/architecture/cdk.md` — CI checks):
- `functions/auth/pre-token-generation/` — Cognito trigger, reads DynamoDB to build claims
- `functions/auth/forgot-provider/` — public endpoint, DynamoDB for rate-limiting only
- `functions/auth/account-provisioning/` — first-login (`withAuthOnly`), no app claims by design
- `functions/accounts/` — platform accounts API, IS the accounts system, inline DynamoDB authz

## Pre-flight

Both scripts were run locally against current develop before commit — both pass. This PR itself passes because develop is clean.

## Test plan

- [ ] `Typecheck & Lint` CI job passes with both new steps green
- [ ] Manually introduce a `requireGroup` call in a test branch → first check fires
- [ ] Manually add a DynamoDB import without an authz helper → second check fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)