### PR TITLE
Root CLAUDE.md: point at operating documents; add operating mode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,34 +1,50 @@
-# Transformotion Apps — Claude Code Instructions
+# Transformotion Apps — Claude Code instructions
 
-This is a pnpm workspace monorepo. Each app lives in `apps/<app>/` with its own `CLAUDE.md`, contracts, infrastructure, and tests.
+This is a pnpm workspace monorepo containing multiple apps and platform code. Read this file first when starting a session.
 
-When working on a specific app, read that app's `CLAUDE.md` first.
+## Operating documents
 
-Cross-app contracts live in `/contracts/`. Shared code lives in `/packages/`. Platform infrastructure lives in `/infrastructure/`.
+Three documents define how this repository works. Read them before substantive work:
 
-Before modifying shared code or platform infrastructure, consider the impact on every app — these changes deploy to all of them.
+- **[`PLAN.md`](./PLAN.md)** — current trajectory of work. Goals, milestones (M-setup, M0–M14, Backlog), gating relationships. Tells you what's in scope right now and what's deferred.
+- **[`CONTRIBUTING.md`](./CONTRIBUTING.md)** — ways of working. Document map, repository conventions, workflow rules, the discipline rule, status-tag system, operating principles. Tells you how to do work correctly.
+- **[`docs/architecture/inventory.md`](./docs/architecture/inventory.md)** — living current-state inventory of the platform. What is true about code, infrastructure, and operating state right now. Updated as state changes.
 
----
+For monorepo structure (current state), import boundaries, and deploy triggers, see **[`MONOREPO.md`](./MONOREPO.md)**.
+
+When working on a specific app, read that app's `CLAUDE.md` first:
+
+- `apps/stock-analyser/CLAUDE.md`
+- `apps/budget-tracker/CLAUDE.md`
+
+## Operating mode
+
+Two principles affect almost every session:
+
+**The discipline rule** (`CONTRIBUTING.md` Section 2.1): PRs that change what a normative document describes update that document in the same PR. PLAN.md, CONTRIBUTING.md, MONOREPO.md, README.md, and `inventory.md` are all normative. GitHub Milestone descriptions are also paired with PLAN.md content.
+
+**Verification mode**: Verification work captures findings, it doesn't fix problems. If a verification surfaces a real issue requiring fix work, the issue gets a tracked GitHub Issue per `CONTRIBUTING.md` Section 4.5; the current PR's scope does not expand to fix it. Out of scope and worth being explicit about: the verification PR closes its issue with findings recorded in the inventory; the fix work happens later in whichever milestone owns it.
 
 ## Branching strategy
 
 - `main` — production. Never commit directly.
 - `develop` — integration branch. Never commit directly.
-- Feature branches: `claude-code/<feature-name>` off `develop`, PR back to `develop`.
-- v0 branches: `v0/<feature-name>` off `develop`, PR back to `develop`.
+- Feature branches off `develop`, PR back to `develop`. Naming convention per `CONTRIBUTING.md` Section 4.1 — `claude-code/<feature-name>` for Claude-Code-driven work, `v0/<feature-name>` for v0-pushed work, `<author>/<feature-name>` for manual work.
 - After merge to `develop`, CD pipeline deploys to dev automatically.
-
----
 
 ## Where to find things
 
-| What | Where |
+Note: some paths are migrating per `CONTRIBUTING.md` Section 3 — see `MONOREPO.md` for current state and `CONTRIBUTING.md` Section 3 for target state.
+
+| What | Where (current) |
 |---|---|
-| Monorepo structure, import rules, deploy triggers | `MONOREPO.md` |
-| Stock Analyser app | `apps/stock-analyser/CLAUDE.md` |
-| Budget Tracker app | `apps/budget-tracker/CLAUDE.md` |
-| Shared packages | `packages/` |
-| Platform Lambda handlers | `functions/` |
-| AWS CDK infrastructure | `infrastructure/` |
-| App contracts (data models, API, state) | `contracts/<app>/` |
-| Migration data artifacts | `migration-artifacts/<app>/` |
+| Cross-app contracts | `/contracts/<scope>/` |
+| Shared packages | `/packages/` |
+| Platform Lambda handlers | `/functions/` (migrating to `/platform/functions/` per M7) |
+| Platform infrastructure | `/infrastructure/lib/platform/` (migrating to `/platform/infrastructure/` per M7) |
+| Per-app infrastructure | `/infrastructure/lib/<app>/` (migrating to `apps/<app>/infrastructure/` per M7) |
+| Migration data artefacts | `/migration-artifacts/<app>/` |
+| Architecture invariants | `/docs/architecture/` |
+| Archived superseded docs | `/docs/archive/` |
+
+Before modifying shared code or platform infrastructure, consider the impact on every app — these changes deploy to all of them.


### PR DESCRIPTION
## What this PR does

Replaces the structural-only root CLAUDE.md with one that orients Claude Code to the operating discipline at session start. Closes #98 (operating-process: Claude Code stop-point behaviour pattern).

## Background

Three times during M-setup and M1, Claude Code ran past 'stop and report' instructions in user-provided prompts. Investigation per #98 surfaced two contributing factors:

1. The original root CLAUDE.md was purely structural — no reference to operating documents (PLAN.md, CONTRIBUTING.md, inventory.md), no statement of operating mode (discipline rule, verification framing). Claude Code's session-start orientation was thin.
2. Multi-step prompts with embedded 'stop after step N' directives were structurally read as one task; the stop directive interpreted as informational rather than as a hard halt.

This PR addresses (1). The fix for (2) is a unilateral prompt-design change applied going forward — verification work splits into diagnostic prompts (read-only, end at 'report findings') and landing prompts (separate user action). No code change needed for that side.

## CLAUDE.md changes

Three additions:

- **Operating documents section** — points at PLAN.md, CONTRIBUTING.md, and inventory.md as authoritative for trajectory, ways of working, and current state respectively.
- **Operating mode section** — states the discipline rule (PRs that change normative documents update them in same PR) and verification mode (capture findings, don't fix; surface follow-up as tracked issues).
- **'Where to find things' updated** — current structure marked, with migration notes referencing MONOREPO.md (current state) and CONTRIBUTING.md Section 3 (target state).

Branching strategy section retained, updated to reflect actual three-prefix convention from CONTRIBUTING.md Section 4.1.

## What this PR doesn't do

- Doesn't change CONTRIBUTING.md. The operating-process change (split prompts) is unilateral and doesn't need codifying.
- Doesn't audit for other CLAUDE.md drift. M3's documentation reconciliation will catch other documents.
- Doesn't investigate the project automation bug surfaced during this work — tracked separately as #100.

Closes #98