### PR TITLE
Update README, CONTRIBUTING, PLAN, MONOREPO: M-setup completion

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -407,6 +407,15 @@ doubt, open the issue first.
 PR titles do not have a required format, but should be descriptive enough
 that the merge commit is meaningful in `git log`.
 
+**Important note on auto-close behaviour:** GitHub's automatic
+`Closes #N` issue-closing only fires when the PR merges into the
+default branch (`main`). PRs in this repository merge into `develop`
+first, then `develop` merges to `main` periodically. This means a PR
+landing on `develop` does *not* auto-close referenced issues, even
+with `Closes #N` syntax. Issues need to be closed manually after the
+PR merges to `develop`, with a comment indicating which PR closed
+them. Auto-close fires only when the change reaches `main`.
+
 PRs must pass all CI checks before merge. Current required checks:
 typecheck, lint baseline, CDK synth. Test execution becomes a required
 check when the test pyramid work lands (PLAN.md tracks).
@@ -434,31 +443,62 @@ applies.
 Every actionable unit of work is an issue. Bug, feature, refactor,
 documentation update — each gets an issue.
 
-Issues belong to a milestone. Milestones map to PLAN.md milestones (M0
-through M12 currently). The first issue of each milestone is a "kickoff"
-issue capturing the preconditions for the milestone to start; subsequent
-issues reference the kickoff issue as parent.
+Issues belong to a milestone. Milestones map to `PLAN.md` milestones
+(M-setup, M0–M14, plus the "Backlog — unsequenced items" milestone).
+The first issue of each milestone is a "kickoff" issue capturing the
+preconditions for the milestone to start; subsequent issues reference
+the kickoff issue as parent.
 
 Dependencies between issues are declared via GitHub's "blocked by" /
 "blocks" relationship. Dependencies between milestones are expressed at
 the issue level: the first issue of milestone Mn is "blocked by" the
 gating issues from milestone Mn-1.
 
