### PR TITLE
fix(budget-tracker): initialize auth before budget store, show sign-in screen when unauthenticated

### DIFF
--- a/apps/budget-tracker/components/budget-tracker/budget-tracker-app.tsx
+++ b/apps/budget-tracker/components/budget-tracker/budget-tracker-app.tsx
@@ -9,6 +9,8 @@ import { CashflowTab } from "./tabs/cashflow-tab"
 import { RulesTab } from "./tabs/rules-tab"
 import { ReviewTab } from "./tabs/review-tab"
 import { useBudgetStore } from "@/stores/budget-tracker/use-budget-store"
+import { useAuthStore } from "@/stores/auth/use-auth-store"
+import { getConfig } from "@/lib/config"
 
 // ============================================================================
 // TAB RENDERER
@@ -46,13 +48,41 @@ export function BudgetTrackerApp({
   onSignOut?: () => void
   onGoToLaunchpad?: () => void
 }) {
+  const initAuth = useAuthStore((s) => s.initialize)
+  const isAuthenticated = useAuthStore((s) => s.isAuthenticated)
+  const authLoading = useAuthStore((s) => s.isLoading)
+
   const initialize = useBudgetStore((s) => s.initialize)
   const isInitialized = useBudgetStore((s) => s.isInitialized)
   const error = useBudgetStore((s) => s.error)
 
   useEffect(() => {
-    initialize()
-  }, [initialize])
+    initAuth()
+  }, [initAuth])
+
+  useEffect(() => {
+    if (isAuthenticated) {
+      initialize()
+    }
+  }, [isAuthenticated, initialize])
+
+  // Redirect to sign-in when auth check completes and user is not authenticated
+  useEffect(() => {
+    if (!authLoading && !isAuthenticated) {
+      window.location.assign(getConfig().apps.signInUrl)
+    }
+  }, [authLoading, isAuthenticated])
+
+  if (authLoading || (!isAuthenticated && !authLoading)) {
+    return (
+      <div className="min-h-screen bg-background flex items-center justify-center">
+        <div className="flex items-center gap-3 text-muted-foreground">
+          <div className="size-5 border-2 border-primary border-t-transparent rounded-full animate-spin" />
+          <span className="text-sm">Loading...</span>
+        </div>
+      </div>
+    )
+  }
 
   if (error) {
     return (

--- a/apps/budget-tracker/components/budget-tracker/budget-tracker-app.tsx
+++ b/apps/budget-tracker/components/budget-tracker/budget-tracker-app.tsx
@@ -66,19 +66,28 @@ export function BudgetTrackerApp({
     }
   }, [isAuthenticated, initialize])
 
-  // Redirect to sign-in when auth check completes and user is not authenticated
-  useEffect(() => {
-    if (!authLoading && !isAuthenticated) {
-      window.location.assign(getConfig().apps.signInUrl)
-    }
-  }, [authLoading, isAuthenticated])
-
-  if (authLoading || (!isAuthenticated && !authLoading)) {
+  if (authLoading) {
     return (
       <div className="min-h-screen bg-background flex items-center justify-center">
         <div className="flex items-center gap-3 text-muted-foreground">
           <div className="size-5 border-2 border-primary border-t-transparent rounded-full animate-spin" />
           <span className="text-sm">Loading...</span>
+        </div>
+      </div>
+    )
+  }
+
+  if (!isAuthenticated) {
+    return (
+      <div className="min-h-screen bg-background flex items-center justify-center">
+        <div className="text-center space-y-4">
+          <p className="text-sm text-muted-foreground">Sign in required</p>
+          <a
+            href={getConfig().apps.signInUrl}
+            className="inline-block px-4 py-2 text-sm bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 transition-colors"
+          >
+            Sign in
+          </a>
         </div>
       </div>
     )


### PR DESCRIPTION
## Summary
- Calls `useAuthStore.initialize()` on mount before `useBudgetStore.initialize()`, so the Cognito session is verified before any API calls are made
- Budget store initialization is gated on `isAuthenticated`
- When auth resolves to unauthenticated, shows a static \"Sign in\" screen (link to sign-in URL) instead of auto-redirecting — prevents an infinite redirect loop

## Context
After PR #211 landed, smoke testing revealed 401 Unauthorized on all budget API calls. Root cause: `Authorization: Bearer` header was being sent with an empty token.

Root cause of empty token: Budget Tracker configures Amplify with `BudgetTrackerAppClient`, but the user's tokens were stored by Stock Analyser sign-in under `StockAnalyserAppClient`. Amplify's `fetchAuthSession()` looks up tokens by client ID → finds nothing → empty Bearer.

This PR fixes the sequencing (budget store no longer fires API calls before auth is checked) and the redirect loop (static screen instead of `window.location.assign`).

## What this PR does NOT fix

The 401 errors will persist until the canonical Hosted UI auth flow is implemented:
1. Launchpad: real `signInWithRedirect` → session cookie set on Cognito domain
2. Each app: `signInWithRedirect` with its own client ID → session cookie enables silent re-auth

That work is tracked as part of the auth substrate canonical implementation. This PR is a safe intermediate state: unauthenticated users see a \"Sign in\" link rather than hitting API errors or looping.

## Test plan
- [ ] Merge this PR
- [ ] Manually trigger Budget Tracker deploy → dev
- [ ] Navigate to `https://dev.apps.transformotion.com.au/budget-tracker/` without signing in — should show \"Sign in required\" screen with a \"Sign in\" link
- [ ] Click the link → goes to sign-in page once (no loop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)