### PR TITLE
M1: Land architectural inventory as committed living document

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -150,7 +150,7 @@ ways of working change. Changes are themselves PRs.
 | Contracts policy | `/docs/architecture/contracts.md` (TBD by Stage 0b) | Normative | The policy for how contracts are organised: where they live, what is normative vs descriptive, single-source-of-truth rules. Location may shift to an extension of an existing document per Stage 0b ratification. | Steve |
 | Per-app contracts | `/contracts/<scope>/*.md` where `<scope>` is `platform` or an app slug | Normative | The actual contracts: data models, API endpoints, state management. Per-app mirrors at `apps/<app>/contracts/` are not allowed. | Per-app team |
 | Per-app guide | `/apps/<app>/CLAUDE.md` | Operational | Per-app guidance for Claude Code agents. Required for every app. Minimum content: app's purpose, key entry points, app-specific conventions, app-specific gotchas, sync flow if v0-driven. | Per-app team |
-| Architectural inventory | `/docs/architectural-inventory.md` | Normative (point-in-time snapshot) | Stage 0a output — read-only inventory of the platform's current state at the time of writing. Treated as a baseline for Stage 0b decisions. Does not get updated as state changes; superseded by future inventories. | Steve |
+| Architectural inventory | `/docs/architecture/inventory.md` | Normative (living document) | The current-state inventory of the platform — what is true about code, infrastructure, and operating state right now. Updated as state changes per the discipline rule (Section 2.1). Findings carry status tags including **Resolved by M*N* / PR #*N*** and **Superseded by [reference]** for living-document use. | Steve |
 
 Documents that have been superseded live in `/docs/archive/` with a header
 noting the supersession date and the document that replaced them.
@@ -518,7 +518,39 @@ normative document is wrong, the document update happens in the same PR
 or the PR pauses until resolved. Documentation problems are not deferred
 the way code problems can be.
 
