### PR TITLE
fix: normalise budgetTrackerUrl to always have trailing slash

### DIFF
--- a/apps/stock-analyser/lib/config/index.ts
+++ b/apps/stock-analyser/lib/config/index.ts
@@ -120,7 +120,7 @@ export function loadConfig(): AppConfig {
       debugMode: process.env.NEXT_PUBLIC_DEBUG_MODE === 'true',
     },
     apps: {
-      budgetTrackerUrl: process.env.NEXT_PUBLIC_BUDGET_URL || '/budget-tracker/',
+      budgetTrackerUrl: (process.env.NEXT_PUBLIC_BUDGET_URL || '/budget-tracker/').replace(/\/*$/, '/'),
     },
   }
 }


### PR DESCRIPTION
## Summary

- `NEXT_PUBLIC_BUDGET_URL` was set in GitHub Actions without a trailing slash (`/budget-tracker` not `/budget-tracker/`)
- `window.location.assign` navigated to `/budget-tracker` (no slash), which CloudFront's `/budget-tracker/*` behaviour does not match
- The default CloudFront behaviour fired instead, serving stock-analyser's SPA — which threw `SyntaxError: Unexpected token '<'` from chunk `11traugt~ghv7.js` while trying to load a non-existent route
- Added `.replace(/\/*$/, '/')` to `budgetTrackerUrl` in `lib/config/index.ts` so the URL always ends with exactly one slash regardless of how the env var is configured
- GitHub Actions `dev` environment variable `NEXT_PUBLIC_BUDGET_URL` corrected to `https://dev.apps.transformotion.com.au/budget-tracker/` (applied directly via `gh variable set`, takes effect on next deploy)

## Test plan

- [ ] Merge → stock-analyser redeploys to dev (path filter: `apps/stock-analyser/**`)
- [ ] Navigate to `/launchpad/`, click Budget Tracker tile
- [ ] Verify browser navigates to `/budget-tracker/` and budget-tracker app loads correctly
- [ ] Verify no SyntaxError in DevTools console

🤖 Generated with [Claude Code](https://claude.com/claude-code)