### PR TITLE
Fix: pre-token-generation trigger durability (AwsCustomResource → addTrigger)

### DIFF
--- a/docs/architecture/inventory.md
+++ b/docs/architecture/inventory.md
@@ -642,6 +642,33 @@ is per-app accounts (one `platform.accounts` row per app per user-account
 relationship); M2.2 ratifies the model formally before M4's writer
 update lands.
 
+### 3.2a Pre-token-generation trigger not durably wired
+
+**Status: Resolved by Issue #141 / PR replacing AwsCustomResource with addTrigger()**
+
+The pre-token-generation Lambda was wired via an `AwsCustomResource`
+that called `UpdateUserPool` with `LambdaConfig`. This approach has a
+structural flaw: `AwsCustomResource.onUpdate` only re-fires when the
+custom resource's *own* properties change. If any other UserPool
+property is updated by CloudFormation (e.g., a Schema change, a
+client update), the UserPool CFN resource is updated directly, and
+`UpdateUserPool` is called without `LambdaConfig` — silently clearing
+the trigger wiring.
+
+This happened on 2026-04-28 when a UserPool-only stack update cleared
+`LambdaConfig`. Symptom: JWTs lacked the `accounts` claim; Stock
+Analyser Market Analysis broke for affected users.
+
+**Fix:** replaced the custom resource with `userPool.addTrigger(
+UserPoolOperation.PRE_TOKEN_GENERATION, preTokenFn)`. `addTrigger()`
+inlines `LambdaConfig` into the `AWS::Cognito::UserPool` CloudFormation
+resource so it is treated as first-class UserPool state and can never
+be cleared by a future stack update.
+
+Note: even with the trigger correctly wired, the `accounts` claim is
+still empty due to Section 3.2 (appSlug not written). Both bugs must
+be fixed before account-scoped Lambda calls will succeed.
+
 ### 3.3 Frontend auth store and JWT claims
 
 **Status uncertain — code verification still needed (M9 scope)**

--- a/infrastructure/lib/platform/auth-stack.ts
+++ b/infrastructure/lib/platform/auth-stack.ts
@@ -1,7 +1,6 @@
 import * as path from 'path';
 import * as cdk from 'aws-cdk-lib';
 import * as cognito from 'aws-cdk-lib/aws-cognito';
-import * as cr from 'aws-cdk-lib/custom-resources';
 import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
 import * as iam from 'aws-cdk-lib/aws-iam';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
@@ -254,51 +253,7 @@ export class AuthStack extends cdk.Stack {
       resources: [`arn:aws:cognito-idp:${this.region}:${this.account}:userpool/*`],
     }));
 
-    // Wire the pre-token trigger via a Custom Resource rather than userPool.addTrigger().
-    //
-    // addTrigger() modifies the AWS::Cognito::UserPool CloudFormation resource to add
-    // LambdaConfig. CloudFormation's resource provider then calls UpdateUserPool with
-    // the full resource state — including Schema — even though Schema hasn't changed.
-    // Cognito rejects any UpdateUserPool call that re-sends existing schema attributes
-    // ("Existing schema attributes cannot be modified or deleted.").
-    //
-    // The AwsCustomResource calls UpdateUserPool with ONLY LambdaConfig (no Schema),
-    // which Cognito accepts as a partial update. The UserPool CloudFormation resource
-    // is never modified, so the schema immutability error is never triggered.
-    preTokenFn.addPermission('CognitoPreTokenInvoke', {
-      principal:  new iam.ServicePrincipal('cognito-idp.amazonaws.com'),
-      sourceArn:  this.userPool.userPoolArn,
-      action:     'lambda:InvokeFunction',
-    });
-
-    new cr.AwsCustomResource(this, 'PreTokenTrigger', {
-      resourceType: 'Custom::CognitoPreTokenTrigger',
-      onCreate: {
-        service:            'CognitoIdentityServiceProvider',
-        action:             'updateUserPool',
-        parameters: {
-          UserPoolId:   this.userPool.userPoolId,
-          LambdaConfig: { PreTokenGeneration: preTokenFn.functionArn },
-        },
-        physicalResourceId: cr.PhysicalResourceId.of('PreTokenTrigger'),
-      },
-      onUpdate: {
-        service:            'CognitoIdentityServiceProvider',
-        action:             'updateUserPool',
-        parameters: {
-          UserPoolId:   this.userPool.userPoolId,
-          LambdaConfig: { PreTokenGeneration: preTokenFn.functionArn },
-        },
-        physicalResourceId: cr.PhysicalResourceId.of('PreTokenTrigger'),
-      },
-      policy: cr.AwsCustomResourcePolicy.fromStatements([
-        new iam.PolicyStatement({
-          actions:   ['cognito-idp:UpdateUserPool'],
-          resources: [`arn:aws:cognito-idp:${this.region}:${this.account}:userpool/*`],
-        }),
-      ]),
-      installLatestAwsSdk: false,
-    });
+    this.userPool.addTrigger(cognito.UserPoolOperation.PRE_TOKEN_GENERATION, preTokenFn);
 
     // ── Cognito Groups ─────────────────────────────────────────────────────
     const groups: Array<{ name: string; description: string; precedence: number }> = [


### PR DESCRIPTION
## Summary

- Replaces `AwsCustomResource` + manual `UpdateUserPool(LambdaConfig)` with `userPool.addTrigger(PRE_TOKEN_GENERATION, preTokenFn)` in `auth-stack.ts`
- Removes 5 custom resource CloudFormation resources (the custom resource, its IAM policy, its Lambda, its IAM role, the old Lambda permission)
- Adds the trigger as first-class `LambdaConfig` on the `AWS::Cognito::UserPool` resource
- Updates `inventory.md` with Section 3.2a documenting the root cause and fix

**Root cause of production bug (2026-04-28):** `AwsCustomResource.onUpdate` only fires when the custom resource's own properties change. A UserPool-only CloudFormation update on April 28 silently cleared `LambdaConfig`, breaking the pre-token trigger. JWTs lost the `accounts` claim; Stock Analyser Market Analysis broke.

## Test plan

- [x] `cdk diff` showed `LambdaConfig` added to `UserPool`, Schema unchanged — no risk of schema rejection error
- [x] `cdk deploy TransformotionDev-Auth` succeeded (UPDATE_COMPLETE in ~42s)
- [x] `describe-user-pool --query UserPool.LambdaConfig` confirms `PreTokenGeneration` ARN is set
- [ ] Sign out and sign back in to confirm fresh JWT contains `accounts` claim (note: `accounts` will still be empty until M4 writes `appSlug` — but it should be present in the token as an empty object `{}` rather than absent)

Closes #141

🤖 Generated with [Claude Code](https://claude.com/claude-code)