### PR TITLE
Fix auth loop: getCurrentUser uses token claims + signInWithRedirect preserves valid tokens

### DIFF
--- a/packages/auth-client/src/cognito-auth.ts
+++ b/packages/auth-client/src/cognito-auth.ts
@@ -6,9 +6,8 @@ import {
   signOut as amplifySignOut,
   signUp as amplifySignUp,
   signInWithRedirect as amplifySignInWithRedirect,
-  getCurrentUser,
+  getCurrentUser as amplifyGetCurrentUser,
   fetchAuthSession,
-  fetchUserAttributes,
 } from 'aws-amplify/auth'
 import type { AuthService, AuthSession, AuthTokens, User, Account, SignInCredentials, SignUpCredentials } from './index'
 
@@ -35,17 +34,19 @@ export class CognitoAuthService implements AuthService {
 
   async getCurrentUser(): Promise<User | null> {
     try {
-      const [cognitoUser, attributes] = await Promise.all([
-        getCurrentUser(),
-        fetchUserAttributes(),
+      const [cognitoUser, session] = await Promise.all([
+        amplifyGetCurrentUser(),
+        fetchAuthSession(),
       ])
-      return {
-        id:    cognitoUser.userId,
-        email: attributes.email ?? '',
-        name:  [attributes.given_name, attributes.family_name].filter(Boolean).join(' ')
-               || attributes.email
-               || '',
-      }
+      if (!session.tokens?.idToken) return null
+      const claims     = session.tokens.idToken.payload
+      const email      = claims['email'] as string
+      const givenName  = claims['given_name'] as string | undefined
+      const familyName = claims['family_name'] as string | undefined
+      const name       = (givenName && familyName)
+        ? `${givenName} ${familyName}`
+        : (givenName ?? email)
+      return { id: cognitoUser.userId, email, name }
     } catch {
       return null
     }
@@ -124,12 +125,24 @@ export class CognitoAuthService implements AuthService {
     try {
       await amplifySignInWithRedirect(args)
     } catch (err) {
-      if (err instanceof Error && err.message?.includes('already a signed in user')) {
-        await amplifySignOut()
-        await amplifySignInWithRedirect(args)
-      } else {
-        throw err
+      const isAlreadyAuthenticated =
+        err instanceof Error &&
+        (err.name === 'UserAlreadyAuthenticatedException' ||
+         err.message?.includes('already a signed in user'))
+      if (!isAlreadyAuthenticated) throw err
+
+      // Discriminate: stale inflightOAuth (no tokens) vs user is genuinely authenticated.
+      // fetchAuthSession() reads localStorage directly and does not fail when tokens exist.
+      const session = await fetchAuthSession()
+      if (session.tokens) {
+        // Tokens are present — user IS authenticated. getCurrentUser() must have failed
+        // for another reason (e.g. transient network error). Do not destroy valid tokens.
+        // The auth guard will pick up the authenticated state on next render.
+        return
       }
+      // No tokens — genuine stale-inflightOAuth state. Clear and retry.
+      await amplifySignOut()
+      await amplifySignInWithRedirect(args)
     }
   }
 


### PR DESCRIPTION
## What this PR does

Fixes the auth redirect loop introduced after PR #214's canonical Hosted UI auth flow landed. Two bugs combined:

### Bug 1 — `getCurrentUser` returned null despite valid tokens

`getCurrentUser` used `Promise.all` with `fetchUserAttributes`. When the network call to Cognito's `GetUser` API failed (rate limit, transient 4xx, or attribute config issue), the entire method returned null — even though valid tokens were in localStorage.

The auth guard then saw `isAuthenticated: false` and called `signInWithRedirect`, triggering Bug 2.

**Fix:** Read identity from ID token claims via `fetchAuthSession`. The ID token contains `email` reliably; `given_name`/`family_name` are present for social sign-ins but absent for direct Cognito signups. Fallback chain handles both:
1. `given_name family_name` (social sign-ins with both)
2. `given_name` alone (partial name attributes)
3. `email` (fallback for direct signups)

No network call. Consistent with how `getAccountIdForApp` and other methods read token claims.

### Bug 2 — `signInWithRedirect` destroyed valid tokens on `UserAlreadyAuthenticatedException`

Commit `0fffd9c` added self-healing recovery for stale `inflightOAuth` state: when `signInWithRedirect` threw "already a signed in user", call `signOut` and retry. This is correct for the stale-state scenario (no tokens; just a stuck flag).

But the same error fires when the user IS authenticated (which is what Bug 1 was incorrectly triggering). The previous handler couldn't distinguish the two cases, so it destroyed valid tokens. SSO then silently re-authenticated, the same `fetchUserAttributes` failure recurred, and the loop perpetuated.

**Fix:** Discriminate using `fetchAuthSession`:
- If tokens exist → user is authenticated, return without action (auth guard syncs on next render)
- If no tokens → genuine stale-inflightOAuth state, `signOut` + retry preserved

## Verification

Pre-deploy:
- TypeScript clean across all three consuming apps (auth-client, stock-analyser, launchpad)
- Pre-commit hooks passed

Post-deploy (dev):
- Sign in via Launchpad → tokens stored → tiles render → no loop
- Click Stock Analyser tile → silent re-auth → SA loads authenticated → no loop
- Click Budget Tracker tile → silent re-auth → BT loads authenticated → no loop
- Sign out → tokens cleared → return to Launchpad sign-in

## Cross-references

- PR #214 — canonical Hosted UI auth flow (foundation)
- Commit `0fffd9c` — original destructive recovery (now corrected)
- `docs/architecture/auth.md` — canonical auth architecture