### PR TITLE
M6 #178: wire useBudgetStore into component tree

### DIFF
--- a/apps/budget-tracker/components/budget-tracker/app-shell.tsx
+++ b/apps/budget-tracker/components/budget-tracker/app-shell.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { createContext, useContext, useState, useCallback, useRef, useEffect, type ReactNode } from "react"
+import { useState, type ReactNode } from "react"
 import { cn } from "@/lib/utils"
 import { Wordmark } from "@/components/brand/wordmark"
 import {
@@ -19,81 +19,9 @@ import {
   Home,
 } from "lucide-react"
 import { ConfirmationModal } from "@/components/ui/design-system"
-import type { Transaction, CustomRule, BudgetSettings, BudgetTabId, TransactionFilters } from "./data/types"
-import { DEFAULT_BUILTIN_RULES, type BuiltinRule } from "./data/builtin-rules"
-
-// ============================================================================
-// TYPES
-// ============================================================================
-
-export interface Account {
-  id: string
-  name: string
-  type: "Personal" | "Household" | "Business"
-}
-
-export interface BudgetUser {
-  name: string
-  email: string
-  avatar?: string
-  accounts: Account[]
-  activeAccountId: string
-}
-
-export interface BudgetNavigationState {
-  activeTab: BudgetTabId
-  // Transaction data
-  transactions: Transaction[]
-  // Rules
-  customRules: CustomRule[]
-  builtinRules: BuiltinRule[]
-  // Settings
-  settings: BudgetSettings
-  // User state
-  user: BudgetUser
-  // UI state
-  uncategorizedCount: number
-  // Transaction filters (persisted across tab navigation)
-  transactionFilters: TransactionFilters
-}
-
-export interface BudgetNavigationActions {
-  navigateTo: (tab: BudgetTabId) => void
-  setTransactions: (transactions: Transaction[]) => void
-  addTransactions: (transactions: Transaction[]) => void
-  updateTransaction: (id: string, updates: Partial<Transaction>) => void
-  deleteTransaction: (id: string) => void
-  setCustomRules: (rules: CustomRule[]) => void
-  addCustomRule: (rule: CustomRule) => void
-  updateCustomRule: (id: string, updates: Partial<CustomRule>) => void
-  deleteCustomRule: (id: string) => void
-  setBuiltinRules: (rules: BuiltinRule[]) => void
-  updateBuiltinRule: (id: string, updates: Partial<BuiltinRule>) => void
-  addBuiltinRule: (rule: BuiltinRule) => void
-  updateSettings: (updates: Partial<BudgetSettings>) => void
-  setTransactionFilters: (filtersOrUpdater: TransactionFilters | ((prev: TransactionFilters) => TransactionFilters)) => void
-  switchAccount: (accountId: string) => void
-  signOut: () => void
-  goToLaunchpad: () => void
-}
-
-interface BudgetNavigationContextValue extends BudgetNavigationState, BudgetNavigationActions {
-  customRulesRef: React.MutableRefObject<CustomRule[]>
-}
-
-// ============================================================================
-// CONTEXT
-// ============================================================================
-
-const BudgetNavigationContext = createContext<BudgetNavigationContextValue | null>(null)
-
-export function useBudgetNavigation() {
-  const context = useContext(BudgetNavigationContext)
-  if (!context) {
-    throw new Error("useBudgetNavigation must be used within BudgetNavigationProvider")
-  }
-  return context
-}
+import type { BudgetTabId } from "./data/types"
+import { useBudgetStore } from "@/stores/budget-tracker/use-budget-store"
+import { useAuthStore } from "@/stores/auth/use-auth-store"
 
 // ============================================================================
 // NAV ITEMS CONFIG
@@ -109,293 +37,13 @@ export const BUDGET_NAV_ITEMS: { id: BudgetTabId; icon: typeof Receipt; label: s
 ]
 
 // ============================================================================
-// LOCALSTORAGE KEYS
-// ============================================================================
-
-const STORAGE_KEYS = {
-  transactions: "budget-tracker-transactions",
-  customRules: "budget-tracker-custom-rules",
-  builtinRules: "budget-tracker-builtin-rules",
-  settings: "budget-tracker-settings",
-  transactionFilters: "budget-tracker-transaction-filters",
-} as const
-
-const DEFAULT_TRANSACTION_FILTERS: TransactionFilters = {
-  dateRange: null,
-  category: null,
-  subcategory: null,
-  bankAccount: null,
-  source: null,
-  businessFilter: "all",
-  uncategorizedOnly: false,
-}
-
-// ============================================================================
-// NAVIGATION PROVIDER
-// ============================================================================
-
-const DEFAULT_USER: BudgetUser = {
-  name: "Steve Moodie",
-  email: "steve@example.com",
-  accounts: [
-    { id: "1", name: "Steve's Account", type: "Personal" },
-    { id: "2", name: "Steve & Liz Household", type: "Household" },
-  ],
-  activeAccountId: "2",
-}
-
-const DEFAULT_SETTINGS: BudgetSettings = {
-  budgetOverrides: {},
-  budgetFreqs: {},
-  customCategories: {},
-  deletedCategories: [],
-  customTopCategories: [],
-  projectBudgets: {},
-  projectTasks: {},
-  customProjectCategories: [],
-  deletedProjectCategories: [],
-  disabledProjectCategories: [],
-}
-
-// Helper to load from localStorage
-function loadFromStorage<T>(key: string, fallback: T): T {
-  if (typeof window === "undefined") return fallback
-  try {
-    const stored = localStorage.getItem(key)
-    if (stored) {
-      return JSON.parse(stored) as T
-    }
-  } catch (e) {
-    console.error(`Failed to load ${key} from localStorage:`, e)
-  }
-  return fallback
-}
-
-// Helper to save to localStorage
-function saveToStorage<T>(key: string, value: T): void {
-  if (typeof window === "undefined") return
-  try {
-    localStorage.setItem(key, JSON.stringify(value))
-  } catch (e) {
-    console.error(`Failed to save ${key} to localStorage:`, e)
-  }
-}
-
-export function BudgetNavigationProvider({ 
-  children,
-  initialTab = "transactions",
-  onSignOut,
-  onGoToLaunchpad,
-}: { 
-  children: ReactNode
-  initialTab?: BudgetTabId
-  onSignOut?: () => void
-  onGoToLaunchpad?: () => void
-}) {
-  // Initialize with empty state for SSR, then hydrate from localStorage
-  const [state, setState] = useState<BudgetNavigationState>({
-    activeTab: initialTab,
-    transactions: [],
-    customRules: [],
-    builtinRules: DEFAULT_BUILTIN_RULES,
-    settings: DEFAULT_SETTINGS,
-    transactionFilters: DEFAULT_TRANSACTION_FILTERS,
-    user: DEFAULT_USER,
-    uncategorizedCount: 0,
-  })
-
-  // Hydrate from localStorage on client mount
-  const [isHydrated, setIsHydrated] = useState(false)
-  useEffect(() => {
-    const transactions = loadFromStorage<Transaction[]>(STORAGE_KEYS.transactions, [])
-    const customRules = loadFromStorage<CustomRule[]>(STORAGE_KEYS.customRules, [])
-    const storedBuiltinRules = loadFromStorage<BuiltinRule[] | null>(STORAGE_KEYS.builtinRules, null)
-    const builtinRules = storedBuiltinRules ?? DEFAULT_BUILTIN_RULES
-    const settings = loadFromStorage<BudgetSettings>(STORAGE_KEYS.settings, DEFAULT_SETTINGS)
-    const transactionFilters = loadFromStorage<TransactionFilters>(STORAGE_KEYS.transactionFilters, DEFAULT_TRANSACTION_FILTERS)
-    const uncategorizedCount = transactions.filter(t => !t.category).length
-    
-    setState({
-      activeTab: initialTab,
-      transactions,
-      customRules,
-      builtinRules,
-      settings,
-      transactionFilters,
-      user: DEFAULT_USER,
-      uncategorizedCount,
-    })
-    setIsHydrated(true)
-  }, [initialTab])
-
-  // Persist transactions to localStorage when they change (only after hydration)
-  useEffect(() => {
-    if (isHydrated) saveToStorage(STORAGE_KEYS.transactions, state.transactions)
-  }, [isHydrated, state.transactions])
-
-  // Persist custom rules to localStorage when they change
-  useEffect(() => {
-    if (isHydrated) saveToStorage(STORAGE_KEYS.customRules, state.customRules)
-  }, [isHydrated, state.customRules])
-
-  // Persist built-in rules to localStorage when they change
-  useEffect(() => {
-    if (isHydrated) saveToStorage(STORAGE_KEYS.builtinRules, state.builtinRules)
-  }, [isHydrated, state.builtinRules])
-
-  // Persist settings to localStorage when they change
-  useEffect(() => {
-    if (isHydrated) saveToStorage(STORAGE_KEYS.settings, state.settings)
-  }, [isHydrated, state.settings])
-
-  // Persist transaction filters to localStorage when they change
-  useEffect(() => {
-    if (isHydrated) saveToStorage(STORAGE_KEYS.transactionFilters, state.transactionFilters)
-  }, [isHydrated, state.transactionFilters])
-
-  // Ref to avoid stale closure issues with custom rules
-  const customRulesRef = useRef<CustomRule[]>([])
-  // Keep ref in sync with state (outside useEffect to avoid timing issues)
-  customRulesRef.current = state.customRules
-
-  const navigateTo = useCallback((tab: BudgetTabId) => {
-    setState(prev => ({ ...prev, activeTab: tab }))
-  }, [])
-
-  const setTransactions = useCallback((transactions: Transaction[]) => {
-    const uncategorizedCount = transactions.filter(t => !t.category).length
-    setState(prev => ({ ...prev, transactions, uncategorizedCount }))
-  }, [])
-
-  const addTransactions = useCallback((newTransactions: Transaction[]) => {
-    setState(prev => {
-      const updated = [...prev.transactions, ...newTransactions]
-      const uncategorizedCount = updated.filter(t => !t.category).length
-      return { ...prev, transactions: updated, uncategorizedCount }
-    })
-  }, [])
-
-  const updateTransaction = useCallback((id: string, updates: Partial<Transaction>) => {
-    setState(prev => {
-      const updated = prev.transactions.map(t => 
-        t.transactionId === id ? { ...t, ...updates } : t
-      )
-      const uncategorizedCount = updated.filter(t => !t.category).length
-      return { ...prev, transactions: updated, uncategorizedCount }
-    })
-  }, [])
-
-  const deleteTransaction = useCallback((id: string) => {
-    setState(prev => {
-      const updated = prev.transactions.filter(t => t.transactionId !== id)
-      const uncategorizedCount = updated.filter(t => !t.category).length
-      return { ...prev, transactions: updated, uncategorizedCount }
-    })
-  }, [])
-
-  const setCustomRules = useCallback((rules: CustomRule[]) => {
-    setState(prev => ({ ...prev, customRules: rules }))
-  }, [])
-
-  const addCustomRule = useCallback((rule: CustomRule) => {
-    setState(prev => ({ ...prev, customRules: [...prev.customRules, rule] }))
-  }, [])
-
-  const updateCustomRule = useCallback((id: string, updates: Partial<CustomRule>) => {
-    setState(prev => ({
-      ...prev,
-      customRules: prev.customRules.map(r => r.ruleId === id ? { ...r, ...updates } : r)
-    }))
-  }, [])
-
-  const deleteCustomRule = useCallback((id: string) => {
-    setState(prev => ({
-      ...prev,
-      customRules: prev.customRules.filter(r => r.ruleId !== id)
-    }))
-  }, [])
-
-  const setBuiltinRules = useCallback((rules: BuiltinRule[]) => {
-    setState(prev => ({ ...prev, builtinRules: rules }))
-  }, [])
-
-  const updateBuiltinRule = useCallback((id: string, updates: Partial<BuiltinRule>) => {
-    setState(prev => ({
-      ...prev,
-      builtinRules: prev.builtinRules.map(r => r.id === id ? { ...r, ...updates } : r)
-    }))
-  }, [])
-
-  const addBuiltinRule = useCallback((rule: BuiltinRule) => {
-    setState(prev => ({ ...prev, builtinRules: [...prev.builtinRules, rule] }))
-  }, [])
-
-  const updateSettings = useCallback((updates: Partial<BudgetSettings>) => {
-    setState(prev => ({
-      ...prev,
-      settings: { ...prev.settings, ...updates }
-    }))
-  }, [])
-
-  const setTransactionFilters = useCallback((filtersOrUpdater: TransactionFilters | ((prev: TransactionFilters) => TransactionFilters)) => {
-    setState(prev => ({
-      ...prev,
-      transactionFilters: typeof filtersOrUpdater === 'function' 
-        ? filtersOrUpdater(prev.transactionFilters)
-        : filtersOrUpdater
-    }))
-  }, [])
-
-  const switchAccount = useCallback((accountId: string) => {
-    setState(prev => ({
-      ...prev,
-      user: { ...prev.user, activeAccountId: accountId }
-    }))
-  }, [])
-
-  const signOut = useCallback(() => {
-    onSignOut?.()
-  }, [onSignOut])
-
-  const goToLaunchpad = useCallback(() => {
-    onGoToLaunchpad?.()
-  }, [onGoToLaunchpad])
-
-  const value: BudgetNavigationContextValue = {
-    ...state,
-    customRulesRef,
-    navigateTo,
-    setTransactions,
-    addTransactions,
-    updateTransaction,
-    deleteTransaction,
-    setCustomRules,
-    addCustomRule,
-    updateCustomRule,
-    deleteCustomRule,
-    setBuiltinRules,
-    updateBuiltinRule,
-    addBuiltinRule,
-    updateSettings,
-    setTransactionFilters,
-    switchAccount,
-    signOut,
-    goToLaunchpad,
-  }
-
-  return (
-    <BudgetNavigationContext.Provider value={value}>
-      {children}
-    </BudgetNavigationContext.Provider>
-  )
-}
-
-// ============================================================================
 // MOBILE NAV
 // ============================================================================
 
 export function BudgetMobileNav() {
-  const { activeTab, navigateTo, uncategorizedCount } = useBudgetNavigation()
+  const activeTab = useBudgetStore((s) => s.activeTab)
+  const setActiveTab = useBudgetStore((s) => s.setActiveTab)
+  const uncategorizedCount = useBudgetStore((s) => s.uncategorizedCount)
 
   return (
     <nav className="fixed bottom-0 left-0 right-0 bg-card/95 backdrop-blur-sm border-t border-border md:hidden z-50 safe-area-inset-bottom">
@@ -403,7 +51,7 @@ export function BudgetMobileNav() {
         {BUDGET_NAV_ITEMS.map((item) => (
           <button
             key={item.id}
-            onClick={() => navigateTo(item.id)}
+            onClick={() => setActiveTab(item.id)}
             className={cn(
               "relative flex flex-col items-center justify-center gap-0.5 w-12 py-1 transition-colors",
               activeTab === item.id ? "text-primary" : "text-muted-foreground"
@@ -411,7 +59,6 @@ export function BudgetMobileNav() {
           >
             <item.icon className="size-5" />
             <span className="text-[10px] font-medium">{item.label}</span>
-            {/* Badge for Review tab showing uncategorized count */}
             {item.id === "review" && uncategorizedCount > 0 && (
               <span className="absolute -top-0.5 right-0.5 size-4 rounded-full bg-signal-amber text-[9px] font-bold text-background flex items-center justify-center">
                 {uncategorizedCount > 99 ? "99+" : uncategorizedCount}
@@ -428,15 +75,29 @@ export function BudgetMobileNav() {
 // USER HEADER (Mobile)
 // ============================================================================
 
-export function BudgetUserHeader() {
-  const { user, switchAccount, signOut, goToLaunchpad } = useBudgetNavigation()
+export function BudgetUserHeader({
+  onGoToLaunchpad,
+  onSignOut,
+}: {
+  onGoToLaunchpad?: () => void
+  onSignOut?: () => void
+}) {
+  const user = useAuthStore((s) => s.user)
+  const accounts = useAuthStore((s) => s.accounts)
+  const currentAccount = useAuthStore((s) => s.currentAccount)
+  const authSignOut = useAuthStore((s) => s.signOut)
+  const switchAccount = useAuthStore((s) => s.switchAccount)
   const [accountMenuOpen, setAccountMenuOpen] = useState(false)
   const [profileMenuOpen, setProfileMenuOpen] = useState(false)
   const [signOutConfirm, setSignOutConfirm] = useState(false)
-  
-  const activeAccount = user.accounts.find(a => a.id === user.activeAccountId)
-  const initials = user.name.split(' ').map(n => n[0]).join('')
-  const firstName = user.name.split(' ')[0]
+
+  const initials = (user?.name ?? '').split(' ').map(n => n[0]).join('')
+  const firstName = (user?.name ?? '').split(' ')[0]
+
+  function handleSignOut() {
+    authSignOut()
+    onSignOut?.()
+  }
 
   return (
     <div className="flex items-center justify-between py-3 px-4 bg-card border-b border-border md:hidden">
@@ -453,25 +114,25 @@ export function BudgetUserHeader() {
               onClick={() => setAccountMenuOpen(!accountMenuOpen)}
               className="flex items-center gap-1 text-xs text-muted-foreground hover:text-primary transition-colors"
             >
-              {activeAccount?.name}
+              {currentAccount?.name}
               <ChevronDown className={cn("size-3 transition-transform", accountMenuOpen && "rotate-180")} />
             </button>
-            
+
             {accountMenuOpen && (
               <>
                 <div className="fixed inset-0 z-40" onClick={() => setAccountMenuOpen(false)} />
                 <div className="absolute left-0 top-full mt-1 w-48 bg-card border border-border rounded-lg shadow-xl z-50 overflow-hidden">
-                  {user.accounts.map((account) => (
+                  {accounts.map((account) => (
                     <button
                       key={account.id}
                       onClick={() => { switchAccount(account.id); setAccountMenuOpen(false) }}
                       className={cn(
                         "w-full flex items-center justify-between px-3 py-2 text-sm hover:bg-surface2 transition-colors",
-                        account.id === user.activeAccountId && "bg-primary/5"
+                        account.id === currentAccount?.id && "bg-primary/5"
                       )}
                     >
                       <span className="text-foreground">{account.name}</span>
-                      {account.id === user.activeAccountId && <Check className="size-4 text-primary" />}
+                      {account.id === currentAccount?.id && <Check className="size-4 text-primary" />}
                     </button>
                   ))}
                 </div>
@@ -480,7 +141,7 @@ export function BudgetUserHeader() {
           </div>
         </div>
       </div>
-      
+
       {/* Profile Menu */}
       <div className="relative">
         <button
@@ -489,13 +150,13 @@ export function BudgetUserHeader() {
         >
           <User className="size-5" />
         </button>
-        
+
         {profileMenuOpen && (
           <>
             <div className="fixed inset-0 z-40" onClick={() => setProfileMenuOpen(false)} />
             <div className="absolute right-0 top-full mt-2 w-48 bg-card border border-border rounded-lg shadow-xl z-50 overflow-hidden">
-              <button 
-                onClick={() => { setProfileMenuOpen(false); goToLaunchpad() }}
+              <button
+                onClick={() => { setProfileMenuOpen(false); onGoToLaunchpad?.() }}
                 className="w-full flex items-center gap-2 px-3 py-2.5 text-sm text-foreground hover:bg-surface2 transition-colors"
               >
                 <Home className="size-4 text-muted-foreground" />
@@ -505,7 +166,7 @@ export function BudgetUserHeader() {
                 <Settings className="size-4 text-muted-foreground" />
                 Settings
               </button>
-              <button 
+              <button
                 onClick={() => { setProfileMenuOpen(false); setSignOutConfirm(true) }}
                 className="w-full flex items-center gap-2 px-3 py-2.5 text-sm text-signal-red hover:bg-signal-red/10 transition-colors"
               >
@@ -516,7 +177,7 @@ export function BudgetUserHeader() {
           </>
         )}
       </div>
-      
+
       {/* Sign Out Confirmation */}
       <ConfirmationModal
         isOpen={signOutConfirm}
@@ -525,7 +186,7 @@ export function BudgetUserHeader() {
         confirmLabel="Sign out"
         cancelLabel="Cancel"
         variant="destructive"
-        onConfirm={() => { setSignOutConfirm(false); signOut() }}
+        onConfirm={() => { setSignOutConfirm(false); handleSignOut() }}
         onCancel={() => setSignOutConfirm(false)}
       />
     </div>
@@ -536,14 +197,31 @@ export function BudgetUserHeader() {
 // DESKTOP SIDEBAR
 // ============================================================================
 
-export function BudgetDesktopSidebar() {
-  const { activeTab, navigateTo, user, switchAccount, signOut, goToLaunchpad, uncategorizedCount } = useBudgetNavigation()
+export function BudgetDesktopSidebar({
+  onGoToLaunchpad,
+  onSignOut,
+}: {
+  onGoToLaunchpad?: () => void
+  onSignOut?: () => void
+}) {
+  const activeTab = useBudgetStore((s) => s.activeTab)
+  const setActiveTab = useBudgetStore((s) => s.setActiveTab)
+  const uncategorizedCount = useBudgetStore((s) => s.uncategorizedCount)
+  const user = useAuthStore((s) => s.user)
+  const accounts = useAuthStore((s) => s.accounts)
+  const currentAccount = useAuthStore((s) => s.currentAccount)
+  const authSignOut = useAuthStore((s) => s.signOut)
+  const switchAccount = useAuthStore((s) => s.switchAccount)
   const [accountMenuOpen, setAccountMenuOpen] = useState(false)
   const [signOutConfirm, setSignOutConfirm] = useState(false)
-  
-  const activeAccount = user.accounts.find(a => a.id === user.activeAccountId)
-  const initials = user.name.split(' ').map(n => n[0]).join('')
-  const firstName = user.name.split(' ')[0]
+
+  const initials = (user?.name ?? '').split(' ').map(n => n[0]).join('')
+  const firstName = (user?.name ?? '').split(' ')[0]
+
+  function handleSignOut() {
+    authSignOut()
+    onSignOut?.()
+  }
 
   return (
     <aside className="hidden md:flex flex-col w-56 h-screen bg-card border-r border-border fixed left-0 top-0">
@@ -554,7 +232,7 @@ export function BudgetDesktopSidebar() {
 
       {/* Back to Launchpad */}
       <button
-        onClick={goToLaunchpad}
+        onClick={onGoToLaunchpad}
         className="mx-3 mt-3 flex items-center gap-2 px-3 py-2 rounded-lg text-sm text-muted-foreground hover:text-foreground hover:bg-surface2 transition-colors"
       >
         <Home className="size-4" />
@@ -571,7 +249,7 @@ export function BudgetDesktopSidebar() {
         {BUDGET_NAV_ITEMS.map((item) => (
           <button
             key={item.id}
-            onClick={() => navigateTo(item.id)}
+            onClick={() => setActiveTab(item.id)}
             className={cn(
               "relative w-full flex items-center gap-3 px-5 py-2.5 text-sm font-medium transition-colors",
               activeTab === item.id
@@ -581,7 +259,6 @@ export function BudgetDesktopSidebar() {
           >
             <item.icon className="size-5" />
             <span>{item.label}</span>
-            {/* Badge for Review tab */}
             {item.id === "review" && uncategorizedCount > 0 && (
               <span className="ml-auto px-1.5 py-0.5 rounded-full bg-signal-amber text-[10px] font-bold text-background">
                 {uncategorizedCount > 99 ? "99+" : uncategorizedCount}
@@ -590,7 +267,7 @@ export function BudgetDesktopSidebar() {
           </button>
         ))}
       </nav>
-      
+
       {/* User Footer */}
       <div className="p-4 border-t border-border">
         <div className="flex items-center gap-3 mb-3">
@@ -605,10 +282,10 @@ export function BudgetDesktopSidebar() {
                 onClick={() => setAccountMenuOpen(!accountMenuOpen)}
                 className="flex items-center gap-1 text-xs text-muted-foreground hover:text-primary transition-colors"
               >
-                <span className="truncate">{activeAccount?.name}</span>
+                <span className="truncate">{currentAccount?.name}</span>
                 <ChevronDown className={cn("size-3 shrink-0 transition-transform", accountMenuOpen && "rotate-180")} />
               </button>
-              
+
               {accountMenuOpen && (
                 <>
                   <div className="fixed inset-0 z-40" onClick={() => setAccountMenuOpen(false)} />
@@ -616,17 +293,17 @@ export function BudgetDesktopSidebar() {
                     <div className="px-3 py-2 border-b border-border">
                       <p className="text-[10px] text-muted-foreground uppercase tracking-wider">Switch account</p>
                     </div>
-                    {user.accounts.map((account) => (
+                    {accounts.map((account) => (
                       <button
                         key={account.id}
                         onClick={() => { switchAccount(account.id); setAccountMenuOpen(false) }}
                         className={cn(
                           "w-full flex items-center justify-between px-3 py-2 text-sm hover:bg-surface2 transition-colors",
-                          account.id === user.activeAccountId && "bg-primary/5"
+                          account.id === currentAccount?.id && "bg-primary/5"
                         )}
                       >
                         <span className="text-foreground">{account.name}</span>
-                        {account.id === user.activeAccountId && <Check className="size-4 text-primary" />}
+                        {account.id === currentAccount?.id && <Check className="size-4 text-primary" />}
                       </button>
                     ))}
                   </div>
@@ -635,7 +312,7 @@ export function BudgetDesktopSidebar() {
             </div>
           </div>
         </div>
-        
+
         {/* Sign Out */}
         <button
           onClick={() => setSignOutConfirm(true)}
@@ -644,13 +321,13 @@ export function BudgetDesktopSidebar() {
           <LogOut className="size-4" />
           Sign out
         </button>
-        
+
         <div className="flex items-center gap-2 text-[10px] text-muted-foreground mt-3 pt-3 border-t border-border">
           <Clock className="size-3" />
           <span>Last sync: 2 min ago</span>
         </div>
       </div>
-      
+
       {/* Sign Out Confirmation */}
       <ConfirmationModal
         isOpen={signOutConfirm}
@@ -659,7 +336,7 @@ export function BudgetDesktopSidebar() {
         confirmLabel="Sign out"
         cancelLabel="Cancel"
         variant="destructive"
-        onConfirm={() => { setSignOutConfirm(false); signOut() }}
+        onConfirm={() => { setSignOutConfirm(false); handleSignOut() }}
         onCancel={() => setSignOutConfirm(false)}
       />
     </aside>
@@ -670,16 +347,19 @@ export function BudgetDesktopSidebar() {
 // APP SHELL
 // ============================================================================
 
-export function BudgetAppShell({ 
-  children 
-}: { 
-  children: ReactNode 
+export function BudgetAppShell({
+  children,
+  onGoToLaunchpad,
+  onSignOut,
+}: {
+  children: ReactNode
+  onGoToLaunchpad?: () => void
+  onSignOut?: () => void
 }) {
   return (
     <div className="min-h-screen bg-background">
-      <BudgetDesktopSidebar />
-      {/* Mobile User Header */}
-      <BudgetUserHeader />
+      <BudgetDesktopSidebar onGoToLaunchpad={onGoToLaunchpad} onSignOut={onSignOut} />
+      <BudgetUserHeader onGoToLaunchpad={onGoToLaunchpad} onSignOut={onSignOut} />
       <main className="md:ml-56 pb-20 md:pb-8 overflow-x-hidden">
         <div className="w-full px-4 md:px-6 lg:px-8">
           {children}

--- a/apps/budget-tracker/components/budget-tracker/budget-tracker-app.tsx
+++ b/apps/budget-tracker/components/budget-tracker/budget-tracker-app.tsx
@@ -1,20 +1,22 @@
 "use client"
 
-import { BudgetNavigationProvider, BudgetAppShell, useBudgetNavigation } from "./app-shell"
+import { useEffect } from "react"
+import { BudgetAppShell } from "./app-shell"
 import { TransactionsTab } from "./tabs/transactions-tab"
 import { SummaryTab } from "./tabs/summary-tab"
 import { BudgetTab } from "./tabs/budget-tab"
 import { CashflowTab } from "./tabs/cashflow-tab"
 import { RulesTab } from "./tabs/rules-tab"
 import { ReviewTab } from "./tabs/review-tab"
+import { useBudgetStore } from "@/stores/budget-tracker/use-budget-store"
 
 // ============================================================================
 // TAB RENDERER
 // ============================================================================
 
 function BudgetTabContent() {
-  const { activeTab } = useBudgetNavigation()
-  
+  const activeTab = useBudgetStore((s) => s.activeTab)
+
   switch (activeTab) {
     case "transactions":
       return <TransactionsTab />
@@ -44,14 +46,44 @@ export function BudgetTrackerApp({
   onSignOut?: () => void
   onGoToLaunchpad?: () => void
 }) {
+  const initialize = useBudgetStore((s) => s.initialize)
+  const isInitialized = useBudgetStore((s) => s.isInitialized)
+  const error = useBudgetStore((s) => s.error)
+
+  useEffect(() => {
+    initialize()
+  }, [initialize])
+
+  if (error) {
+    return (
+      <div className="min-h-screen bg-background flex items-center justify-center">
+        <div className="text-center space-y-4">
+          <p className="text-sm text-signal-red">{error}</p>
+          <button
+            onClick={() => window.location.reload()}
+            className="px-4 py-2 text-sm bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 transition-colors"
+          >
+            Reload
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  if (!isInitialized) {
+    return (
+      <div className="min-h-screen bg-background flex items-center justify-center">
+        <div className="flex items-center gap-3 text-muted-foreground">
+          <div className="size-5 border-2 border-primary border-t-transparent rounded-full animate-spin" />
+          <span className="text-sm">Loading...</span>
+        </div>
+      </div>
+    )
+  }
+
   return (
-    <BudgetNavigationProvider 
-      onSignOut={onSignOut}
-      onGoToLaunchpad={onGoToLaunchpad}
-    >
-      <BudgetAppShell>
-        <BudgetTabContent />
-      </BudgetAppShell>
-    </BudgetNavigationProvider>
+    <BudgetAppShell onGoToLaunchpad={onGoToLaunchpad} onSignOut={onSignOut}>
+      <BudgetTabContent />
+    </BudgetAppShell>
   )
 }

--- a/apps/budget-tracker/components/budget-tracker/tabs/budget-tab.tsx
+++ b/apps/budget-tracker/components/budget-tracker/tabs/budget-tab.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useState, useMemo } from "react"
-import { useBudgetNavigation } from "../app-shell"
+import { useBudgetStore } from "@/stores/budget-tracker/use-budget-store"
 import { PageHeader, Card, PrimaryButton, SecondaryButton } from "@/components/ui/design-system"
 import { ChevronDown, Plus, Pencil, Trash2, RotateCcw, X, Check, Undo2 } from "lucide-react"
 import { BUDGET_CATEGORIES, CATEGORY_LIST } from "../data/categories"
@@ -28,12 +28,10 @@ function formatCurrency(amount: number): string {
 }
 
 export function BudgetTab() {
-  const { 
-    transactions,
-    setTransactions,
-    settings,
-    updateSettings
-  } = useBudgetNavigation()
+  const transactions = useBudgetStore((s) => s.transactions)
+  const setTransactions = useBudgetStore((s) => s.setTransactions)
+  const settings = useBudgetStore((s) => s.settings)
+  const updateSettings = useBudgetStore((s) => s.updateSettings)
   const budgetSettings = settings
   const setBudgetSettings = updateSettings
 

--- a/apps/budget-tracker/components/budget-tracker/tabs/cashflow-tab.tsx
+++ b/apps/budget-tracker/components/budget-tracker/tabs/cashflow-tab.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useState, useMemo } from "react"
-import { useBudgetNavigation } from "../app-shell"
+import { useBudgetStore } from "@/stores/budget-tracker/use-budget-store"
 import { PageHeader, Card, EmptyState, PillSelector } from "@/components/ui/design-system"
 import { BarChart3 } from "lucide-react"
 import { CATEGORY_LIST } from "../data/categories"
@@ -74,7 +74,7 @@ function formatCurrencyFull(amount: number): string {
 }
 
 export function CashflowTab() {
-  const { transactions } = useBudgetNavigation()
+  const transactions = useBudgetStore((s) => s.transactions)
   const [timeRange, setTimeRange] = useState<TimeRange>("6M")
 
   // Calculate monthly data

--- a/apps/budget-tracker/components/budget-tracker/tabs/review-tab.tsx
+++ b/apps/budget-tracker/components/budget-tracker/tabs/review-tab.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useState } from "react"
-import { useBudgetNavigation } from "../app-shell"
+import { useBudgetStore } from "@/stores/budget-tracker/use-budget-store"
 import { PageHeader, Card, PrimaryButton, EmptyState } from "@/components/ui/design-system"
 import { Sparkles, Check, X, ChevronRight, Pencil, AlertCircle } from "lucide-react"
 import { getCategoryBadgeClasses } from "../data/category-colors"
@@ -18,7 +18,9 @@ interface ReviewResult {
 }
 
 export function ReviewTab() {
-  const { transactions, uncategorizedCount, updateTransaction } = useBudgetNavigation()
+  const transactions = useBudgetStore((s) => s.transactions)
+  const uncategorizedCount = useBudgetStore((s) => s.uncategorizedCount)
+  const updateTransaction = useBudgetStore((s) => s.updateTransaction)
   const { callClaude, isLoading: loading, error } = useClaude<{
     suggestions: Array<{
       transactionId: string

--- a/apps/budget-tracker/components/budget-tracker/tabs/rules-tab.tsx
+++ b/apps/budget-tracker/components/budget-tracker/tabs/rules-tab.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useState, useRef, useMemo, useEffect } from "react"
-import { useBudgetNavigation } from "../app-shell"
+import { useBudgetStore } from "@/stores/budget-tracker/use-budget-store"
 import { PageHeader, Card, PrimaryButton, SecondaryButton } from "@/components/ui/design-system"
 import { Search, Plus, RotateCcw, ChevronDown, Check, X, Pencil, Trash2, Ban, Eye, HelpCircle, Sparkles, AlertCircle } from "lucide-react"
 import { findAllMatchingRules, applyRules, type BuiltinRule } from "../data/builtin-rules"
@@ -22,7 +22,12 @@ interface SuggestedRule {
 }
 
 export function RulesTab() {
-  const { customRules, setCustomRules, builtinRules, updateBuiltinRule, addBuiltinRule, transactions, setTransactions } = useBudgetNavigation()
+  const customRules = useBudgetStore((s) => s.customRules)
+  const setCustomRules = useBudgetStore((s) => s.setCustomRules)
+  const builtinRules = useBudgetStore((s) => s.builtinRules)
+  const updateBuiltinRule = useBudgetStore((s) => s.updateBuiltinRule)
+  const transactions = useBudgetStore((s) => s.transactions)
+  const setTransactions = useBudgetStore((s) => s.setTransactions)
   
   // Fix stale closure issue with useRef
   const customRulesRef = useRef<CustomRule[]>([])

--- a/apps/budget-tracker/components/budget-tracker/tabs/summary-tab.tsx
+++ b/apps/budget-tracker/components/budget-tracker/tabs/summary-tab.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useState, useMemo } from "react"
-import { useBudgetNavigation } from "../app-shell"
+import { useBudgetStore } from "@/stores/budget-tracker/use-budget-store"
 import { PageHeader, Card, EmptyState } from "@/components/ui/design-system"
 import { ChevronLeft, ChevronRight, ChevronDown, PieChart, Briefcase } from "lucide-react"
 import { BUDGET_CATEGORIES, CATEGORY_LIST } from "../data/categories"
@@ -47,7 +47,8 @@ function formatDateShort(dateStr: string): string {
 }
 
 export function SummaryTab() {
-  const { transactions, settings } = useBudgetNavigation()
+  const transactions = useBudgetStore((s) => s.transactions)
+  const settings = useBudgetStore((s) => s.settings)
   const budgetSettings = settings // alias for compatibility
   
   // Get available months from transactions

--- a/apps/budget-tracker/components/budget-tracker/tabs/transactions-tab.tsx
+++ b/apps/budget-tracker/components/budget-tracker/tabs/transactions-tab.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useState, useMemo, useRef } from "react"
-import { useBudgetNavigation } from "../app-shell"
+import { useBudgetStore } from "@/stores/budget-tracker/use-budget-store"
 import { PageHeader, Card, PrimaryButton, SecondaryButton, EmptyState } from "@/components/ui/design-system"
 import { 
   Upload, Receipt, Filter, Download, Briefcase, X, ChevronDown, ChevronRight,
@@ -89,7 +89,15 @@ function exportToCSV(transactions: Transaction[], filename: string) {
 }
 
 export function TransactionsTab() {
-  const { transactions, setTransactions, settings, customRules, addCustomRule, builtinRules, uncategorizedCount, transactionFilters, setTransactionFilters } = useBudgetNavigation()
+  const transactions = useBudgetStore((s) => s.transactions)
+  const setTransactions = useBudgetStore((s) => s.setTransactions)
+  const settings = useBudgetStore((s) => s.settings)
+  const customRules = useBudgetStore((s) => s.customRules)
+  const addCustomRule = useBudgetStore((s) => s.addCustomRule)
+  const builtinRules = useBudgetStore((s) => s.builtinRules)
+  const uncategorizedCount = useBudgetStore((s) => s.uncategorizedCount)
+  const filters = useBudgetStore((s) => s.filters)
+  const setFilters = useBudgetStore((s) => s.setFilters)
   const customRulesRef = useRef(customRules) // Fix stale closure
   customRulesRef.current = customRules
 
@@ -117,8 +125,6 @@ export function TransactionsTab() {
   const [showBulkEdit, setShowBulkEdit] = useState(false)
   
   // Use filters from context (persisted across tab navigation)
-  const filters = transactionFilters
-  const setFilters = setTransactionFilters
 
   // Get unique sources for filter dropdown
   const uniqueSources = useMemo(() => {
@@ -1047,7 +1053,12 @@ function TransactionRow({
 
 // CSV Import Modal
 function CSVImportModal({ onClose }: { onClose: () => void }) {
-  const { transactions, setTransactions, settings, updateSettings, builtinRules, customRules } = useBudgetNavigation()
+  const transactions = useBudgetStore((s) => s.transactions)
+  const setTransactions = useBudgetStore((s) => s.setTransactions)
+  const settings = useBudgetStore((s) => s.settings)
+  const updateSettings = useBudgetStore((s) => s.updateSettings)
+  const builtinRules = useBudgetStore((s) => s.builtinRules)
+  const customRules = useBudgetStore((s) => s.customRules)
   const [step, setStep] = useState<"upload" | "preview" | "categorizing" | "importing">("upload")
   
   // AI Smart Import

--- a/apps/budget-tracker/lib/repositories/budget-tracker/settings-repository.ts
+++ b/apps/budget-tracker/lib/repositories/budget-tracker/settings-repository.ts
@@ -13,6 +13,13 @@ export interface BudgetSettings {
   budgetFreqs: Record<string, BudgetFrequency>
   customCategories: Record<string, string[]>
   projectBudgets: Record<string, number>
+  deletedCategories: string[]
+  customTopCategories: string[]
+  projectTasks: Record<string, string[]>
+  customProjectCategories: string[]
+  deletedProjectCategories: string[]
+  disabledProjectCategories: string[]
+  csvFormatMappings?: Record<string, unknown>
 }
 
 export interface TransactionFilters {
@@ -33,6 +40,12 @@ const DEFAULT_SETTINGS: BudgetSettings = {
   budgetFreqs: {},
   customCategories: {},
   projectBudgets: {},
+  deletedCategories: [],
+  customTopCategories: [],
+  projectTasks: {},
+  customProjectCategories: [],
+  deletedProjectCategories: [],
+  disabledProjectCategories: [],
 }
 
 const DEFAULT_FILTERS: TransactionFilters = {

--- a/apps/budget-tracker/stores/budget-tracker/use-budget-store.ts
+++ b/apps/budget-tracker/stores/budget-tracker/use-budget-store.ts
@@ -3,14 +3,13 @@ import { persist } from 'zustand/middleware'
 import {
   getTransactionRepository,
   getCustomRulesRepository,
-  getRulesRepository,
   getSettingsRepository,
   type Transaction,
   type CustomRule,
-  type BuiltinRule,
   type BudgetSettings,
   type TransactionFilters,
 } from '@/lib/repositories/budget-tracker'
+import { DEFAULT_BUILTIN_RULES, type BuiltinRule } from '@/components/budget-tracker/data/builtin-rules'
 
 export type BudgetTabId = 'transactions' | 'summary' | 'budget' | 'cashflow' | 'rules' | 'review'
 
@@ -57,7 +56,7 @@ interface BudgetState {
   updateSettings: (updates: Partial<BudgetSettings>) => Promise<void>
 
   // Filter actions
-  setFilters: (filters: TransactionFilters) => void
+  setFilters: (filtersOrUpdater: TransactionFilters | ((prev: TransactionFilters) => TransactionFilters)) => void
   resetFilters: () => void
 
   // Initialization
@@ -79,6 +78,12 @@ const DEFAULT_SETTINGS: BudgetSettings = {
   budgetFreqs: {},
   customCategories: {},
   projectBudgets: {},
+  deletedCategories: [],
+  customTopCategories: [],
+  projectTasks: {},
+  customProjectCategories: [],
+  deletedProjectCategories: [],
+  disabledProjectCategories: [],
 }
 
 export const useBudgetStore = create<BudgetState>()(
@@ -140,8 +145,7 @@ export const useBudgetStore = create<BudgetState>()(
       // Rules
       loadRules: async () => {
         const customRules = await getCustomRulesRepository().findAll('')
-        const builtinRules = getRulesRepository().getBuiltinRules() ?? []
-        set({ customRules, builtinRules })
+        set({ customRules, builtinRules: DEFAULT_BUILTIN_RULES })
       },
 
       addCustomRule: async (rule) => {
@@ -172,10 +176,9 @@ export const useBudgetStore = create<BudgetState>()(
       },
 
       updateBuiltinRule: async (id, updates) => {
-        const localRepo = getRulesRepository()
-        localRepo.updateBuiltinRule(id, updates)
-        const builtinRules = localRepo.getBuiltinRules() ?? []
-        set({ builtinRules })
+        set((state) => ({
+          builtinRules: state.builtinRules.map(r => r.id === id ? { ...r, ...updates } : r),
+        }))
       },
 
       setBuiltinRules: (builtinRules) => {
@@ -199,7 +202,8 @@ export const useBudgetStore = create<BudgetState>()(
       },
 
       // Filters
-      setFilters: (filters) => {
+      setFilters: (filtersOrUpdater) => {
+        const filters = typeof filtersOrUpdater === 'function' ? filtersOrUpdater(get().filters) : filtersOrUpdater
         set({ filters })
         getSettingsRepository().updateFilters(filters)
       },


### PR DESCRIPTION
## What this PR does

Completes the repository swap by activating the DynamoDB-backed data path. Previously the Zustand store (\`useBudgetStore\`) and DynamoDB repositories existed but were dead code — every component used \`useBudgetNavigation()\` which hydrated from localStorage on mount.

## Changes

**Architecture:**
- \`BudgetTrackerApp\` calls \`useBudgetStore.initialize()\` on mount
- Every tab converted from \`useBudgetNavigation()\` to \`useBudgetStore\` selectors
- App-level loading state (spinner) while \`!isInitialized\`
- App-level error state with Reload button on fetch failure
- \`BudgetNavigationProvider\` and its localStorage hydration deleted
- \`BudgetUserHeader\` / \`BudgetDesktopSidebar\` now read \`user\`, \`accounts\`, \`currentAccount\` from \`useAuthStore\`; \`goToLaunchpad\`/\`onSignOut\` thread through \`BudgetAppShell\` props

**Type fixes (pre-existing mismatches surfaced by migration):**
- \`BudgetSettings\` in \`settings-repository.ts\` was missing 6 fields used by budget-tab; type and \`DEFAULT_SETTINGS\` updated
- \`BuiltinRule\` had two incompatible definitions (repo vs UI layer); store now uses UI type from \`data/builtin-rules\` and loads \`DEFAULT_BUILTIN_RULES\` directly
- \`setFilters\` now accepts function updater (transactions-tab uses \`setFilters(f => {...})\` extensively)
- \`addBuiltinRule\` removed from rules-tab (confirmed dead code — see recon in PR conversation)

## Data path after this PR

\`NEXT_PUBLIC_RUNTIME_PROFILE\` → \`selectProvider\` → repository factory → DynamoDB (live) or localStorage (mock).

Transactions and rules now read from DynamoDB in the deployed dev environment. Settings remain on localStorage until #179 lands (\`DynamoSettingsRepository\` is that issue's scope).

## Files changed

10 files: every budget-tracker tab + app shell + budget-tracker-app + settings-repository + use-budget-store. Net: −446 / +192.

## Verification

### TypeScript + build
- \`pnpm --filter @transformotion/budget exec tsc --noEmit\` — clean
- \`pnpm --filter @transformotion/budget build\` — clean (4 static routes)
- Pre-commit hooks passed

### Deployed dev (post-merge)
- Transactions tab should show 732 migrated transactions from #187
- Rules tab empty (rules migration #200 not yet run)
- Settings tab works (localStorage; #179 is its own scope)
- Loading spinner visible briefly on first load
- No 400 errors (header fix in #209 unblocked auth)

## Cross-references

- M6 #208 (PR #209) — header case-sensitivity fix; prerequisite
- M6 #179 — settings repository swap (not in scope)
- M6 #182 — tab error boundaries (granular loading deferred)
- #210 — auth store refactor, Backlog

Closes #178.