### PR TITLE
M0: Set selfSignUpEnabled to false on Cognito user pool

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -136,12 +136,16 @@ gate sitting open.
 ### Outcome
 
 - `selfSignUpEnabled: false` set in `infrastructure/lib/platform/auth-stack.ts`.
-- Public Create Account screen removed from the launchpad if it exists.
 - Cognito hosted UI no longer accepts public signup. Account creation
   requires invitation (the invitation flow itself is M11).
 - The compound vulnerability (gap #1 + gap #2 from the inventory's Section
   3.4) reduces to a single vulnerability pending M10's app-access gate
   enforcement.
+
+The launchpad does not currently have a public Create Account screen
+(verified during M0 scoping; no `signUp`, `register`, or
+`createAccount` references in `apps/launchpad/`), so no frontend work
+is required.
 
 ### Goals served
 
@@ -150,8 +154,12 @@ hygiene by ensuring only invited users can reach platform resources).
 
 ### Gate to next
 
-Setting deployed to production via the platform stack. Hosted UI signup
-attempts return the expected "self-signup disabled" response.
+Setting deployed to dev via the platform stack (`TransformotionDev-Auth`).
+Hosted UI signup attempts return the expected "self-signup disabled"
+response. The platform has no prod environment yet; when prod is later
+established, the `selfSignUpEnabled: false` setting applies
+automatically as part of the standard prod deploy of the auth stack —
+no additional M0-specific work needed.
 
 ### Dependencies
 

--- a/infrastructure/lib/platform/auth-stack.ts
+++ b/infrastructure/lib/platform/auth-stack.ts
@@ -65,7 +65,7 @@ export class AuthStack extends cdk.Stack {
     // ── User Pool ──────────────────────────────────────────────────────────
     this.userPool = new cognito.UserPool(this, 'UserPool', {
       userPoolName: `transformotion-${stage}`,
-      selfSignUpEnabled: true,
+      selfSignUpEnabled: false,
 
       // Sign-in via email address
       signInAliases: { email: true },


### PR DESCRIPTION
## What this PR does

Closes the open signup gate (M0) by setting \`selfSignUpEnabled: false\` on the Cognito user pool, and updates PLAN.md M0 to reflect actual scoping findings.

## Code change

\`infrastructure/lib/platform/auth-stack.ts\` line 68: \`selfSignUpEnabled\` changed from \`true\` to \`false\`.

This triggers redeploy of \`TransformotionDev-Auth\` via \`deploy-platform.yml\` (path filter: \`infrastructure/lib/platform/**\`).

After deploy, the Cognito hosted UI will no longer offer public signup — the 'Sign up' link disappears or returns a 'self-signup disabled' response.

## PLAN.md update

Per the discipline rule (CONTRIBUTING.md Section 2.1), PLAN.md M0 is updated in the same PR:

- Removed 'Public Create Account screen removed from launchpad if it exists' outcome bullet — diagnostic confirmed launchpad has no signup UI.
- Added explicit note that no frontend work is required.
- Gate to next changed from 'Setting deployed to production' to 'Setting deployed to dev' — the platform has no prod environment yet; the setting will apply automatically when prod is later established.

## Verification

After merge and dev deploy:

1. Visit the Cognito hosted UI for the dev user pool.
2. Confirm 'Sign up' link is absent or yields 'self-signup disabled'.

## Compound vulnerability resolution

After M0 lands, the compound vulnerability (open signup + ungated stock-analyser Lambdas) reduces to a single vulnerability pending M10's app-access enforcement on stock-analyser Lambdas. M10 closes the second half.

Closes #76