### PR TITLE
fix: exclude budget-tracker prefix from stock-analyser S3 sync

### DIFF
--- a/.github/workflows/deploy-stock-analyser.yml
+++ b/.github/workflows/deploy-stock-analyser.yml
@@ -80,7 +80,7 @@ jobs:
         run: pnpm build
 
       - name: Deploy to S3
-        run: aws s3 sync apps/stock-analyser/out s3://transformotion-web-dev-959516291617 --delete
+        run: aws s3 sync apps/stock-analyser/out s3://transformotion-web-dev-959516291617 --delete --exclude "budget-tracker/*"
 
       - name: Invalidate CloudFront
         run: aws cloudfront create-invalidation --distribution-id E1128DYYBLMWYK --paths "/*"
@@ -142,7 +142,7 @@ jobs:
         run: pnpm build
 
       - name: Deploy to S3
-        run: aws s3 sync apps/stock-analyser/out s3://transformotion-prod-bucket --delete
+        run: aws s3 sync apps/stock-analyser/out s3://transformotion-prod-bucket --delete --exclude "budget-tracker/*"
 
       - name: Invalidate CloudFront
         run: aws cloudfront create-invalidation --distribution-id ${{ vars.CLOUDFRONT_DISTRIBUTION_ID_PROD }} --paths "/*"


### PR DESCRIPTION
## Summary

- Stock-analyser deploy workflow ran `aws s3 sync ... --delete` against the S3 bucket root, wiping co-located app prefixes on every deploy
- PR #196 triggered a stock-analyser redeploy which emptied `budget-tracker/` in S3 — causing `/budget-tracker/` to serve stock-analyser HTML via the CloudFront global error response, breaking budget-tracker entirely
- Added `--exclude "budget-tracker/*"` to both dev and prod S3 sync commands, matching the safe-sync pattern documented in `urls-and-deploy.md`

## Root cause

`urls-and-deploy.md` explicitly warns: *"No deploy syncs the bucket root with `--delete` across the entire bucket — that would wipe other apps' artefacts."* The stock-analyser workflow violated this invariant.

## Test plan

- [ ] Merge this PR → stock-analyser redeploys to dev (triggered by workflow path filter on `apps/stock-analyser/**` ... wait, this only changes `.github/workflows/` — trigger manually if needed)
- [ ] Trigger budget-tracker `workflow_dispatch` to restore `budget-tracker/` S3 prefix
- [ ] Verify `/budget-tracker/` serves budget-tracker HTML (not stock-analyser)
- [ ] Verify `/stock-signal/` still loads correctly after next stock-analyser deploy

## Follow-up (M7 scope)

Once stock-analyser migrates off root to `stock-signal/` prefix (M7), the sync command should change to `aws s3 sync apps/stock-analyser/out/stock-signal s3://${BUCKET}/stock-signal --delete` — eliminating this class of bug permanently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)