### PR TITLE
M1 #79: Auth helpers verified — already in active use

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -272,9 +272,15 @@ Three architectural decisions ratified and documented:
   take `appSlug` (or split into per-app variants).
 - UI invariant: the account switcher shows only accounts for the current
   app.
-- Helper interface documented: `requireAppAccess`, `requireAccountAccess`,
-  `requireSiteAdmin`, `requireAccountOwner`,
-  `requireSelfOrAccountManager`.
+- Helper interface documented as canonical. M1 #79 verified that all
+  five helpers (`requireSiteAdmin`, `requireAppAccess`,
+  `requireAnyAppAccess`, `requireAccountAccess`, `requireAccountOwner`)
+  already exist in `packages/lambda-middleware/` with signatures
+  matching `auth.md`, and are in active use across all nine consumer
+  Lambdas. M2.2's role here is to document this existing pattern as
+  canonical rather than ratifying a proposal. (`requireSelfOrAccountManager`
+  was listed in v4 inventory but is not a helper — see inventory
+  Section 2.5.)
 - JWT-claim consumer pattern documented: parse strings to objects/booleans
   on read (because Cognito V1 trigger forces string claims).
 - Position on `resolveAccountContext` JWT-claim fallback (currently dead
@@ -736,44 +742,49 @@ This milestone can run in parallel with M8 and M10.
 
 ### Purpose
 
-`auth.md` documents a helper interface (`requireAppAccess`,
-`requireAccountAccess`, `requireSiteAdmin`, `requireAccountOwner`,
-`requireSelfOrAccountManager`). Whether these helpers are implemented in
-`packages/lambda-middleware` is currently uncertain (M1 verifies). This
-milestone implements any missing helpers and migrates consumer Lambdas
-to use them.
+`auth.md` documents a helper interface and `packages/lambda-middleware/`
+implements it (verified by M1 #79 — see inventory Section 2.5). All
+nine consumer Lambdas already use the helpers. M10's remaining work
+is filling specific gaps in role enforcement and any legacy
+`requireGroup` callsites in budget-tracker that haven't migrated to
+the canonical pattern.
 
 ### Outcome
 
-- All five helpers implemented in `packages/lambda-middleware` per
-  `auth.md`.
-- Stock-analyser Lambdas (`portfolio`, `watchlist`, `analysis-cache`)
-  now enforce `requireAppAccess('stock-signal')`. This closes inventory
-  Section 3.4 finding #2 (the compound vulnerability with M0).
-- Budget-tracker Lambdas migrated from legacy `requireGroup('budget-app',
-  'admin')` calls to `requireAppAccess('budget-tracker')` and equivalent.
-- Member-role enforcement now possible at the Lambda layer:
-  `requireAccountAccess(auth, app, accountId, minRole)` rejects
-  insufficient-role calls with 403.
-- Site-admin paths use `requireSiteAdmin(auth)`.
-- Account-owner-only operations use `requireAccountOwner(auth, app,
-  accountId)`.
+- Budget-tracker Lambdas verified to use the canonical helpers
+  consistently. Any remaining legacy `requireGroup('budget-app',
+  'admin')` calls migrated to `requireAppAccess('budget-tracker')` +
+  `requireAccountAccess` per the documented pattern. (Scope depends
+  on M1 #80 verification; if no legacy calls remain, this outcome
+  reduces to verification only.)
+- Member-role enforcement audited at the Lambda layer. Where
+  write/destructive operations exist that don't currently call
+  `requireAccountAccess(..., minRole)`, the call is added.
+- Site-admin paths verified to use `requireSiteAdmin(auth)`.
+- Account-owner-only operations verified to use
+  `requireAccountOwner(auth, app, accountId)`.
+
+Note: Stock-analyser Lambda app-access enforcement was previously
+listed here as an outcome. M1 #79 verified this is already in place
+(see inventory Section 3.4.2) — M10 no longer needs to add it.
 
 ### Goals served
 
-Goal 4 primarily (role enforcement is now real, not decorative). Goal 3
+Goal 4 primarily (role enforcement is real and consistent). Goal 3
 (every Lambda's auth check uses the same helper interface).
 
 ### Gate to next
 
-All consumer Lambdas migrated. End-to-end test: a user with viewer role
-calls a write endpoint and receives 403; a user with member role calls
-the same endpoint and succeeds.
+All consumer Lambdas verified to use the canonical pattern with
+appropriate role enforcement. End-to-end test: a user with viewer
+role calls a write endpoint and receives 403; a user with member
+role calls the same endpoint and succeeds.
 
 ### Dependencies
 
-- M1 complete (helper-availability verification finding informs scope).
-- M2.2 complete (the helper interface is ratified).
+- M1 complete (helper-availability and budget-tracker group-name
+  verifications inform scope).
+- M2.2 complete (the helper interface is documented as canonical).
 - M4 complete (account context populates correctly so
   `requireAccountAccess` has something to validate).
 

--- a/docs/architecture/inventory.md
+++ b/docs/architecture/inventory.md
@@ -241,37 +241,65 @@ verification before M2 decisions reference it.
 
 **M1 #78 will populate this section with verified findings.**
 
-### 2.4 Stock-analyser Lambdas don't enforce app access
+### 2.4 Stock-analyser Lambdas enforce app access (corrected finding)
 
-**Status: Confirmed (verified during initial inventory)**
+**Status: Resolved by M1 #79 (v4 finding was stale)**
 
-Stock-analyser Lambdas (portfolio, watchlist, analysis-cache) do not
-currently call `requireAppAccess('stock-signal')` or equivalent. They
-authenticate (via API Gateway authoriser checking the JWT) but do not
-authorize at the app level — any authenticated user can call them
-regardless of whether they have access to the stock-signal app.
+All three stock-analyser Lambdas (portfolio, watchlist, analysis-cache)
+call the documented helper pair:
 
-M10 (Auth middleware extension) closes this. Until then, this is the
-"second half" of the compound vulnerability that M0 reduced — M0
-closed signup, but a hypothetical bypass of signup (via M11's
-invitation flow eventually) followed by a user without stock-signal
-group access could still call stock-analyser endpoints directly.
+- `requireAppAccess(auth, 'stock-signal')` — fail-fast app gate
+- `requireAccountAccess(auth, 'stock-signal', account.accountId)` —
+  account-membership check before data access
 
-### 2.5 Auth helpers documented in auth.md
+This matches the pattern prescribed in `auth.md` lines 356-357.
+Verified during M1 #79 by inspection of
+`apps/stock-analyser/functions/{portfolio,watchlist,analysis-cache}/src/index.ts`.
 
-**Status uncertain — verify (M1 issue #79)**
+The v4 inventory finding "Stock-analyser Lambdas don't enforce app
+access" was stale — likely true at some earlier point but the
+helper-call pattern landed in code before the inventory was last
+updated. The finding was carried forward without re-verification
+during v4 inventory production.
 
-`auth.md` documents a five-helper interface for Lambda authorization:
+**Implication for M0 framing:** The "compound vulnerability"
+description used during M0 scoping was based on this stale Section
+2.4 finding. In retrospect, the compound never existed at deploy time
+— stock-analyser Lambdas were already gated by `requireAppAccess`
+when M0 ran. M0's value was real (closing the public signup gate),
+but the framing overstated the exposure.
 
-- `requireAppAccess(auth, appSlug)`
-- `requireAccountAccess(auth, app, accountId, minRole?)`
-- `requireSiteAdmin(auth)`
-- `requireAccountOwner(auth, app, accountId)`
-- `requireSelfOrAccountManager(auth, app, accountId, targetUserId)`
+### 2.5 Auth helpers in packages/lambda-middleware
 
-Whether each helper is implemented in `packages/lambda-middleware/`
-is uncertain. M2.2 ratifies the interface; M10 implements them.
-M1 needs to know which exist before M2.2 can be written confidently.
+**Status: Resolved by M1 #79 (verified)**
+
+`auth.md` documents the helper interface for Lambda authorization, and
+`packages/lambda-middleware/` implements it. Five helpers are exported,
+all matching `auth.md`'s documented signatures exactly:
+
+- `requireSiteAdmin(auth)` — line 94
+- `requireAppAccess(auth, app)` — line 102
+- `requireAnyAppAccess(auth, apps)` — line 113
+- `requireAccountAccess(auth, app, accountId, minRole?)` — line 126
+- `requireAccountOwner(auth, app, accountId)` — line 146
+
+The v4 inventory listed `requireSelfOrAccountManager` as a sixth
+helper. This was incorrect — `auth.md` describes the
+self-or-account-manager *policy pattern* but does not define a helper
+of that name. The pattern is covered by
+`requireAccountAccess(..., minRole: 'manager')` plus a self-id check
+in the handler.
+
+**Adoption.** All nine consumer Lambdas use these helpers:
+
+- Stock-analyser (3/3): analysis-cache, portfolio, watchlist
+- Budget-tracker (6/6): budget-ai, budget-export, budget-migrate,
+  budget-rules, budget-settings, budget-transactions
+
+The helper interface is not theoretical — it is the actual pattern in
+production code across all consumer Lambdas. M2.2's role is to
+document this existing pattern as canonical rather than ratifying a
+proposal.
 
 **M1 #79 will populate this section with verified findings.**
 
@@ -510,18 +538,38 @@ This subsection lists security/integrity findings that affect Goal 4.
 
 Pre-M0: `selfSignUpEnabled: true` in `auth-stack.ts` allowed anyone to
 create a Cognito account via the hosted UI without invitation.
-Compounded with finding 3.4.2 to create a real exposure.
 
 M0 set `selfSignUpEnabled: false`. Cognito hosted UI no longer offers
 public signup. Verified post-deploy: hosted UI shows no Sign Up link;
 account creation now requires invitation flow (M11).
 
-#### 3.4.2 Stock-analyser Lambdas don't enforce app access
+The "compound vulnerability" framing used during M0 scoping (Sections
+3.4.1 + 3.4.2 combining to create exposure) was based on the v4
+inventory's stale Section 2.4 finding. M1 #79 verification revealed
+stock-analyser Lambdas were already gated by `requireAppAccess` —
+there was no compound. M0's value was real (closing the public signup
+gate); the framing overstated the exposure. See Section 2.4 for
+detail.
 
-**Status: Confirmed (open; addressed in M10)**
+#### 3.4.2 Stock-analyser Lambdas — verified to enforce app access
 
-See Section 2.4. M10 closes by migrating stock-analyser handlers to
-use `requireAppAccess('stock-signal')`.
+**Status: Resolved by M1 #79 (v4 finding was stale — see Section 2.4)**
+
+The v4 inventory recorded this as an open security gap. M1 #79
+verification revealed stock-analyser Lambdas (portfolio, watchlist,
+analysis-cache) all enforce `requireAppAccess(auth, 'stock-signal')`
+plus `requireAccountAccess(auth, 'stock-signal', accountId)` per the
+documented pattern. The v4 finding was carried forward without
+re-verification.
+
+**Implication for M10 scope:** PLAN.md M10's outcomes previously
+listed "Stock-analyser Lambdas now enforce
+`requireAppAccess('stock-signal')`" as in-scope. That work is already
+done. M10's remaining substance is migrating budget-tracker Lambdas
+from any legacy `requireGroup` calls to the new helpers (Section 2.6
+territory; pending M1 #80 verification) and adding role-based
+enforcement via `requireAccountAccess(..., minRole)` where it isn't
+already in use.
 
 #### 3.4.3 forgot-provider Lambda fails on federated users
 


### PR DESCRIPTION
## What this PR does

Resolves M1 #79 by verifying auth helper availability and adoption. Surfaces and corrects two adjacent stale findings in the inventory; updates PLAN.md M2.2 and M10 outcomes accordingly.

## Verification summary

All five helpers documented in \`auth.md\` are implemented in \`packages/lambda-middleware/\` and in active use:

| Helper | Implemented | auth.md signature match |
|---|---|---|
| \`requireSiteAdmin\` | line 94 | exact |
| \`requireAppAccess\` | line 102 | exact |
| \`requireAnyAppAccess\` | line 113 | exact (bonus) |
| \`requireAccountAccess\` | line 126 | exact |
| \`requireAccountOwner\` | line 146 | exact |

All nine consumer Lambdas use these helpers: stock-analyser (3/3 — analysis-cache, portfolio, watchlist) and budget-tracker (6/6 — budget-ai, budget-export, budget-migrate, budget-rules, budget-settings, budget-transactions).

\`requireSelfOrAccountManager\` (listed in v4 inventory as a fifth/sixth helper) is not a real helper — auth.md describes the policy pattern but the implementation is via \`requireAccountAccess(..., minRole: 'manager')\` plus a self-id check.

## Adjacent findings surfaced

The diagnostic revealed v4 inventory's Section 2.4 was stale: stock-analyser Lambdas DO enforce app access. All three call \`requireAppAccess(auth, 'stock-signal')\` plus \`requireAccountAccess(auth, 'stock-signal', accountId)\` per the canonical pattern (auth.md lines 356-357).

This invalidates the 'compound vulnerability' framing used during M0 scoping. M0's value was real (closing the public signup gate), but the framing overstated the exposure — there was no compound at deploy time. Inventory updated accordingly.

## Inventory updates

- **Section 2.4:** Status changed to 'Resolved by M1 #79'. Corrected text: stock-analyser Lambdas enforce app access via the canonical pattern. Note added that v4 finding was stale.
- **Section 2.5:** Status changed to 'Resolved by M1 #79'. Verified content lists all five helpers with implementation lines, auth.md signature match, and full consumer-Lambda adoption. Note added that \`requireSelfOrAccountManager\` is not a real helper.
- **Section 3.4.1:** M0 framing context added — compound vulnerability was based on stale Section 2.4 finding.
- **Section 3.4.2:** Status changed to 'Resolved by M1 #79' — corrected to reflect that the gap doesn't exist.

## PLAN.md updates

- **M2.2 helper-interface bullet:** Refined to reflect that the helpers exist and are in active use. Stage 0b's role is to document the existing canonical pattern as canonical, not ratify a proposal.
- **M10 Purpose and Outcome:** Reworked. Stock-analyser app-access enforcement no longer in M10 scope (already done). Remaining scope is budget-tracker legacy migration (pending M1 #80) plus role-enforcement audit.

## What this PR doesn't do

No code change — current state was already correct on the dimensions verified. No follow-up issues needed.

Closes #79