### PR TITLE
M4 #144: handleSetup writes appSlug to platform.accounts

### DIFF
--- a/functions/auth/account-provisioning/src/index.ts
+++ b/functions/auth/account-provisioning/src/index.ts
@@ -26,6 +26,11 @@ const ACCOUNTS_TABLE        = process.env.ACCOUNTS_TABLE!;
 const ACCOUNT_MEMBERS_TABLE = process.env.ACCOUNT_MEMBERS_TABLE!;
 const USER_POOL_ID          = process.env.USER_POOL_ID!;
 
+const APP_CLIENT_TO_SLUG: Record<string, string> = {
+  [process.env.APP_CLIENT_STOCK_SIGNAL!]:   'stock-signal',
+  [process.env.APP_CLIENT_BUDGET_TRACKER!]: 'budget-tracker',
+};
+
 /**
  * Auth setup Lambda — handles two routes:
  *
@@ -60,6 +65,12 @@ async function handleSetup(
     return ok({ accountId: existingAccountId, created: false });
   }
 
+  // aud identifies which App Client the user signed in through → determines appSlug.
+  const aud = claims?.aud;
+  if (!aud) throw badRequest('Missing aud claim — token must be issued by a known App Client');
+  const appSlug = APP_CLIENT_TO_SLUG[aud];
+  if (!appSlug) throw new Error(`Unknown App Client ID in aud claim: ${aud}`);
+
   const accountId = randomUUID();
   const now       = new Date().toISOString();
 
@@ -71,6 +82,7 @@ async function handleSetup(
             TableName: ACCOUNTS_TABLE,
             Item: {
               accountId,
+              appSlug,
               name:      `${email}'s account`,
               ownerId:   userId,
               plan:      'free',

--- a/infrastructure/bin/app.ts
+++ b/infrastructure/bin/app.ts
@@ -70,10 +70,12 @@ const devStockAnalyserTables = new StockAnalyserTablesStack(app, 'Transformotion
 
 const devPlatformApi = new PlatformApiStack(app, 'TransformotionDev-Api', {
   env,
-  stage:              'dev',
-  description:        'Transformotion Apps — Dev platform API (shared routes for all apps)',
-  userPool:           devAuth.userPool,
-  analysisCacheTable: devStockAnalyserTables.analysisCacheTable,
+  stage:                    'dev',
+  description:              'Transformotion Apps — Dev platform API (shared routes for all apps)',
+  userPool:                 devAuth.userPool,
+  stockSignalAppClientId:   devAuth.stockAnalyserAppClient.userPoolClientId,
+  budgetTrackerAppClientId: devAuth.budgetTrackerAppClient.userPoolClientId,
+  analysisCacheTable:       devStockAnalyserTables.analysisCacheTable,
 });
 
 new StockAnalyserApiStack(app, 'TransformotionDev-StockAnalyserApi', {
@@ -140,10 +142,12 @@ const prodStockAnalyserTables = new StockAnalyserTablesStack(app, 'Transformotio
 
 const prodPlatformApi = new PlatformApiStack(app, 'TransformotionProd-Api', {
   env,
-  stage:              'prod',
-  description:        'Transformotion Apps — Prod platform API (shared routes for all apps)',
-  userPool:           prodAuth.userPool,
-  analysisCacheTable: prodStockAnalyserTables.analysisCacheTable,
+  stage:                    'prod',
+  description:              'Transformotion Apps — Prod platform API (shared routes for all apps)',
+  userPool:                 prodAuth.userPool,
+  stockSignalAppClientId:   prodAuth.stockAnalyserAppClient.userPoolClientId,
+  budgetTrackerAppClientId: prodAuth.budgetTrackerAppClient.userPoolClientId,
+  analysisCacheTable:       prodStockAnalyserTables.analysisCacheTable,
 });
 
 new StockAnalyserApiStack(app, 'TransformotionProd-StockAnalyserApi', {

--- a/infrastructure/lib/platform/platform-api-stack.ts
+++ b/infrastructure/lib/platform/platform-api-stack.ts
@@ -13,6 +13,9 @@ export interface PlatformApiStackProps extends cdk.StackProps {
   stage: 'dev' | 'prod';
   /** Imported from AuthStack */
   userPool: cognito.IUserPool;
