### PR TITLE
fix: update remaining @/lib/api/client imports to use new local client

### DIFF
--- a/apps/stock-analyser/components/budget-tracker/tabs/transactions-tab.tsx
+++ b/apps/stock-analyser/components/budget-tracker/tabs/transactions-tab.tsx
@@ -9,7 +9,7 @@ import {
   RotateCcw, Check, BookOpen, Calendar, Search, FileText, Sparkles, AlertCircle,
   Database,
 } from "lucide-react"
-import { getBudgetApiClient } from "@/lib/api/client"
+import { budgetClient } from "@/lib/api"
 import { BUDGET_CATEGORIES, CATEGORY_LIST, getSubcategories } from "../data/categories"
 import { CATEGORY_COLORS } from "../data/category-colors"
 import { applyRules } from "../data/builtin-rules"
@@ -107,9 +107,7 @@ function EmptyStateWithMigration() {
       const transactions = JSON.parse(localStorage.getItem('budget-tracker-transactions') || '[]')
       const settings     = JSON.parse(localStorage.getItem('budget-tracker-settings') || '{}')
 
-      const res = await getBudgetApiClient().post<{
-        migrated: { transactions: number; rules: number; settings: string[] }
-      }>('/migrate-from-localstorage', { transactions, rules: [], settings })
+      const res = await budgetClient.migrateFromLocalStorage({ transactions, rules: [], settings })
 
       setResult(`Migrated ${res.migrated.transactions} transactions. Reloading…`)
       setStatus('done')

--- a/apps/stock-analyser/lib/api/index.ts
+++ b/apps/stock-analyser/lib/api/index.ts
@@ -95,4 +95,7 @@ export const budgetClient = {
   bulkImportTransactions(body: { transactions: Omit<Transaction, '_id'>[] }): Promise<{ transactions: Transaction[] }> {
     return budgetHttp().post('transactions/bulk', body)
   },
+  migrateFromLocalStorage(body: { transactions: unknown[]; rules: unknown[]; settings: unknown }): Promise<{ migrated: { transactions: number; rules: number; settings: string[] } }> {
+    return budgetHttp().post('migrate-from-localstorage', body)
+  },
 }


### PR DESCRIPTION
## What broke

PR #67 deleted `lib/api/client.ts` and migrated the known callers (repository files, `use-claude.ts`), but missed one: `components/budget-tracker/tabs/transactions-tab.tsx`. That file has `// @ts-nocheck` at line 1, which silences the TypeScript compiler — so `tsc` and the pre-commit typecheck hook didn't catch the dangling import. Turbopack's module resolver caught it at build time, failing the CD build on PR #67's merge. **Dev has been broken for two days.**

The same failure then repeated on the debug-logging PR (#68) merge, since it was branched off the already-broken develop.

## What was changed

- **`components/budget-tracker/tabs/transactions-tab.tsx`** — replaced `import { getBudgetApiClient } from "@/lib/api/client"` with `import { budgetClient } from "@/lib/api"`, and replaced the raw `getBudgetApiClient().post('/migrate-from-localstorage', ...)` call with `budgetClient.migrateFromLocalStorage(...)`
- **`lib/api/index.ts`** — added `migrateFromLocalStorage()` to `budgetClient` (the endpoint didn't exist on the typed client yet)

`@ts-nocheck` directive left in place — not in scope for this PR.

## Verification

- `pnpm turbo typecheck` — 30/30 packages pass
- `pnpm turbo build --filter=@transformotion/stock-analyser` — builds clean, all 8 static pages generated

## What this unblocks

Once merged, the CD deploy to dev will succeed, which unblocks:
1. Confirming PR #67's X-Account-Id wiring is live on dev
2. Rebasing the debug-logging branch (#68 / `debug/account-id-logging`) onto the fixed develop and deploying it for the user to capture console output

🤖 Generated with [Claude Code](https://claude.com/claude-code)