### PR TITLE
M6 #155 follow-up: add /launchpad/* CloudFront behavior + M7 architectural captures

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -697,6 +697,26 @@ deduplication of duplicated runtime code.
     deploying commit; sign-in completes; repository operations succeed
   - CloudFront cache invalidation strategy confirmed (stale cached content
     flushed when root occupant changes)
+- `additionalBehaviors` abstracted into a reusable helper: once 3+ sub-app
+  behaviors exist (budget-tracker, launchpad, stock-signal), the repeated
+  `additionalBehaviors` entries in `NetworkStack` are extracted into a
+  helper (e.g., `addSubAppBehavior(distribution, prefix, rewriteFn)`) in
+  `packages/cdk-constructs/`. The helper encapsulates the canonical
+  configuration (S3BucketOrigin with OAC, REDIRECT_TO_HTTPS,
+  CACHING_OPTIMIZED, compress, function association on VIEWER_REQUEST).
+  Each sub-app extraction then becomes a single helper invocation rather
+  than ~10 lines of repeated configuration. Pattern emerged through
+  PRs #194 and the launchpad routing fix; the third recurrence triggers
+  the abstraction.
+- Post-deploy app-identity verification: extend `verify-deploy.sh` (or
+  equivalent per-workflow check) to assert the deployed URL returns HTML
+  containing the expected app's identity marker in addition to the
+  `data-commit` hash check already in place. This catches the class of
+  routing failure surfaced by PRs #194 and the launchpad fix — bugs where
+  S3 returns the wrong app's HTML with a 200 status, making the commit
+  hash check pass while the wrong content is served. Verification should
+  run as the final step of every deploy workflow after CloudFront
+  invalidation completes.
 
 ### Goals served
 
@@ -717,7 +737,9 @@ table renames complete (analysis-cache, rate-limits). Each app deployed
 at its canonical S3 prefix per `docs/architecture/urls-and-deploy.md`
 target layout. No app served via the SPA fallback (every path resolves
 to its intended app via an explicit CloudFront behavior or the root
-default).
+default). Sub-app `additionalBehaviors` entries abstracted into a
+`cdk-constructs` helper. Post-deploy app-identity verification running
+in every deploy workflow.
 
 ### Dependencies
 