+  /** Imported from AuthStack — used by account-provisioning to map aud → appSlug */
+  stockSignalAppClientId: string;
+  budgetTrackerAppClientId: string;
   /** Imported from StockAnalyserTablesStack */
   analysisCacheTable: dynamodb.ITable;
 }
@@ -48,7 +51,7 @@ export class PlatformApiStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props: PlatformApiStackProps) {
     super(scope, id, props);
 
-    const { stage, userPool, analysisCacheTable } = props;
+    const { stage, userPool, stockSignalAppClientId, budgetTrackerAppClientId, analysisCacheTable } = props;
 
     // ── REST API ─────────────────────────────────────────────────────────────
     this.api = new apigateway.RestApi(this, 'Api', {
@@ -95,9 +98,11 @@ export class PlatformApiStack extends cdk.Stack {
       timeout:      cdk.Duration.seconds(15),
       memorySize:   256,
       environment: {
-        ACCOUNTS_TABLE:        accountsTable.tableName,
-        ACCOUNT_MEMBERS_TABLE: accountMembersTable.tableName,
-        USER_POOL_ID:          userPool.userPoolId,
+        ACCOUNTS_TABLE:            accountsTable.tableName,
+        ACCOUNT_MEMBERS_TABLE:     accountMembersTable.tableName,
+        USER_POOL_ID:              userPool.userPoolId,
+        APP_CLIENT_STOCK_SIGNAL:   stockSignalAppClientId,
+        APP_CLIENT_BUDGET_TRACKER: budgetTrackerAppClientId,
       },
       bundling: { externalModules: ['@aws-sdk/*'], minify: true, sourceMap: false, forceDockerBundling: false },
     });


### PR DESCRIPTION
## Summary

- **`functions/auth/account-provisioning/src/index.ts`**: `handleSetup` now reads the `aud` claim from the API Gateway JWT context, maps it to an `appSlug` via `APP_CLIENT_TO_SLUG`, and writes `appSlug` into the `platform.accounts` TransactWriteCommand item. Unknown `aud` values throw a 500 (not a 400, since this indicates misconfiguration, not bad user input).
- **`infrastructure/lib/platform/platform-api-stack.ts`**: Added `stockSignalAppClientId` and `budgetTrackerAppClientId` to `PlatformApiStackProps`; wired them into the account-provisioning Lambda environment as `APP_CLIENT_STOCK_SIGNAL` / `APP_CLIENT_BUDGET_TRACKER`.
- **`infrastructure/bin/app.ts`**: Both dev and prod `PlatformApiStack` instantiations pass the respective `AuthStack` app client IDs.

## Why

Without this fix, `platform.accounts` rows created by `handleSetup` had no `appSlug`. The pre-token-generation Lambda silently skipped those rows, so the `accounts` JWT claim was empty for any user whose account was created via the normal sign-up flow. The only accounts with `appSlug` were the two rows manually seeded on 2026-04-25 (documented in inventory.md §3.2).

## Deployed

Verified on `transformotion-account-provisioning-dev`:
```
APP_CLIENT_STOCK_SIGNAL:   2j1a025q8b1g9a94ac3uoui3s
APP_CLIENT_BUDGET_TRACKER: 291vbglkino4h7b9t39krg9c69
```

## Test plan

- [ ] Sign up a new user via Stock Analyser App Client — verify `platform.accounts-dev` row has `appSlug: "stock-signal"`
- [ ] Confirm pre-token Lambda includes the account in the `accounts` JWT claim on next sign-in
- [ ] Repeat for Budget Tracker App Client if a test user is available
- [ ] Existing seeded accounts unaffected (already have `appSlug`)

Closes #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)