### PR TITLE
fix: Cognito Hosted UI styling + sign-in redirect flow

### DIFF
--- a/apps/budget-tracker/app/callback/page.tsx
+++ b/apps/budget-tracker/app/callback/page.tsx
@@ -5,6 +5,17 @@ import { useRouter } from 'next/navigation'
 import { Hub } from 'aws-amplify/utils'
 import { authService } from '@/lib/services/auth'
 
+function sanitizeAmplifyOAuthState() {
+  const keysToFix: string[] = []
+  for (let i = 0; i < localStorage.length; i++) {
+    const key = localStorage.key(i)
+    if (key?.endsWith('.oauthSignIn') && localStorage.getItem(key) === 'true,false') {
+      keysToFix.push(key)
+    }
+  }
+  keysToFix.forEach(key => localStorage.setItem(key, 'true'))
+}
+
 export default function CallbackPage() {
   const router = useRouter()
   const [error, setError] = useState<string | null>(null)
@@ -12,6 +23,7 @@ export default function CallbackPage() {
   useEffect(() => {
     const unsubscribe = Hub.listen('auth', ({ payload }) => {
       if (payload.event === 'signInWithRedirect') {
+        sanitizeAmplifyOAuthState()
         router.replace('/')
       }
       if (payload.event === 'signInWithRedirect_failure') {

--- a/apps/launchpad/app/callback/page.tsx
+++ b/apps/launchpad/app/callback/page.tsx
@@ -5,15 +5,25 @@ import { useRouter } from 'next/navigation'
 import { Hub } from 'aws-amplify/utils'
 import { authService } from '@/lib/services/auth'
 
+function sanitizeAmplifyOAuthState() {
+  const keysToFix: string[] = []
+  for (let i = 0; i < localStorage.length; i++) {
+    const key = localStorage.key(i)
+    if (key?.endsWith('.oauthSignIn') && localStorage.getItem(key) === 'true,false') {
+      keysToFix.push(key)
+    }
+  }
+  keysToFix.forEach(key => localStorage.setItem(key, 'true'))
+}
+
 export default function CallbackPage() {
   const router = useRouter()
   const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
-    // Ensure Amplify is configured (authService import triggers this) then
-    // subscribe to the OAuth code exchange completion event.
     const unsubscribe = Hub.listen('auth', ({ payload }) => {
       if (payload.event === 'signInWithRedirect') {
+        sanitizeAmplifyOAuthState()
         router.replace('/')
       }
       if (payload.event === 'signInWithRedirect_failure') {

--- a/apps/launchpad/components/auth/sign-in.tsx
+++ b/apps/launchpad/components/auth/sign-in.tsx
@@ -1,186 +1,54 @@
 'use client'
 
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { cn } from '@/lib/utils'
 import { Wordmark } from '@/components/brand/wordmark'
-import { ArrowRight, HelpCircle } from 'lucide-react'
 import { Spinner } from '@/components/ui/spinner'
 import { authService } from '@/lib/services/auth'
 
-function GoogleIcon({ className }: { className?: string }) {
-  return (
-    <svg className={className} viewBox="0 0 24 24" fill="currentColor">
-      <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z" fill="#4285F4"/>
-      <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853"/>
-      <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" fill="#FBBC05"/>
-      <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335"/>
-    </svg>
-  )
-}
-
-function MicrosoftIcon({ className }: { className?: string }) {
-  return (
-    <svg className={className} viewBox="0 0 24 24" fill="currentColor">
-      <path d="M11.4 11.4H2V2h9.4v9.4z" fill="#F35325"/>
-      <path d="M22 11.4h-9.4V2H22v9.4z" fill="#81BC06"/>
-      <path d="M11.4 22H2v-9.4h9.4V22z" fill="#05A6F0"/>
-      <path d="M22 22h-9.4v-9.4H22V22z" fill="#FFBA08"/>
-    </svg>
-  )
-}
-
-function FacebookIcon({ className }: { className?: string }) {
-  return (
-    <svg className={className} viewBox="0 0 24 24" fill="#1877F2">
-      <path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/>
-    </svg>
-  )
-}
-
-function AppleIcon({ className }: { className?: string }) {
-  return (
-    <svg className={className} viewBox="0 0 24 24" fill="currentColor">
-      <path d="M18.71 19.5c-.83 1.24-1.71 2.45-3.05 2.47-1.34.03-1.77-.79-3.29-.79-1.53 0-2 .77-3.27.82-1.31.05-2.3-1.32-3.14-2.53C4.25 17 2.94 12.45 4.7 9.39c.87-1.52 2.43-2.48 4.12-2.51 1.28-.02 2.5.87 3.29.87.78 0 2.26-1.07 3.81-.91.65.03 2.47.26 3.64 1.98-.09.06-2.17 1.28-2.15 3.81.03 3.02 2.65 4.03 2.68 4.04-.03.07-.42 1.44-1.38 2.83M13 3.5c.73-.83 1.94-1.46 2.94-1.5.13 1.17-.34 2.35-1.04 3.19-.69.85-1.83 1.51-2.95 1.42-.15-1.15.41-2.35 1.05-3.11z"/>
-    </svg>
-  )
-}
-
-function SocialButton({
-  provider,
-  icon: Icon,
-  disabled = false,
-  onClick,
-}: {
-  provider: string
-  icon: React.ComponentType<{ className?: string }>
-  disabled?: boolean
-  onClick: () => void
-}) {
-  return (
-    <button
-      onClick={onClick}
-      disabled={disabled}
-      className={cn(
-        'flex items-center justify-center gap-3 w-full h-12 rounded-xl border transition-all font-medium text-sm',
-        disabled
-          ? 'bg-surface2/50 border-border/50 text-muted-foreground cursor-not-allowed opacity-50'
-          : 'bg-card border-border hover:border-primary/30 hover:bg-surface2 text-foreground',
-      )}
-    >
-      <Icon className="size-5" />
-      <span>Continue with {provider}</span>
-      {disabled && <span className="text-xs text-muted-foreground">(Coming soon)</span>}
-    </button>
-  )
-}
-
-function Divider() {
-  return (
-    <div className="flex items-center gap-4 my-6">
-      <div className="flex-1 h-px bg-border" />
-      <span className="text-xs text-muted-foreground">or continue with email</span>
-      <div className="flex-1 h-px bg-border" />
-    </div>
-  )
-}
-
 export function SignIn() {
-  const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
-  const handleSignIn = async (provider?: string) => {
-    setIsLoading(true)
-    setError(null)
-    try {
-      await authService.signInWithRedirect(provider ? { provider } : undefined)
-    } catch (err) {
-      setIsLoading(false)
+  useEffect(() => {
+    authService.signInWithRedirect().catch(err => {
       setError(err instanceof Error ? err.message : 'Sign in failed. Please try again.')
-    }
-  }
+    })
+  }, [])
 
   return (
     <div className="min-h-screen bg-background flex flex-col">
       <div className="absolute top-0 left-0 right-0 h-64 bg-gradient-to-b from-primary/5 to-transparent pointer-events-none" />
 
       <main className="flex-1 flex items-center justify-center p-4">
-        <div className="w-full max-w-md sm:max-w-lg lg:max-w-xl">
-          <div className="text-center mb-6 sm:mb-8">
-            <div className="flex justify-center mb-4 sm:mb-6">
-              <Wordmark size="xl" />
-            </div>
-            <h1 className="text-2xl font-bold text-foreground mb-1">Welcome back</h1>
-            <p className="text-muted-foreground">Sign in to access your dashboard</p>
+        <div className="w-full max-w-md text-center">
+          <div className="flex justify-center mb-10">
+            <Wordmark size="xl" />
           </div>
 
-          <div className="bg-card border border-border rounded-2xl p-5 sm:p-6 shadow-xl shadow-black/5">
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-              <SocialButton
-                provider="Google"
-                icon={GoogleIcon}
-                onClick={() => handleSignIn('Google')}
-              />
-              <SocialButton
-                provider="Microsoft"
-                icon={MicrosoftIcon}
-                onClick={() => handleSignIn('Microsoft')}
-              />
-              <SocialButton
-                provider="Facebook"
-                icon={FacebookIcon}
-                onClick={() => handleSignIn('Facebook')}
-              />
-              <SocialButton provider="Apple" icon={AppleIcon} disabled onClick={() => {}} />
-            </div>
-
-            <Divider />
-
-            {error && (
-              <p className="text-sm text-destructive text-center mb-4">{error}</p>
-            )}
-
-            <button
-              onClick={() => handleSignIn()}
-              disabled={isLoading}
-              className={cn(
-                'w-full h-12 rounded-xl font-medium transition-all flex items-center justify-center gap-2',
-                'bg-primary text-primary-foreground shadow-lg shadow-primary/25',
-                'hover:bg-primary/90 active:scale-[0.98]',
-                'disabled:opacity-70 disabled:cursor-not-allowed disabled:active:scale-100',
-              )}
-            >
-              {isLoading ? (
-                <Spinner className="size-5" />
-              ) : (
-                <>
-                  Continue with email
-                  <ArrowRight className="size-4" />
-                </>
-              )}
-            </button>
-
-            <button
-              type="button"
-              onClick={() => handleSignIn()}
-              disabled={isLoading}
-              className="w-full flex items-center justify-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors mt-3"
-            >
-              <HelpCircle className="size-4" />
-              Forgot how you signed in?
-            </button>
-          </div>
-
-          <div className="text-center mt-8">
-            <p className="text-sm text-muted-foreground">
-              Don&apos;t have an account?{' '}
+          {error ? (
+            <div className="space-y-4">
+              <p className="text-sm text-destructive">{error}</p>
               <button
-                onClick={() => handleSignIn()}
-                className="text-primary hover:text-primary/80 font-medium transition-colors"
+                onClick={() => {
+                  setError(null)
+                  authService.signInWithRedirect().catch(err => {
+                    setError(err instanceof Error ? err.message : 'Sign in failed.')
+                  })
+                }}
+                className={cn(
+                  'px-6 h-10 rounded-xl font-medium text-sm transition-all',
+                  'bg-primary text-primary-foreground hover:bg-primary/90',
+                )}
               >
-                Create one
+                Try again
               </button>
-            </p>
-          </div>
+            </div>
+          ) : (
+            <div className="flex items-center justify-center gap-3 text-muted-foreground">
+              <Spinner className="size-5" />
+              <span className="text-sm">Signing in…</span>
+            </div>
+          )}
         </div>
       </main>
 

--- a/apps/stock-analyser/app/stock-signal/callback/page.tsx
+++ b/apps/stock-analyser/app/stock-signal/callback/page.tsx
@@ -5,6 +5,17 @@ import { useRouter } from 'next/navigation'
 import { Hub } from 'aws-amplify/utils'
 import { authService } from '@/lib/services/auth'
 
+function sanitizeAmplifyOAuthState() {
+  const keysToFix: string[] = []
+  for (let i = 0; i < localStorage.length; i++) {
+    const key = localStorage.key(i)
+    if (key?.endsWith('.oauthSignIn') && localStorage.getItem(key) === 'true,false') {
+      keysToFix.push(key)
+    }
+  }
+  keysToFix.forEach(key => localStorage.setItem(key, 'true'))
+}
+
 export default function CallbackPage() {
   const router = useRouter()
   const [error, setError] = useState<string | null>(null)
@@ -12,6 +23,7 @@ export default function CallbackPage() {
   useEffect(() => {
     const unsubscribe = Hub.listen('auth', ({ payload }) => {
       if (payload.event === 'signInWithRedirect') {
+        sanitizeAmplifyOAuthState()
         router.replace('/stock-signal/')
       }
       if (payload.event === 'signInWithRedirect_failure') {

--- a/apps/stock-analyser/components/auth/sign-in.tsx
+++ b/apps/stock-analyser/components/auth/sign-in.tsx
@@ -1,165 +1,54 @@
 "use client"
 
-import { useState } from "react"
+import { useEffect, useState } from "react"
 import { cn } from "@/lib/utils"
 import { Wordmark } from "@/components/brand/wordmark"
-import { ArrowRight, HelpCircle } from "lucide-react"
 import { Spinner } from "@/components/ui/spinner"
 import { authService } from "@/lib/services/auth"
 
-// Social provider icons (inline SVG for consistent styling)
-function GoogleIcon({ className }: { className?: string }) {
-  return (
-    <svg className={className} viewBox="0 0 24 24" fill="currentColor">
-      <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z" fill="#4285F4"/>
-      <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853"/>
-      <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" fill="#FBBC05"/>
-      <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335"/>
-    </svg>
-  )
-}
-
-function MicrosoftIcon({ className }: { className?: string }) {
-  return (
-    <svg className={className} viewBox="0 0 24 24" fill="currentColor">
-      <path d="M11.4 11.4H2V2h9.4v9.4z" fill="#F35325"/>
-      <path d="M22 11.4h-9.4V2H22v9.4z" fill="#81BC06"/>
-      <path d="M11.4 22H2v-9.4h9.4V22z" fill="#05A6F0"/>
-      <path d="M22 22h-9.4v-9.4H22V22z" fill="#FFBA08"/>
-    </svg>
-  )
-}
-
-function FacebookIcon({ className }: { className?: string }) {
-  return (
-    <svg className={className} viewBox="0 0 24 24" fill="#1877F2">
-      <path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/>
-    </svg>
-  )
-}
-
-function AppleIcon({ className }: { className?: string }) {
-  return (
-    <svg className={className} viewBox="0 0 24 24" fill="currentColor">
-      <path d="M18.71 19.5c-.83 1.24-1.71 2.45-3.05 2.47-1.34.03-1.77-.79-3.29-.79-1.53 0-2 .77-3.27.82-1.31.05-2.3-1.32-3.14-2.53C4.25 17 2.94 12.45 4.7 9.39c.87-1.52 2.43-2.48 4.12-2.51 1.28-.02 2.5.87 3.29.87.78 0 2.26-1.07 3.81-.91.65.03 2.47.26 3.64 1.98-.09.06-2.17 1.28-2.15 3.81.03 3.02 2.65 4.03 2.68 4.04-.03.07-.42 1.44-1.38 2.83M13 3.5c.73-.83 1.94-1.46 2.94-1.5.13 1.17-.34 2.35-1.04 3.19-.69.85-1.83 1.51-2.95 1.42-.15-1.15.41-2.35 1.05-3.11z"/>
-    </svg>
-  )
-}
-
-// Components
-function SocialButton({ 
-  provider, 
-  icon: Icon, 
-  disabled = false,
-  onClick 
-}: { 
-  provider: string
-  icon: React.ComponentType<{ className?: string }>
-  disabled?: boolean
-  onClick: () => void
-}) {
-  return (
-    <button
-      onClick={onClick}
-      disabled={disabled}
-      className={cn(
-        "flex items-center justify-center gap-3 w-full h-12 rounded-xl border transition-all",
-        "font-medium text-sm",
-        disabled
-          ? "bg-surface2/50 border-border/50 text-muted-foreground cursor-not-allowed opacity-50"
-          : "bg-card border-border hover:border-primary/30 hover:bg-surface2 text-foreground"
-      )}
-    >
-      <Icon className="size-5" />
-      <span>Continue with {provider}</span>
-      {disabled && <span className="text-xs text-muted-foreground">(Coming soon)</span>}
-    </button>
-  )
-}
-
-function Divider() {
-  return (
-    <div className="flex items-center gap-4 my-6">
-      <div className="flex-1 h-px bg-border" />
-      <span className="text-xs text-muted-foreground">or continue with email</span>
-      <div className="flex-1 h-px bg-border" />
-    </div>
-  )
-}
-
 export function SignIn() {
-  const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
-  const handleSignIn = async (provider?: string) => {
-    setIsLoading(true)
-    setError(null)
-    try {
-      await authService.signInWithRedirect(provider ? { provider } : undefined)
-    } catch (err) {
-      setIsLoading(false)
-      setError(err instanceof Error ? err.message : 'Sign in failed. Please try again.')
-    }
-  }
+  useEffect(() => {
+    authService.signInWithRedirect().catch(err => {
+      setError(err instanceof Error ? err.message : "Sign in failed. Please try again.")
+    })
+  }, [])
 
   return (
     <div className="min-h-screen bg-background flex flex-col">
       <div className="absolute top-0 left-0 right-0 h-64 bg-gradient-to-b from-primary/5 to-transparent pointer-events-none" />
 
       <main className="flex-1 flex items-center justify-center p-4">
-        <div className="w-full max-w-md sm:max-w-lg lg:max-w-xl">
-          <div className="text-center mb-6 sm:mb-8">
-            <div className="flex justify-center mb-4 sm:mb-6">
-              <Wordmark size="lg" />
-            </div>
-            <h1 className="text-2xl font-bold text-foreground mb-1">Welcome back</h1>
-            <p className="text-muted-foreground">Sign in to access your dashboard</p>
+        <div className="w-full max-w-md text-center">
+          <div className="flex justify-center mb-10">
+            <Wordmark size="lg" />
           </div>
 
-          <div className="bg-card border border-border rounded-2xl p-5 sm:p-6 shadow-xl shadow-black/5">
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-              <SocialButton provider="Google" icon={GoogleIcon} onClick={() => handleSignIn("Google")} />
-              <SocialButton provider="Microsoft" icon={MicrosoftIcon} onClick={() => handleSignIn("Microsoft")} />
-              <SocialButton provider="Facebook" icon={FacebookIcon} onClick={() => handleSignIn("Facebook")} />
-              <SocialButton provider="Apple" icon={AppleIcon} disabled onClick={() => {}} />
-            </div>
-
-            <Divider />
-
-            {error && <p className="text-sm text-red-400 text-center mb-4">{error}</p>}
-
-            <button
-              onClick={() => handleSignIn()}
-              disabled={isLoading}
-              className={cn(
-                "w-full h-12 rounded-xl font-medium transition-all flex items-center justify-center gap-2",
-                "bg-primary text-primary-foreground shadow-lg shadow-primary/25",
-                "hover:bg-primary/90 active:scale-[0.98]",
-                "disabled:opacity-70 disabled:cursor-not-allowed disabled:active:scale-100"
-              )}
-            >
-              {isLoading ? <Spinner className="size-5" /> : <><span>Continue with email</span><ArrowRight className="size-4" /></>}
-            </button>
-
-            <button
-              type="button"
-              onClick={() => handleSignIn()}
-              disabled={isLoading}
-              className="w-full flex items-center justify-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors mt-3"
-            >
-              <HelpCircle className="size-4" />
-              Forgot how you signed in?
-            </button>
-          </div>
-
-          <div className="text-center mt-8">
-            <p className="text-sm text-muted-foreground">
-              Don&apos;t have an account?{" "}
-              <button onClick={() => handleSignIn()} className="text-primary hover:text-primary/80 font-medium transition-colors">
-                Create one
+          {error ? (
+            <div className="space-y-4">
+              <p className="text-sm text-red-400">{error}</p>
+              <button
+                onClick={() => {
+                  setError(null)
+                  authService.signInWithRedirect().catch(err => {
+                    setError(err instanceof Error ? err.message : "Sign in failed.")
+                  })
+                }}
+                className={cn(
+                  "px-6 h-10 rounded-xl font-medium text-sm transition-all",
+                  "bg-primary text-primary-foreground hover:bg-primary/90"
+                )}
+              >
+                Try again
               </button>
-            </p>
-          </div>
+            </div>
+          ) : (
+            <div className="flex items-center justify-center gap-3 text-muted-foreground">
+              <Spinner className="size-5" />
+              <span className="text-sm">Signing in…</span>
+            </div>
+          )}
         </div>
       </main>
 

--- a/infrastructure/lib/platform/auth-stack.ts
+++ b/infrastructure/lib/platform/auth-stack.ts
@@ -7,6 +7,7 @@ import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as lambdaNodejs from 'aws-cdk-lib/aws-lambda-nodejs';
 import * as secretsmanager from 'aws-cdk-lib/aws-secretsmanager';
 import { Construct } from 'constructs';
+import { cognitoHostedUiCss } from './cognito-hosted-ui-css';
 
 export interface AuthStackProps extends cdk.StackProps {
   stage: 'dev' | 'prod';
@@ -277,6 +278,20 @@ export class AuthStack extends cdk.Stack {
         precedence:  group.precedence,
       });
     }
+
+    // ── Hosted UI Customisation ────────────────────────────────────────────
+    // Applies the dark navy + teal theme to the Cognito Classic Hosted UI.
+    // Applied to all app clients (clientId: 'ALL'). SA and BT clients don't
+    // render social IDP buttons so those CSS rules are harmlessly unused for them.
+    const hostedUiCustomisation = new cognito.CfnUserPoolUICustomizationAttachment(
+      this, 'HostedUICustomisation', {
+        userPoolId: this.userPool.userPoolId,
+        clientId:   'ALL',
+        css:        cognitoHostedUiCss,
+      },
+    );
+    // Domain must exist before customisation can be applied.
+    hostedUiCustomisation.node.addDependency(this.userPoolDomain);
 
     // ── Outputs ────────────────────────────────────────────────────────────
     new cdk.CfnOutput(this, 'UserPoolId', {

--- a/infrastructure/lib/platform/cognito-hosted-ui-css.ts
+++ b/infrastructure/lib/platform/cognito-hosted-ui-css.ts
@@ -1,0 +1,138 @@
+/**
+ * CSS for the Cognito Classic Hosted UI.
+ *
+ * Applied via CfnUserPoolUICustomizationAttachment in auth-stack.ts.
+ * Matches the Transformotion dark theme: navy background (#0D1B2A), teal primary (#00C4B3).
+ *
+ * If the user pool is ever migrated to Cognito Managed Login (v2), these selectors
+ * will need to be replaced with the Managed Login CSS custom properties instead.
+ */
+export const cognitoHostedUiCss = `
+body {
+  background-color: #0D1B2A;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
+}
+
+.banner-customizable {
+  padding: 24px 0 8px 0;
+  background-color: #0D1B2A;
+}
+
+.modal-content {
+  background-color: #141720;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 16px;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.4);
+}
+
+h1 {
+  color: #e8eaf0;
+  font-size: 24px;
+  font-weight: 700;
+}
+
+h2 {
+  color: #e8eaf0;
+  font-size: 18px;
+  font-weight: 600;
+}
+
+.label-customizable {
+  font-weight: 500;
+  font-size: 14px;
+  color: #e8eaf0;
+}
+
+.textDescription-customizable {
+  font-size: 14px;
+  color: #6b7280;
+  padding-top: 8px;
+  padding-bottom: 12px;
+}
+
+.inputField-customizable {
+  color: #e8eaf0;
+  background-color: #1c2030;
+  border: 1px solid rgba(255, 255, 255, 0.10);
+  border-radius: 10px;
+  font-size: 14px;
+}
+
+.inputField-customizable:focus {
+  border-color: #00C4B3;
+  box-shadow: 0 0 0 3px rgba(0, 196, 179, 0.15);
+  outline: none;
+}
+
+.submitButton-customizable {
+  background-color: #00C4B3;
+  border-color: #00C4B3;
+  border-radius: 10px;
+  font-size: 14px;
+  font-weight: 600;
+  color: #ffffff;
+}
+
+.submitButton-customizable:hover {
+  background-color: #00b0a0;
+  border-color: #00b0a0;
+  color: #ffffff;
+}
+
+.submitButton-customizable:active {
+  background-color: #009e8f;
+  border-color: #009e8f;
+}
+
+.errorMessage-customizable {
+  color: #f05656;
+  font-size: 14px;
+  background-color: transparent;
+}
+
+.idpButton-customizable {
+  background-color: #1c2030;
+  border: 1px solid rgba(255, 255, 255, 0.10);
+  border-radius: 10px;
+  color: #e8eaf0;
+  font-size: 14px;
+  font-weight: 500;
+}
+
+.idpButton-customizable:hover {
+  background-color: #252a3a;
+  border-color: rgba(0, 196, 179, 0.3);
+}
+
+.idpButtonText-customizable {
+  color: #e8eaf0;
+  font-weight: 500;
+}
+
+.or-customizable {
+  color: #6b7280;
+  font-size: 12px;
+}
+
+.lostPassword-customizable {
+  color: #6b7280;
+  font-size: 14px;
+}
+
+.lostPassword-customizable:hover {
+  color: #00C4B3;
+}
+
+.redirectToSignUp {
+  color: #6b7280;
+  font-size: 14px;
+}
+
+a {
+  color: #00C4B3;
+}
+
+a:hover {
+  color: #00b0a0;
+}
+`;


### PR DESCRIPTION
## Summary

- **Cognito Hosted UI CSS** — adds `CfnUserPoolUICustomizationAttachment` to `auth-stack` with the dark navy (`#0D1B2A`) + teal (`#00C4B3`) theme, matching the Transformotion design system. First time styling has been applied to the Hosted UI.
- **Sign-in redirect flow** — both SA and Launchpad sign-in components now auto-redirect to the Hosted UI on mount (Wordmark + spinner briefly, then Cognito's email/password form directly visible — no intermediate button click required).
- **`oauthSignIn` sanitization** — all three callback pages now fix the Amplify v6 bug that writes `'true,false'` to localStorage and corrupts auth state after every OAuth code exchange, which was causing infinite redirect loops.

## Deploy order

1. **CDK platform deploy** (fires from `infrastructure/` change) — applies Hosted UI CSS to Cognito
2. **SA + Launchpad + BT frontend deploys** (fire from `apps/` changes) — updated sign-in components and callback pages

CDK should land first so the Hosted UI isn't unstyled during the window between deploys, but there is no hard ordering requirement.

## Test plan

- [ ] Navigate to `dev.apps.transformotion.com.au/sign-in/` — should briefly show Transformotion wordmark + spinner, then redirect to styled Cognito Hosted UI with email + password fields visible directly
- [ ] Sign in with email/password — should redirect to `/launchpad/` after successful auth
- [ ] Sign in with Google — should SSO via Google, return to callback, redirect to `/launchpad/`
- [ ] Navigate to `/stock-signal/` without session — should redirect to Hosted UI, sign in silently via SSO cookie if Launchpad session exists
- [ ] Navigate to `/budget-tracker/` without session — same SSO behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)