### PR TITLE
revert: remove getAccountIdForApp debug logging

### DIFF
--- a/apps/stock-analyser/lib/services/auth/cognito-auth.ts
+++ b/apps/stock-analyser/lib/services/auth/cognito-auth.ts
@@ -137,28 +137,11 @@ export const cognitoAuth = {
   async getAccountIdForApp(appSlug: string): Promise<string | null> {
     try {
       const session = await fetchAuthSession()
-      const payload = session.tokens?.idToken?.payload
-      const raw = payload?.['accounts']
-      console.log('[getAccountIdForApp]', {
-        appSlug,
-        hasSession: !!session,
-        hasIdToken: !!session.tokens?.idToken,
-        payloadKeys: payload ? Object.keys(payload) : null,
-        rawType: typeof raw,
-        rawValue: raw,
-      })
-      if (!raw) {
-        console.log('[getAccountIdForApp] returning null — raw is falsy')
-        return null
-      }
-      const map = typeof raw === 'string'
-        ? JSON.parse(raw) as Record<string, Array<{ accountId: string }>>
-        : raw as Record<string, Array<{ accountId: string }>>
-      const result = map[appSlug]?.[0]?.accountId ?? null
-      console.log('[getAccountIdForApp] result:', result)
-      return result
-    } catch (err) {
-      console.error('[getAccountIdForApp] threw:', err)
+      const raw = session.tokens?.idToken?.payload?.['accounts'] as string | undefined
+      if (!raw) return null
+      const map = JSON.parse(raw) as Record<string, Array<{ accountId: string }>>
+      return map[appSlug]?.[0]?.accountId ?? null
+    } catch {
       return null
     }
   },


### PR DESCRIPTION
Reverts the debug logging added in #68 (merge commit b77b417).

Restore `getAccountIdForApp` to its clean production state — removes the three `console.log` / `console.error` statements added for diagnosing the missing X-Account-Id header.

**Merge this PR immediately after the user has captured the console output from the debug session.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)