### PR TITLE
M2.2: Auth model decisions ratified

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -739,6 +739,35 @@ budget-tracker.rules-{stage}           # app-scoped to budget-tracker
 
 Existing tables that don't conform are migrated to canonical form. No grandfathering — the rule is universal.
 
+### 5.6 Auth model
+
+Auth follows the same layered architecture as data access. The platform's auth concerns — JWT claim consumption, authorization decisions, cross-Lambda trust — apply the patterns documented in 5.1 through 5.4 to a different domain.
+
+**Helper interface in `packages/lambda-middleware/`.** All Lambda handlers use the canonical helper interface for auth concerns. The interface has two layers:
+
+- **Middleware wrappers** (`middleware.ts`) — `withAuth(handler)` provides JWT plus account context; `withAuthOnly(handler)` provides JWT without account context (for routes that operate on the user themselves rather than account-scoped data). Both internally call `extractAuthClaims` to read raw claims; consumers do not import `extractAuthClaims` directly.
+- **Claim-based helpers** (`auth.ts`) — `requireAppAccess`, `requireAnyAppAccess`, `requireAccountAccess`, `requireAccountOwner`, `requireSiteAdmin`. These operate on the typed `auth` object provided by the wrappers and throw 403 on authorization failure.
+
+The full interface and per-helper semantics are documented in `auth.md`.
+
+**JWT-claim consumption is layered.** Raw claim reads occur only in the middleware layer (`packages/lambda-middleware/`). Business-logic Lambdas access claims via the typed `auth` object provided by `withAuth` / `withAuthOnly`, using documented helpers when authorization decisions are needed. New Lambdas never read claims directly — that is the middleware layer's responsibility.
+
+This is a layering rule of the same shape as 5.1's data-access architecture. The middleware layer encapsulates raw-claim concerns; business logic operates on typed values. Direct claim access in business-logic code is non-conforming and migrates to helper-mediated access.
+
+**Cross-Lambda trust uses Pattern B with strict constraints.** When one platform Lambda invokes another (currently only `budget-ai → claude-proxy`), the receiving Lambda does not validate JWT signatures itself. Trust comes from IAM scope strictly limiting which callers can invoke. The caller propagates JWT claims via a synthetic event; the receiver reads them as if validated.
+
+This is consistent with the platform's general edge-validation posture (API Gateway validates at the edge; claim-reading helpers trust prior validation). Pattern A — per-hop JWT re-validation — would create an asymmetric posture inside the platform and adds operational complexity without proportionate benefit at the platform's current threat model (single trust domain, all Lambdas under common operational control).
+
+The pattern is permitted only with the following constraints, all binding:
+
+- IAM scope is load-bearing. Receiving Lambdas have IAM policies that strictly limit invokers. Reviewers of these policies must understand that policy broadness has security consequences beyond least-privilege.
+- CI verification of IAM scope is mandatory. A check confirms that receiving Lambdas using Pattern B have invoke-permission policies locked to expected callers. If a policy drifts to allow unexpected callers, CI fails. Without this verification, Pattern B is not acceptable.
+- Platform-Lambda-to-platform-Lambda only. External services or third-party callers must use Pattern A or go through API Gateway.
+
+If the platform's threat model changes (third-party Lambda code, multi-tenant Lambda deployment), Pattern B would be reconsidered.
+
+**Client-side auth follows the same layered architecture as data access.** A domain interface (`AuthService`) lives in contracts. Implementations are named for what they wrap: `CognitoAuthService` (production) and `MockAuthService` (v0). Selection is build-time per 5.3. Components, services, and hooks access claim-derived data only via the `AuthService` interface — never by reading JWT claims directly. Frontend treatment of auth is symmetric to Lambda treatment: typed access via interface; raw access only in the implementation layer.
+
 ---
 
 ## 6. Utility categories and conventions

--- a/PLAN.md
+++ b/PLAN.md
@@ -697,18 +697,20 @@ both states. This milestone retires the legacy.
 
 - Legacy Cognito groups removed: `admin`, `stock-app`, `budget-app`,
   `transformotion`, `family`.
