### PR TITLE
fix(lambda-middleware): case-insensitive X-Account-Id header lookup

### DIFF
--- a/packages/lambda-middleware/src/auth.test.ts
+++ b/packages/lambda-middleware/src/auth.test.ts
@@ -7,6 +7,7 @@ import {
   requireAccountOwner,
   requireGroup,
   extractAuthClaims,
+  resolveAccountContext,
 } from './auth';
 import type { AuthClaims } from './types';
 import { HttpError } from './errors';
@@ -261,6 +262,39 @@ describe('requireAccountOwner', () => {
 
   it('passes for site admin', () => {
     expect(() => requireAccountOwner(makeClaims({ siteAdmin: true }), 'budget-tracker', 'acc-1')).not.toThrow();
+  });
+});
+
+// ── resolveAccountContext ─────────────────────────────────────────────────────
+
+describe('resolveAccountContext', () => {
+  function makeHeaderEvent(headers: Record<string, string>): APIGatewayProxyEvent {
+    return { headers } as unknown as APIGatewayProxyEvent;
+  }
+
+  it('accepts lowercase x-account-id', () => {
+    expect(resolveAccountContext(makeHeaderEvent({ 'x-account-id': 'acc-123' })))
+      .toEqual({ accountId: 'acc-123' });
+  });
+
+  it('accepts HTTP-conventional X-Account-Id', () => {
+    expect(resolveAccountContext(makeHeaderEvent({ 'X-Account-Id': 'acc-123' })))
+      .toEqual({ accountId: 'acc-123' });
+  });
+
+  it('accepts all-caps X-ACCOUNT-ID', () => {
+    expect(resolveAccountContext(makeHeaderEvent({ 'X-ACCOUNT-ID': 'acc-123' })))
+      .toEqual({ accountId: 'acc-123' });
+  });
+
+  it('throws 400 when header is absent', () => {
+    expect(() => resolveAccountContext(makeHeaderEvent({})))
+      .toThrow(expect.objectContaining({ statusCode: 400 }));
+  });
+
+  it('throws 400 when header value is whitespace only', () => {
+    expect(() => resolveAccountContext(makeHeaderEvent({ 'x-account-id': '   ' })))
+      .toThrow(expect.objectContaining({ statusCode: 400 }));
   });
 });
 

--- a/packages/lambda-middleware/src/auth.ts
+++ b/packages/lambda-middleware/src/auth.ts
@@ -48,10 +48,15 @@ export function extractAuthClaims(event: APIGatewayProxyEvent): AuthClaims {
 
 /**
  * Resolve the active account for this request from the `X-Account-Id` header.
- * Throws HttpError(400) if the header is absent.
+ * Header name matching is case-insensitive (RFC 7230). API Gateway v1 preserves
+ * the original casing sent by the client, so a literal key lookup would silently
+ * reject requests that use conventional HTTP capitalisation (X-Account-Id).
+ * Throws HttpError(400) if the header is absent or blank.
  */
 export function resolveAccountContext(event: APIGatewayProxyEvent): AccountContext {
-  const headerAccountId = event.headers?.['x-account-id']?.trim();
+  const headers = event.headers ?? {};
+  const entry = Object.entries(headers).find(([k]) => k.toLowerCase() === 'x-account-id');
+  const headerAccountId = entry?.[1]?.trim();
   if (headerAccountId) {
     return { accountId: headerAccountId };
   }


### PR DESCRIPTION
## Summary

- `resolveAccountContext` in `packages/lambda-middleware` was doing a case-sensitive key lookup for `x-account-id`
- API Gateway v1 preserves original header casing — sending `X-Account-Id` (conventional HTTP form) returned HTTP 400 with no account context
- Fixed with a case-insensitive `Object.entries` scan (RFC 7230 compliant)

## What changed

**`packages/lambda-middleware/src/auth.ts`**
- `resolveAccountContext` now scans headers with `.toLowerCase() === 'x-account-id'` instead of direct key access

**`packages/lambda-middleware/src/auth.test.ts`**
- Added `resolveAccountContext` describe block with 5 tests: lowercase, HTTP-conventional mixed-case, all-caps, missing header (→ 400), whitespace-only value (→ 400)

## Test plan

- [x] `pnpm --filter @transformotion/lambda-middleware test` — 42 tests pass (37 pre-existing + 5 new)
- [x] `pnpm --filter @transformotion/lambda-middleware typecheck` — clean
- [x] `pnpm --filter @transformotion/lambda-middleware build` — clean
- [x] Pre-commit hooks passed

Closes #208

🤖 Generated with [Claude Code](https://claude.com/claude-code)