### PR TITLE
M1 #80: Budget-tracker group-name reads verified — handlers never read groups

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -669,9 +669,14 @@ both states. This milestone retires the legacy.
   `transformotion`, `family`.
 - `custom:active_account` Cognito attribute removed (now dead code with
   no writers under the new model).
-- Old group names removed from any remaining `requireGroup` calls.
-- `requireGroup` helper itself removed if unused after the call-site
-  migrations.
+- Per M1 #80: Lambda handlers do not read group names directly, so
+  no handler-level callsite migration is needed. The
+  "callsite migration" outcome originally framed in M8 turned out
+  unnecessary — all 9 consumer Lambdas use claim-based helpers that
+  never read group names.
+- `requireGroup` helper removed from `packages/lambda-middleware/` if
+  it exists and is unused (verify before removing — M1 #79 confirmed
+  it is exported but its call-sites must be checked).
 - `resolveAccountContext` JWT-claim fallback to `custom:active_account`
   removed (per M2.2 decision on the fallback's fate).
 

--- a/docs/architecture/inventory.md
+++ b/docs/architecture/inventory.md
@@ -366,12 +366,35 @@ Budget-tracker Lambdas (`apps/budget-tracker/functions/`):
 - `migrate/` (the `/api/budget/v1/migrate-from-localstorage` endpoint;
   M6 renames to `/import`)
 
-Whether budget-tracker Lambdas read the new Cognito group names
-(`stock-app-access`, `budget-app-access`, `site-admin`) or still
-reference the legacy ones (`stock-app`, `budget-app`, `admin`) is
-uncertain. M8 (legacy auth substrate cleanup) depends on knowing.
+**Status: Resolved by M1 #80 (verified clean)**
 
-**M1 #80 will populate the group-name read findings.**
+Budget-tracker Lambdas do not read Cognito group names directly —
+neither legacy nor new. The auth helpers in
+`packages/lambda-middleware/` are claim-based, not group-based:
+
+- `requireAppAccess` checks `auth.apps` (injected `apps` JWT claim)
+- `requireAccountAccess` checks `auth.accounts` (injected `accounts`
+  JWT claim)
+- `isSuperUser` / `requireSiteAdmin` check `auth.siteAdmin` (injected
+  `site_admin` JWT claim, line 82 of `auth.ts`)
+
+Tests in `packages/lambda-middleware/src/auth.test.ts` confirm:
+legacy group names like `budget-app` and `stock-app` cause helpers
+to throw 403 — the group name is irrelevant because helpers never
+read it. The `site-admin` *group* alone also throws 403 on
+`requireSiteAdmin`; only the `site_admin` *claim* passes.
+
+The only `cognito:groups` reference in any budget-tracker Lambda is
+`budget-ai/src/index.ts:36` — propagating the already-parsed
+`auth.groups` array into a synthetic event for the Claude proxy
+Lambda-to-Lambda call. This is claim propagation, not a group-name
+check.
+
+**M8 scope implication:** Handler-level callsite migration for group
+names is not needed and never was — the handlers never read group
+names. M8's substantive scope is Cognito group cleanup (deleting
+legacy groups from the user pool) and pre-token Lambda reconciliation
+logic. See PLAN.md Section 12 for the updated M8 scope.
 
 ### 2.7 Platform-cache misnomer
 
@@ -839,6 +862,28 @@ Approximately 22 environment variables are exposed to the client side
 There is no runtime feature-flag library; toggles are deployment-mode
 flags only (build-time, global). Adding runtime feature-flag support
 is a Stage 0b consideration if relevant.
+
+### 5.8 auth.md migration note is stale (M3 reconciles)
+
+**Status: Confirmed (documentation gap; addressed in M3)**
+
+`auth.md` line 144 states: "During migration both old and new groups
+coexist; handlers accept either."
+
+This is misleading. Handler-side authorization never reads raw group
+names — the helpers read `apps`, `accounts`, and `site_admin` claims
+at all points in the migration. The migration note conflates:
+
+- Cognito group management (where the pre-token Lambda's
+  reconciliation logic manages coexistence of old and new groups)
+- Handler-side authorization (where group names are never read)
+
+The auth.md note implies a handler-level concern that doesn't exist.
+M3 (documentation reconciliation) should clarify the migration note
+to distinguish between Cognito-level group state (where coexistence
+exists) and handler-level authorization (where it doesn't).
+
+Surfaced by M1 #80.
 
 ---
 


### PR DESCRIPTION
## What this PR does

Resolves M1 #80 by verifying that budget-tracker Lambdas don't read Cognito group names directly. Surfaces and corrects an adjacent stale claim in auth.md. Updates PLAN.md M8 outcomes and the corresponding GitHub Milestone description to reflect verified scope.

## Verification summary

The auth helpers in \`packages/lambda-middleware/\` are claim-based, not group-based:

- \`requireAppAccess\` checks \`auth.apps\` (line 104)
- \`requireAccountAccess\` checks \`auth.accounts\` (line 133)
- \`isSuperUser\` reads \`auth.siteAdmin\` (line 82, from the \`site_admin\` JWT claim)

Tests in \`packages/lambda-middleware/\` confirm: legacy group names like \`budget-app\` and \`stock-app\` cause helpers to throw 403 — the group name is irrelevant because the helper never reads it. The \`site-admin\` *group* alone also throws 403 on \`requireSiteAdmin\`; only the \`site_admin\` *claim* passes.

The only \`cognito:groups\` reference in any budget-tracker Lambda is in \`budget-ai/src/index.ts:36\` propagating already-parsed claims to the Claude proxy synthetic event — not a group-name check.

## Adjacent finding — auth.md line 144 stale

\`auth.md\` line 144 claims "handlers accept either [old and new groups]" during migration. This is misleading — handlers never read raw group names at any point. The migration note conflates Cognito group management (where pre-token Lambda reconciliation handles old-and-new) with handler-side authorization (where group names are never read).

Captured as a new Section 5.8 in the inventory; M3 reconciles in documentation cleanup.

## PLAN.md M8 update

M8's prior Outcome bullet "Old group names removed from any remaining \`requireGroup\` calls" implicitly assumed handler-level callsites. Verification showed handlers don't have any. M8's substantive scope adjusts:

- Cognito group cleanup in the user pool (delete \`admin\`, \`stock-app\`, \`budget-app\`, \`transformotion\`, \`family\`)
- Pre-token Lambda reconciliation logic update
- \`requireGroup\` helper removal if it exists in middleware (verify before removing)

The handler-migration outcome originally framed is dropped — never needed.

## GitHub Milestone description update

The GitHub M8 Milestone description was updated via \`gh api PATCH\` to match PLAN.md M8. Not visible in git diff but part of this PR's scope.

## Inventory updates

- **Section 2.6:** Status changed to 'Resolved by M1 #80 (verified clean)'. Verified content explains claim-based helpers and the budget-ai claim propagation.
- **Section 5.8 (new):** Documents the stale auth.md migration note for M3.

## What this PR doesn't do

No code change required. No follow-up issues needed.

Closes #80