### PR TITLE
M1 #81: Workflow path-filter gaps verified — fix scoped to M14

### DIFF
--- a/MONOREPO.md
+++ b/MONOREPO.md
@@ -195,7 +195,7 @@ the other app's deployment.
 | `infrastructure/lib/platform/**` | `deploy-platform.yml` |
 | `infrastructure/bin/**` | `deploy-platform.yml` |
 | `functions/**` | `deploy-platform.yml` |
-| `packages/**` | `deploy-stock-analyser.yml` + `deploy-budget-tracker.yml` |
+| `packages/**` | `deploy-stock-analyser.yml` only (gap: `deploy-budget-tracker.yml` missing this filter — tracked for M14 fix; currently latent because budget-tracker workflow is a no-op placeholder pending Issue #17/M5) |
 
 Path filter completeness is not yet verified for `.github/workflows/**`
 and `scripts/ci/**` — changes to CI machinery may not auto-trigger the

--- a/PLAN.md
+++ b/PLAN.md
@@ -977,10 +977,20 @@ ceremonial.
 - Prod GitHub Actions environment populated with all `[REQUIRED]`
   env vars per the documentation set in PRs #19–24. First prod deploy
   passes the env-var check.
-- Deploy workflow path filters extended to cover `.github/workflows/**`
-  and `scripts/ci/**` for both `deploy-stock-analyser.yml` and
-  `deploy-budget-tracker.yml`. Changes to CI machinery trigger the
-  workflows they modify.
+- Deploy workflow path filters extended for completeness, covering:
+  - `.github/workflows/**` and `scripts/ci/**` for both
+    `deploy-stock-analyser.yml` and `deploy-budget-tracker.yml`.
+    Changes to CI machinery trigger the workflows they modify.
+  - `packages/**` for `deploy-budget-tracker.yml` (per M1 #81
+    finding — currently in stock-analyser's workflow but missing
+    from budget-tracker's). Once #17/M5 activates the real
+    budget-tracker deployment, this gap becomes a live bug.
+  - `functions/**` asymmetry investigated for
+    `deploy-budget-tracker.yml`. Stock-analyser triggers on
+    `functions/**`; budget-tracker does not. Whether
+    budget-tracker Lambdas have dependencies on `functions/**`
+    changes determines whether the asymmetry is intentional or
+    a gap.
 - Post-deploy smoke testing: a known-good request hits each app's
   primary endpoint after deploy, asserts a 2xx response or expected
   redirect. Failure rolls back or alerts. Existing PR #28 verification

--- a/docs/architecture/inventory.md
+++ b/docs/architecture/inventory.md
@@ -757,7 +757,7 @@ incompatibility. M7 re-enables once the upstream fix lands.
 
 ### 5.2 CI/CD workflows and path filters
 
-**Status: Confirmed in part (deploy paths verified during initial inventory; packages/** trigger pending)**
+**Status: Resolved by M1 #81 (gaps confirmed, fix scoped to M14)**
 
 GitHub Actions workflows in `.github/workflows/`:
 
@@ -766,20 +766,38 @@ GitHub Actions workflows in `.github/workflows/`:
 - `deploy-platform.yml` — triggers on `infrastructure/lib/platform/**`,
   `infrastructure/bin/**`, `functions/**`
 - `deploy-stock-analyser.yml` — triggers on `apps/stock-analyser/**`,
-  `infrastructure/lib/stock-analyser/**`
+  `infrastructure/lib/stock-analyser/**`, `packages/**`, `functions/**`
 - `deploy-budget-tracker.yml` — triggers on `apps/budget-tracker/**`,
-  `infrastructure/lib/budget-tracker/**`
+  `infrastructure/lib/budget-tracker/**`. **Currently a no-op
+  placeholder** (the job echoes a message); active deployment is
+  pending Issue #17 / M5.
 
-Path filter completeness is incomplete:
+Verified gaps (M1 #81):
 
-- `.github/workflows/**` and `scripts/ci/**` are not covered by any
-  app's deploy workflow trigger; changes to CI machinery don't
-  auto-trigger the workflows they modify. M14 covers.
-- Whether `packages/**` triggers both `deploy-stock-analyser.yml` and
-  `deploy-budget-tracker.yml` (as `MONOREPO.md` declares) needs
-  verification.
+1. **`packages/**` missing from `deploy-budget-tracker.yml`.**
+   `MONOREPO.md` documents `packages/**` triggering both workflows;
+   only stock-analyser does. Once #17/M5 activates the real
+   budget-tracker deployment, a shared package change would not
+   trigger budget-tracker redeploy. Currently latent (no-op
+   workflow); becomes live bug at activation.
+2. **`functions/**` asymmetry.** Stock-analyser deploy triggers on
+   `functions/**` (platform Lambda changes); budget-tracker does
+   not. Whether budget-tracker Lambdas depend on `functions/**`
+   changes is worth investigating in M14 — could be intentional
+   asymmetry or a gap.
+3. **`.github/workflows/**` not in any deploy workflow.** Changes
+   to a deploy workflow don't trigger that workflow itself.
+   Changes to CI machinery (`ci.yml` etc.) don't propagate to
+   downstream deploy workflows. Already in M14 scope.
+4. **`scripts/ci/**` similarly uncovered.** Already in M14 scope.
 
-**M1 #81 will resolve the packages/** trigger verification.**
+Fix work belongs to M14 (deployment verification). New tracking
+issue created under M14 captures gaps 1 and 2 specifically; gaps
+3 and 4 are already in M14's outcome list.
+
+`MONOREPO.md`'s deploy-table claim that `packages/**` triggers both
+workflows is corrected in this PR (single-line change to reflect
+actual state).
 
 ### 5.3 Production environment state
 


### PR DESCRIPTION
## What this PR does

Resolves M1 #81 by verifying deploy workflow path filters. First M1 verification to surface real gaps rather than confirming v4 concerns were stale.

## Verification summary

| Workflow | Path filters |
|---|---|
| \`deploy-stock-analyser.yml\` | apps/stock-analyser/**, infrastructure/lib/stock-analyser/**, **packages/**, functions/** |
| \`deploy-budget-tracker.yml\` | apps/budget-tracker/**, infrastructure/lib/budget-tracker/** *(no-op placeholder pending #17/M5)* |

## Gaps verified

1. **\`packages/**\` missing from deploy-budget-tracker.yml.** MONOREPO.md documented both workflows triggering on \`packages/**\`; only stock-analyser does. Currently latent (no-op workflow); becomes live bug once #17/M5 activates real budget-tracker deployment.
2. **\`functions/**\` asymmetry.** Stock-analyser triggers on \`functions/**\`; budget-tracker doesn't. Could be intentional or a gap — investigation needed.
3. **\`.github/workflows/**\` not in any deploy workflow.** Already in M14 outcomes.
4. **\`scripts/ci/**\` similarly uncovered.** Already in M14 outcomes.

## Document updates

- **inventory.md Section 5.2:** Resolved by M1 #81 with verified content describing all four gaps and the no-op placeholder context.
- **MONOREPO.md deploy table:** Corrected the \`packages/**\` row to reflect actual state.
- **PLAN.md M14 outcomes:** Extended with gaps 1 and 2.

## New M14 issue created

Issue #93 attached to M14 captures gaps 1 and 2 for fix during M14 execution. Gaps 3 and 4 are already in M14's outcome list and don't need separate issues.

Issue stays at Backlog status — M14 hasn't started yet.

## Tracking issue #92 update

Comment added to #92 noting M14's GitHub Milestone description will need sync at M1 close (since PLAN.md M14 outcomes changed in this PR).

## What this PR doesn't do

No code change to fix the gaps. Per CONTRIBUTING.md Section 4.5, fix work is scoped to M14, not folded into M1 verification PRs. The fix is one-line additions to the deploy workflow YAML files but belongs structurally to M14.

Closes #81