### PR TITLE
M6 #175: establish migration-utilities namespace and CI/CD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,3 +82,7 @@ jobs:
       - name: CDK Synth — prod
         working-directory: infrastructure
         run: pnpm exec cdk synth TransformotionProd-Network
+
+      - name: CDK Synth — MigrationsApi (dev)
+        working-directory: infrastructure
+        run: pnpm exec cdk synth TransformotionDev-MigrationsApi

--- a/.github/workflows/deploy-migration-utilities.yml
+++ b/.github/workflows/deploy-migration-utilities.yml
@@ -1,0 +1,87 @@
+name: Deploy — Migration Utilities
+
+on:
+  push:
+    branches: [develop, main]
+    paths:
+      - 'migration-utilities/**'
+      - 'packages/**'
+  workflow_dispatch:
+    inputs:
+      target:
+        description: 'Deploy target'
+        required: true
+        default: 'dev'
+        type: choice
+        options: [dev, prod]
+
+concurrency:
+  group: deploy-migration-utilities-${{ github.ref_name }}
+  cancel-in-progress: false
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  AWS_REGION: ap-southeast-2
+  ROLE_ARN: arn:aws:iam::959516291617:role/GitHubActionsDeployRole
+
+jobs:
+  deploy-dev:
+    name: Migration Utilities → Dev
+    runs-on: ubuntu-latest
+    if: github.ref_name == 'develop' || (github.event_name == 'workflow_dispatch' && inputs.target == 'dev')
+    environment: dev
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: '10.33.0'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ env.ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: CDK Deploy — Migration Utilities stack (dev)
+        working-directory: infrastructure
+        run: pnpm exec cdk deploy 'TransformotionDev-MigrationsApi' --require-approval never
+
+  deploy-prod:
+    name: Migration Utilities → Prod
+    runs-on: ubuntu-latest
+    if: github.ref_name == 'main' || (github.event_name == 'workflow_dispatch' && inputs.target == 'prod')
+    environment: prod
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: '10.33.0'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ env.ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: CDK Deploy — Migration Utilities stack (prod)
+        working-directory: infrastructure
+        run: pnpm exec cdk deploy 'TransformotionProd-MigrationsApi' --require-approval never

--- a/MONOREPO.md
+++ b/MONOREPO.md
@@ -90,13 +90,21 @@ transformotion-apps/
 ├── migration-artifacts/                   # Historical data fixtures for backfill
 │   └── budget-tracker/                    # 726-transaction Budget Tracker export
 │
+├── migration-utilities/                   # Data migration utilities (CONTRIBUTING.md Section 6)
+│   └── infrastructure/                    # CDK stacks for the /api/migrations/... namespace
+│       ├── lib/
+│       │   └── migrations-api-stack.ts    # MigrationsApiStack — skeleton, routes added by consumers
+│       ├── package.json                   # @transformotion/migration-utilities-infrastructure
+│       └── tsconfig.json
+│
 ├── .github/
 │   ├── workflows/
 │   │   ├── ci.yml                         # PR typecheck + lint + CDK synth
 │   │   ├── cd.yml                         # Manual full-platform redeploy
 │   │   ├── deploy-platform.yml            # Triggered by infrastructure/lib/platform/** changes
 │   │   ├── deploy-stock-analyser.yml      # Triggered by apps/stock-analyser/** changes
-│   │   └── deploy-budget-tracker.yml      # Triggered by apps/budget-tracker/** changes
+│   │   ├── deploy-budget-tracker.yml      # Triggered by apps/budget-tracker/** changes
+│   │   └── deploy-migration-utilities.yml # Triggered by migration-utilities/** changes
 │   └── CODEOWNERS
 │
 ├── CLAUDE.md                              # Repository-level guide for Claude Code
@@ -121,6 +129,12 @@ Several directories above are migrating to different homes per
 - `contracts/platform/` and `contracts/stock-analyser/` will be created
   (M2.3 ratifies the contracts policy; subsequent work creates them).
 
