### PR TITLE
PLAN.md: correct M5 dependency (matches M6/M11 pattern from PR #169)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -517,8 +517,7 @@ Goal 2 primarily (platform deployment substrate now supports shared gateway acro
 
 ### Dependencies
 
-- M4 complete (the auth substrate works end-to-end; gateway consolidation
-  doesn't add value if the auth chain underneath is broken).
+- M4 #144 done (handleSetup writer fix; PR #157). **Done.** M5 originally listed M4-as-a-milestone as a dependency, but the only piece M5 actually needs from M4 is the writer fix to ensure account-scoped JWT claims work correctly during gateway consolidation. The remainder of M4 folded into M11; none of that gates M5.
 
 ---
 


### PR DESCRIPTION
## What this PR does

One-line correction to PLAN.md M5 Dependencies section, matching the M6 and M11 corrections that landed in PR #169.

## Why this matters

PR #169 caught that M11 and M6 had overstated M4-as-a-milestone dependencies when the actual dependency reduces to "#144 done." M5 had the same overstatement but wasn't included in #169. This PR catches it before M5 work starts so PLAN.md is honest about what M5 actually waits on (nothing; everything's done).

## Verification

Doc-only. No code changes.

## Cross-references

- PR #169 (M11 and M6 corrections) — sets the pattern this PR continues
- M4 #144 / PR #157 — the writer fix that's M5's only real M4 dependency

🤖 Generated with [Claude Code](https://claude.com/claude-code)