### PR TITLE
M6 #176: Relocate budget-migrate Lambda to migration-utilities

### DIFF
--- a/apps/budget-tracker/CLAUDE.md
+++ b/apps/budget-tracker/CLAUDE.md
@@ -53,7 +53,6 @@ Source: `infrastructure/lib/budget-tracker/`
 | `budget-ai-review-handler-{stage}` | `POST /api/budget/v1/ai/review` |
 | `budget-ai-csv-analysis-handler-{stage}` | `POST /api/budget/v1/ai/csv-analysis` |
 | `budget-export-handler-{stage}` | `GET /api/budget/v1/business-export` |
-| `budget-migrate-handler-{stage}` | `POST /api/budget/v1/migrate-from-localstorage` |
 
 ## DynamoDB tables
 

--- a/apps/budget-tracker/contracts/api-endpoints.md
+++ b/apps/budget-tracker/contracts/api-endpoints.md
@@ -240,8 +240,10 @@ Only transactions with `_business: true` are included.
 
 ## Migration
 
-### `POST /api/budget/migrate-from-localstorage`
+### `POST /api/migrations/budget-tracker/transactions/import`
 One-click migration from browser localStorage to backend. Called once per account when a user first logs in with local data present.
+
+This endpoint lives in the `migration-utilities` namespace (stack: `Transformotion{Stage}-MigrationsApi`), not under `/api/budget/v1`. See `migration-utilities/budget-tracker/transactions/` for the Lambda source.
 
 **Request:**
 ```typescript

--- a/apps/budget-tracker/contracts/aws-infrastructure.md
+++ b/apps/budget-tracker/contracts/aws-infrastructure.md
@@ -150,11 +150,13 @@ Streams CSV directly from DynamoDB Query results.
 IAM permissions:
 - `dynamodb:Query` on `budget-tracker.transactions`
 
-### `budget-migrate-handler`
+### `migration-budget-tracker-transactions`
 
-Handles: `POST /migrate-from-localstorage`
+Handles: `POST /api/migrations/budget-tracker/transactions/import`
 
 Idempotent bulk import. Uses composite key `{date, amount, description, file}` to deduplicate.
+
+Lives in `migration-utilities/budget-tracker/transactions/` and is deployed by `Transformotion{Stage}-MigrationsApi` (not BudgetTrackerApi).
 
 IAM permissions:
 - `dynamodb:BatchWriteItem`, `dynamodb:Query`, `dynamodb:PutItem` on all `budget-tracker.*` tables

--- a/apps/budget-tracker/contracts/state-management.md
+++ b/apps/budget-tracker/contracts/state-management.md
@@ -78,7 +78,8 @@ interface BudgetRepository {
   // Business export
   generateBusinessExportCsv(filters?: { from?: string; to?: string }): Promise<Blob>;
 
-  // Migration
+  // Migration — calls POST /api/migrations/budget-tracker/transactions/import
+  // (MigrationsApi stack, not BudgetTrackerApi). UI adaptor update tracked in #180.
   migrateFromLocalStorage(data: {
     transactions: Transaction[];
     rules: CustomRule[];

--- a/infrastructure/lib/budget-tracker/budget-tracker-api-stack.ts
+++ b/infrastructure/lib/budget-tracker/budget-tracker-api-stack.ts
@@ -35,7 +35,6 @@ export interface BudgetTrackerApiStackProps extends cdk.StackProps {
  *   POST   /ai/review
  *   POST   /ai/csv-analysis
  *   GET    /business-export
- *   POST   /migrate-from-localstorage
  */
 export class BudgetTrackerApiStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props: BudgetTrackerApiStackProps) {
@@ -138,25 +137,6 @@ export class BudgetTrackerApiStack extends cdk.Stack {
     });
     txTable.grantReadData(exportFn);
 
-    // ── budget-migrate-handler ────────────────────────────────────────────────
-    const migrateFn = new lambdaNodejs.NodejsFunction(this, 'MigrateFn', {
-      functionName: `budget-migrate-handler-${stage}`,
-      entry:        path.join(fnDir, 'budget-migrate/src/index.ts'),
-      handler:      'handler',
-      runtime:      lambda.Runtime.NODEJS_20_X,
-      timeout:      cdk.Duration.seconds(120),
-      memorySize:   512,
-      environment: {
-        TRANSACTIONS_TABLE: txTable.tableName,
-        RULES_TABLE:        rulesTable.tableName,
-        SETTINGS_TABLE:     settingsTable.tableName,
-      },
-      bundling,
-    });
-    txTable.grantReadWriteData(migrateFn);
-    rulesTable.grantReadWriteData(migrateFn);
-    settingsTable.grantReadWriteData(migrateFn);
-
     // ── API routes ────────────────────────────────────────────────────────────
     // /transactions
     const txRes     = apiResource.addResource('transactions');
@@ -193,11 +173,6 @@ export class BudgetTrackerApiStack extends cdk.Stack {
     // /business-export
     apiResource.addResource('business-export').addMethod(
       'GET', new apigateway.LambdaIntegration(exportFn, { proxy: true }), auth
-    );
-
-    // /migrate-from-localstorage
-    apiResource.addResource('migrate-from-localstorage').addMethod(
-      'POST', new apigateway.LambdaIntegration(migrateFn, { proxy: true }), auth
     );
 
   }

--- a/migration-utilities/budget-tracker/transactions/package.json
+++ b/migration-utilities/budget-tracker/transactions/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "@transformotion/fn-budget-migrate",
+  "name": "@transformotion/fn-migration-budget-tracker-transactions",
   "version": "0.0.0",
   "private": true,
   "main": "./src/index.ts",
   "scripts": {
     "build": "tsc --noEmit",
     "typecheck": "tsc --noEmit",
-    "lint": "echo \"lint: budget-migrate\""
+    "lint": "echo \"lint: fn-migration-budget-tracker-transactions\""
   },
   "dependencies": {
     "@transformotion/budget-domain": "workspace:*",
@@ -15,7 +15,6 @@
   "devDependencies": {
     "@aws-sdk/client-dynamodb": "^3",
     "@aws-sdk/lib-dynamodb": "^3",
-    "@aws-sdk/client-lambda": "^3",
     "@types/aws-lambda": "^8",
     "@types/node": "^22",
     "typescript": "*"

--- a/migration-utilities/budget-tracker/transactions/src/index.ts
+++ b/migration-utilities/budget-tracker/transactions/src/index.ts
@@ -66,7 +66,7 @@ async function batchWrite(table: string, items: Record<string, unknown>[]) {
   }
 }
 
-// POST /api/budget/v1/migrate-from-localstorage
+// POST /api/migrations/budget-tracker/transactions/import
 export const handler = withAuth(async ({ auth, account, event }) => {
   requireAppAccess(auth, 'budget-tracker');
   requireAccountAccess(auth, 'budget-tracker', account.accountId);

--- a/migration-utilities/budget-tracker/transactions/tsconfig.json
+++ b/migration-utilities/budget-tracker/transactions/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../../../tsconfig.json",
+  "extends": "../../../tsconfig.json",
   "compilerOptions": {
     "outDir": "dist",
     "rootDir": "src",

--- a/migration-utilities/infrastructure/lib/migrations-api-stack.ts
+++ b/migration-utilities/infrastructure/lib/migrations-api-stack.ts
@@ -1,5 +1,9 @@
+import * as path from 'path';
 import * as cdk from 'aws-cdk-lib';
 import * as apigateway from 'aws-cdk-lib/aws-apigateway';
+import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import * as lambdaNodejs from 'aws-cdk-lib/aws-lambda-nodejs';
 import { Construct } from 'constructs';
 
 export interface MigrationsApiStackProps extends cdk.StackProps {
@@ -29,7 +33,7 @@ export class MigrationsApiStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props: MigrationsApiStackProps) {
     super(scope, id, props);
 
-    const { apiResource } = props;
+    const { stage, apiResource, authoriser } = props;
 
     // Consistent with StockAnalyserApiStack and BudgetTrackerApiStack:
     // addResource() scopes the construct to the parent resource (a
@@ -41,6 +45,81 @@ export class MigrationsApiStack extends cdk.Stack {
     this.migrationsResource = apiResource.addResource('migrations');
 
     cdk.Tags.of(this).add('app', 'migration-utilities');
-    cdk.Tags.of(this).add('environment', props.stage);
+    cdk.Tags.of(this).add('environment', stage);
+
+    const auth = authMethodOptions(authoriser);
+
+    const bundling: lambdaNodejs.BundlingOptions = {
+      externalModules: ['@aws-sdk/*'],
+      minify: true,
+      sourceMap: false,
+      forceDockerBundling: false,
+    };
+
+    // ── budget-tracker tables (imported by name) ──────────────────────────────
+    const txTable = dynamodb.Table.fromTableName(
+      this, 'BudgetTrackerTxTable', `budget-tracker.transactions-${stage}`,
+    );
+    const rulesTable = dynamodb.Table.fromTableName(
+      this, 'BudgetTrackerRulesTable', `budget-tracker.rules-${stage}`,
+    );
+    const settingsTable = dynamodb.Table.fromTableName(
+      this, 'BudgetTrackerSettingsTable', `budget-tracker.settings-${stage}`,
+    );
+
+    // ── migration-budget-tracker-transactions Lambda ───────────────────────────
+    const fnDir = path.join(__dirname, '..', '..', 'budget-tracker');
+
+    const transactionsMigrateFn = new lambdaNodejs.NodejsFunction(this, 'BudgetTrackerTransactionsMigrateFn', {
+      functionName: `migration-budget-tracker-transactions-${stage}`,
+      entry:        path.join(fnDir, 'transactions/src/index.ts'),
+      handler:      'handler',
+      runtime:      lambda.Runtime.NODEJS_20_X,
+      timeout:      cdk.Duration.seconds(120),
+      memorySize:   512,
+      environment: {
+        TRANSACTIONS_TABLE: txTable.tableName,
+        RULES_TABLE:        rulesTable.tableName,
+        SETTINGS_TABLE:     settingsTable.tableName,
+      },
+      bundling,
+    });
+
+    txTable.grantReadWriteData(transactionsMigrateFn);
+    rulesTable.grantReadWriteData(transactionsMigrateFn);
+    settingsTable.grantReadWriteData(transactionsMigrateFn);
+
+    // ── POST /api/migrations/budget-tracker/transactions/import ───────────────
+    const budgetTrackerMigrations = this.migrationsResource.addResource('budget-tracker');
+    const transactionsMigrations  = budgetTrackerMigrations.addResource('transactions');
+    transactionsMigrations.addResource('import').addMethod(
+      'POST',
+      new apigateway.LambdaIntegration(transactionsMigrateFn, { proxy: true }),
+      auth,
+    );
   }
+}
+
+function authMethodOptions(
+  authoriser: apigateway.CognitoUserPoolsAuthorizer,
+): apigateway.MethodOptions {
+  return {
+    authorizer:        authoriser,
+    authorizationType: apigateway.AuthorizationType.COGNITO,
+    methodResponses: [
+      {
+        statusCode: '200',
+        responseParameters: {
+          'method.response.header.Access-Control-Allow-Origin':  true,
+          'method.response.header.Access-Control-Allow-Headers': true,
+        },
+      },
+      { statusCode: '400' },
+      { statusCode: '401' },
+      { statusCode: '403' },
+      { statusCode: '429' },
+      { statusCode: '500' },
+      { statusCode: '502' },
+    ],
+  };
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -273,34 +273,6 @@ importers:
         specifier: '*'
         version: 5.7.3
 
-  apps/budget-tracker/functions/budget-migrate:
-    dependencies:
-      '@transformotion/budget-domain':
-        specifier: workspace:*
-        version: link:../../../../packages/budget-domain
-      '@transformotion/lambda-middleware':
-        specifier: workspace:*
-        version: link:../../../../packages/lambda-middleware
-    devDependencies:
-      '@aws-sdk/client-dynamodb':
-        specifier: ^3
-        version: 3.1032.0
-      '@aws-sdk/client-lambda':
-        specifier: ^3
-        version: 3.1032.0
-      '@aws-sdk/lib-dynamodb':
-        specifier: ^3
-        version: 3.1032.0(@aws-sdk/client-dynamodb@3.1032.0)
-      '@types/aws-lambda':
-        specifier: ^8
-        version: 8.10.161
-      '@types/node':
-        specifier: ^22
-        version: 22.19.17
-      typescript:
-        specifier: '*'
-        version: 5.7.3
-
   apps/budget-tracker/functions/budget-rules:
     dependencies:
       '@transformotion/budget-domain':
@@ -883,6 +855,31 @@ importers:
         version: 10.9.2(@types/node@22.19.17)(typescript@5.7.3)
       typescript:
         specifier: ^5.4.0
+        version: 5.7.3
+
+  migration-utilities/budget-tracker/transactions:
+    dependencies:
+      '@transformotion/budget-domain':
+        specifier: workspace:*
+        version: link:../../../packages/budget-domain
+      '@transformotion/lambda-middleware':
+        specifier: workspace:*
+        version: link:../../../packages/lambda-middleware
+    devDependencies:
+      '@aws-sdk/client-dynamodb':
+        specifier: ^3
+        version: 3.1032.0
+      '@aws-sdk/lib-dynamodb':
+        specifier: ^3
+        version: 3.1032.0(@aws-sdk/client-dynamodb@3.1032.0)
+      '@types/aws-lambda':
+        specifier: ^8
+        version: 8.10.161
+      '@types/node':
+        specifier: ^22
+        version: 22.19.17
+      typescript:
+        specifier: '*'
         version: 5.7.3
 
   migration-utilities/infrastructure:


### PR DESCRIPTION
## Summary

- Moves `budget-migrate` Lambda source from `apps/budget-tracker/functions/budget-migrate/` to `migration-utilities/budget-tracker/transactions/`
- Removes `budget-migrate-handler-{stage}` from `BudgetTrackerApiStack`; adds `migration-budget-tracker-transactions-{stage}` to `MigrationsApiStack`
- Route moves from `POST /api/budget/v1/migrate-from-localstorage` → `POST /api/migrations/budget-tracker/transactions/import`
- Updates contracts (`api-endpoints.md`, `aws-infrastructure.md`, `state-management.md`) and `apps/budget-tracker/CLAUDE.md` to reflect new function name, stack, and URL

## Deploy notes

Three stacks deployed to dev in order: MigrationsApi (new Lambda) → Api --exclusively (drops old route, adds new) → BudgetTrackerApi (deletes old Lambda). This deploy order is required because of CloudFormation cross-stack export dependency; documented in the PR commit message.

## Test plan

- [x] `pnpm turbo typecheck` — 31/31 pass
- [x] `npx cdk synth` — clean for all three stacks
- [x] AWS: `migration-budget-tracker-transactions-dev` Lambda exists (nodejs20.x, 120s, 512MB)
- [x] AWS: `budget-migrate-handler-dev` Lambda deleted (ResourceNotFoundException confirmed)
- [x] AWS API Gateway: `/api/migrations/budget-tracker/transactions/import` route present
- [x] AWS API Gateway: `/api/budget/v1/migrate-from-localstorage` route absent

Closes #176

🤖 Generated with [Claude Code](https://claude.com/claude-code)