### PR TITLE
docs(cdk): make three-category Lambda taxonomy explicit in CI checks section

### DIFF
--- a/docs/architecture/cdk.md
+++ b/docs/architecture/cdk.md
@@ -177,6 +177,18 @@ Secrets Manager entries for social IDP credentials are always `RETAIN` in both e
 
 ## CI checks
 
+### Lambda categories
+
+There are three categories of Lambda in this repo. Category determines authorization pattern and CI check applicability.
+
+**App handlers** — Lambdas serving authenticated user requests for a specific app. Located in `apps/*/functions/` (per-app) or `functions/claude-proxy/` (cross-app). Subject to the documented authorization pattern: `requireAppAccess` (or `requireAnyAppAccess`) at the top, then `requireAccountAccess` before account-scoped data operations. CI enforces this pattern.
+
+**Auth infrastructure** — Lambdas that produce, verify, or recover identity-related state. Located in `functions/auth/`. Examples: `pre-token-generation`, `forgot-provider`, `account-provisioning`, `invitations` (forthcoming). Each has a bespoke authorization pattern (some unauthenticated, some `withAuthOnly`, some `requireAccountOwner`, etc.). Not subject to the CI handler-authz check.
+
+**Platform infrastructure** — Lambdas managing platform-level data. Currently: `functions/accounts/`. Uses inline membership checks against the data it manages rather than consuming JWT claims. Not subject to the CI handler-authz check.
+
+---
+
 Two grep-based checks run in the `Typecheck & Lint` CI job on every PR. They enforce the handler authorization patterns described in [auth.md](./auth.md).
 
 ### `check-no-new-require-group.sh`


### PR DESCRIPTION
## Summary

Adds a named Lambda category taxonomy to `docs/architecture/cdk.md` before the CI checks description. The categories were implied by the PR #65 exemption table but not stated — readers had to infer.

**Three categories defined:**
- **App handlers** — `apps/*/functions/` + `functions/claude-proxy/`; subject to CI authz checks
- **Auth infrastructure** — `functions/auth/`; bespoke patterns, CI-exempt
- **Platform infrastructure** — `functions/accounts/`; inline membership authz, CI-exempt

The existing exemption table is unchanged.

## Why now

Load-bearing for the upcoming invitation-api PR, which adds new Lambdas under `functions/auth/`. Explicit taxonomy means placement decisions reference an architectural choice rather than inferring from a table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)