--- a/docs/architecture/inventory.md
+++ b/docs/architecture/inventory.md
@@ -977,11 +977,12 @@ The `NetworkStack` CloudFront distribution currently has two configured behavior
 |---|---|---|---|
 | Default (`*`) | S3 root | None | Serves stock-analyser (transitional; canonical target: launchpad) |
 | `/budget-tracker/*` | S3 `budget-tracker/` prefix | `SubAppIndexRewrite` | Implemented (M6 #154 PR #194) |
+| `/launchpad/*` | S3 `launchpad/` prefix | `SubAppIndexRewrite` | Implemented (M6 #155 follow-up, this PR) |
 
 Remaining behaviors not yet implemented (M7 scope):
 
 - `/stock-signal/*` — requires stock-analyser to gain `basePath: '/stock-signal'` in `next.config.mjs`, deploy workflow updated to sync to `stock-signal/` prefix, and a new `additionalBehaviors` entry with `SubAppIndexRewrite`
-- Launchpad at root — requires launchpad to gain `output: 'export'`, a new deploy workflow, and stock-analyser to have vacated root first; no `SubAppIndexRewrite` needed since launchpad will be the root occupant
+- Launchpad at root — requires stock-analyser to vacate S3 root and launchpad to gain a `deploy-launchpad.yml` workflow syncing to root; the `/launchpad/*` behavior (above) is transitional and will be removed once launchpad occupies the root default behavior
 
 Current S3 bucket root occupant is stock-analyser (transitional; should be launchpad per target architecture). The SPA fallback (403/404 → `/index.html`) compensates but creates the routing failure that PR #194 fixed for budget-tracker. M7 closes the gap by completing the extractions.
 

--- a/docs/architecture/urls-and-deploy.md
+++ b/docs/architecture/urls-and-deploy.md
@@ -85,6 +85,8 @@ Single distribution (`TransformotionDev-Network` / `TransformotionProd-Network`)
 
 ### Sub-app index rewrite pattern
 
+**Rule: Every sub-app deployed to a nested S3 prefix MUST have its own CloudFront `additionalBehaviors` entry with the `SubAppIndexRewrite` function association. Without this entry, requests for the sub-app's path fall through to the default behavior's SPA fallback (403 → `/index.html`), which serves whichever app currently occupies the S3 root (currently stock-analyser, transitionally). This produces a silent routing failure where the user sees the wrong app's HTML for their requested URL.** This rule was established by M6 #154 (PR #194, budget-tracker) and relearned for launchpad (M6 #155 follow-up). Future sub-app extractions in M7 must follow it.
+
 Sub-apps deployed to nested S3 prefixes (e.g. `/budget-tracker/*` → `s3://bucket/budget-tracker/*`) hit a routing failure at the CloudFront/S3 boundary: a request for `/budget-tracker/` asks S3 for the object key `budget-tracker/` (with trailing slash). S3's OAC REST API returns 403 for this key (no object exists at that key), triggering the default behavior's SPA fallback to the root `/index.html`.
 
 The fix is a CloudFront Function (`SubAppIndexRewrite`) attached to each sub-app cache behavior on the `VIEWER_REQUEST` event. The function rewrites directory requests to append `index.html` before they reach S3:
@@ -99,16 +101,21 @@ function handler(event) {
 }
 ```
 
-The function is path-agnostic and shared by every sub-app behavior. Each sub-app adds an `additionalBehaviors` entry in `NetworkStack` referencing the same function instance. Implemented for `/budget-tracker/*` in M6 #154 (PR #194). The same pattern applies to `/stock-signal/*` when the stock-analyser extraction lands (M7).
+The function is path-agnostic and shared by every sub-app behavior. Each sub-app adds an `additionalBehaviors` entry in `NetworkStack` referencing the same function instance. Implemented for `/budget-tracker/*` in M6 #154 (PR #194) and `/launchpad/*` in M6 #155 follow-up. The same pattern applies to `/stock-signal/*` when the stock-analyser extraction lands (M7).
 
 ### Current state
 
-The `/budget-tracker/*` cache behavior with `SubAppIndexRewrite` was implemented in M6 #154 (PR #194). Remaining extractions:
+Implemented behaviors with `SubAppIndexRewrite`:
 
-- **stock-analyser:** currently serves from S3 root; needs `basePath: '/stock-signal'` in `next.config.mjs`, deploy workflow updated to sync to the `stock-signal/` prefix, and a new `/stock-signal/*` behavior (M7 scope)
-- **launchpad:** not yet static-export-ready (`output: 'export'` not set); will be promoted to S3 root once stock-analyser moves off root (M7 scope); no `SubAppIndexRewrite` needed since it will be the root occupant
+- `/budget-tracker/*` — M6 #154 (PR #194)
+- `/launchpad/*` — M6 #155 follow-up (transitional; will be removed when launchpad promotes to S3 root and the default behavior takes over)
 
-Until M7 completes the remaining extractions, the SPA fallback (403/404 → `/index.html`) returns stock-analyser content for any path not handled by an explicit behavior. This is acceptable transitional behaviour: stock-analyser routes continue to work via the fallback, and budget-tracker routes are now handled by the explicit behavior.
+Remaining extractions (M7 scope):
+
+- **stock-analyser:** currently serves from S3 root; needs `basePath: '/stock-signal'` in `next.config.mjs`, deploy workflow updated to sync to the `stock-signal/` prefix, and a new `/stock-signal/*` behavior
+- **launchpad at root:** requires stock-analyser to vacate root first; once promoted, the `/launchpad/*` transitional behavior is removed and launchpad serves via the default behavior (no `SubAppIndexRewrite` needed for the root occupant)
+
+Until M7 completes the remaining extractions, the SPA fallback (403/404 → `/index.html`) returns stock-analyser content for any path not handled by an explicit behavior. This is acceptable transitional behaviour: stock-analyser routes continue to work via the fallback, and budget-tracker and launchpad routes are handled by their explicit behaviors.
 
 ---
 

--- a/infrastructure/lib/platform/network-stack.ts
+++ b/infrastructure/lib/platform/network-stack.ts
@@ -97,6 +97,16 @@ export class NetworkStack extends cdk.Stack {
             eventType: cloudfront.FunctionEventType.VIEWER_REQUEST,
           }],
         },
+        '/launchpad/*': {
+          origin: origins.S3BucketOrigin.withOriginAccessControl(this.bucket),
+          viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
+          cachePolicy: cloudfront.CachePolicy.CACHING_OPTIMIZED,
+          compress: true,
+          functionAssociations: [{
+            function: subAppIndexRewrite,
+            eventType: cloudfront.FunctionEventType.VIEWER_REQUEST,
+          }],
+        },
       },
       defaultRootObject: 'index.html',
       errorResponses: [


### PR DESCRIPTION
## Problem

Navigating to `/launchpad/` triggered an infinite redirect loop between `/launchpad/` and `/sign-in/` requiring ~5 hard resets to break.

**Root cause:** CloudFront had no `/launchpad/*` behavior. Requests for `/launchpad/` hit the default behavior; S3 OAC REST API returned 403 for the trailing-slash key `launchpad/` (no object at that key, only at `launchpad/index.html`); the SPA fallback (403 → `/index.html`) served stock-analyser's root `index.html` instead. Stock-analyser's root `app/page.tsx` calls `redirect('/sign-in')` server-side — this redirect is baked into the pre-rendered RSC payload. When the App Router processed that payload for a `/launchpad/` URL, it redirected to `/sign-in/`. Sign-in saw a valid session and redirected back to `/launchpad/`. Loop.

This is the same class of failure as the `/budget-tracker/*` fix in PR #194.

## Fix

**`infrastructure/lib/platform/network-stack.ts`** — add `/launchpad/*` to `additionalBehaviors` with `SubAppIndexRewrite` function association (identical pattern to `/budget-tracker/*`). The `SubAppIndexRewrite` CloudFront Function rewrites trailing-slash requests (`/launchpad/` → `/launchpad/index.html`) before they reach S3, so the correct HTML is served.

CDK diff: additions only — new `CacheBehavior` entry + new `Origin` entry. No modifications to existing behaviors.

## Documentation

- **`docs/architecture/urls-and-deploy.md`** — adds explicit rule: *every sub-app deployed to a nested S3 prefix MUST have its own `additionalBehaviors` entry with `SubAppIndexRewrite`*. Documents the failure mode and the fix. Updates "Current state" table.
- **`docs/architecture/inventory.md`** — adds `/launchpad/*` row to CloudFront behaviors table; corrects launchpad description (behavior is transitional — will be removed when launchpad promotes to S3 root in M7).
- **`PLAN.md`** — adds two M7 outcome captures:
  1. Abstract `additionalBehaviors` entries into a `cdk-constructs` helper once 3+ sub-apps exist (budget-tracker, launchpad, stock-signal)
  2. Extend `verify-deploy.sh` with post-deploy app-identity verification (assert correct app HTML returned, catching the class of routing failure where wrong-app HTML is served with 200)

## Deploy

Merging to `develop` triggers `deploy-platform.yml` (path: `infrastructure/lib/platform/**`), which deploys `TransformotionDev-Network`. The new `/launchpad/*` CloudFront behavior activates on that deploy.

## Test plan

- [ ] Merge to develop and wait for `deploy-platform.yml` to complete
- [ ] Navigate to `https://dev.apps.transformotion.com.au/launchpad/` — should load launchpad UI without redirect loop
- [ ] Navigate to `https://dev.apps.transformotion.com.au/budget-tracker/` — confirm existing behavior unchanged
- [ ] Navigate to stock-analyser routes — confirm SPA fallback still works for paths without explicit behaviors

🤖 Generated with [Claude Code](https://claude.com/claude-code)