-### 4.6 Commit messages
+### 4.6 Updating the architectural inventory
+
+The architectural inventory at `docs/architecture/inventory.md` is a
+living document — findings are updated as state changes, not appended
+as separate notes.
+
+When a PR addresses an inventory finding, the PR updates the finding
+in `inventory.md` in the same PR. The discipline rule (Section 2.1)
+applies. Specifically:
+
+- **Resolving a finding:** Change the finding's status tag to
+  **Resolved by M*N* / PR #*N***. Update the finding's text to
+  describe the new state. Preserve a brief note of what changed
+  (typically one sentence) so the resolution is auditable in the
+  document, not just in git history.
+- **Refining a finding:** If verification or investigation reveals a
+  finding was wrong or incomplete, update the text and the status
+  tag to match what was actually found. The git history preserves
+  the previous version.
+- **Superseding a finding:** When deeper investigation produces a
+  better-shaped finding that subsumes earlier ones, set the older
+  finding's status to **Superseded by [reference]** and keep its
+  description for context.
+
+PRs that introduce new findings (e.g., M1 verifications producing
+findings the inventory didn't have) add them to the relevant section
+with appropriate status tags.
+
+The inventory is one of the documents that PRs are most likely to
+touch over the platform's lifetime. Updates are normal — not a
+sign of drift.
+
+### 4.7 Commit messages
 
 Commit message style is freeform; the merge commit is the unit that
 matters in the long-term log. Conventional Commits style (`feat:`,
@@ -528,7 +560,7 @@ Commit messages reference issues where relevant ("Refs #42", "Closes
 #43"). The PR body is the canonical place for issue references; commit
 messages are convenience.
 
-### 4.7 The Backlog milestone
+### 4.8 The Backlog milestone
 
 `PLAN.md`'s "Beyond M14" section lists items scoped but not yet
 sequenced into numbered milestones. Each such item has a corresponding
@@ -597,6 +629,17 @@ If verification surfaces a discrepancy, that is itself a finding to
 record (open an issue, update PLAN.md or the relevant document) before
 proceeding with the original work.
 
+**Specific application: writing or rewriting normative documents.**
+When drafting or rewriting any normative document (architecture docs,
+`MONOREPO.md`, `README.md`, contracts policy), a ground-truth check
+of the relevant code, directories, and existing documents is a
+prerequisite, not a nice-to-have. Drafting against
+remembered-or-imagined state produces documents that contradict
+reality and need re-writing once the discrepancies surface. The
+pattern is: list the directories or files the document will describe,
+read them, then write. This applies whether the document is being
+created or rewritten, and whether the writer is human or Claude.
+
 ### 5.2 Audit cheerful PR-description framings before reading the rest
 
 PR descriptions that say "drift removed", "simplified to X-only", "cleaned
@@ -648,11 +691,15 @@ different resolution path.
 | **Stale-by-decision** | The divergence is the result of a deliberate choice to retire or replace something; cleanup is sequenced. |
 | **Aspirational-never-built** | Documented as intent, no implementation has caught up. |
 | **Deferred** | Scaffolded with intent to complete, paused for reasons orthogonal to whether it should exist. |
+| **Resolved by M*N* / PR #*N*** | Finding has been addressed; the finding's text is updated to describe the new state, with a note of what changed and the reference to the milestone or PR that resolved it. Used in living documents like the architectural inventory. |
+| **Superseded by [reference]** | Finding has been subsumed by another finding, usually after deeper investigation. Description preserved for context; reference points to the superseding finding. Used in living documents. |
 
 The tags exist to make divergence between code and documents visible
 rather than invisible. A finding without a status tag implicitly claims
-"Confirmed", which is often false. Future audits and inventories use this
-system; one-off documents may use it where helpful.
+"Confirmed", which is often false. Living documents (such as the
+architectural inventory) use the full set including **Resolved by** and
+**Superseded by**; one-off audit outputs typically use only the first
+six.
 
 ---
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -186,7 +186,8 @@ inspect.
 ### Outcome
 
 - All seven Blocking-0b verification items resolved with confirmed
-  findings:
+  findings, captured directly in the architectural inventory at
+  `docs/architecture/inventory.md`:
   - X-Account-Id post-PR-#67 deployed state (Section 2.3 of inventory).
   - Helper availability in `packages/lambda-middleware` (Sections 2.5,
     3.3 of inventory).
@@ -200,15 +201,18 @@ inspect.
     inventory).
   - Claude proxy authorization (Section 2.11 of inventory).
 - Direct contents of the existing architecture documents read and
-  catalogued: `docs/architecture/data.md`, `docs/architecture/cdk.md`,
-  `docs/architecture/urls-and-deploy.md`, `docs/architecture/README.md`,
-  `apps/<app>/CLAUDE.md` (per app).
-- Diff of inventory Section 2.10 schema view against `data.md`.
-- Diff of inventory Section 5.6 CDK topology against `cdk.md`.
-- Diff of inventory's auth substrate against `auth.md`.
-- Verification findings written up either as an appendix to the inventory
-  (v5) or as a standalone verification report at
-  `docs/verification-pass-M1.md`.
+  catalogued in the inventory: `docs/architecture/data.md`,
+  `docs/architecture/cdk.md`, `docs/architecture/urls-and-deploy.md`,
+  `docs/architecture/README.md`, `apps/<app>/CLAUDE.md` (per app).
+- Diff of inventory Section 2.10 schema view against `data.md`,
+  Section 5.6 CDK topology against `cdk.md`, auth substrate against
+  `auth.md` — discrepancies updated in the inventory or surfaced as
+  M3 / M2 inputs.
+- Each M1 issue closes with the relevant inventory section having a
+  status tag of **Confirmed**, **Resolved by [reference]**, or
+  **Superseded by [reference]** (per `CONTRIBUTING.md` Section 6).
+  No M1 verification leaves an inventory section at "Status uncertain
+  — verify".
 
 ### Goals served
 

--- a/docs/architecture/inventory.md
+++ b/docs/architecture/inventory.md
@@ -1,0 +1,785 @@
+# Architectural inventory
+
+This document is the living current-state inventory of the Transformotion
+Apps platform. It describes what is true about the platform now, and is
+updated as state changes per the discipline rule (`CONTRIBUTING.md`
+Section 2.1).
+
+When work addresses a finding here, the PR doing that work updates the
+relevant finding in this document in the same PR.
+
+## How this document is used
+
+- **Findings describe state.** Each finding is a specific, testable claim
+  about the codebase, infrastructure, or operating state.
+- **Status tags** indicate the confidence level and lifecycle of each
+  finding (per `CONTRIBUTING.md` Section 6, with two extensions for
+  living-document use).
+- **Section numbering is stable.** PLAN.md and milestone issues reference
+  findings by section number (e.g., "inventory Section 3.2"). Numbering
+  changes only when a section is genuinely retired.
+- **Interpretive content lives in `PLAN.md` or architecture decision
+  documents**, not here. This document records what *is*, not what *should
+  be*.
+
+## Status tag legend
+
+| Tag | Meaning |
+|---|---|
+| **Confirmed** | Verified against current code, infrastructure, or runtime evidence. |
+| **Inferred** | Derived from code patterns or surrounding evidence, not directly verified. |
+| **Status uncertain — verify** | Known to have been planned or partially built; needs verification before being treated as either pending or done. |
+| **Stale-by-decision** | The divergence is the result of a deliberate choice; cleanup is sequenced in a milestone. |
+| **Aspirational-never-built** | Documented as intent, no implementation has caught up. |
+| **Deferred** | Scaffolded with intent to complete, paused for orthogonal reasons. |
+| **Resolved by M*N* / PR #*N*** | Finding addressed; text describes new state with a note on what changed. |
+| **Superseded by [reference]** | Finding subsumed by another; description preserved for context. |
+
+---
+
+## 1. Code structure and ownership
+
+### 1.1 Top-level repository structure
+
+**Status: Confirmed (current state)**
+
+The repository contains the following top-level directories:
+
+- `apps/` — five subdirectories: `budget-tracker/`, `launchpad/`,
+  `stock-analyser/`, `web/` (0-LOC shell, M3 cleanup), `web-vite-backup/`
+  (M3 cleanup, excluded from workspaces)
+- `packages/` — six subdirectories: `api-client/`, `auth-client/` (stub),
+  `budget-domain/`, `cycle-engine/` (stub), `lambda-middleware/`, `ui/`
+  (stub)
+- `infrastructure/` — CDK app with `bin/app.ts` entrypoint and
+  `lib/{platform,stock-analyser,budget-tracker}/` per-scope subdirs
+- `functions/` — platform Lambda source: `accounts/`, `auth/` (with
+  `account-provisioning/`, `pre-token-generation/`, `invitations/`,
+  `forgot-provider/`), `claude-proxy/`, `user/`. Migrating to
+  `platform/functions/` per M7.
+- `contracts/` — only `budget-tracker/` exists. M2.3 ratifies the
+  contracts policy; subsequent work creates `platform/` and
+  `stock-analyser/` siblings.
+- `docs/` — `architecture/` (5 files: README.md, auth.md, cdk.md,
+  data.md, urls-and-deploy.md), `archive/` (DEVELOPMENT_PLAN.md,
+  STABILISATION_FREEZE.md)
+- `migration-artifacts/` — `budget-tracker/` only
+
+CLAUDE.md exists at root (1371 bytes); `apps/stock-analyser/` and
+`apps/budget-tracker/` have per-app CLAUDE.md; `apps/launchpad/` is
+missing one (M3 outcome).
+
+`pnpm-workspace.yaml` covers `apps/*`,
+`apps/stock-analyser/functions/*`, `apps/budget-tracker/functions/*`,
+`packages/*`, `functions/*`, `functions/auth/*`, `infrastructure`.
+`apps/web-vite-backup` is explicitly excluded.
+
+The migration toward the canonical structure documented in
+`CONTRIBUTING.md` Section 3 is tracked across PLAN.md milestones — M3
+removes `apps/web/` and `apps/web-vite-backup/`; M7 creates `platform/`
+and reorganises `infrastructure/`.
+
+### 1.2 Import boundaries
+
+**Status: Confirmed (current state)**
+
+Cross-app imports are forbidden per `MONOREPO.md`. Enforcement via
+`eslint-plugin-boundaries` is currently disabled because of an ESLint
+10 incompatibility — the rule is in the lint baseline as "investigated,
+deferred." M7 re-enables enforcement after the upstream fix lands.
+
+The rules don't address cross-app *code residence* — that is, code
+about app X living in app Y's tree. This is currently happening (see
+1.3) and isn't captured by the import-boundary rules because import
+boundaries only fire on import statements, not file location.
+
+### 1.3 Bilateral code duplication between stock-analyser and budget-tracker
+
+**Status: Confirmed (verified during initial inventory)**
+
+Approximately 75% of stock-analyser's codebase exists as duplicate code
+in budget-tracker. Of the duplicated content:
+
+- ~60% is byte-identical (UI primitives, hooks, utility files)
+- ~40% has drifted (layouts, app shells, integration tabs — exactly the
+  files where coordination matters most)
+
+The duplication is the primary structural barrier to Goal 1 ("work on
+one app without affecting another"). M7 is the corrective work; its
+scope explicitly covers refining the 60/40 split into semantic vs
+cosmetic drift, deciding per-concern lift targets, and migrating
+sequentially.
+
+### 1.4 v0 development workflow
+
+**Status: Confirmed (operating constraint)**
+
+The frontend is developed using v0 (vercel.com/v0) with mocked
+persistence (localStorage). The same components run against real
+DynamoDB-via-Lambda persistence in production. Operationally:
+
+- v0 commits to a separate repo (`transformotion-apps-b8`)
+- `scripts/sync-v0.sh` pulls from that repo into a gitignored
+  `v0-reference/` directory
+- Claude Code adapts components from `v0-reference/` into the main
+  repo's `apps/<app>/` structure
+
+This workflow is documented in `CONTRIBUTING.md` Section 1.2 as a
+cross-cutting constraint on architectural decisions involving
+frontend, persistence, contracts, and build pipeline.
+
+### 1.5 Stub packages
+
+**Status: Confirmed (current state)**
+
+Three packages exist in `packages/` as stubs (single-file or
+near-single-file with no runtime dependencies):
+
+- `packages/auth-client/` — single `src/index.ts`, type definitions
+  only, no dependencies beyond TypeScript
+- `packages/cycle-engine/` — single `src/index.ts`, has vitest test
+  script but no runtime dependencies declared
+- `packages/ui/` — minimal stub
+
+The disposition of each (build out as canonical, retire as orphan, or
+leave as type-only contracts) is unresolved. M7 (deduplication)
+should resolve this in the course of lifting duplicated code.
+
+### 1.6 Launchpad as platform shell
+
+**Status: Confirmed (current state)**
+
+`apps/launchpad/` is the platform shell — sign-in flow, account
+switcher, app tile rendering. Treated as an app for structural
+purposes (consumes platform services through packages like any other
+app) per `CONTRIBUTING.md` Section 3.2.
+
+Per M0 verification: `apps/launchpad/` contains no public signup UI
+(no `signUp`, `register`, `createAccount` references in any `.ts` or
+`.tsx` file).
+
+The hard-coded `userCanAccessFramework` prop in launchpad currently
+governs tile visibility for the Transformotion Framework app. M9
+migrates tile rendering from `cognito:groups` (the legacy substrate)
+to the `apps` JWT claim, removing this hard-coded prop.
+
+### 1.7 Stale-by-decision artefacts
+
+**Status: Stale-by-decision**
+
+Several artefacts in the repo describe earlier states that have been
+superseded:
+
+- `apps/web/` — 0-LOC shell from the launchpad rename. M3 cleanup.
+- `apps/web-vite-backup/` — backup directory from earlier scaffolding.
+  Contributes 18 lint baseline entries. M3 cleanup.
+- Branch naming convention in root `CLAUDE.md` (`claude-code/<n>` only)
+  is partial — the actual practice (per `CONTRIBUTING.md` Section
+  4.1) includes `v0/<n>` and `<author>/<n>` prefixes. M3 reconciles.
+- Various stale `first-login` references in code or docs that didn't
+  propagate from the rename to `account-provisioning`. M3 covers.
+
+---
+
+## 2. Data, persistence, and APIs
+
+### 2.1 Persistence patterns coexist without canonical rule
+
+**Status: Confirmed (verified during initial inventory)**
+
+Three persistence patterns currently exist in the codebase, with no
+documented rule for which is canonical:
+
+- **Service layer pattern** — used by stock-analyser portfolio and
+  watchlist. `portfolio-service.ts` and `watchlist-service.ts` call
+  `getStockSignalClient()` directly; no swap point at the data-access
+  layer.
+- **Repository pattern** — used by what was Budget Tracker drift in
+  `apps/stock-analyser/lib/repositories/budget-tracker/` (now removed).
+  Featured a swap point: `createSettingsRepository()` and
+  `createTransactionRepository()` returned either localStorage or
+  Dynamo-backed implementations based on config.
+- **Service-class pattern** — used by `DynamoTTLCacheService` for the
+  analysis cache. A class with methods, not a repository interface or
+  service object.
+
+The v0 development workflow (1.4) requires a swap point at the data-
+access layer — components must work against localStorage in v0 and
+DynamoDB in production. Only the repository pattern currently has
+this seam. M2.1 ratifies the canonical pattern.
+
+### 2.2 Stock-analyser portfolio production data path
+
+**Status: Confirmed (verified during initial inventory)**
+
+Production path:
+
+```
+portfolioService.getHoldings()
+  → getStockSignalClient().getPortfolio()
+  → ApiClient → HttpClient.request()
+  → fetch(baseUrl + '/portfolio')
+    with Authorization: Bearer <idToken>
+    and X-Account-Id: <accountId>
+  → transformotion-portfolio-{stage} Lambda
+  → stock-analyser.portfolio-{stage} DynamoDB
+```
+
+No localStorage anywhere in this path. The same shape applies to
+watchlist (`watchlist-service.ts` → `getStockSignalClient().getWatchlist()`
+→ `transformotion-watchlist-{stage}` Lambda → `stock-analyser.watchlist-{stage}`).
+
+### 2.3 X-Account-Id contract
+
+**Status uncertain — verify (M1 issue #78)**
+
+PR #67 narrowed scope to X-Account-Id work and merged. The deployed
+state of the X-Account-Id chain — whether the header is being produced
+by the client, whether handlers are reading it correctly, whether
+`auth.md`'s documented contract matches what's running — needs
+verification before M2 decisions reference it.
+
+**M1 #78 will populate this section with verified findings.**
+
+### 2.4 Stock-analyser Lambdas don't enforce app access
+
+**Status: Confirmed (verified during initial inventory)**
+
+Stock-analyser Lambdas (portfolio, watchlist, analysis-cache) do not
+currently call `requireAppAccess('stock-signal')` or equivalent. They
+authenticate (via API Gateway authoriser checking the JWT) but do not
+authorize at the app level — any authenticated user can call them
+regardless of whether they have access to the stock-signal app.
+
+M10 (Auth middleware extension) closes this. Until then, this is the
+"second half" of the compound vulnerability that M0 reduced — M0
+closed signup, but a hypothetical bypass of signup (via M11's
+invitation flow eventually) followed by a user without stock-signal
+group access could still call stock-analyser endpoints directly.
+
+### 2.5 Auth helpers documented in auth.md
+
+**Status uncertain — verify (M1 issue #79)**
+
+`auth.md` documents a five-helper interface for Lambda authorization:
+
+- `requireAppAccess(auth, appSlug)`
+- `requireAccountAccess(auth, app, accountId, minRole?)`
+- `requireSiteAdmin(auth)`
+- `requireAccountOwner(auth, app, accountId)`
+- `requireSelfOrAccountManager(auth, app, accountId, targetUserId)`
+
+Whether each helper is implemented in `packages/lambda-middleware/`
+is uncertain. M2.2 ratifies the interface; M10 implements them.
+M1 needs to know which exist before M2.2 can be written confidently.
+
+**M1 #79 will populate this section with verified findings.**
+
+### 2.6 Lambda inventory and group-name reads
+
+**Status uncertain — verify (M1 issue #80, partial)**
+
+Platform Lambdas (`functions/`):
+
+- `accounts/` — account management
+- `auth/account-provisioning/` — first-sign-in account creation
+  (renamed from `first-login/`)
+- `auth/pre-token-generation/` — Cognito pre-token trigger; emits
+  the `apps`, `accounts`, `site_admin` claims into JWTs
+- `auth/invitations/` — invitation flow handlers
+- `auth/forgot-provider/` — federated identity recovery (has known bug
+  per M12)
+- `claude-proxy/` — Anthropic API proxy
+- `user/` — platform user data
+
+Stock-analyser Lambdas (`apps/stock-analyser/functions/`):
+
+- `portfolio/`
+- `watchlist/`
+- `analysis-cache/`
+- `cycle-check/`
+
+Budget-tracker Lambdas (`apps/budget-tracker/functions/`):
+
+- `transactions/`
+- `rules/`
+- `settings/`
+- `ai/`
+- `export/`
+- `migrate/` (the `/api/budget/v1/migrate-from-localstorage` endpoint;
+  M6 renames to `/import`)
+
+Whether budget-tracker Lambdas read the new Cognito group names
+(`stock-app-access`, `budget-app-access`, `site-admin`) or still
+reference the legacy ones (`stock-app`, `budget-app`, `admin`) is
+uncertain. M8 (legacy auth substrate cleanup) depends on knowing.
+
+**M1 #80 will populate the group-name read findings.**
+
+### 2.7 Platform-cache misnomer
+
+**Status: Confirmed (verified during initial inventory)**
+
+The `platform.analysis-cache-{stage}` DynamoDB table is named with the
+`platform.` prefix (consistent with the platform table-naming pattern)
+but is functionally stock-analyser data — it caches per-ticker analysis
+results scoped by accountId.
+
+The misnomer has IAM consequence: any Lambda with platform-table access
+can read it; the reclassification to stock-analyser scope implies
+tightening to stock-analyser Lambdas only. M2.1 ratifies the
+reclassification as a Stage 0b decision; the consequent IAM policy
+update follows in M7.
+
+### 2.8 Budget Tracker migration endpoint
+
+**Status: Confirmed (verified during initial inventory)**
+
+The endpoint `POST /api/budget/v1/migrate-from-localstorage` exists,
+implemented at `apps/budget-tracker/functions/budget-migrate/`. It
+accepts a JSON body of `{ transactions, rules, settings }` and writes
+to DynamoDB. The "from-localstorage" naming reflects the client side's
+historical pattern (read from localStorage, post the result), not any
+server-side constraint — the server doesn't know or care about
+localStorage.
+
+M6 renames this endpoint to `/api/budget/v1/import` and removes the
+client-side localStorage middleman. The 726-transaction historical
+fixture at `migration-artifacts/budget-tracker/budget-tracker-export-2026-04-18.json`
+is backfilled via the renamed endpoint.
+
+### 2.9 Two-gateway architecture (drift)
+
+**Status: Confirmed (verified during initial inventory)**
+
+The platform currently has two API Gateways:
+
+- **Platform gateway** — defined in `infrastructure/lib/platform/platform-api-stack.ts`,
+  serves stock-analyser and (eventually) launchpad routes.
+- **BudgetTrackerApi gateway** — defined separately, serves budget-
+  tracker routes. Documented in code as a workaround for a CDK
+  cross-stack dependency cycle.
+
+`MONOREPO.md` declares apps share the platform gateway — true for
+stock-analyser, false for budget-tracker. M5 retires the separate
+gateway and moves budget-tracker handlers onto the platform gateway,
+removing the dependency-cycle workaround.
+
+### 2.10 DynamoDB schema
+
+**Status: Confirmed in part (initial inventory); SK schema mismatch verification pending (M1 issue #82)**
+
+#### 2.10.1 Platform tables
+
+| Table | PK | SK | Notes |
+|---|---|---|---|
+| `platform.accounts-{stage}` | accountId | — | Currently lacks `appSlug` field; see Section 3.2. |
+| `platform.account-members-{stage}` | accountId | userId | Has `userId-index` GSI for reverse lookup. |
+| `platform.invitations-{stage}` | invitationId | — | Used by invitation flow (M11). |
+| `platform.users-{stage}` | userId | — | |
+| `platform.rate-limits-{stage}` | (cf. claude-proxy) | | |
+| `platform.analysis-cache-{stage}` | accountId | cacheKey | Misnamed — see Section 2.7. |
+
+#### 2.10.2 Stock-analyser tables — SK schema mismatch
+
+**Status uncertain — verify (M1 issue #82) — potential production data integrity issue**
+
+The CDK source for `stock-analyser.portfolio-{stage}-v2` and
+`stock-analyser.watchlist-{stage}-v2` declares them as PK-only tables
+(PK: accountId). However, runtime handler code uses
+`Key: { accountId, ticker }` for Delete operations, implying an SK of
+`ticker`.
+
+Either:
+- CDK source is wrong — the deployed table really has the SK; a future
+  redeploy could destroy the SK definition, or
+- Runtime code is wrong — there's no SK; Delete operations are failing
+  silently or via undocumented behaviour
+
+**M1 #82 will resolve this.** If production data integrity is at risk,
+findings escalate to a pre-M2 fix milestone.
+
+#### 2.10.3 Budget-tracker tables
+
+| Table | PK | SK |
+|---|---|---|
+| `budget-tracker.transactions-{stage}` | accountId | transactionId |
+| `budget-tracker.rules-{stage}` | accountId | ruleId |
+| `budget-tracker.settings-{stage}` | accountId | settingKey |
+
+Original plan called for separate `categories` and `budgets` tables.
+These were collapsed into the `settings` table — `categoryTree` and
+`budgetOverrides` are stored as values keyed by `settingKey`. The
+deviation is reasonable (matches the BudgetSettings shape in
+`packages/budget-domain/`) but constitutes a plan-vs-actual divergence
+M3 may want to record.
+
+A `budget-tracker.accounts-{stage}` table also exists but appears
+dormant — no runtime code references it. Likely a leftover from an
+earlier design (Inferred). M3 may resolve.
+
+### 2.11 Claude proxy
+
+**Status uncertain — verify (M1 issue #84, partial)**
+
+The `functions/claude-proxy/` Lambda proxies requests to the Anthropic
+API. It is invoked by Lambda-to-Lambda calls (e.g., from `budget-ai/`).
+The authorization on its invocation, the IAM scope of which Lambdas
+have permission to call it, and whether per-user attribution is
+possible from the current invocation pattern all need verification.
+
+Per-user / per-account observability of Claude consumption is M13
+scope; the input it needs from this verification is whether the
+current invocation pattern can support attribution at all.
+
+**M1 #84 will populate verified findings.**
+
+---
+
+## 3. Auth, accounts, and permissions
+
+### 3.1 Two-dimension permission model
+
+**Status: Confirmed (documented in auth.md)**
+
+The permission model has two orthogonal dimensions:
+
+- **Dimension A — App access (ceiling)**: Cognito group membership
+  determines which apps a user can use at all. Groups:
+  `stock-app-access`, `budget-app-access`, `site-admin`. Surfaced in
+  the JWT as the `apps` claim.
+- **Dimension B — Within-account capability (restriction)**:
+  `account-members` table determines what a user can do within a
+  specific account. Roles: `owner | manager | member | viewer`.
+  Surfaced in the JWT as the `accounts` claim.
+
+Site-admin bypasses both dimensions. Dimension A is the ceiling;
+Dimension B can only restrict within it.
+
+### 3.2 appSlug not written on platform.accounts
+
+**Status: Confirmed (active blocker, addressed in M4)**
+
+The pre-token-generation Lambda joins `platform.account-members`
+through `platform.accounts` to populate the `accounts` JWT claim.
+The join logic reads `appSlug` from the accounts row to bucket each
+account into `accountsByApp[appSlug]`. However, neither writer
+(`account-provisioning/handleSetup` or `accounts/createAccount`)
+currently writes `appSlug` onto the accounts row.
+
+Consequence: `accountsByApp` is empty for every JWT. The `accounts`
+claim ships empty. Every account-scoped Lambda call fails
+authorization. This is the single biggest active blocker in the
+inventory.
+
+M4 closes this. The user-expressed preference recorded during M-setup
+is per-app accounts (one `platform.accounts` row per app per user-account
+relationship); M2.2 ratifies the model formally before M4's writer
+update lands.
+
+### 3.3 Frontend auth store and JWT claims
+
+**Status uncertain — verify (M1 issue #85, partial — overlaps with auth.md read)**
+
+The frontend auth store needs to retain `apps`, `accounts`, and
+`site_admin` claims atomically with rendering decisions. If claim
+state is updated piecemeal (e.g., during token refresh), there's a
+window where rendering uses stale values from one claim and fresh
+from another.
+
+The current shape of the store, and whether it preserves claims
+atomically, needs verification. M9 (launchpad tile rendering migration)
+specifically requires this invariant to hold.
+
+**M1 #85's architecture document read will surface this.**
+
+### 3.4 Security gaps with material impact
+
+This subsection lists security/integrity findings that affect Goal 4.
+
+#### 3.4.1 Open signup gate
+
+**Status: Resolved by M0 / PR #77**
+
+Pre-M0: `selfSignUpEnabled: true` in `auth-stack.ts` allowed anyone to
+create a Cognito account via the hosted UI without invitation.
+Compounded with finding 3.4.2 to create a real exposure.
+
+M0 set `selfSignUpEnabled: false`. Cognito hosted UI no longer offers
+public signup. Verified post-deploy: hosted UI shows no Sign Up link;
+account creation now requires invitation flow (M11).
+
+#### 3.4.2 Stock-analyser Lambdas don't enforce app access
+
+**Status: Confirmed (open; addressed in M10)**
+
+See Section 2.4. M10 closes by migrating stock-analyser handlers to
+use `requireAppAccess('stock-signal')`.
+
+#### 3.4.3 forgot-provider Lambda fails on federated users
+
+**Status: Confirmed (open; addressed in M12)**
+
+Per Issue #49: `functions/auth/forgot-provider/` uses
+`AdminGetUserCommand(Username=email)` which works for native Cognito
+users but fails for federated users because Cognito indexes federated
+users by sub, not email. M12 fixes.
+
+#### 3.4.4 Three-client Cognito authoriser acceptance
+
+**Status uncertain — verify (M1 issue #83)**
+
+The Cognito user pool has three app clients (stock-analyser, budget-
+tracker, launchpad). Whether the API Gateway authoriser accepts tokens
+from all three clients, or only specific ones, is uncertain. Cross-app
+navigation correctness depends on the answer.
+
+**M1 #83 will populate verified findings.**
+
+### 3.5 Platform Lambda permission model
+
+**Status: Deferred (decision pending in M2.2)**
+
+Five platform Lambdas (`accounts`, `user`, `auth/invitations`,
+`auth/account-provisioning`, `auth/forgot-provider`) were deliberately
+not gated during sub-phase 7b.5-beta because their permission model
+needed dedicated thought. Each needs a documented decision on its
+authorisation model — including how onboarding-stage users (no app
+groups yet) interact with them.
+
+M2.2 is the decision; M10 implements.
+
+---
+
+## 4. Contracts and types
+
+### 4.1 Contracts directory asymmetry
+
+**Status: Confirmed (verified during initial inventory)**
+
+`contracts/` contains only `budget-tracker/`. There is no
+`contracts/platform/` or `contracts/stock-analyser/`. Stock-analyser
+contracts either live inline in `apps/stock-analyser/lib/` or aren't
+called contracts at all.
+
+M2.3 ratifies the contracts policy; subsequent work creates the
+missing folders.
+
+### 4.2 Bilateral contract mirrors forbidden
+
+**Status: Confirmed (rule established in CONTRIBUTING.md Section 3.5)**
+
+Per `CONTRIBUTING.md` Section 3.5, contracts have exactly one canonical
+location at `contracts/<scope>/<file>.md`. Per-app mirrors at
+`apps/<app>/contracts/` are forbidden. Currently
+`apps/budget-tracker/contracts/ui-patterns.md` exists — M3 covers
+resolving this against the canonical location.
+
+### 4.3 v0-sufficient subset pattern
+
+**Status: Deferred (M2.3 takes a position)**
+
+Across budget-tracker contract files, a recurring pattern is that the
+contract describes the *v0-sufficient subset* of an interface — what's
+needed for v0 to mock it — rather than the production interface in
+full. Production handlers extend this with additional fields.
+
+Whether contracts should be the production interface (with v0 reading
+a subset) or the v0-sufficient subset (with production extending) is
+a Stage 0b decision. M2.3 takes the position.
+
+### 4.4 Domain packages and type ownership
+
+**Status: Confirmed (current state)**
+
+`packages/budget-domain/` exists with TypeScript types and pure helpers
+for Budget Tracker domain shapes. The equivalent for stock-analyser
+does not exist — stock-analyser domain types live inline in
+`apps/stock-analyser/lib/`.
+
+M7 lifts shared concerns to packages; the stock-analyser domain
+package question may be resolved as part of that work.
+
+---
+
+## 5. Build, test, deploy
+
+### 5.1 ESLint baseline
+
+**Status: Confirmed (current state)**
+
+The lint baseline contains 36 entries documenting "investigated,
+deferred" lint rule violations. 18 of these are from `apps/web-vite-backup/`
+and `v0-reference/` ("rule not found" violations from un-discovered
+plugin configs). M3 removes both directories, eliminating those
+entries.
+
+`eslint-plugin-boundaries` is in the lint baseline due to ESLint 10
+incompatibility. M7 re-enables once the upstream fix lands.
+
+### 5.2 CI/CD workflows and path filters
+
+**Status: Confirmed in part (deploy paths verified during initial inventory; packages/** trigger pending)**
+
+GitHub Actions workflows in `.github/workflows/`:
+
+- `ci.yml` — PR typecheck, lint, CDK synth
+- `cd.yml` — manual full-platform redeploy
+- `deploy-platform.yml` — triggers on `infrastructure/lib/platform/**`,
+  `infrastructure/bin/**`, `functions/**`
+- `deploy-stock-analyser.yml` — triggers on `apps/stock-analyser/**`,
+  `infrastructure/lib/stock-analyser/**`
+- `deploy-budget-tracker.yml` — triggers on `apps/budget-tracker/**`,
+  `infrastructure/lib/budget-tracker/**`
+
+Path filter completeness is incomplete:
+
+- `.github/workflows/**` and `scripts/ci/**` are not covered by any
+  app's deploy workflow trigger; changes to CI machinery don't
+  auto-trigger the workflows they modify. M14 covers.
+- Whether `packages/**` triggers both `deploy-stock-analyser.yml` and
+  `deploy-budget-tracker.yml` (as `MONOREPO.md` declares) needs
+  verification.
+
+**M1 #81 will resolve the packages/** trigger verification.**
+
+### 5.3 Production environment state
+
+**Status: Confirmed (current state)**
+
+- The `prod` GitHub Actions environment exists but has no variables
+  populated. First prod deploy will hard-fail at the env-var check.
+- The platform has not been deployed to prod yet — too many issues in
+  develop. M14 covers prod-deploy verification when the platform is
+  ready.
+
+### 5.4 Test coverage
+
+**Status: Confirmed (current state, partial)**
+
+Test files exist in approximately 8 places across the monorepo (~951
+total LOC of tests). Notable: `functions/auth/pre-token-generation/`
+has tests; other auth Lambdas (`account-provisioning`, `accounts`,
+`user`, `forgot-provider`) do not. Tests are non-uniform.
+
+CI does not currently run tests on PRs — `ci.yml` runs typecheck,
+lint, and CDK synth only. Test gating in CI is post-M-setup work
+listed in PLAN.md Section 19 (Beyond M14).
+
+### 5.5 Deploy verification
+
+**Status: Confirmed (current state, partial)**
+
+PR #28 added "verify deployed artefact after deploy" to the deploy
+workflows. The depth of this verification is unclear — whether it's
+"the artefact exists in S3" (insufficient) or "the artefact responds
+correctly to a known request" (smoke-test sufficient) needs
+investigation before M14 can scope its post-deploy work properly.
+
+### 5.6 CDK stack topology
+
+**Status: Confirmed in part (verified during initial inventory)**
+
+CDK stacks under `infrastructure/lib/`:
+
+**Platform stacks:**
+- `auth-stack.ts` — Cognito user pool, app clients, groups
+- `auth-api-stack.ts` — auth-related API endpoints
+- `network-stack.ts` — CloudFront, S3, certificates
+- `platform-api-stack.ts` — shared API Gateway (the platform gateway
+  per Section 2.9)
+- `platform-tables-stack.ts` — platform DynamoDB tables
+
+**Stock-analyser stacks:**
+- `stock-analyser-api-stack.ts`
+- `stock-analyser-tables-stack.ts`
+
+**Budget-tracker stacks:**
+- `budget-tracker-api-stack.ts` — defines the BudgetTrackerApi gateway
+  (the workaround per Section 2.9; M5 retires)
+- `budget-tracker-tables-stack.ts`
+
+There is no `MonitoringStack` despite `infrastructure/lib/README.md`
+declaring one. M13 creates it.
+
+There is no shared CDK construct library at `packages/cdk-constructs/`.
+Each new Lambda or table reimplements boilerplate. M7 populates
+`packages/cdk-constructs/` as part of deduplication.
+
+### 5.7 Environment variables
+
+**Status: Confirmed (verified during initial inventory)**
+
+Approximately 22 environment variables are exposed to the client side
+(`NEXT_PUBLIC_*`). Notable:
+
+- `NEXT_PUBLIC_USE_MOCK_DATA` — defaults to mock-mode in code,
+  reclassified as `[REQUIRED]` in PR #23. Long-term default-flip to
+  production values is in PLAN.md Section 19 (Backlog).
+- `NEXT_PUBLIC_AI_PROVIDER` and `NEXT_PUBLIC_AUTH_PROVIDER` — same
+  pattern.
+- `NEXT_PUBLIC_BUDGET_API_URL` — points at the BudgetTrackerApi
+  gateway. Removed in M5.
+
+There is no runtime feature-flag library; toggles are deployment-mode
+flags only (build-time, global). Adding runtime feature-flag support
+is a Stage 0b consideration if relevant.
+
+---
+
+## 6. Cross-cutting platform concerns
+
+### 6.1 Observability
+
+**Status: Aspirational-never-built (addressed in M13)**
+
+The platform has fragmented observability — to understand whether
+Stock Signal or Budget Tracker is healthy, you visit multiple AWS
+consoles. There are no per-app health dashboards, no cross-app
+monitoring at the platform level, no per-user / per-account Claude
+consumption visibility.
+
+`infrastructure/lib/README.md` declares a `MonitoringStack` that does
+not exist. M13 creates it.
+
+### 6.2 Configuration and secrets
+
+**Status: Confirmed (current state)**
+
+Secrets are managed via AWS Secrets Manager (referenced via
+`ANTHROPIC_SECRET_NAME` etc.). Configuration is deployment-mode env
+vars (5.7).
+
+The Claude proxy holds the Anthropic API key via
+`CLAUDE_PROXY_FUNCTION_NAME` and `ANTHROPIC_SECRET_NAME` references.
+Per-user / per-account quota or rate-limiting on Claude consumption
+is not currently enforced. M13 makes consumption observable; M2.2 may
+take a position on whether quota enforcement is in-scope for the
+platform.
+
+### 6.3 Account switcher
+
+**Status: Aspirational-never-built**
+
+The account switcher UI (per-app account selection in the launchpad
+or per-app header) is not currently scoped in any numbered milestone.
+It needs the per-app account model from M2.2 / M4 to be in place
+first. PLAN.md Section 19 (Beyond M14) lists this as a future item.
+
+### 6.4 Mobile-first design
+
+**Status uncertain — verify**
+
+The mobile-first design constraint (375px-first, Tailwind mobile-first,
+bottom tab nav on mobile, sidebar on desktop, no max-width media
+queries) was declared at S1.1. Current state of compliance across
+components is unknown. PLAN.md Section 19 covers mobile-first audit
+and enforcement.
+
+### 6.5 PWA and push notifications
+
+**Status: Aspirational-never-built**
+
+PWA manifest, service worker, push notifications via EventBridge + SES
+were Phase 4 work in the original plan. None are implemented. PLAN.md
+Section 19 lists these as future items.


### PR DESCRIPTION
## What this PR does

Establishes the architectural inventory at \`docs/architecture/inventory.md\` as a committed living document. This is M1's documentation infrastructure — the surface that subsequent verification work updates.

The inventory has existed as a series of \`.docx\` files in conversation but has never been committed to the repo. M1 issue #85 was framed around this gap. Rather than landing the inventory and patching it later, this PR lands the document with verified v4 content, leaves the M1-pending findings as marked placeholders, and adds the CONTRIBUTING.md framing for how the inventory gets updated as a living document.

## inventory.md (new file)

Six top-level dimensions following v4's structure:

1. Code structure and ownership
2. Data, persistence, and APIs
3. Auth, accounts, and permissions
4. Contracts and types
5. Build, test, deploy
6. Cross-cutting platform concerns

Findings carry status tags from the existing six-tag system plus two new tags for living-document use (Resolved by, Superseded by). v4 content with file/line citations is preserved with provenance. Findings marked 'Status uncertain — verify' include the M1 issue number that will resolve them.

Interpretive content from v4 (judgments about what findings mean) is not carried forward — that's M2 decision-document territory, not inventory state.

## CONTRIBUTING.md changes

Three substantive additions reflecting the inventory's evolved role:

- **Section 2.3 document map:** Inventory's category changed from 'Normative (point-in-time snapshot)' to 'Normative (living document)'. Description updated to describe the living-document framing including the new status tags.
- **Section 4.6 (new):** Inventory update discipline. PRs that address inventory findings update the inventory in the same PR per the discipline rule (Section 2.1). Specifies how to resolve, refine, or supersede findings. Notes that updating the inventory is normal — not a sign of drift.
- **Section 6 status tags:** Extended with **Resolved by M*N* / PR #*N*** (finding addressed; text updated to describe new state with note of what changed) and **Superseded by [reference]** (finding subsumed by another).

Sections 4.6 and 4.7 renumbered to 4.7 and 4.8 to make room for the new 4.6.

## PLAN.md changes

M1 outcomes updated to reference the committed inventory directly. Removes the v5/separate verification document framing — findings now live in the inventory itself. Each M1 issue closes with its inventory section having a final status tag.

## What this PR doesn't do

This PR is M1's documentation infrastructure, not M1 verification work. The eight M1 issues (#78–#85) remain open. Each closes individually as its verification completes, with a corresponding inventory section update in that issue's PR.

## After merge

M1 verification work begins. The natural order:

1. Move the eight M1 issues from Backlog status to Todo (signals M1 is active)
2. #82 first (SK schema mismatch — highest risk profile)
3. Six other quick verifications
4. #85 last (architecture document read — informs M2 directly)

Refs M1 milestone, issues #78, #79, #80, #81, #82, #83, #84, #85