### PR TITLE
M6 #154 follow-up: CloudFront routing for /budget-tracker/*

### DIFF
--- a/infrastructure/lib/platform/network-stack.ts
+++ b/infrastructure/lib/platform/network-stack.ts
@@ -59,6 +59,25 @@ export class NetworkStack extends cdk.Stack {
       ? acm.Certificate.fromCertificateArn(this, 'Certificate', certificateArn)
       : undefined;
 
+    // ── CloudFront Function — sub-app index rewrite ───────────────────────
+    // S3 OAC REST API returns 403 for trailing-slash keys (e.g. /budget-tracker/)
+    // because there is no object at that key — only at /budget-tracker/index.html.
+    // Without this rewrite those requests fall through to the default SPA
+    // fallback (403 → /index.html), which serves the stock-analyser root instead.
+    const subAppIndexRewrite = new cloudfront.Function(this, 'SubAppIndexRewrite', {
+      code: cloudfront.FunctionCode.fromInline(`
+        function handler(event) {
+          var request = event.request;
+          if (request.uri.endsWith('/')) {
+            request.uri += 'index.html';
+          }
+          return request;
+        }
+      `),
+      comment: 'Rewrite sub-app directory requests to index.html (e.g. /budget-tracker/ → /budget-tracker/index.html)',
+      runtime: cloudfront.FunctionRuntime.JS_2_0,
+    });
+
     // ── CloudFront distribution ────────────────────────────────────────────
     this.distribution = new cloudfront.Distribution(this, 'WebDistribution', {
       defaultBehavior: {
@@ -66,6 +85,18 @@ export class NetworkStack extends cdk.Stack {
         viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
         cachePolicy: cloudfront.CachePolicy.CACHING_OPTIMIZED,
         compress: true,
+      },
+      additionalBehaviors: {
+        '/budget-tracker/*': {
+          origin: origins.S3BucketOrigin.withOriginAccessControl(this.bucket),
+          viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
+          cachePolicy: cloudfront.CachePolicy.CACHING_OPTIMIZED,
+          compress: true,
+          functionAssociations: [{
+            function: subAppIndexRewrite,
+            eventType: cloudfront.FunctionEventType.VIEWER_REQUEST,
+          }],
+        },
       },
       defaultRootObject: 'index.html',
       errorResponses: [


### PR DESCRIPTION
## Summary

- Adds `SubAppIndexRewrite` CloudFront Function (JS_2.0, VIEWER_REQUEST) that rewrites trailing-slash URIs to append `index.html` (e.g. `/budget-tracker/` → `/budget-tracker/index.html`)
- Adds `/budget-tracker/*` cache behaviour in `NetworkStack` with the function wired to VIEWER_REQUEST
- Zero change to the default behaviour — stock-analyser SPA routing is unaffected

**Root cause of the verify-deploy failure in #193:**
S3 OAC (REST API mode) returns 403 for `/budget-tracker/` because there is no S3 object at that key (only at `/budget-tracker/index.html`). The existing 403→`/index.html` SPA fallback fires, serving the stock-analyser root `index.html` instead of the budget-tracker app. The additional CloudFront behaviour with the URI rewrite intercepts `/budget-tracker/*` requests before they hit S3, converting trailing-slash requests to the real object key.

**CDK diff (additions only):**
- `[+]` `AWS::CloudFront::Function SubAppIndexRewrite`
- `[+]` `AWS::CloudFront::OriginAccessControl` for the second origin
- `[~]` Distribution: `CacheBehaviors` added, `Origins` extended — no replacements

## Test plan

- [ ] CI green
- [ ] `pnpm exec cdk deploy TransformotionDev-Network` (manual post-merge)
- [ ] Wait ~5 min CloudFront propagation
- [ ] `curl -sI https://dev.apps.transformotion.com.au/budget-tracker/` returns 200 with budget-tracker HTML (not stock-analyser)
- [ ] Cognito sign-in flow completes for budget-tracker
- [ ] Stock-analyser still loads at `/` and `/stock-analyser/` (regression check)

Closes #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)