### PR TITLE
fix: don't update auth store state on successful sign-out

### DIFF
--- a/apps/budget-tracker/components/budget-tracker/app-shell.tsx
+++ b/apps/budget-tracker/components/budget-tracker/app-shell.tsx
@@ -85,7 +85,6 @@ export function BudgetUserHeader({
   const user = useAuthStore((s) => s.user)
   const accounts = useAuthStore((s) => s.accounts)
   const currentAccount = useAuthStore((s) => s.currentAccount)
-  const authSignOut = useAuthStore((s) => s.signOut)
   const switchAccount = useAuthStore((s) => s.switchAccount)
   const [accountMenuOpen, setAccountMenuOpen] = useState(false)
   const [profileMenuOpen, setProfileMenuOpen] = useState(false)
@@ -95,7 +94,6 @@ export function BudgetUserHeader({
   const firstName = (user?.name ?? '').split(' ')[0]
 
   function handleSignOut() {
-    authSignOut()
     onSignOut?.()
   }
 
@@ -210,7 +208,6 @@ export function BudgetDesktopSidebar({
   const user = useAuthStore((s) => s.user)
   const accounts = useAuthStore((s) => s.accounts)
   const currentAccount = useAuthStore((s) => s.currentAccount)
-  const authSignOut = useAuthStore((s) => s.signOut)
   const switchAccount = useAuthStore((s) => s.switchAccount)
   const [accountMenuOpen, setAccountMenuOpen] = useState(false)
   const [signOutConfirm, setSignOutConfirm] = useState(false)
@@ -219,7 +216,6 @@ export function BudgetDesktopSidebar({
   const firstName = (user?.name ?? '').split(' ')[0]
 
   function handleSignOut() {
-    authSignOut()
     onSignOut?.()
   }
 

--- a/apps/budget-tracker/stores/auth/use-auth-store.ts
+++ b/apps/budget-tracker/stores/auth/use-auth-store.ts
@@ -55,22 +55,12 @@ export const useAuthStore = create<AuthState>()(
       },
 
       signOut: async () => {
-        set({ isLoading: true })
         try {
           await authService.signOut()
-          set({
-            user:            null,
-            currentAccount:  null,
-            accounts:        [],
-            isAuthenticated: false,
-            isLoading:       false,
-            error:           null,
-          })
+          // Success: Cognito navigates the browser to /signed-out/. Page unloads.
         } catch (error) {
-          set({
-            isLoading: false,
-            error: error instanceof Error ? error.message : 'Sign out failed',
-          })
+          // signOut failed — user is stuck. Reset so the auth guard redirects.
+          set({ user: null, currentAccount: null, accounts: [], isAuthenticated: false, error: error instanceof Error ? error.message : 'Sign out failed' })
         }
       },
 

--- a/apps/launchpad/stores/auth/use-auth-store.ts
+++ b/apps/launchpad/stores/auth/use-auth-store.ts
@@ -41,11 +41,12 @@ export const useAuthStore = create<AuthState>()(
       },
 
       signOut: async () => {
-        set({ isLoading: true })
         try {
           await authService.signOut()
-        } finally {
-          set({ user: null, isAuthenticated: false, isLoading: false, isInitialized: false, error: null })
+          // Success: Cognito navigates the browser to /signed-out/. Page unloads.
+        } catch (error) {
+          // signOut failed — user is stuck. Reset so the auth guard redirects.
+          set({ user: null, isAuthenticated: false, error: error instanceof Error ? error.message : 'Sign out failed' })
         }
       },
 

--- a/apps/stock-analyser/stores/auth/use-auth-store.ts
+++ b/apps/stock-analyser/stores/auth/use-auth-store.ts
@@ -41,11 +41,12 @@ export const useAuthStore = create<AuthState>()(
       },
 
       signOut: async () => {
-        set({ isLoading: true })
         try {
           await authService.signOut()
-        } finally {
-          set({ user: null, isAuthenticated: false, isLoading: false, error: null })
+          // Success: Cognito navigates the browser to /signed-out/. Page unloads.
+        } catch (error) {
+          // signOut failed — user is stuck. Reset so the auth guard redirects.
+          set({ user: null, isAuthenticated: false, error: error instanceof Error ? error.message : 'Sign out failed' })
         }
       },
 


### PR DESCRIPTION
## Problem

Sign-out appeared to do nothing on SA, and triggered a new callback flow on BT.

Root cause: all three auth stores updated `isAuthenticated: false` in a `finally` block (SA, Launchpad) or on the success path (BT). This state change triggered the `AuthGuard.signInWithRedirect()` call **before** `amplifySignOut({ global: true })` had a chance to clear the Cognito Hosted UI session cookie. With the cookie still alive, Cognito silently re-authenticated the user via SSO — the sign-out appeared to do nothing or immediately loop back in.

Secondary bug in BT: `BudgetAppShell.handleSignOut` called `authSignOut()` (unawaited) **and** `onSignOut?.()`, which itself called `useAuthStore().signOut()` — two concurrent `amplifySignOut` calls racing each other.

## Fix

**Auth stores (all three apps):** Remove state updates from the success path. `amplifySignOut({ global: true })` navigates the browser to Cognito's `/logout` endpoint, which clears the session cookie and redirects to the registered `logout_uri`. Once that navigation fires, the React tree is gone — state updates are pointless. Only update state in the `catch` block, so a stuck user can be recovered by the auth guard.

**`BudgetAppShell`:** Remove `authSignOut()` call from both `handleSignOut` functions (mobile header + desktop sidebar). The page-level `onSignOut` handler calls `useAuthStore().signOut()` directly — the shell must not duplicate it.

## Files changed

- `apps/stock-analyser/stores/auth/use-auth-store.ts` — `finally` → `catch`-only
- `apps/budget-tracker/stores/auth/use-auth-store.ts` — removed success-path `set()`; `catch`-only
- `apps/launchpad/stores/auth/use-auth-store.ts` — `finally` → `catch`-only; removed `isInitialized: false`
- `apps/budget-tracker/components/budget-tracker/app-shell.tsx` — removed `authSignOut()` double-call from both handlers; removed dead `authSignOut` selector assignments

## Test plan

- [ ] Sign out from SA — browser navigates to `/signed-out/`, does not return to `/stock-signal/`
- [ ] Sign out from BT — browser navigates to `/signed-out/`, does not return to `/budget-tracker/`
- [ ] Sign out from Launchpad — browser navigates to `/signed-out/`, does not return to Launchpad
- [ ] Sign out with network error (mock: override `signOut` to throw) — auth guard redirects to sign-in
- [ ] No double-signOut network calls from BT mobile or desktop header

🤖 Generated with [Claude Code](https://claude.com/claude-code)