### PR TITLE
docs: canonical sub-app structure (urls-and-deploy, inventory, M7)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -670,6 +670,33 @@ deduplication of duplicated runtime code.
   migrations touch this document in the same PR.
 - The `apps/web/` 0-LOC shell cleanup (if not done in M3) folded in
   here.
+- Stock-analyser migrated from S3 root to `/stock-signal/` prefix:
+  - `apps/stock-analyser/next.config.mjs` gains `basePath: '/stock-signal'`
+    (`output: 'export'` already present)
+  - `deploy-stock-analyser.yml` syncs to `s3://transformotion-web-{stage}-{account}/stock-signal/`
+    (not bucket root; `--delete` scoped to prefix only)
+  - New `additionalBehaviors` entry for `/stock-signal/*` in `NetworkStack`
+    with `SubAppIndexRewrite` function (function established by M6 #154 PR #194)
+  - CDK deploy of `TransformotionDev-Network` / `TransformotionProd-Network`
+    to activate the behavior
+  - Stock-analyser sign-in, launchpad tile, and budget-tracker tile URLs
+    verified post-migration
+- Launchpad promoted to root deployment:
+  - `apps/launchpad/next.config.mjs` gains `output: 'export'` and
+    `trailingSlash: true` (currently not static-export-ready)
+  - New deploy workflow `deploy-launchpad.yml` mirroring
+    `deploy-stock-analyser.yml`'s pattern but syncing to S3 root
+    (`--exclude "stock-signal/*" --exclude "budget-tracker/*"`)
+  - Default CloudFront behavior verified to serve launchpad correctly
+    (root `index.html` resolves directly; no `SubAppIndexRewrite` needed)
+  - Atomic swap concern: stock-analyser must be moved off root in the same
+    milestone window; CloudFront cache invalidation for `/*` required at
+    swap time to flush stale stock-analyser content from edge nodes
+- Cross-cutting deployment verification for all migrated apps:
+  - Smoke check per app post-deploy: `data-commit` hash matches the
+    deploying commit; sign-in completes; repository operations succeed
+  - CloudFront cache invalidation strategy confirmed (stale cached content
+    flushed when root occupant changes)
 
 ### Goals served
 
@@ -686,7 +713,11 @@ Lint re-enabled and passing. Cross-app file copies caught at CI. Per-app
 infrastructure split into the canonical structure. All non-conforming
 data-access code migrated to layered architecture (Position A). Domain
 interfaces in contracts; implementations named for physical store. Two
-table renames complete (analysis-cache, rate-limits).
+table renames complete (analysis-cache, rate-limits). Each app deployed
+at its canonical S3 prefix per `docs/architecture/urls-and-deploy.md`
+target layout. No app served via the SPA fallback (every path resolves
+to its intended app via an explicit CloudFront behavior or the root
+default).
 
 ### Dependencies
 

--- a/docs/architecture/inventory.md
+++ b/docs/architecture/inventory.md
@@ -969,6 +969,22 @@ There is no shared CDK construct library at `packages/cdk-constructs/`.
 Each new Lambda or table reimplements boilerplate. M7 populates
 `packages/cdk-constructs/` as part of deduplication.
 
+**CloudFront behaviors and S3 prefix occupancy — current state (post M6 #154 PR #194):**
+
+The `NetworkStack` CloudFront distribution currently has two configured behaviors:
+
+| Behavior pattern | Origin | Function | Status |
+|---|---|---|---|
+| Default (`*`) | S3 root | None | Serves stock-analyser (transitional; canonical target: launchpad) |
+| `/budget-tracker/*` | S3 `budget-tracker/` prefix | `SubAppIndexRewrite` | Implemented (M6 #154 PR #194) |
+
+Remaining behaviors not yet implemented (M7 scope):
+
+- `/stock-signal/*` — requires stock-analyser to gain `basePath: '/stock-signal'` in `next.config.mjs`, deploy workflow updated to sync to `stock-signal/` prefix, and a new `additionalBehaviors` entry with `SubAppIndexRewrite`
+- Launchpad at root — requires launchpad to gain `output: 'export'`, a new deploy workflow, and stock-analyser to have vacated root first; no `SubAppIndexRewrite` needed since launchpad will be the root occupant
+
+Current S3 bucket root occupant is stock-analyser (transitional; should be launchpad per target architecture). The SPA fallback (403/404 → `/index.html`) compensates but creates the routing failure that PR #194 fixed for budget-tracker. M7 closes the gap by completing the extractions.
+
 ### 5.7 Environment variables
 
 **Status: Confirmed (verified during initial inventory)**

--- a/docs/architecture/urls-and-deploy.md
+++ b/docs/architecture/urls-and-deploy.md
@@ -83,9 +83,32 @@ Single distribution (`TransformotionDev-Network` / `TransformotionProd-Network`)
 - **Caching:** `CachingOptimized` policy (default behavior)
 - **Compression:** enabled
 
-> **Current limitation:** The CloudFront distribution has a single default behavior with no path-based behaviors. The 403/404 error fallback serves `/index.html` (the launchpad). This means direct navigation to `/stock-signal/some-route` will correctly load the stock-analyser SPA at `/stock-signal/index.html` only if the error response for 403 is updated to be path-aware, OR if S3 serves the correct `index.html` for the path prefix.
->
-> The target architecture has path-based CloudFront behaviors routing `/stock-signal/*` and `/budget-tracker/*` to their respective S3 path prefixes with per-prefix SPA fallbacks. This CDK change is part of sub-phase 7b/7g.
+### Sub-app index rewrite pattern
+
+Sub-apps deployed to nested S3 prefixes (e.g. `/budget-tracker/*` → `s3://bucket/budget-tracker/*`) hit a routing failure at the CloudFront/S3 boundary: a request for `/budget-tracker/` asks S3 for the object key `budget-tracker/` (with trailing slash). S3's OAC REST API returns 403 for this key (no object exists at that key), triggering the default behavior's SPA fallback to the root `/index.html`.
+
+The fix is a CloudFront Function (`SubAppIndexRewrite`) attached to each sub-app cache behavior on the `VIEWER_REQUEST` event. The function rewrites directory requests to append `index.html` before they reach S3:
+
+```javascript
+function handler(event) {
+  var request = event.request;
+  if (request.uri.endsWith('/')) {
+    request.uri += 'index.html';
+  }
+  return request;
+}
+```
+
+The function is path-agnostic and shared by every sub-app behavior. Each sub-app adds an `additionalBehaviors` entry in `NetworkStack` referencing the same function instance. Implemented for `/budget-tracker/*` in M6 #154 (PR #194). The same pattern applies to `/stock-signal/*` when the stock-analyser extraction lands (M7).
+
+### Current state
+
+The `/budget-tracker/*` cache behavior with `SubAppIndexRewrite` was implemented in M6 #154 (PR #194). Remaining extractions:
+
+- **stock-analyser:** currently serves from S3 root; needs `basePath: '/stock-signal'` in `next.config.mjs`, deploy workflow updated to sync to the `stock-signal/` prefix, and a new `/stock-signal/*` behavior (M7 scope)
+- **launchpad:** not yet static-export-ready (`output: 'export'` not set); will be promoted to S3 root once stock-analyser moves off root (M7 scope); no `SubAppIndexRewrite` needed since it will be the root occupant
+
+Until M7 completes the remaining extractions, the SPA fallback (403/404 → `/index.html`) returns stock-analyser content for any path not handled by an explicit behavior. This is acceptable transitional behaviour: stock-analyser routes continue to work via the fallback, and budget-tracker routes are now handled by the explicit behavior.
 
 ---
 
@@ -148,7 +171,7 @@ The deploy verification script (`scripts/ci/verify-deploy.sh`) checks that the c
 | `transformotion-api-{stage}` | Platform + Stock Analyser routes | `TransformotionDev-Api` stack output |
 | `budget-tracker-api-{stage}` | Budget Tracker routes (own gateway) | `TransformotionDev-BudgetTrackerApi` stack output |
 
-> The Budget Tracker has its own API Gateway rather than sharing the platform gateway. This is a known architectural divergence (tracked in the Stabilisation backlog as sub-phase 7f). The separate gateway is functional; consolidation is optional.
+> The Budget Tracker has its own API Gateway rather than sharing the platform gateway. This is a known architectural divergence (tracked as M5 in PLAN.md). The separate gateway is functional; consolidation is optional.
 
 ---
 


### PR DESCRIPTION
## What this PR does

Captures architectural target state and current gap surfaced by M6 #154's CloudFront routing work (PR #194). Three documentation updates across `docs/architecture/` and `PLAN.md`.

### Scope

**`docs/architecture/urls-and-deploy.md`:**
- New subsection documenting the `SubAppIndexRewrite` CloudFront Function pattern (why S3 OAC returns 403 for trailing-slash keys; how the function fixes it; which apps need it)
- Updated "Current limitation" → "Current state" reflecting PR #194's partial implementation and naming remaining work as M7 scope
- Removed dangling "sub-phase 7b" and "sub-phase 7g" labels (vestigial; don't appear in current PLAN.md)
- Fixed "sub-phase 7f" → "M5" in the API Gateway section

**`docs/architecture/inventory.md`:**
- New CloudFront behaviors table within §5.6 (CDK stack topology): current behaviors (default + `/budget-tracker/*`) vs target state
- Documents stock-analyser-at-root as transitional, remaining extractions as M7 scope

**`PLAN.md` M7:**
- Added stock-analyser-from-root migration as an explicit M7 outcome (basePath, S3 sync target, CF behavior, CDK deploy)
- Added launchpad-to-root promotion as an explicit M7 outcome (static-export readiness, deploy workflow, atomic swap)
- Added cross-cutting deployment verification outcome
- Extended M7 Gate: "each app deployed at canonical S3 prefix; no app served via SPA fallback alone"

### Why this PR exists

PR #194 surfaced two gaps:
1. The `SubAppIndexRewrite` CloudFront pattern was undocumented despite being canonical for all sub-apps
2. The remaining sub-app extractions (stock-analyser-from-root, launchpad-to-root) weren't tracked anywhere — they belong in M7's canonical-structure scope but were missing from the outcomes list

### No code changes

Pure documentation. No CI implications beyond Markdown linting.

### Cross-references

- M6 #154 (PR #194) — established the `SubAppIndexRewrite` pattern
- M7 — host milestone for the captured extension work

🤖 Generated with [Claude Code](https://claude.com/claude-code)