### PR TITLE
M6 #155: launchpad tile navigates to deployed budget-tracker

### DIFF
--- a/apps/stock-analyser/app/launchpad/page.tsx
+++ b/apps/stock-analyser/app/launchpad/page.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "next/navigation"
 import { Launchpad } from "@/components/launchpad/launchpad"
 import { AuthGuard } from "@/components/providers/auth-guard"
 import { useAuthStore } from "@/stores/auth/use-auth-store"
+import { getConfig } from "@/lib/config"
 
 function LaunchpadContent() {
   const router = useRouter()
@@ -14,7 +15,7 @@ function LaunchpadContent() {
   }
 
   const handleLaunchBudgetTracker = () => {
-    router.push("/budget-tracker")
+    window.location.assign(getConfig().apps.budgetTrackerUrl)
   }
 
   const handleSignOut = async () => {

--- a/apps/stock-analyser/components/launchpad/launchpad.tsx
+++ b/apps/stock-analyser/components/launchpad/launchpad.tsx
@@ -65,7 +65,7 @@ const APPS: App[] = [
     name: "Budget Tracker",
     description: "Track income, expenses and savings across accounts",
     icon: Wallet,
-    available: false,
+    available: true,
     color: "text-signal-green",
     bgGradient: "from-signal-green/20 via-signal-green/5 to-transparent",
   },

--- a/apps/stock-analyser/lib/config/index.ts
+++ b/apps/stock-analyser/lib/config/index.ts
@@ -55,6 +55,11 @@ export interface FeaturesConfig {
   debugMode: boolean
 }
 
+export interface AppsConfig {
+  /** URL for the Budget Tracker app (cross-app navigation requires full page load) */
+  budgetTrackerUrl: string
+}
+
 export interface AppConfig {
   api: APIConfig
   auth: AuthConfig
@@ -63,6 +68,7 @@ export interface AppConfig {
   logging: LoggingConfig
   claude: ClaudeConfig
   features: FeaturesConfig
+  apps: AppsConfig
 }
 
 /**
@@ -112,6 +118,9 @@ export function loadConfig(): AppConfig {
     features: {
       useMockData: process.env.NEXT_PUBLIC_USE_MOCK_DATA !== 'false', // Default to true for dev
       debugMode: process.env.NEXT_PUBLIC_DEBUG_MODE === 'true',
+    },
+    apps: {
+      budgetTrackerUrl: process.env.NEXT_PUBLIC_BUDGET_URL || '/budget-tracker/',
     },
   }
 }


### PR DESCRIPTION
## What this PR does

Closes #155. PR #193 added `NEXT_PUBLIC_BUDGET_URL` to the deploy workflow but didn't consume it; the launchpad tile still showed 'Coming Soon' (hardcoded `available: false`) and would have routed via SPA-internal `router.push` if enabled. This PR completes the actual #155 outcome.

### Three changes

- **`lib/config/index.ts`** — new `AppsConfig` interface + `apps.budgetTrackerUrl` field wired from `NEXT_PUBLIC_BUDGET_URL` (falls back to `'/budget-tracker/'`)
- **`components/launchpad/launchpad.tsx`** — flip `available: false` → `available: true` for budget-tracker in the `APPS` constant
- **`app/launchpad/page.tsx`** — budget-tracker tile uses `window.location.assign(getConfig().apps.budgetTrackerUrl)` for cross-app navigation; stock-signal keeps `router.push` since it's an internal SPA route

### Why `window.location.assign` not `router.push`

`router.push("/budget-tracker")` does client-side SPA navigation within the stock-analyser app. The stock-analyser has no `/budget-tracker` route (deleted in M5 PR #174). A full HTTP request is required so CloudFront can route to the `/budget-tracker/*` behavior and serve the budget-tracker `index.html`. `window.location.assign` triggers that full request.

### Why this isn't M9 territory

M9 (sub-phase 7e-launchpad-tiles) replaces the hardcoded `available` flag with claim-based rendering using the `apps` JWT claim. This PR does the minimal fix to deliver #155's outcome; M9 does the architectural fix later.

### Verification

- Build: clean (`pnpm --filter @transformotion/stock-analyser build`)
- TypeScript: clean (`tsc --noEmit`)
- Pre-commit hooks: pass

### Post-merge

- Stock-analyser auto-redeploys via path filter (`apps/stock-analyser/**`)
- Verify tile state on deployed launchpad: 'Coming Soon' → active
- Verify tile click lands at `https://dev.apps.transformotion.com.au/budget-tracker/`

### Cross-references

- M6 #154 (PR #194) — deployed budget-tracker that this tile now points to
- M9 — claim-based tile rendering (architectural fix; future)

🤖 Generated with [Claude Code](https://claude.com/claude-code)