### PR TITLE
M1 close: Milestone description sync + CONTRIBUTING.md discipline updates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -500,6 +500,30 @@ GitHub milestone in the same PR. The discipline rule (Section 2.1)
 applies — `PLAN.md` is a normative document and the GitHub state it
 references is part of what the document describes.
 
+**Milestone content pairing rule:** GitHub Milestone descriptions
+mirror `PLAN.md` milestone content (Purpose, Outcome, Goals served,
+Gate, Dependencies). When `PLAN.md` content for a milestone changes,
+the corresponding GitHub Milestone description is updated in the
+same PR. Descriptions don't auto-sync — they are part of what the
+PR landing the change is responsible for.
+
+**Milestone close convention:** Milestones close when their progress
+reaches 100% (all attached issues closed). Closure is a manual step
+(GitHub doesn't auto-close milestones). The PR landing the final
+issue's resolution may include the milestone closure as a follow-up
+step, or it may be done as a separate small action immediately
+after. Either is acceptable; what matters is that closed milestones
+disappear from the active list once their work is complete.
+
+**Bootstrap exception:** Milestones whose work establishes the
+issue-tracking infrastructure itself (notably M-setup) are exempt
+from the "every PR closes an issue" rule (Section 4.4). Such PRs
+land work *before* the issue infrastructure exists to track it. The
+milestone closes based on its `PLAN.md` outcomes being met, evidenced
+by merged PRs, rather than by issue closures. This exception applies
+only to bootstrap milestones; subsequent milestones follow the
+standard pattern.
+
 ### 4.5 When new problems are discovered mid-work
 
 If during a PR a new problem is discovered (a bug elsewhere, a


### PR DESCRIPTION
## What this PR does

Final M1 PR — resolves tracking issue #92, lands the operating-discipline rules accumulated during M1, and prepares M1 milestone for closure.

## GitHub Milestone description sync

Wholesale resync of seven milestone descriptions from current PLAN.md content:

- M2 — updated M2.2 framing: all five helpers already exist in packages/lambda-middleware/ (M1 #79 verified); M2.2's role is to document the existing pattern as canonical
- M3 — extended outcomes list: added M1 #85 arch-doc gaps reconciliation, missing apps/launchpad/CLAUDE.md, root CLAUDE.md reconciliation
- M5 — no material change; regenerated for consistency
- M6 — no material change; regenerated for consistency
- M8 — already updated (M1 #80 outcome added during M1); regenerated for consistency
- M10 — updated: stock-analyser enforcement removed as outcome (already in place per M1 #79); budget-tracker scope updated to verification-first per M1 #80
- M14 — updated: added packages/** gap for deploy-budget-tracker.yml and functions/** asymmetry (M1 #81 findings)

Note: Milestone description updates are GitHub state, not repo files, so they are not visible in the git diff for this PR. Applied via \`gh api PATCH\` calls during landing.

## CONTRIBUTING.md additions

Three discipline rules added near Section 4.4:

**Milestone content pairing rule** — PLAN.md milestone content changes require corresponding GitHub Milestone description updates in the same PR. Prevents the drift that required a resync in this very PR.

**Milestone close convention** — Milestones close at 100% complete (manual step). GitHub doesn't auto-close. PR landing the final issue's resolution may include closure or it may be a separate small action immediately after.

**Bootstrap exception** — Milestones establishing the issue-tracking infrastructure itself (M-setup) are exempt from the 'every PR closes an issue' rule. They close based on PLAN.md outcomes evidenced by merged PRs.

## New Backlog issue

Issue #98 attached to Backlog milestone captures the prompt-design / Claude Code stop-point behaviour pattern surfaced during M1. Three times during M-setup and M1, Claude Code ran past 'stop and report' directives. Investigation and resolution candidates documented in the new issue.

## After merge

M1 milestone closes manually (per the new milestone-close convention this PR documents). M2 becomes the next eligible milestone.

Closes #92