-The GitHub Project provides views over issues and PRs:
+**The GitHub Project lives at the organisation level:**
+[github.com/orgs/transformotion/projects/1](https://github.com/orgs/transformotion/projects/1)
+— "Platform development".
 
-- A kanban board (Backlog / In Progress / In Review / Done) for day-to-day
-  work tracking.
+The Project provides views over issues and PRs:
+
+- A kanban board (Backlog / Todo / In Progress / In Review / Done)
+  for day-to-day work tracking.
 - A roadmap view grouped by milestone for trajectory visibility.
+
+The Status field has five options that drive the kanban columns:
+
+| Status | Meaning |
+|---|---|
+| **Backlog** | Issue raised but not yet prioritised. Typical state for items in the "Backlog — unsequenced items" milestone. |
+| **Todo** | Prioritised (in a numbered milestone), not yet started. |
+| **In Progress** | Actively being worked. |
+| **In Review** | A PR linked to the issue is open, awaiting review or CI. |
+| **Done** | Issue is closed. |
+
+The Backlog/Todo distinction matters: an issue in a numbered milestone
+has been prioritised by the act of being placed in that milestone, so
+it sits at Todo; an issue in the "Backlog — unsequenced items"
+milestone has not been prioritised yet, so it sits at Backlog. An
+unsequenced issue can be triaged into Todo state without yet being
+promoted to a numbered milestone — that signals "next backlog item to
+pick up" without committing to a specific milestone.
 
 Project automation rules are configured to:
 
-- Add new issues to the Project automatically when added to a milestone.
-- Move cards to In Progress when an issue is assigned to someone.
-- Move cards to In Review when a PR linked to the issue is opened.
+- Add new issues to the Project automatically when attached to a
+  milestone.
+- Set Status to Backlog when an item is first added.
 - Move cards to Done when the issue is closed.
+- Move cards to Done when a linked PR is merged.
 
-Milestone completion percentage updates automatically as issues close. A
-milestone is "complete" when 100% of its issues are closed.
+Milestone completion percentage updates automatically as issues close.
+A milestone is "complete" when 100% of its issues are closed.
+
+**Milestone pairing rule:** Numbered milestones in `PLAN.md` and
+GitHub Milestones are paired. Creating or removing a numbered
+milestone in `PLAN.md` requires creating or closing the corresponding
+GitHub milestone in the same PR. The discipline rule (Section 2.1)
+applies — `PLAN.md` is a normative document and the GitHub state it
+references is part of what the document describes.
 
 ### 4.5 When new problems are discovered mid-work
 
@@ -515,6 +555,16 @@ a corresponding GitHub Issue is a documentation gap — the `PLAN.md`
 text references a thing that isn't tracked anywhere actionable. Either
 the item gets a tracked issue in the Backlog milestone, or the
 `PLAN.md` reference gets removed.
+
+**Status field interaction:** Issues in the Backlog milestone usually
+have Status = Backlog (raised but not prioritised). When an issue in
+the Backlog milestone is triaged as "next backlog item to pick up
+soon" but not yet promoted to a numbered milestone, its Status can be
+moved to Todo while remaining in the Backlog milestone. This signals
+prioritisation without committing to a specific milestone's
+sequencing. When the item is later promoted to a numbered milestone,
+both the milestone and the Status (if not already Todo) get updated
+together.
 
 ---
 

--- a/MONOREPO.md
+++ b/MONOREPO.md
@@ -1,105 +1,189 @@
 # Transformotion Apps — Monorepo Guide
 
-## Structure
+This document describes the monorepo's **current** structure, import
+boundaries, and deploy machinery. It reflects what exists in the
+repository today, not target structures from `CONTRIBUTING.md`.
+
+For ways of working (workflow rules, discipline rule, branch naming,
+status-tag system), see [`CONTRIBUTING.md`](./CONTRIBUTING.md). For
+the canonical target structure that some directories below are
+migrating toward, see [`CONTRIBUTING.md`](./CONTRIBUTING.md) Section
+3. For the trajectory of work that includes those migrations, see
+[`PLAN.md`](./PLAN.md).
+
+When milestones in `PLAN.md` change the structure described here
+(particularly M3 and M7), this document is updated in the same PR
+that lands the migration. The discipline rule
+(`CONTRIBUTING.md` Section 2.1) applies.
+
+## Current structure
 
 ```
 transformotion-apps/
-├── apps/
-│   ├── stock-analyser/           # Stock Analyser Next.js app — basePath /stock-signal
-│   │   ├── app/                  # Next.js App Router pages
-│   │   ├── components/           # React components
-│   │   ├── contracts/            # Stock Analyser interface contracts
-│   │   ├── functions/            # Stock Analyser Lambda source
-│   │   │   ├── portfolio/
-│   │   │   ├── watchlist/
-│   │   │   ├── analysis-cache/
-│   │   │   └── cycle-check/
-│   │   ├── lib/                  # Domain logic, services, adaptors
-│   │   ├── stores/               # Zustand stores
-│   │   └── package.json          # @transformotion/stock-analyser
-│   ├── budget-tracker/           # Budget Tracker app — basePath /budget-tracker
-│   │   ├── functions/            # Budget Tracker Lambda source
-│   │   └── package.json          # @transformotion/budget-tracker
-│   └── launchpad/                # Launchpad shell app — serves /, /sign-in/, /launchpad/
-│       └── package.json          # @transformotion/launchpad (planned — not yet deployed)
+├── apps/                                  # User-facing applications
+│   ├── budget-tracker/                    # Budget Tracker, basePath /budget-tracker
+│   │   ├── functions/                     # App-specific Lambda source
+│   │   ├── CLAUDE.md
+│   │   └── package.json                   # @transformotion/budget-tracker
+│   ├── launchpad/                         # Platform shell — sign-in, app tile rendering
+│   │   └── package.json                   # @transformotion/launchpad
+│   ├── stock-analyser/                    # Stock Signal Analyser, basePath /stock-signal
+│   │   ├── app/                           # Next.js App Router pages
+│   │   ├── components/                    # App-specific React components
+│   │   ├── functions/                     # App-specific Lambda source
+│   │   ├── lib/                           # Domain logic, services, adaptors
+│   │   ├── stores/                        # Zustand stores
+│   │   ├── CLAUDE.md
+│   │   └── package.json                   # @transformotion/stock-analyser
+│   ├── web/                               # 0-LOC shell from earlier rename (M3 cleanup)
+│   └── web-vite-backup/                   # Backup directory (M3 cleanup; excluded from workspaces)
 │
-├── packages/                      # Shared code — imported by any app
-│   ├── auth-client/               # Auth interface types (@transformotion/auth-client)
-│   ├── api-client/                # HTTP client utilities (@transformotion/api-client)
-│   ├── lambda-middleware/         # Lambda handler middleware (@transformotion/lambda-middleware)
-│   ├── cycle-engine/              # Market cycle computation (@transformotion/cycle-engine)
-│   └── ui/                        # Shared React components (@transformotion/ui — stub)
+├── packages/                              # Shared code consumed by 2+ apps
+│   ├── api-client/                        # Typed HTTP client (@transformotion/api-client)
+│   ├── auth-client/                       # Auth type definitions (stub — single file)
+│   ├── budget-domain/                     # Budget Tracker domain types and helpers
+│   ├── cycle-engine/                      # Market cycle computation (stub — single file)
+│   ├── lambda-middleware/                 # Shared withAuth/withAuthOnly wrappers
+│   └── ui/                                # Shared UI components (stub — minimal)
 │
-├── infrastructure/                 # AWS CDK — all environments
-│   ├── lib/
-│   │   ├── platform/              # Platform stacks (Cognito, S3/CF, API GW, tables)
-│   │   │   ├── auth-stack.ts
-│   │   │   ├── auth-api-stack.ts
-│   │   │   ├── network-stack.ts
-│   │   │   ├── platform-api-stack.ts
-│   │   │   └── platform-tables-stack.ts
-│   │   ├── stock-analyser/        # Stock Analyser-specific stacks
-│   │   │   ├── stock-analyser-api-stack.ts
-│   │   │   └── stock-analyser-tables-stack.ts
-│   │   └── budget-tracker/        # Budget Tracker-specific stacks
-│   │       ├── budget-tracker-api-stack.ts
-│   │       └── budget-tracker-tables-stack.ts
-│   └── bin/app.ts                 # CDK app entry — instantiates all stacks
+├── infrastructure/                        # AWS CDK
+│   ├── bin/
+│   │   └── app.ts                         # CDK app entry — instantiates all stacks
+│   └── lib/
+│       ├── platform/                      # Platform stacks
+│       │   ├── auth-stack.ts              # Cognito user pool, app clients, groups
+│       │   ├── auth-api-stack.ts          # Auth-related API endpoints
+│       │   ├── network-stack.ts           # CloudFront, S3, certificates
+│       │   ├── platform-api-stack.ts      # Shared API Gateway
+│       │   └── platform-tables-stack.ts   # Platform DynamoDB tables
+│       ├── stock-analyser/                # Stock Analyser-specific stacks
+│       │   ├── stock-analyser-api-stack.ts
+│       │   └── stock-analyser-tables-stack.ts
+│       └── budget-tracker/                # Budget Tracker-specific stacks
+│           ├── budget-tracker-api-stack.ts
+│           └── budget-tracker-tables-stack.ts
 │
-├── functions/                      # Platform Lambda source (shared across apps)
-│   ├── first-login/
-│   ├── user/
-│   ├── accounts/
-│   ├── invitations/
-│   ├── forgot-provider/
-│   ├── claude-proxy/
-│   └── pre-token-generation/      # Cognito pre-token trigger (added in sub-phase 7e)
+├── functions/                             # Platform Lambda source (shared across apps)
+│   ├── auth/                              # Auth-related Lambdas (own pnpm workspace glob)
+│   │   ├── account-provisioning/          # First-sign-in account creation
+│   │   ├── pre-token-generation/          # Cognito pre-token trigger (claims)
+│   │   ├── invitations/                   # Invitation flow
+│   │   └── forgot-provider/               # Federated identity recovery
+│   ├── accounts/                          # Account management
+│   ├── claude-proxy/                      # Anthropic API proxy
+│   └── user/                              # Platform user data
 │
-├── contracts/                      # Cross-app contracts only (auth, platform)
+├── contracts/                             # Per-scope normative contracts
+│   └── budget-tracker/                    # (M2.3 will add platform/ and stock-analyser/)
+│
+├── docs/
+│   ├── architecture/                      # Architecture invariants
+│   │   ├── README.md
+│   │   ├── auth.md
+│   │   ├── data.md
+│   │   ├── urls-and-deploy.md
+│   │   └── cdk.md
+│   └── archive/                           # Superseded documents
+│       ├── DEVELOPMENT_PLAN.md
+│       └── STABILISATION_FREEZE.md
+│
+├── migration-artifacts/                   # Historical data fixtures for backfill
+│   └── budget-tracker/                    # 726-transaction Budget Tracker export
+│
 ├── .github/
 │   ├── workflows/
-│   │   ├── deploy-platform.yml     # Triggered by infrastructure/lib/platform/** changes
-│   │   ├── deploy-stock-analyser.yml # Triggered by apps/stock-analyser/** changes
-│   │   ├── deploy-budget-tracker.yml # Placeholder — activates when BT is scaffolded
-│   │   ├── ci.yml                  # PR typecheck + lint + CDK synth
-│   │   └── cd.yml                  # Manual full-platform redeploy
+│   │   ├── ci.yml                         # PR typecheck + lint + CDK synth
+│   │   ├── cd.yml                         # Manual full-platform redeploy
+│   │   ├── deploy-platform.yml            # Triggered by infrastructure/lib/platform/** changes
+│   │   ├── deploy-stock-analyser.yml      # Triggered by apps/stock-analyser/** changes
+│   │   └── deploy-budget-tracker.yml      # Triggered by apps/budget-tracker/** changes
 │   └── CODEOWNERS
-├── pnpm-workspace.yaml
-└── CLAUDE.md
+│
+├── CLAUDE.md                              # Repository-level guide for Claude Code
+├── CONTRIBUTING.md                        # Ways of working
+├── MONOREPO.md                            # This document
+├── PLAN.md                                # Trajectory of work
+├── README.md                              # Repo overview
+├── SECURITY.md                            # Security policy
+└── pnpm-workspace.yaml
 ```
+
+Several directories above are migrating to different homes per
+`CONTRIBUTING.md` Section 3:
+
+- `functions/` will move to `platform/functions/` (M7 covers this).
+- `infrastructure/lib/platform/` will move to `platform/infrastructure/`
+  (M7).
+- `infrastructure/lib/<app>/` will move to `apps/<app>/infrastructure/`
+  (M7).
+- `apps/web/` will be deleted (M3).
+- `apps/web-vite-backup/` will be deleted (M3).
+- `contracts/platform/` and `contracts/stock-analyser/` will be created
+  (M2.3 ratifies the contracts policy; subsequent work creates them).
+
+When those migrations run, this document gets updated in the same PR
+that lands them.
+
+## Workspace configuration
+
+`pnpm-workspace.yaml` declares the following workspace globs:
+
+- `apps/*` — direct children only (does not include nested workspaces)
+- `apps/stock-analyser/functions/*` — explicit nested glob for stock
+  analyser Lambdas
+- `apps/budget-tracker/functions/*` — explicit nested glob for budget
+  tracker Lambdas
+- `packages/*`
+- `functions/*`
+- `functions/auth/*` — explicit nested glob because `functions/auth/`
+  contains its own per-Lambda workspaces
+- `infrastructure` (single workspace at root)
+
+`apps/web-vite-backup` is explicitly excluded from workspaces.
 
 ## Import rules
 
-Cross-app imports are **forbidden** and enforced by `eslint-plugin-boundaries`.
+Cross-app imports are **forbidden** and (when the lint baseline allows)
+enforced by `eslint-plugin-boundaries`. The current lint baseline
+disables this rule pending an ESLint 10 / `eslint-plugin-boundaries`
+compatibility fix; M7 re-enables it.
 
 | From | Can import from | Cannot import from |
 |---|---|---|
-| `apps/stock-analyser/` | `packages/*` | `apps/budget-tracker/` |
-| `apps/budget-tracker/` | `packages/*` | `apps/stock-analyser/` |
-| `packages/*` | Nothing outside `packages/` | `apps/*` |
-| `infrastructure/*` | `functions/*` (via file paths) | `apps/*` |
+| `apps/stock-analyser/` | `packages/*` | `apps/budget-tracker/`, `apps/launchpad/` |
+| `apps/budget-tracker/` | `packages/*` | `apps/stock-analyser/`, `apps/launchpad/` |
+| `apps/launchpad/` | `packages/*` | `apps/stock-analyser/`, `apps/budget-tracker/` |
+| `packages/*` | Other `packages/*` | `apps/*`, `functions/*`, `infrastructure/*` |
+| `infrastructure/*` | `functions/*` (via file paths), `apps/*/functions/*` (via file paths) | `apps/*` source code |
+| `functions/*` | `packages/*` | `apps/*`, other `functions/*` (each Lambda is independent) |
 
 **Valid imports:**
-```typescript
-// ✅ Stock Analyser importing from a shared package
-import { AuthService } from '@transformotion/auth-client'
 
-// ✅ Any app importing from api-client
+```typescript
+// Stock Analyser importing from a shared package
 import { ApiClient } from '@transformotion/api-client'
+
+// Lambda using shared middleware
+import { withAuth } from '@transformotion/lambda-middleware'
 ```
 
-**Invalid imports — CI will fail:**
+**Invalid imports — CI will fail when lint is re-enabled:**
+
 ```typescript
 // ❌ Stock Analyser importing from Budget Tracker
 import { BudgetStore } from '../../budget-tracker/stores/use-budget-store'
 
 // ❌ A package importing from an app
 import { portfolioService } from '../../apps/stock-analyser/lib/services/portfolio'
+
+// ❌ A Lambda importing from another Lambda
+import { handler as accountHandler } from '../../accounts/handler'
 ```
 
 ## How deploys work
 
-Push-triggered, path-filtered per app:
+Push-triggered, path-filtered per app. Changes to one app never trigger
+the other app's deployment.
 
 | Changed path | Workflow triggered |
 |---|---|
@@ -107,33 +191,77 @@ Push-triggered, path-filtered per app:
 | `infrastructure/lib/stock-analyser/**` | `deploy-stock-analyser.yml` |
 | `apps/budget-tracker/**` | `deploy-budget-tracker.yml` |
 | `infrastructure/lib/budget-tracker/**` | `deploy-budget-tracker.yml` |
+| `apps/launchpad/**` | `deploy-platform.yml` |
 | `infrastructure/lib/platform/**` | `deploy-platform.yml` |
 | `infrastructure/bin/**` | `deploy-platform.yml` |
 | `functions/**` | `deploy-platform.yml` |
 | `packages/**` | `deploy-stock-analyser.yml` + `deploy-budget-tracker.yml` |
 
-Changes to one app never trigger the other app's deployment.
+Path filter completeness is not yet verified for `.github/workflows/**`
+and `scripts/ci/**` — changes to CI machinery may not auto-trigger the
+workflows they modify. M14 covers this.
 
 ## Adding a new app
 
-1. Create `apps/<app-name>/` with its own `package.json` (`@transformotion/<app-name>`)
-2. Add `apps/<app-name>/contracts/` with the 6 contract files (copy from budget-tracker as template)
-3. Add CDK stacks in `infrastructure/lib/<app-name>/`
-4. Register stacks in `infrastructure/bin/app.ts`
-5. Add Lambda source at `apps/<app-name>/functions/` if needed; register in `pnpm-workspace.yaml`
-6. Add a deployment workflow at `.github/workflows/deploy-<app-name>.yml`
-7. Add a `CODEOWNERS` entry for `apps/<app-name>/`
+The full canonical procedure is in `CONTRIBUTING.md` Section 3. The
+mechanical steps within this monorepo are:
+
+1. Create `apps/<app-name>/` with its own `package.json`
+   (`@transformotion/<app-name>`).
+2. Add a `CLAUDE.md` at `apps/<app-name>/CLAUDE.md` per
+   `CONTRIBUTING.md` Section 2.3.
+3. Add the app's normative contracts at `contracts/<app-name>/` —
+   *not* at `apps/<app-name>/contracts/`. Per-app contract mirrors are
+   forbidden per `CONTRIBUTING.md` Section 3.5.
+4. Add CDK stacks in `infrastructure/lib/<app-name>/` (or
+   `apps/<app-name>/infrastructure/` post-M7).
+5. Register stacks in `infrastructure/bin/app.ts`.
+6. Add Lambda source at `apps/<app-name>/functions/`. Register the
+   nested workspace glob in `pnpm-workspace.yaml` if Lambdas are
+   workspaces themselves.
+7. Add a deployment workflow at `.github/workflows/deploy-<app-name>.yml`.
+8. Add a `CODEOWNERS` entry for `apps/<app-name>/`.
+9. Create a corresponding GitHub Milestone if onboarding the app is
+   substantive enough to warrant phased work, per `CONTRIBUTING.md`
+   Section 4.4's milestone pairing rule.
 
 ## Adding a shared package
 
-1. Create `packages/<package-name>/` with `package.json` (`@transformotion/<package-name>`)
-2. Export from `src/index.ts`
-3. Add to consuming app's `package.json` as `"@transformotion/<package-name>": "workspace:*"`
-4. Add a `CODEOWNERS` entry for `packages/<package-name>/`
+1. Create `packages/<package-name>/` with `package.json`
+   (`@transformotion/<package-name>`).
+2. Export from `src/index.ts`.
+3. Add to consuming app's `package.json` as
+   `"@transformotion/<package-name>": "workspace:*"`.
+4. Add a `CODEOWNERS` entry for `packages/<package-name>/`.
+
+UI packages live under `packages/ui/<concern>/` per `CONTRIBUTING.md`
+Section 3.4 (e.g., `packages/ui/primitives/`,
+`packages/ui/error-boundaries/`). `packages/ui/` is purely
+organisational, not itself a package.
 
 ## Common gotchas
 
-- **CDK paths**: Lambda entry paths in CDK stacks use `path.join(__dirname, '../../../apps/...')` relative to `infrastructure/lib/<subdir>/`. Double-check the depth when adding new stacks.
-- **pnpm workspace globs**: `apps/*` matches direct children only. Nested workspaces (like `apps/stock-analyser/functions/*`) need explicit entries in `pnpm-workspace.yaml`.
-- **Shared API Gateway**: All apps use the same API Gateway defined in `PlatformApiStack`. Each app stack receives `api` and `authoriser` as props and adds its own routes. Do not create a second API Gateway.
-- **Analysis cache table**: The `platform.analysis-cache` table is shared by all apps via the claude-proxy Lambda. App-specific cache (like Stock Analyser's per-ticker analysis) lives here too — it is keyed by `accountId + cacheKey`.
+- **CDK paths.** Lambda entry paths in CDK stacks use
+  `path.join(__dirname, '../../../apps/...')` relative to
+  `infrastructure/lib/<subdir>/`. Double-check the depth when adding
+  new stacks. Post-M7 reorganisation will change these depths.
+
+- **pnpm workspace globs.** `apps/*` matches direct children only.
+  Nested workspaces (like `apps/stock-analyser/functions/*` and
+  `functions/auth/*`) need explicit globs in `pnpm-workspace.yaml`.
+
+- **Shared API Gateway (mostly).** `apps/stock-analyser` and
+  `apps/launchpad` use the shared API Gateway from `PlatformApiStack`.
+  `apps/budget-tracker` currently uses its own separate API Gateway
+  (a CDK dependency-cycle workaround). M5 retires the workaround and
+  consolidates onto the shared gateway.
+
+- **Analysis cache table.** The `platform.analysis-cache` table is
+  used by stock-analyser via the claude-proxy Lambda. Despite the
+  `platform.` prefix it is functionally stock-analyser data; M2.1
+  ratifies the reclassification as a Stage 0b decision.
+
+- **Stub packages.** `packages/auth-client/`, `packages/cycle-engine/`,
+  and `packages/ui/` are minimal stubs. Their disposition (build out,
+  retire as orphans, or leave as type-only contracts) is unresolved;
+  consider before importing anything substantive from them.

--- a/PLAN.md
+++ b/PLAN.md
@@ -79,19 +79,28 @@ supporting all subsequent milestones.
 
 - `/PLAN.md` (this document) merged.
 - `/CONTRIBUTING.md` merged.
+- `/README.md` updated to reflect actual current state and reference
+  the canonical operating documents.
 - `/MONOREPO.md` updated to reference branch-naming convention from
   `CONTRIBUTING.md`.
 - `/SECURITY.md` exists (minimum-viable; expanded later as needed).
 - `docs/archive/` exists with `DEVELOPMENT_PLAN.md` and
   `STABILISATION_FREEZE.md` archived.
-- GitHub Milestones M0–M12 created with names, descriptions, and "gate to
-  next" conditions in their descriptions.
-- GitHub Issues created under each milestone, including a "kickoff" issue
-  per milestone.
-- GitHub Project (Projects v2) created with kanban and roadmap views,
-  filtered/grouped by milestone.
-- Project automation rules configured: new issues added to milestone
-  auto-add to Project; cards move on assignment, PR-open, issue-close.
+- GitHub Milestones M0–M14 (and the "Backlog — unsequenced items"
+  milestone) created with names, descriptions, and "gate to next"
+  conditions in their descriptions.
+- GitHub Issues created under each milestone, including a "kickoff"
+  issue per milestone where appropriate.
+- GitHub Project (Projects v2) created at the organisation level with
+  kanban and roadmap views, grouped by milestone:
+  [github.com/orgs/transformotion/projects/1](https://github.com/orgs/transformotion/projects/1)
+  — "Platform development".
+- Project Status field configured with five options matching
+  `CONTRIBUTING.md` Section 4.4: Backlog, Todo, In Progress, In
+  Review, Done.
+- Project automation rules configured: new issues attached to a
+  milestone auto-add to Project; new items default to Backlog status;
+  cards move to Done when issue closes or linked PR merges.
 
 ### Goals served
 
@@ -342,7 +351,26 @@ rewrites them so the documentation set reflects the post-M2 state.
   gitignored.
 - `MONOREPO.md` extended to document the actual `claude-code/<n>` /
   `v0/<n>` / `<author>/<n>` branch-naming convention (per
-  `CONTRIBUTING.md` Section 4.1).
+  `CONTRIBUTING.md` Section 4.1). Already done in current `MONOREPO.md`
+  via the cross-reference; if the root `CLAUDE.md` is retired (see
+  below) any branch-naming content there moves to `CONTRIBUTING.md` or
+  `MONOREPO.md`.
+- Missing `apps/launchpad/CLAUDE.md` created per `CONTRIBUTING.md`
+  Section 2.3 (per-app CLAUDE.md is required). Stock Analyser and
+  Budget Tracker already have theirs.
+- Root `CLAUDE.md` reconciled. Currently exists but is not described
+  in `CONTRIBUTING.md` Section 2.3. Decision: either archive (if its
+  content duplicates `CONTRIBUTING.md`/`MONOREPO.md`) or formalise
+  the root-level CLAUDE.md role with `CONTRIBUTING.md` Section 2.3
+  updated to cover it. The root file currently has stale content
+  (branch-naming convention out of date with `CONTRIBUTING.md`
+  Section 4.1, and assumes `contracts/<app>/` mirrors that don't
+  exist for all apps).
+- `MONOREPO.md` updated to reflect any structural changes landed in
+  this milestone (e.g., `apps/web/` removal, `apps/web-vite-backup/`
+  removal, `v0-reference/` formalisation). Per `CONTRIBUTING.md`
+  Section 2.1 discipline rule, structural changes touch this document
+  in the same PR.
 
 ### Goals served
 
@@ -568,6 +596,18 @@ work.
   per-app stacks moved to `apps/<app>/infrastructure/`, platform stacks
   moved to `platform/infrastructure/`, root `infrastructure/` reduced to
   CDK app entrypoint only.
+- `platform/` top-level directory created. Platform Lambdas moved
+  from root `functions/` to `platform/functions/` (with `auth/`,
+  `accounts/`, `claude-proxy/`, `user/` substructure preserved).
+  Platform infrastructure moved to `platform/infrastructure/` per
+  the line above. CDK path constants and `pnpm-workspace.yaml` globs
+  updated.
+- `MONOREPO.md` updated to reflect the new structure: `platform/`
+  documented as a top-level directory, `apps/<app>/infrastructure/`
+  documented in per-app structure, root `infrastructure/` reduced
+  scope documented, deploy workflow path filters updated. Per
+  `CONTRIBUTING.md` Section 2.1 discipline rule, structural
+  migrations touch this document in the same PR.
 - The `apps/web/` 0-LOC shell cleanup (if not done in M3) folded in
   here.
 

--- a/README.md
+++ b/README.md
@@ -2,23 +2,79 @@
 
 Multi-tenant PWA platform — Stock Signal Analyser, Budget Tracker, and Transformotion Framework.
 
-**Platform URL:** apps.transformotion.com.au  
-**AWS Region:** ap-southeast-2  
+**Platform URL:** apps.transformotion.com.au
+**AWS Region:** ap-southeast-2
 **IaC:** AWS CDK (TypeScript)
+
+## Operating documents
+
+This repository is governed by three canonical documents. New
+contributors — human or Claude — read these first.
+
+- **[PLAN.md](./PLAN.md)** — current trajectory of work. Goals,
+  v0 development constraint, milestones, gating relationships,
+  sequencing.
+- **[CONTRIBUTING.md](./CONTRIBUTING.md)** — ways of working.
+  Document map, repository conventions, workflow rules, discipline
+  rule, status-tag system, operating principles.
+- **[MONOREPO.md](./MONOREPO.md)** — workspace structure, import
+  boundaries.
+
+The architectural invariants live at
+[`docs/architecture/`](./docs/architecture/) — `auth.md`, `data.md`,
+`urls-and-deploy.md`, `cdk.md`. These describe the platform's
+canonical structure and behaviour.
+
+## Project tracking
+
+Work is tracked in a GitHub Project (Projects v2) at the organisation
+level:
+
+**[github.com/orgs/transformotion/projects/1](https://github.com/orgs/transformotion/projects/1)** — "Platform development"
+
+The Project shows all issues across milestones, with kanban and
+roadmap views. Every actionable unit of work has a corresponding
+GitHub Issue belonging to a milestone (M-setup, M0–M14, or "Backlog
+— unsequenced items"). See `CONTRIBUTING.md` Section 4.4 for how
+issues, milestones, and the Project relate.
 
 ## Monorepo structure
 
+The directory layout below reflects the structure documented in
+`CONTRIBUTING.md` Section 3. Migration from earlier layouts is
+tracked in `PLAN.md`.
+
 ```
-apps/launchpad/     Platform shell — sign-in page, launchpad with group-based tile visibility
-apps/budget/        Budget Tracker (Phase 5)
-packages/api-client Typed API wrappers (shared)
-packages/cycle-engine  RSI/MACD/volume cycle scoring (extracted from HTML version)
-packages/ui/        Shared component library (long-term)
-infra/              AWS CDK stacks
-functions/          Lambda functions
-test-data/          Sample CSVs and mock API responses for tests
-.github/workflows/  CI/CD pipelines (GitHub Actions + OIDC)
+apps/                   User-facing applications
+  launchpad/            Platform shell — sign-in, app tile rendering
+  stock-analyser/       Stock Signal Analyser
+  budget-tracker/       Budget Tracker
+
+platform/               Platform-owned deployable artefacts
+  functions/            Platform Lambda handlers (auth, accounts, claude-proxy, user)
+  infrastructure/       Platform CDK stacks (Network, Auth, PlatformTables, PlatformApi)
+
+packages/               Shared code consumed by 2+ apps or platform
+  api-client/           Typed API client
+  budget-domain/        Budget Tracker domain types and helpers
+  lambda-middleware/    Shared withAuth/withAuthOnly wrappers
+  ui/                   UI packages organised by concern (per-concern packages live here)
+
+contracts/              Per-scope normative contracts
+  platform/             Platform-wide contracts
+  stock-analyser/       Stock Analyser contracts
+  budget-tracker/       Budget Tracker contracts
+
+docs/                   Documentation
+  architecture/         Architecture invariants (auth, data, urls-and-deploy, cdk)
+  archive/              Superseded documents preserved for historical reference
+
+infrastructure/         CDK app entrypoint only; stacks live with their owners
+.github/workflows/      CI/CD pipelines (GitHub Actions + OIDC)
 ```
+
+Per-app structure within `apps/<app>/` is documented in
+`CONTRIBUTING.md` Section 3.2.
 
 ## Getting started
 
@@ -30,13 +86,13 @@ npm run typecheck    # typecheck all packages
 npm run test         # run all tests
 ```
 
-## Architecture
-
-See [DEVELOPMENT_PLAN.md](./DEVELOPMENT_PLAN.md) for the full phased plan, technical decisions, DynamoDB schema, auth model, and testing strategy.
-
 ## Branch strategy
 
 - `main` — production (apps.transformotion.com.au)
 - `develop` — integration (dev.apps.transformotion.com.au)
-- `phase/N-name` — phase branches
-- `feature/`, `fix/`, `chore/` — working branches off develop
+- Working branches use prefixes by source per `CONTRIBUTING.md`
+  Section 4.1: `claude-code/<n>` (Claude-Code-driven), `v0/<n>`
+  (v0-pushed), `<author>/<n>` (manual).
+
+For pull request conventions, the discipline rule, and the operating
+principles that govern this codebase, see `CONTRIBUTING.md`.


### PR DESCRIPTION
## What this PR does

Completes the documentation portion of M-setup. Four files updated to
reflect actual current state and resolve drift surfaced during M-setup
execution.

### README.md — full rewrite

Replaces fictional monorepo structure (apps/budget/, infra/, etc.)
with the actual current state. Adds an "Operating documents" section
pointing to PLAN.md, CONTRIBUTING.md, and MONOREPO.md as canonical.
Adds a "Project tracking" section with the org-level Project URL.
Removes the broken DEVELOPMENT_PLAN.md link.

### CONTRIBUTING.md changes

Three substantive additions surfaced during M-setup execution:

- **Section 4.2 — Closes #N behaviour:** GitHub's automatic issue
  closure on PR merge fires only when the PR merges to the default
  branch (main). PRs landing on develop don't auto-close. Documents
  the manual-closure requirement.

- **Section 4.4 — Five-Status flow:** Status field has five options
  (Backlog, Todo, In Progress, In Review, Done) rather than four.
  Backlog vs Todo distinction documented. Project URL added.
  Milestone pairing rule added.

- **Section 4.7 — Backlog milestone Status interaction:** Issues in
  the Backlog milestone usually have Backlog status; can move to
  Todo when triaged as next-pickup without being promoted to a
  numbered milestone.

### PLAN.md changes

- M-setup outcomes updated to reflect actual completed state:
  M0-M14 milestone range, Backlog milestone, Project URL, Status
  field configuration, README rewrite.
- M3 outcomes extended with three documentation reconciliation
  items: missing apps/launchpad/CLAUDE.md, root CLAUDE.md
  reconciliation, MONOREPO.md update reminder for any structural
  changes M3 lands.
- M7 outcomes extended: platform/ directory creation made explicit
  (Lambdas and infrastructure both move there); MONOREPO.md update
  reminder.

### MONOREPO.md — full rewrite as current-state

Replaces the previous mix of current and aspirational content with
an accurate current-state description. Cross-references
CONTRIBUTING.md for target-state structure. Cross-references PLAN.md
M3 and M7 for migrations that change structure. Notes stub packages
(auth-client, cycle-engine, ui). Documents budget-tracker's separate
API Gateway as the M5-pending workaround. Updates "Adding a new app"
recipe to align with CONTRIBUTING.md (per-app contracts forbidden,
CLAUDE.md required, milestone pairing rule).

## What this PR doesn't do

- Create per-milestone kickoff issues. Trivial enough to create when
  each milestone starts.
- Migrate apps/web/, apps/web-vite-backup/, contracts/platform/,
  contracts/stock-analyser/, or platform/ — these are M3, M7, and
  M2.3 work respectively.
- Address the missing apps/launchpad/CLAUDE.md or root CLAUDE.md
  reconciliation — these are M3 outcomes.

## After merge

M-setup is substantively complete. M0 (close the open signup gate)
becomes the first eligible milestone to start.

Refs M-setup outcomes in PLAN.md Section 3.