### PR TITLE
M2.1: Architectural patterns and utility categories ratified

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -623,13 +623,225 @@ both the milestone and the Status (if not already Todo) get updated
 together.
 
 ---
+## 5. Architectural patterns
 
-## 5. Operating principles
+This section documents the canonical architectural patterns that all platform code conforms to. The patterns here bind both new code and migrations of existing non-conforming code.
+
+The principles in this section serve the four goals stated in Section 1.1 and the v0 constraint stated in Section 1.2. Where a pattern decision involves trade-offs, the trade-off is resolved in favour of those goals and that constraint.
+
+### 5.1 Layered architecture
+
+All data access in the platform follows a strict layered architecture. Three layers, clearly separated:
+
+**Business logic layer.** UI components, application services, request handlers. The code that does work users care about. This layer calls domain interfaces by name; it never references physical implementations.
+
+**Data-access layer.** Implementations of domain interfaces. Each implementation knows about exactly one physical store (DynamoDB, localStorage, an HTTP API, Redis, etc.) and implements the domain interface against it.
+
+**Physical store.** The actual storage technology. DynamoDB tables, localStorage, S3 buckets, Redis instances, HTTP APIs. The data-access layer encapsulates these.
+
+The strict rule: **business logic never references physical implementations directly**. A UI component calls `transactionRepository.findAll()`, not `dynamoClient.query(...)`. A Lambda handler calls `cacheService.get(key)`, not `dynamodb.getItem(...)`.
+
+This separation serves two concrete needs:
+
+1. **The v0 constraint** (Section 1.2). v0 has no AWS access; UI components must work against localStorage in v0 and against real APIs in production. Only the layered architecture's swap point at the data-access layer makes this possible — the same UI component, the same domain interface, two different implementations.
+
+2. **Physical-layer flexibility.** Decisions about where data physically lives are encapsulated. A cache currently in DynamoDB could move to Redis later; only the data-access layer changes. Business logic doesn't know and doesn't care.
+
+The layered architecture applies broadly. All data access goes through domain interfaces — both client-side and server-side. New code conforms; existing non-conforming code is migrated.
+
+### 5.2 Domain interfaces and implementations
+
+**Domain interfaces** declare data-access shapes in store-agnostic terms. They live in `contracts/<scope>/`. A domain interface specifies what operations exist (`findAll`, `getById`, `save`, `delete`) and what types they take and return. It does not specify how those operations are implemented.
+
+**Implementations** of a domain interface live in the data-access layer. Each implementation is named for its physical store. Examples:
+
+- `DynamoTransactionRepository` — implements `TransactionRepository` against DynamoDB
+- `LocalStorageTransactionRepository` — implements `TransactionRepository` against browser localStorage
+- `HttpTransactionRepository` — implements `TransactionRepository` by calling a platform API
+- `DynamoTTLCacheService` — implements `CacheService` against DynamoDB with TTL semantics
+
+The implementation name makes the physical store explicit. A reader can tell at a glance where data goes.
+
+Multiple implementations of the same domain interface coexist. A single domain interface (`TransactionRepository`) typically has at least two implementations — one for v0 (localStorage) and one for production (HTTP-via-ApiClient on client-side, DynamoDB on server-side). They never conflict because only one is wired in at a time.
+
+### 5.3 Implementation selection
+
+The decision of which implementation gets wired in is made at the environment layer, not at runtime. Implementations are selected by configuration; nothing flips during execution.
+
+**Client-side selection: build-time config.** The build mode (`MODE` in Vite, equivalent in Next.js) determines which implementation is bundled. Production builds include only the production implementation; v0 builds include only the mock implementation. The unused implementation is tree-shaken out — production bundles do not carry mock code.
+
+The build-time config is typically driven by an environment variable like `NEXT_PUBLIC_USE_MOCK_DATA`, set per build environment. The variable is consumed at the module level where the implementation is wired into the domain interface.
+
+**Server-side selection: deployment-time config via CDK.** Lambdas receive their physical-store choice via environment variables defined in their CDK stack definition. A Lambda using `CacheService` reads (for example) `CACHE_BACKEND=dynamodb` at startup and wires the corresponding implementation.
+
+Deployment-time config is set in CDK because that is where deployment topology is defined. Different stages (`dev`, `prod`) can use different physical stores if needed; the CDK stack decides.
+
+The shared principle: the implementation choice is an environment concern, not a runtime concern. Code does not test "are we in mock mode?" at every call site. The wiring is decided once, at the appropriate environment layer.
+
+### 5.4 Domain interface naming conventions
+
+Domain interface names are store-agnostic — they describe what is being accessed, not where it lives. Two naming patterns apply, distinguished by what the interface abstracts.
+
+**Repository pattern** — for interfaces that abstract a collection of entities. The consuming code thinks of the data as "entities in a collection we look up, save, modify, delete." Operations are CRUD-shaped: `findById`, `findAll`, `save`, `delete`, etc.
+
+Repository names end with `Repository`. Examples:
+
+- `TransactionRepository` — operations on transactions
+- `WatchlistRepository` — operations on watchlists
+- `AccountRepository` — operations on accounts
+
+**Service pattern** — for interfaces that abstract a capability rather than a collection. The consuming code thinks of the data as something it invokes operations on, but the operations don't map cleanly to CRUD on identifiable entities. Examples include caches (key-value memoisation, not entity collections), email sending (a capability, not a thing), and orchestration utilities.
+
+Service names end with `Service`. Examples:
+
+- `CacheService` — cache reads/writes by key
+- `EmailService` — sending email
+- `RateLimiterService` — rate-limit decisions
+
+**A practical test for which pattern applies.** Try writing the interface signature in your head. If the operations naturally include `findById`, `getAll`, `save`, `delete` operating on entities with identity — it's a Repository. If the operations are whatever-makes-sense for the capability without that CRUD shape — it's a Service.
+
+Where an interface seems to fit neither cleanly, the test usually reveals which way to lean. Force-fitting a poorly-matched name confuses readers; if neither pattern fits well, write down what the interface actually does and the right name usually emerges.
+
+### 5.5 Table-naming policy
+
+Logical entities (commonly called "tables", though the policy applies regardless of physical storage backend) follow a canonical naming rule.
+
+**The rule:** `{scope}.{entity}-{stage}`
+
+- `scope` is one of:
+  - `platform` — for tables used by multiple apps or by platform infrastructure
+  - An app slug (`stock-analyser`, `budget-tracker`, `launchpad`, etc.) — for tables owned by a single app
+- `.` separates scope from entity
+- `entity` describes what the table holds (`accounts`, `transactions`, `analysis-cache`, etc.)
+- `-` separates entity from stage
+- `stage` is the deployment environment (`dev`, `prod`, etc.)
+
+All components are lowercase. Multi-word components within `scope` and `entity` use hyphens (`stock-analyser`, `analysis-cache`).
+
+**Scope is categorical, not stylistic.** A table prefixed `platform.` is platform-scoped — used by multiple apps or by platform infrastructure. A table prefixed `stock-analyser.` is app-scoped — owned by stock-analyser, accessed by stock-analyser Lambdas only. The categorisation matters because IAM grants follow scope: platform-scoped tables grant access to platform-eligible Lambdas; app-scoped tables grant access only to that app's Lambdas.
+
+The policy applies to all logical tables regardless of physical storage backend. DynamoDB, Redis, or other future storage choices follow the same naming convention.
+
+The policy does not apply to other AWS resources (S3 buckets, SQS queues, Lambda function names) — those follow their own conventions or CDK defaults.
+
+**No reserved prefixes** beyond the ones already in use. Future expansion can add reserved prefixes if needed; over-specifying now is premature.
+
+**Examples:**
+
+```
+platform.accounts-{stage}              # platform-scoped, used by all apps
+platform.account-members-{stage}       # platform-scoped
+stock-analyser.portfolio-{stage}       # app-scoped to stock-analyser
+stock-analyser.watchlist-{stage}       # app-scoped to stock-analyser
+budget-tracker.transactions-{stage}    # app-scoped to budget-tracker
+budget-tracker.rules-{stage}           # app-scoped to budget-tracker
+```
+
+Existing tables that don't conform are migrated to canonical form. No grandfathering — the rule is universal.
+
+---
+
+## 6. Utility categories and conventions
+
+Some code in this repository is not part of the running platform's architecture. It is tooling — utilities that solve specific operational concerns. These utilities live as their own peer categories at the repository root, alongside `apps/`, `packages/`, and `platform/`.
+
+This section documents the principle and the specific utility categories currently established.
+
+### 6.1 What is a utility category
+
+A utility category is a top-level repo directory housing a coherent class of operational tools. Three properties define a utility category:
+
+1. **Distinct from the running platform's code.** Utilities are not part of the architecture documented in Section 5. They are tools that operate alongside the platform, not within it.
+2. **Has its own infrastructure if needed.** Utilities that require AWS resources (Lambdas, API routes, etc.) bring their own CDK stacks, kept separate from `platform/infrastructure/`. The infrastructure separation matches the conceptual separation: utility infrastructure isn't platform infrastructure.
+3. **Permanent in the repository.** The category itself persists; individual utilities within the category may be one-shot (run once and become reference / replay material), but the category remains as a documented home for similar future tooling.
+
+When a piece of code fits all three criteria, it belongs in a utility category, not in `apps/` or `platform/`.
+
+### 6.2 Data migration utilities
+
+`migration-utilities/` is the established category for data migration tooling.
+
+**Purpose.** A data migration utility moves data from one storage location into another (typically as a one-shot migration during platform activation or schema change). Each migration utility is:
+
+- Specific to one app's namespace (`budget-tracker/`, `stock-analyser/`, etc.)
+- Specific to one data type within that app (`transactions/`, `watchlists/`, etc.)
+- One Lambda per migration; each instance runs once per user
+- Named for what it does, not for the technology underneath
+
+The category as a whole is permanent. Individual utilities are not — each runs once for each user, then sits in the repository as documentation, replay capability, or reference for future similar migrations.
+
+**Repo structure.**
+
+```
+migration-utilities/
+  infrastructure/                          # CDK stacks for the utilities namespace
+  budget-tracker/                          # target app namespace
+    transactions/                          # data type within app
+      src/                                 # Lambda code
+      package.json
+  stock-analyser/                          # future migrations group here
+    watchlist/
+      src/
+      package.json
+```
+
+The hierarchy reflects the URL path structure (Section 6.3): top-level by app namespace, then by data type, with the Lambda code beneath.
+
+**Data artefacts** for migrations live separately at `migration-artifacts/<app>/`. Migration utilities (the code) and migration artifacts (the data being migrated) are different categories with different concerns; they live in different locations.
+
+### 6.3 URL namespace for utilities
+
+Utilities exposed as HTTP endpoints follow a dedicated URL namespace:
+
+```
+/api/migrations/<app>/<data-type>/<operation>
+```
+
+For example:
+
+```
+POST /api/migrations/budget-tracker/transactions/import
+POST /api/migrations/stock-analyser/watchlist/import
+```
+
+The `/api/migrations/` namespace is distinct from app-level API namespaces (`/api/budget/...`, `/api/stocks/...`). The distinction matters: a utility endpoint is not part of the app's API surface; it's a separate operational tool that happens to share the same API Gateway infrastructure.
+
+**No version segment** in utility paths. Utilities are one-shot per instance; if a utility's data structure changes, the Lambda is updated directly rather than a new version being introduced. There will never be a `/v1/` and `/v2/` of the same utility active simultaneously, so versioning adds noise without value.
+
+This is a deliberate departure from app-level API versioning (where `/v1/` is canonical). The reasoning: app APIs may need to support multiple consumer versions during migrations; utility endpoints don't have that constraint.
+
+### 6.4 Utility infrastructure
+
+Utility categories that need AWS infrastructure carry their own CDK stacks at `<category>/infrastructure/`. For example, `migration-utilities/infrastructure/` holds the CDK stacks for the `/api/migrations/...` namespace.
+
+Utility infrastructure is a peer to `platform/infrastructure/`, not a child of it. The two are conceptually distinct:
+
+- `platform/infrastructure/` holds infrastructure for the running platform — API stacks, table stacks, auth stacks
+- `<category>/infrastructure/` holds infrastructure for utilities — separate stacks, owned by the utility category
+
+The same separation principle that keeps the running platform's code out of utility directories also keeps the running platform's infrastructure out of utility infrastructure directories.
+
+**AWS function naming.** Lambdas within a utility category follow a naming convention that matches the URL path:
+
+```
+migration-<app>-<data-type>-<stage>
+```
+
+For example:
+
+- `migration-budget-tracker-transactions-dev`
+- `migration-stock-analyser-watchlist-dev`
+
+The function name and URL path mirror each other. This makes operational debugging easier: matching a CloudWatch log stream to a URL route is direct.
+
+---
+
+## 7. Operating principles
 
 These are standing rules about how to *work safely* on this codebase. They
 emerged from prior failure modes and are codified to prevent recurrence.
 