+`migration-utilities/infrastructure/` is **not** subject to the M7
+platform restructuring. Per CONTRIBUTING.md Section 6.4, it is a
+permanent peer to `platform/infrastructure/` — utility infrastructure
+is conceptually distinct from platform infrastructure and stays
+separate.
+
 When those migrations run, this document gets updated in the same PR
 that lands them.
 
@@ -138,6 +152,10 @@ that lands them.
 - `functions/auth/*` — explicit nested glob because `functions/auth/`
   contains its own per-Lambda workspaces
 - `infrastructure` (single workspace at root)
+- `migration-utilities/infrastructure` — CDK stack package for the
+  migrations namespace
+- `migration-utilities/**` — pre-registered glob for future Lambda
+  packages within the namespace (e.g. `migration-utilities/budget-tracker/transactions/`)
 
 `apps/web-vite-backup` is explicitly excluded from workspaces.
 
@@ -195,7 +213,8 @@ the other app's deployment.
 | `infrastructure/lib/platform/**` | `deploy-platform.yml` |
 | `infrastructure/bin/**` | `deploy-platform.yml` |
 | `functions/**` | `deploy-platform.yml` |
-| `packages/**` | `deploy-stock-analyser.yml` only (gap: `deploy-budget-tracker.yml` missing this filter — tracked for M14 fix; currently latent because budget-tracker workflow is a no-op placeholder pending Issue #17/M5) |
+| `migration-utilities/**` | `deploy-migration-utilities.yml` |
+| `packages/**` | `deploy-stock-analyser.yml` only (gap: `deploy-budget-tracker.yml` and `deploy-migration-utilities.yml` missing this filter — tracked for M14 fix; currently latent because budget-tracker workflow is a no-op placeholder pending Issue #17/M5) |
 
 Path filter completeness is not yet verified for `.github/workflows/**`
 and `scripts/ci/**` — changes to CI machinery may not auto-trigger the

--- a/infrastructure/bin/app.ts
+++ b/infrastructure/bin/app.ts
@@ -18,6 +18,9 @@ import { StockAnalyserTablesStack } from '../lib/stock-analyser/stock-analyser-t
 import { BudgetTrackerTablesStack } from '../lib/budget-tracker/budget-tracker-tables-stack';
 import { BudgetTrackerApiStack }    from '../lib/budget-tracker/budget-tracker-api-stack';
 
+// ── Migration Utilities stacks ────────────────────────────────────────────────
+import { MigrationsApiStack } from '../../migration-utilities/infrastructure/lib/migrations-api-stack';
+
 const app = new cdk.App();
 
 const env = {
@@ -101,6 +104,15 @@ new BudgetTrackerApiStack(app, 'TransformotionDev-BudgetTrackerApi', {
   apiResource: devPlatformApi.apiResource,
 });
 
+new MigrationsApiStack(app, 'TransformotionDev-MigrationsApi', {
+  env,
+  stage:       'dev',
+  description: 'Transformotion Apps — Dev Migration Utilities API routes',
+  api:         devPlatformApi.api,
+  authoriser:  devPlatformApi.authoriser,
+  apiResource: devPlatformApi.apiResource,
+});
+
 // ── Prod stacks ────────────────────────────────────────────────────────────────
 
 new StorageStack(app, 'TransformotionProd-Storage', {
@@ -170,6 +182,15 @@ new BudgetTrackerApiStack(app, 'TransformotionProd-BudgetTrackerApi', {
   env,
   stage:       'prod',
   description: 'Transformotion Apps — Prod Budget Tracker API routes',
+  api:         prodPlatformApi.api,
+  authoriser:  prodPlatformApi.authoriser,
+  apiResource: prodPlatformApi.apiResource,
+});
+
+new MigrationsApiStack(app, 'TransformotionProd-MigrationsApi', {
+  env,
+  stage:       'prod',
+  description: 'Transformotion Apps — Prod Migration Utilities API routes',
   api:         prodPlatformApi.api,
   authoriser:  prodPlatformApi.authoriser,
   apiResource: prodPlatformApi.apiResource,

--- a/infrastructure/tsconfig.json
+++ b/infrastructure/tsconfig.json
@@ -2,11 +2,14 @@
   "extends": "../tsconfig.json",
   "compilerOptions": {
     "outDir": "cdk.out",
-    "rootDir": ".",
     "module": "CommonJS",
     "moduleResolution": "node",
     "lib": ["ES2022"]
   },
-  "include": ["bin/**/*.ts", "lib/**/*.ts"],
+  "include": [
+    "bin/**/*.ts",
+    "lib/**/*.ts",
+    "../migration-utilities/infrastructure/lib/**/*.ts"
+  ],
   "exclude": ["node_modules", "cdk.out"]
 }

--- a/migration-utilities/infrastructure/lib/migrations-api-stack.ts
+++ b/migration-utilities/infrastructure/lib/migrations-api-stack.ts
@@ -1,0 +1,46 @@
+import * as cdk from 'aws-cdk-lib';
+import * as apigateway from 'aws-cdk-lib/aws-apigateway';
+import { Construct } from 'constructs';
+
+export interface MigrationsApiStackProps extends cdk.StackProps {
+  stage: 'dev' | 'prod';
+  api: apigateway.RestApi;
+  authoriser: apigateway.CognitoUserPoolsAuthorizer;
+  /** Pre-built /api resource from PlatformApiStack — migrations mount under /api/migrations/... */
+  apiResource: apigateway.Resource;
+}
+
+/**
+ * MigrationsApiStack — skeleton API namespace for migration utilities.
+ *
+ * Establishes /api/migrations on the shared platform API Gateway.
+ * Routes (e.g. /api/migrations/budget-tracker/transactions/import) are
+ * mounted by downstream issues that consume this namespace.
+ *
+ * Per CONTRIBUTING.md Section 6.4, this stack is a permanent peer to
+ * platform infrastructure — not subject to the M7 platform restructuring.
+ *
+ * First consumer: M6 #176 (budget-migrate Lambda relocation).
+ */
+export class MigrationsApiStack extends cdk.Stack {
+  /** The /api/migrations resource — downstream stacks mount app-specific routes here. */
+  public readonly migrationsResource: apigateway.Resource;
+
+  constructor(scope: Construct, id: string, props: MigrationsApiStackProps) {
+    super(scope, id, props);
+
+    const { apiResource } = props;
+
+    // Consistent with StockAnalyserApiStack and BudgetTrackerApiStack:
+    // addResource() scopes the construct to the parent resource (a
+    // PlatformApiStack construct), so the AWS::ApiGateway::Resource
+    // for /api/migrations lives in PlatformApiStack's CFN template.
+    // Using new apigateway.Resource(this, ...) instead would scope it
+    // to MigrationsApiStack, causing a CDK dependency cycle between
+    // PlatformApiStack's Deployment and this stack.
+    this.migrationsResource = apiResource.addResource('migrations');
+
+    cdk.Tags.of(this).add('app', 'migration-utilities');
+    cdk.Tags.of(this).add('environment', props.stage);
+  }
+}

--- a/migration-utilities/infrastructure/package.json
+++ b/migration-utilities/infrastructure/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@transformotion/migration-utilities-infrastructure",
+  "version": "0.1.0",
+  "private": true,
+  "description": "CDK stacks for the migration-utilities namespace",
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "lint": "echo \"lint: migration-utilities-infrastructure\""
+  },
+  "dependencies": {
+    "aws-cdk-lib": "^2.100.0",
+    "constructs": "^10.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.4.0"
+  }
+}

--- a/migration-utilities/infrastructure/tsconfig.json
+++ b/migration-utilities/infrastructure/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "lib": ["ES2022"]
+  },
+  "include": ["lib/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -885,6 +885,22 @@ importers:
         specifier: ^5.4.0
         version: 5.7.3
 
+  migration-utilities/infrastructure:
+    dependencies:
+      aws-cdk-lib:
+        specifier: ^2.100.0
+        version: 2.250.0(constructs@10.6.0)
+      constructs:
+        specifier: ^10.0.0
+        version: 10.6.0
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.17
+      typescript:
+        specifier: ^5.4.0
+        version: 5.7.3
+
   packages/api-client:
     devDependencies:
       typescript:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,3 +7,5 @@ packages:
   - 'functions/*'
   - 'functions/auth/*'
   - 'infrastructure'
+  - 'migration-utilities/infrastructure'
+  - 'migration-utilities/**'


### PR DESCRIPTION
## What this PR does

Closes #175 — creates the `migration-utilities/` repo category and supporting infrastructure per CONTRIBUTING.md Section 6.

## Scope

- `migration-utilities/` directory at repo root, peer to `apps/`, `packages/`, `platform/`
- `migration-utilities/infrastructure/` with skeleton `MigrationsApiStack` (no routes yet — #176 mounts first route)
- `migration-utilities/infrastructure/package.json` + `tsconfig.json` (workspace member `@transformotion/migration-utilities-infrastructure`)
- `infrastructure/bin/app.ts` — import + dev and prod `MigrationsApiStack` instantiations
- `infrastructure/tsconfig.json` — `rootDir` removed; migration-utilities path added to `include` (enables cross-directory import from `infrastructure/bin/app.ts`)
- `pnpm-workspace.yaml` — two new globs: `migration-utilities/infrastructure` and `migration-utilities/**`
- `.github/workflows/deploy-migration-utilities.yml` — CDK-only deploy workflow (no frontend build, no S3/CloudFront); matches `deploy-stock-analyser.yml` conventions exactly
- `.github/workflows/ci.yml` — adds `TransformotionDev-MigrationsApi` synth step
- `MONOREPO.md` — structure tree, workflow listing, workspace config section, deploy table, M7 permanence note

## Out of scope

- Lambda relocation — #176
- Endpoint registrations — start in #176
- `authMethodOptions` extraction — deferred (existing duplication between SA/BT stacks remains; M7 territory)

## CDK design note

Consistent with `StockAnalyserApiStack` and `BudgetTrackerApiStack`, `MigrationsApiStack` calls `apiResource.addResource('migrations')` to establish the namespace. This means the `AWS::ApiGateway::Resource` for `/api/migrations` lives in `PlatformApiStack`'s CFN template — the same pattern used by all app stacks. Using `new apigateway.Resource(this, ...)` scoped to `MigrationsApiStack` instead causes a CDK dependency cycle between `PlatformApiStack`'s Deployment and `MigrationsApiStack` (CDK automatically adds the Deployment dependency on the new resource, which cycles back through the stack dependency on `PlatformApiStack`). The resource appears on the gateway after `PlatformApiStack` is redeployed.

## Verification

- TypeScript compilation passes (both `infrastructure` and `migration-utilities/infrastructure` workspaces)
- CDK synth passes: `TransformotionDev-MigrationsApi` synthesises cleanly; existing stacks unchanged
- Lint passes — no new violations
- Manual deploy: `TransformotionDev-MigrationsApi` → `CREATE_COMPLETE`; `TransformotionDev-Api` redeployed → `UPDATE_COMPLETE`
- Gateway verified: `/api/migrations` resource `e0havk` visible on `yqtrjzrnp3`

## Cross-references

- CONTRIBUTING.md Section 6 — utility categories pattern (the canonical structure this PR conforms to)
- M2.1 #107 — original migration-utilities decision
- M6 #176 — the next consumer of this namespace (budget-migrate Lambda relocation)