-- `custom:active_account` Cognito attribute removed (now dead code with
-  no writers under the new model).
+- `custom:active_account` writes removed from `account-provisioning` (`/auth/setup` and `/auth/switch`). The `/auth/switch` route itself is removed (no live callers; only called from the archived `web-vite-backup`). The attribute itself remains declared in the user pool schema permanently — Cognito does not permit removal of existing user pool schema attributes — but is inert post-M8.
+- `resolveAccountContext` JWT-claim fallback to `custom:active_account`
+  removed (per M2.2 #112 decision).
 - Per M1 #80: Lambda handlers do not read group names directly, so
   no handler-level callsite migration is needed. The
   "callsite migration" outcome originally framed in M8 turned out
   unnecessary — all 9 consumer Lambdas use claim-based helpers that
   never read group names.
-- `requireGroup` helper removed from `packages/lambda-middleware/` if
-  it exists and is unused (verify before removing — M1 #79 confirmed
-  it is exported but its call-sites must be checked).
-- `resolveAccountContext` JWT-claim fallback to `custom:active_account`
-  removed (per M2.2 decision on the fallback's fate).
+- `requireGroup` and `userInGroup` helpers removed from `packages/lambda-middleware/`. Both are group-name-based legacy patterns superseded by claim-based helpers; both retire together at this milestone (per M2.2 #109 + #111). Verify before removing — M1 #79 confirmed `requireGroup` is exported; `userInGroup` was found exported with zero callers during M2.2 diagnostic work.
+- **`auth/forgot-provider` abuse-resistance tightenings** (per M2.2 #111):
+  - SES grant scoped to the specific verified sender identity ARN (currently `Resource: ['*']` — broader than necessary)
+  - API Gateway stage throttling added as a second layer independent of the Lambda's DDB-based limiter
+  - CORS allowlist replacing `ALL_ORIGINS` — restrict to the sign-in page origin
+  - Rate-limiter changed from fail-open to fail-closed (if rate-limit table is unavailable, requests are blocked rather than bypassed; availability trade-off accepted for this endpoint)
 
 ### Goals served
 
@@ -717,8 +719,7 @@ artefacts). Goal 3 (one canonical naming, not two).
 
 ### Gate to next
 
-Legacy groups absent from `auth-stack.ts`. No code references to the
-old names. No references to `custom:active_account`.
+Legacy groups absent from `auth-stack.ts`. No code references to the old group names. `custom:active_account` writes absent from all Lambda code. `/auth/switch` route absent from `account-provisioning`. `forgot-provider` abuse-resistance tightenings landed (SES grant scoped, API Gateway throttling active, CORS restricted, rate-limiter fail-closed).
 
 ### Dependencies
 
@@ -1011,6 +1012,7 @@ ceremonial.
   - `functions/**` asymmetry investigated for `deploy-budget-tracker.yml`. Stock-analyser triggers on `functions/**`; budget-tracker does not. Whether budget-tracker Lambdas have dependencies on `functions/**` changes determines whether the asymmetry is intentional or a gap.
   - `deploy-migration-utilities.yml` path filters verified for completeness — triggers on `migration-utilities/**` and `migration-utilities/infrastructure/**` plus the same CI machinery paths (`.github/workflows/**`, `scripts/ci/**`).
 - Post-deploy smoke testing: a known-good request hits each app's primary endpoint after deploy, asserts a 2xx response or expected redirect. Failure rolls back or alerts. Existing PR #28 verification reviewed and extended if it doesn't already do this. Smoke testing extends to migration-utilities deployments — a known-good request hits a deployed migration utility's endpoint after deploy.
+- **Pattern B IAM scope CI verification** (per M2.2 #110): a CI check confirms that receiving Lambdas using Pattern B (cross-Lambda invocation with synthetic-event claim propagation, currently `claude-proxy`) have their `lambda:InvokeFunction` IAM policy locked to expected callers only. If the policy drifts to allow unexpected callers, CI fails. This verification is the load-bearing constraint that makes Pattern B acceptable; without it, the platform's cross-Lambda trust posture is weaker.
 - A first prod deploy executed against the populated environment as the milestone's verification — confirms the pipeline works end-to-end against prod.
 
 ### Goals served

--- a/docs/architecture/auth.md
+++ b/docs/architecture/auth.md
@@ -35,7 +35,7 @@ The Cognito user pool declares these custom attributes:
 | Attribute | Type | Status | Purpose |
 |---|---|---|---|
 | `custom:accounts` | String (max 2048) | Active | Comma-separated account IDs the user belongs to (all apps combined). Maintained by the Lambdas that modify account membership; read by the pre-token Lambda. Not consulted directly by frontend or API handlers. |
-| `custom:active_account` | String (max 36) | Declared but unused | Historical attribute; no longer written or read by any code. Cannot be removed from the schema — Cognito does not permit removal of existing user pool schema attributes. Remains declared but inert. |
+| `custom:active_account` | String (max 36) | Inert (writes pending removal) | Currently still written by `account-provisioning` (`/auth/setup` and `/auth/switch`). The writes and the `/auth/switch` route are removed in M8 — they reflect a server-side approach to account switching that has been superseded by client-side switching (X-Account-Id header). The attribute itself remains declared in the user pool schema permanently — Cognito does not permit removal of existing user pool schema attributes — but is inert (no writers, no readers) post-M8. Account switching as a working feature is provided by the client-side header-based design described in *Auth middleware* below. |
 
 **Active account is not a Cognito attribute.** Which account a user is currently viewing in an app is browser-local UI state, persisted in localStorage per-app. API requests include the `accountId` as a request parameter. The auth middleware validates the parameter against the token's `accounts` claim and rejects requests where the caller is not a member of the stated account.
 
@@ -296,7 +296,18 @@ App deployment state is statically known to the launchpad (hardcoded list of dep
 
 ## Auth middleware (`packages/lambda-middleware`)
 
-All API Lambda handlers use `withAuth` to validate the Cognito JWT from the `Authorization: Bearer` header. The middleware parses the custom claims (JSON-stringified → objects) and exposes:
+The middleware has two layers:
+
+**Middleware wrappers** (`middleware.ts`) — the consumer-facing entry points that wrap Lambda handlers. Two wrappers exist:
+
+| Wrapper | Provides | Use case |
+|---|---|---|
+| `withAuth(handler)` | `{ auth, account, event }` | JWT + active account context (X-Account-Id header). Most account-scoped handlers. |
+| `withAuthOnly(handler)` | `{ auth, event }` | JWT only, no account context. Routes that operate on the user themselves rather than account-scoped data — e.g., user profile reads, first-login flows. |
+
+Both wrappers internally call `extractAuthClaims` to read JWT claims. Consumers do not import `extractAuthClaims` directly; it is the internal extractor for the wrappers.
+
+**Claim-based helpers** (`auth.ts`) — operate on the typed `auth` object that the wrappers provide:
 
 | Property | Type | Source |
 |---|---|---|
@@ -306,9 +317,13 @@ All API Lambda handlers use `withAuth` to validate the Cognito JWT from the `Aut
 | `auth.siteAdmin` | `boolean` | `site_admin` custom claim (parsed from `"true"`/`"false"`) |
 | `auth.accounts` | `Record<string, Array<{accountId: string, role: string}>>` | `accounts` custom claim (parsed from JSON string) |
 
+`resolveAccountContext(handler)` — middleware that adds `account.accountId` to the wrapped handler context by reading the X-Account-Id header. If the header is absent, throws `badRequest("No active account context")`. There is no fallback to JWT-claim-based account resolution. Account switching is a client-side concern (the client tracks active-account state and sends the appropriate header value); this middleware reads the result.
+
+`resolveAccountContext` is composed with `withAuth` rather than replacing it: handlers that need both JWT and account context get both. Handlers that only need JWT (no account context) use `withAuthOnly` and do not include `resolveAccountContext`.
+
 ### Authorization helpers
 
-The following helpers are provided by `packages/lambda-middleware`. Handlers use these instead of inspecting the `auth` object directly.
+The following helpers are provided by `packages/lambda-middleware` and operate on the `auth` object. Handlers use these instead of inspecting the `auth` object directly.
 
 ```typescript
 requireSiteAdmin(auth)
@@ -341,7 +356,18 @@ All helpers check `auth.siteAdmin` first as an override. A site-admin caller pas
 
 **Fail-closed semantics.** When `auth.apps` or `auth.accounts` are absent or empty (e.g., due to a pre-token Lambda failure), helpers deny access rather than granting it. The pre-token Lambda documents this under "On failure" above.
 
-Handlers do NOT call `requireGroup` (the old pattern) for new work. `requireGroup` remains during the 7e migration for transitional purposes and is removed at 7e-cleanup.
+### Claim-consumption layering
+
+Raw JWT claim reads occur only in the middleware layer (`packages/lambda-middleware/`). Business-logic Lambdas access claims via the typed `auth` object provided by `withAuth` / `withAuthOnly`, using documented helpers (`requireAccountAccess`, `requireAppAccess`, `requireSiteAdmin`, etc.) when authorization decisions are needed. New Lambdas never read claims directly; the middleware layer is the only place raw claim access belongs.
+
+This is a layering rule of the same shape as the data-access layered architecture (see `CONTRIBUTING.md` Section 5). Concerns are separated by layer: the middleware layer encapsulates raw-claim concerns; business logic operates on typed values.
+
+### Deprecated helpers (retiring in M8)
+
+- `requireGroup(auth, group)` — group-name-based pattern superseded by claim-based helpers. Currently retained for the legacy `auth/forgot-provider` route's IP-based rate limiter; retires when `auth/forgot-provider` migrates to the canonical claim-based pattern.
+- `userInGroup(auth, group)` — utility check, also group-name-based; zero current callers; retires alongside `requireGroup`.
+
+Handlers do NOT call `requireGroup` for new work.
 
 ---
 
@@ -379,6 +405,30 @@ export const handler = withAuth(async ({ auth, account, event }) => {
 5. **Ownership-only operations** (account deletion, ownership transfer) use `requireAccountOwner`.
 6. **Platform-admin operations** (cross-app user management, user disable/delete) use `requireSiteAdmin`.
 7. **`requireGroup` must not appear in new handler code.** It is deprecated and will be removed at 7e-cleanup.
+
+---
+
+## Per-Lambda permission models
+
+Five platform Lambdas have explicit permission models. Each is documented here for reference; the patterns reflect what each Lambda does and the authorization shape it requires.
+
+| Lambda | Wrapper | Authorization | IAM scope |
+|---|---|---|---|
+| `accounts` | `withAuth` | Per-route guards (`requireAccountAccess` / `requireAccountOwner`) | `platform.accounts` RW + `platform.account-members` RW |
+| `user` | `withAuthOnly` | None — user owns their own data | `platform.users` RW |
+| `auth/account-provisioning` | `withAuthOnly` | None — first-login flow; user has JWT but no app group memberships yet | `platform.accounts` RW + `platform.account-members` RW + `AdminUpdateUserAttributes` on user pool ARN |
+| `auth/invitations` | `withAuth` | Account-context guards | `platform.accounts` R + `platform.invitations` RW |
+| `auth/forgot-provider` | None (raw handler — pre-authentication) | None | `platform-rate-limits` RW + `AdminGetUser` on user pool ARN + SES `SendEmail` (scoped to verified sender identity ARN, pending tightening in M8) |
+
+**`accounts`, `user`, `auth/account-provisioning`, `auth/invitations`** are user-facing API endpoints. Each uses the appropriate middleware wrapper based on whether account context is required, and authorization helpers based on what the operation needs to verify.
+
+**`auth/forgot-provider`** is pre-authentication by necessity (the user has forgotten their identity provider; they cannot authenticate). It uses no middleware wrapper — the handler reads the request directly. Abuse-resistance is provided by Lambda-side IP-based rate limiting, plus tightenings scheduled for M8 (API Gateway throttling, CORS allowlist to the sign-in page origin, SES grant scoping, rate-limiter fail-closed behaviour). See *Forgot-provider flow* below.
+
+### Cross-Lambda trust pattern
+
+`claude-proxy` is invoked by `budget-ai` (a Lambda-to-Lambda call, not API-Gateway-to-Lambda). The trust model for this path is documented in `CONTRIBUTING.md` Section 5 as the canonical pattern for cross-Lambda invocations: **Pattern B with strict constraints** — the receiving Lambda does not validate JWT signatures itself; trust comes from IAM scope strictly limiting which callers can invoke. The caller propagates JWT claims via a synthetic event; the receiver reads them as if validated.
+
+This pattern is binding only for cross-Lambda invocations between platform Lambdas under common operational control. External services or third-party callers must use API-Gateway-validated paths (the standard `withAuth` flow).
 
 ---
 
@@ -578,7 +628,32 @@ The Lambda `transformotion-forgot-provider-{stage}` (in `AuthApiStack`):
 3. Reads the `identities` attribute to detect which IDP was used
 4. Sends an SES email to the user naming the sign-in method and a link
 
+The handler is pre-authentication by necessity. It uses no `withAuth` / `withAuthOnly` wrapper — there is no JWT to extract. Abuse-resistance is the load-bearing security property.
+
+### Abuse-resistance posture
+
+Current state has Lambda-side IP-based rate limiting (5 requests per IP per 15 minutes, stored in `platform-rate-limits-{stage}`). The rate limiter currently fails open: if the rate-limit table is unavailable, requests proceed without limiting.
+
+The following tightenings are scheduled for M8:
+
+- **SES grant scoping.** Current grant is `ses:SendEmail` on `Resource: ['*']` — broader than necessary. M8 scopes the grant to the specific verified sender identity ARN.
+- **API Gateway throttling.** A second layer independent of the Lambda's DDB-based limiter. Specific throttle parameters decided during M8 implementation.
+- **CORS allowlist.** Current configuration is `ALL_ORIGINS`; M8 restricts to the sign-in page origin so browser-based requests from other origins are blocked.
+- **Rate-limiter fail-closed.** The current fail-open behaviour is changed to fail-closed: if the rate-limit table is unavailable, requests are blocked rather than bypassed. The availability trade-off is accepted for this endpoint — it is not critical-path for active users; legitimate users can retry after DDB recovers; the abuse window stays closed during outages.
+
 **Known limitation:** For federated users, `AdminGetUser(Username=email)` fails because their Cognito username is `Google_{sub}` (not email). The fix using `ListUsersCommand` resolves this. See sub-phase `7e-forgot-provider-fix` in `docs/sub-phase-7e-plan.md`.
+
+---
+
+## Client-side auth
+
+Frontend code follows the same layered architecture pattern as data access (see `CONTRIBUTING.md` Section 5).
+
+A domain interface (`AuthService`) lives in contracts. Implementations are named for what they wrap: `CognitoAuthService` (production; reads JWT claims from a Cognito session) and `MockAuthService` (v0; returns mocked auth state without any real auth backend). Selection is build-time per the layered architecture pattern.
+
+Components, services, and hooks access claim-derived data only via the `AuthService` interface — never by reading JWT claims directly. The interface is the canonical access path for any claim-derived value (active account ID, app access flags, user identity, etc.).
+
+The current state has the interface duplicated across `packages/auth-client/`, `apps/stock-analyser/`, and `apps/budget-tracker/`, with the production implementation only existing for stock-analyser. Migration to the canonical pattern (interface in contracts, both implementations in `packages/auth-client/`, build-time selection) happens alongside the production bug fix for the missing `accounts` JWT claim.
 
 ---
 


### PR DESCRIPTION
## What this PR does

Lands all seven M2.2 architectural decisions (#108-#113 plus #130) as a coherent batch. M2.2's substantive output is one new CONTRIBUTING.md subsection plus substantial expansion of auth.md, with downstream-milestone updates for M8 and M14.

## CONTRIBUTING.md changes

**New subsection 5.6 — Auth model.** Covers the canonical helper interface (withAuth, withAuthOnly, plus the claim-based helpers in auth.ts), claim-consumption layering rule (raw claim reads only in middleware layer; business logic uses helpers), cross-Lambda trust pattern (Pattern B with strict IAM constraints and CI verification), and client-side auth following the same layered architecture as data access.

## auth.md changes

Substantial expansion. Key additions:

- **Auth middleware section** restructured to document the two-layer structure (wrappers and claim-based helpers), withAuthOnly added, resolveAccountContext documented by name, claim-consumption layering rule articulated as a normative rule, deprecated helpers (requireGroup, userInGroup) subsection
- **New Per-Lambda permission models section** with summary table covering all five platform Lambdas (accounts, user, account-provisioning, invitations, forgot-provider), plus cross-Lambda trust pattern subsection covering claude-proxy
- **Forgot-provider section** expanded with abuse-resistance posture subsection covering all four M8 tightenings (SES grant scoping, API Gateway throttling, CORS allowlist, rate-limiter fail-closed change)
- **New Client-side auth section** covering layered architecture pattern applied to frontend auth, with cross-reference to CONTRIBUTING.md Section 5
- **custom:active_account description** updated to reflect current state (writes still in account-provisioning, /auth/switch route still present), the M8 cleanup scope, and the Cognito schema-removal limitation

## PLAN.md changes

**M8 outcomes** expanded for the implementation work that falls out of M2.2: more accurate framing of custom:active_account cleanup, userInGroup retirement alongside requireGroup, four-part forgot-provider abuse-resistance tightenings.

**M14 outcomes** added Pattern B IAM scope CI verification (the load-bearing constraint that makes Pattern B acceptable per M2.2 #110).

## Milestone description syncs

GitHub M8 and M14 milestone descriptions updated via gh api PATCH (in this same PR) per the milestone-content pairing rule.

## Issues closed

Closes #108 — per-app account model ratification.
Closes #109 — auth helper interface canonicalisation.
Closes #110 — Pattern B trust pattern ratification.
Closes #111 — permission models for the five platform Lambdas.
Closes #112 — resolveAccountContext header-only design.
Closes #113 — JWT-claim consumer pattern.
Closes #130 — client-side JWT claim consumption pattern.