-### 5.1 Verify current state before acting on architectural prompts
+### 7.1 Verify current state before acting on architectural prompts
 
 Before acting on any prompt that touches multi-component architecture, the
 first step is "confirm what's actually deployed against what the prompt
@@ -664,7 +876,7 @@ pattern is: list the directories or files the document will describe,
 read them, then write. This applies whether the document is being
 created or rewritten, and whether the writer is human or Claude.
 
-### 5.2 Audit cheerful PR-description framings before reading the rest
+### 7.2 Audit cheerful PR-description framings before reading the rest
 
 PR descriptions that say "drift removed", "simplified to X-only", "cleaned
 up unused code" are exactly the kind of cheerful framings that make
@@ -683,7 +895,7 @@ flagged for either (a) reverting in this PR and re-doing in a properly-
 scoped PR, or (b) explicit acknowledgement and rationale in the PR
 description.
 
-### 5.3 Architecture decisions are evaluated against the goals
+### 7.3 Architecture decisions are evaluated against the goals
 
 When two contributors disagree about an architectural choice, the
 resolution is to identify which of the four goals (Section 1.1) each
@@ -700,7 +912,7 @@ them tend to drift toward whoever spoke last.
 
 ---
 
-## 6. The status-tag system
+## 8. The status-tag system
 
 Documents that have a "status" column for findings (the architectural
 inventory; verification reports; audit-style outputs) use a six-tag
@@ -727,7 +939,7 @@ six.
 
 ---
 
-## 7. Archived documents
+## 9. Archived documents
 
 Documents that have been superseded live in `/docs/archive/`. Each
 archived document carries a header at the top:
@@ -755,7 +967,7 @@ PLAN.md's documentation reconciliation milestone (Stage 0c).
 
 ---
 
-## 8. Changing this document
+## 10. Changing this document
 
 This document is itself operational — changes to ways of working are made
 by changing this document, in PRs.
@@ -770,9 +982,15 @@ Changes to Section 3 (repository structure) are coordinated with the
 relevant code reorganisation and ratified through the architecture
 decision process.
 
-Changes to Section 4 (workflow) and Section 5 (operating principles) are
+Changes to Section 4 (workflow) and Section 7 (operating principles) are
 made when ways of working change. The change itself is a PR and goes
 through normal review.
 
-Changes to Section 6 (status-tag system) and Section 7 (archived
+Changes to Section 5 (architectural patterns) and Section 6 (utility
+categories and conventions) are made when canonical architectural
+decisions change. Such changes are typically ratified through dedicated
+decision work (e.g., milestone-scoped decision documents) before
+landing in this document.
+
+Changes to Section 8 (status-tag system) and Section 9 (archived
 documents) are mechanical.

--- a/PLAN.md
+++ b/PLAN.md
@@ -243,25 +243,21 @@ subsequent implementation work — Stage 0b in the prior nomenclature.
 
 Three architectural decisions ratified and documented:
 
-**Decision M2.1 — Data-access content placement and substance.**
+**Decision M2.1 — Data-access patterns and table-naming policy.**
 
-- Whether to fold data-access content into the existing
-  `docs/architecture/data.md` or write a sibling
-  `docs/architecture/data-access.md`. (User-expressed preference: fold
-  into `data.md`. To be ratified.)
-- The canonical persistence pattern for the frontend, given the v0 swap
-  point requirement. (User-expressed preference: repository-or-equivalent
-  above ApiClient. To be ratified.)
-- Where the swap point lives — interface in a domain package,
-  implementations selected by config.
-- Cache reclassification: `platform.analysis-cache` as stock-analyser
-  data (currently misnamed); pattern-vs-data separation for future apps.
-- The `/migrate-from-localstorage` → `/import` rename target documented
-  (implementation in M6).
-- DynamoDB table-naming policy and ownership (per-app vs platform vs
-  shared).
-- Account-scoping invariant: every account-scoped Lambda must read
-  `account.accountId` from `withAuth`.
+Documented in `CONTRIBUTING.md` Section 5 (Architectural patterns) and Section 6 (Utility categories and conventions). Specific outcomes:
+
+- Layered architecture ratified as the canonical pattern: business logic, data-access layer, physical store. Strict separation — business logic never references physical implementations directly.
+- Domain interfaces live in `contracts/<scope>/`. Names are store-agnostic.
+- Implementations of domain interfaces are named for their physical store (e.g., `DynamoTransactionRepository`, `LocalStorageTransactionRepository`).
+- Naming conventions for domain interfaces: Repository pattern for collection-of-entities access; Service pattern for capability-style operations.
+- Implementation selection is an environment concern — build-time config client-side, deployment-time config via CDK server-side. Nothing flips at runtime.
+- Canonical table-naming policy: `{scope}.{entity}-{stage}`. Scope is either `platform` or an app slug; categorical, not stylistic. Applies to all logical tables regardless of physical storage backend.
+- Cache reclassification: `platform.analysis-cache-{stage}` reclassifies to `stock-analyser.analysis-cache-{stage}`; the `platform.` prefix is reserved for tables used by multiple apps or platform infrastructure.
+- Account-scoping invariant: every account-scoped Lambda reads `account.accountId` from `withAuth` via the `requireAccountAccess` helper. Already in compliance per M1 #79's verification of all nine consumer Lambdas.
+- New utility category established: data migration utilities at `migration-utilities/` (peer to `apps/`, `packages/`, `platform/`). One Lambda per migration, hierarchical structure by app namespace and data type. URL namespace `/api/migrations/<app>/<data-type>/<operation>` (no version segment).
+- The `/migrate-from-localstorage` endpoint is recategorised as a data migration utility. Renames to `POST /api/migrations/budget-tracker/transactions/import`; relocates to `migration-utilities/budget-tracker/transactions/`. Implementation in M6.
+- All non-conforming code migrates to the canonical patterns. New code conforms from inception. Migration scope is M7.
 
 **Decision M2.2 — `auth.md` extension.**
 
@@ -532,35 +528,31 @@ and makes Budget Tracker usable end-to-end with real users.
 
 ### Outcome
 
-- Budget Tracker frontend wired to real backend through the canonical
-  persistence pattern ratified in M2.1.
-- `/api/budget/v1/migrate-from-localstorage` renamed to
-  `/api/budget/v1/import` (Issue #17 from the stabilisation backlog).
-- The localStorage middleman removed: client posts file contents
-  directly to the import endpoint without an intermediate localStorage
-  hop.
-- 726-transaction historical fixture
-  (`migration-artifacts/budget-tracker/budget-tracker-export-2026-04-18.json`)
-  backfilled.
+- Budget Tracker frontend wired to real backend through the canonical layered architecture ratified in M2.1 (`CONTRIBUTING.md` Section 5).
+- `/api/budget/v1/migrate-from-localstorage` recategorised as a data migration utility per M2.1's #107 decision. Specifically:
+  - URL path renamed to `POST /api/migrations/budget-tracker/transactions/import` (no version segment, per the utility namespace convention in `CONTRIBUTING.md` Section 6.3).
+  - Lambda code relocated from `apps/budget-tracker/functions/budget-migrate/` to `migration-utilities/budget-tracker/transactions/`.
+  - Old Lambda directory and old endpoint deleted cleanly (no production consumers).
+  - AWS function renamed to follow the `migration-<app>-<data-type>-<stage>` naming convention.
+- New repository categories created at repo root (per `CONTRIBUTING.md` Section 6):
+  - `migration-utilities/` — peer to `apps/`, `packages/`, `platform/`. Houses migration utility code organised by app namespace and data type.
+  - `migration-utilities/infrastructure/` — peer to `platform/infrastructure/`. Houses CDK stacks for the utilities namespace.
+- `MigrationsApiStack` (or similar) created in `migration-utilities/infrastructure/`. Owns the `/api/migrations/...` API namespace. Route registration for `budget-tracker/transactions/import` lives here, not in `budget-tracker-api-stack.ts`.
+- New deploy workflow `deploy-migration-utilities.yml` created. Triggers on `migration-utilities/**` and `migration-utilities/infrastructure/**` path changes. Deploys the `MigrationsApiStack` and the Lambda functions within `migration-utilities/`. Workflow follows the same patterns as existing app deploys (authentication, pipeline stages, post-deploy verification).
+- `ci.yml` updated to include `migration-utilities/**` in CI scope (typecheck, lint, test).
+- Contract files updated to reflect the new endpoint path. `/v1/` documentation drift fixed in the same change (contracts previously omitted the `v1` segment that exists in the actual route).
+- `MONOREPO.md` updated to document `migration-utilities/` as a peer category alongside `apps/`, `packages/`, `platform/`. The new `deploy-migration-utilities.yml` workflow documented alongside existing app and platform deploy workflows.
+- The localStorage middleman removed: client posts file contents directly to the import endpoint without an intermediate localStorage hop.
+- 726-transaction historical fixture (`migration-artifacts/budget-tracker/budget-tracker-export-2026-04-18.json`) backfilled.
 - CSV import UI for ANZ and Macquarie statements implemented.
-- Mock auth removed from Budget Tracker; replaced with real Cognito
-  auth.
-- localStorage repositories removed; replaced with real
-  DynamoDB-via-Lambda implementations through the canonical pattern.
-- Tab-level error-boundary support: new `packages/ui/error-boundaries/`
-  package implementing a generic `TabErrorBoundary` component that
-  wraps tab content so a crash in one tab does not unmount the whole
-  app. Both budget-tracker tabs and stock-analyser tabs wrapped using
-  the same package (per Issue #16; bilateral application avoids leaving
-  stock-analyser shipping without boundaries while waiting for a later
-  milestone).
+- Mock auth removed from Budget Tracker; replaced with real Cognito auth.
+- localStorage repositories removed; replaced with real DynamoDB-via-Lambda implementations through the canonical layered architecture pattern.
+- Tab-level error-boundary support: new `packages/ui/error-boundaries/` package implementing a generic `TabErrorBoundary` component that wraps tab content so a crash in one tab does not unmount the whole app. Both budget-tracker tabs and stock-analyser tabs wrapped using the same package (per Issue #16; bilateral application avoids leaving stock-analyser shipping without boundaries while waiting for a later milestone).
 - Budget Tracker functional end-to-end with the live user account.
 
 ### Goals served
 
-Goal 4 (the budget-tracker permissions model is now exercised by real
-use). Goal 1 (Budget Tracker is now genuinely an app, not a mock; it
-exercises the platform substrate the same way stock-analyser does).
+Goal 4 (the budget-tracker permissions model is now exercised by real use). Goal 1 (Budget Tracker is now genuinely an app, not a mock; it exercises the platform substrate the same way stock-analyser does). Goal 3 indirectly (the data migration utilities category is established as a worked example of the utility-categories pattern in `CONTRIBUTING.md` Section 6).
 
 ### Gate to next
 
@@ -598,8 +590,31 @@ This milestone is comparable in scope to M5 — substantial enough that it
 gets its own sub-phase rather than being folded into smaller cleanup
 work.
 
+M2.1's architectural decisions (#103, #105, #106) add additional
+pattern-conformance work to M7. The layered-architecture migration
+(#103) — all non-conforming code restructured to go through domain
+interfaces in contracts — naturally pairs with the deduplication scope,
+since extracting domain interfaces from duplicated shapes simultaneously
+deduplicates AND migrates code to Position A. Two table renames (#105,
+#106) bring exception cases into canonical form.
+
 ### Outcome
 
+- Cache reclassification: rename `platform.analysis-cache-{stage}` to
+  `stock-analyser.analysis-cache-{stage}` and tighten IAM scope to
+  stock-analyser Lambdas only. Per M2.1 #105.
+- Rate-limits rename: rename `platform-rate-limits-{stage}` to
+  `platform.rate-limits-{stage}` to match the canonical separator rule
+  (`{scope}.{entity}-{stage}`). Rate-limit data loss acceptable
+  (counters self-heal). Per M2.1 #106.
+- Layered-architecture migration: all non-conforming code restructured
+  to go through domain interfaces in contracts (per M2.1 #103). Existing
+  service-layer code (stock-analyser portfolio/watchlist) migrates to
+  repository pattern. Existing direct-DynamoDB Lambda code migrates
+  behind domain interfaces. Implementations named for their physical
+  store (e.g., `DynamoTransactionRepository`,
+  `LocalStorageTransactionRepository`). Selection by build-time config
+  client-side, deployment-time config server-side.
 - Drift refinement of the 60/40 split: within the drifted 40%,
   *semantic* drift (real behavioural differences, e.g., `Transaction._id`
   string-vs-number) distinguished from *cosmetic* drift (1-line deltas,
@@ -651,15 +666,21 @@ irrelevant code).
 
 Bilateral duplication reduced to whatever the canonical pattern dictates.
 Lint re-enabled and passing. Cross-app file copies caught at CI. Per-app
-infrastructure split into the canonical structure.
+infrastructure split into the canonical structure. All non-conforming
+data-access code migrated to layered architecture (Position A). Domain
+interfaces in contracts; implementations named for physical store. Two
+table renames complete (analysis-cache, rate-limits).
 
 ### Dependencies
 
-- M2 complete (canonical pattern ratified).
+- M2.1 complete (canonical pattern ratified) — strictly required for the
+  layered-architecture migration and table renames.
+- M2.3 complete (contracts policy ratified) — strictly required for
+  domain interfaces in contracts. M2.2 not strictly required for M7 work.
 - M3 complete (documentation set accurate so the migration is against
   documented targets).
 - M6 useful but not blocking (Budget Tracker activation is its own
-  trajectory; deduplication can run in parallel with M6 once M2 is done).
+  trajectory; deduplication can run in parallel with M6 once M2.1 is done).
 
 ---
 
@@ -984,30 +1005,14 @@ ceremonial.
 
 ### Outcome
 
-- Prod GitHub Actions environment populated with all `[REQUIRED]`
-  env vars per the documentation set in PRs #19–24. First prod deploy
-  passes the env-var check.
+- Prod GitHub Actions environment populated with all `[REQUIRED]` env vars per the documentation set in PRs #19–24. First prod deploy passes the env-var check.
 - Deploy workflow path filters extended for completeness, covering:
-  - `.github/workflows/**` and `scripts/ci/**` for both
-    `deploy-stock-analyser.yml` and `deploy-budget-tracker.yml`.
-    Changes to CI machinery trigger the workflows they modify.
-  - `packages/**` for `deploy-budget-tracker.yml` (per M1 #81
-    finding — currently in stock-analyser's workflow but missing
-    from budget-tracker's). Once #17/M5 activates the real
-    budget-tracker deployment, this gap becomes a live bug.
-  - `functions/**` asymmetry investigated for
-    `deploy-budget-tracker.yml`. Stock-analyser triggers on
-    `functions/**`; budget-tracker does not. Whether
-    budget-tracker Lambdas have dependencies on `functions/**`
-    changes determines whether the asymmetry is intentional or
-    a gap.
-- Post-deploy smoke testing: a known-good request hits each app's
-  primary endpoint after deploy, asserts a 2xx response or expected
-  redirect. Failure rolls back or alerts. Existing PR #28 verification
-  reviewed and extended if it doesn't already do this.
-- A first prod deploy executed against the populated environment as
-  the milestone's verification — confirms the pipeline works
-  end-to-end against prod.
+  - `.github/workflows/**` and `scripts/ci/**` for `deploy-stock-analyser.yml`, `deploy-budget-tracker.yml`, and `deploy-migration-utilities.yml` (per M6's creation). Changes to CI machinery trigger the workflows they modify.
+  - `packages/**` for `deploy-budget-tracker.yml` (per M1 #81 finding — currently in stock-analyser's workflow but missing from budget-tracker's). Once #17/M5 activates the real budget-tracker deployment, this gap becomes a live bug.
+  - `functions/**` asymmetry investigated for `deploy-budget-tracker.yml`. Stock-analyser triggers on `functions/**`; budget-tracker does not. Whether budget-tracker Lambdas have dependencies on `functions/**` changes determines whether the asymmetry is intentional or a gap.
+  - `deploy-migration-utilities.yml` path filters verified for completeness — triggers on `migration-utilities/**` and `migration-utilities/infrastructure/**` plus the same CI machinery paths (`.github/workflows/**`, `scripts/ci/**`).
+- Post-deploy smoke testing: a known-good request hits each app's primary endpoint after deploy, asserts a 2xx response or expected redirect. Failure rolls back or alerts. Existing PR #28 verification reviewed and extended if it doesn't already do this. Smoke testing extends to migration-utilities deployments — a known-good request hits a deployed migration utility's endpoint after deploy.
+- A first prod deploy executed against the populated environment as the milestone's verification — confirms the pipeline works end-to-end against prod.
 
 ### Goals served
 


### PR DESCRIPTION
## What this PR does

Lands all five M2.1 architectural decisions (#103-#107) as a coherent batch. M2.1's substantive output is two new normative sections in CONTRIBUTING.md plus updates to three PLAN.md milestone outcomes (M2.1, M6, M14).

## CONTRIBUTING.md changes

**New Section 5 — Architectural patterns.** Documents the layered architecture (business logic / data-access layer / physical store), domain interfaces in contracts, implementation selection mechanisms (build-time client-side, deployment-time server-side), domain interface naming conventions (Repository vs Service), and table-naming policy.

**New Section 6 — Utility categories and conventions.** Establishes utility categories as a peer concept to apps, packages, and platform. Documents the data migration utilities category with its URL namespace, infrastructure separation, and AWS function naming convention.

**Renumbered:** Sections 5-8 of the previous structure (Operating principles, Status-tag system, Archived documents, Changing this document) are now Sections 7-10. Subsection numbers updated accordingly. Internal cross-references updated.

## PLAN.md changes

**M2.1 outcomes** replaced with consolidated content reflecting the five decisions.

**M6 outcomes** updated to capture #107's recategorisation work — Lambda relocation, new repo category creation, MigrationsApiStack, deploy-migration-utilities.yml workflow, ci.yml update, MONOREPO.md updates, contract file updates. Goal 3 added to Goals served.

**M14 outcomes** updated to include path-filter verification for deploy-migration-utilities.yml and smoke testing extension to migration-utilities deployments.

## Milestone description syncs

GitHub M6 and M14 milestone descriptions updated via gh api PATCH (in this same PR) per the milestone-content pairing rule. Not visible in git diff but part of the PR's scope.

## Issues closed

Closes #103 — canonical persistence pattern.
Closes #104 — data-access content placement.
Closes #105 — cache reclassification scope.
Closes #106 — table-naming policy.
Closes #107 — /import endpoint rename and utility categorisation.