### PR TITLE
Remove CustomRule.projectId — forward-declared field, never used

### DIFF
--- a/apps/budget-tracker/functions/budget-rules/src/index.ts
+++ b/apps/budget-tracker/functions/budget-rules/src/index.ts
@@ -51,7 +51,6 @@ async function createRule(event: APIGatewayProxyEvent, accountId: string) {
     isBusiness: body.isBusiness ?? false,
     isIgnore: body.isIgnore,
     overridesBuiltinId: body.overridesBuiltinId,
-    projectId: body.projectId,
     learned: body.learned ?? false,
     createdAt: new Date().toISOString(),
   };
@@ -78,7 +77,6 @@ async function updateRule(event: APIGatewayProxyEvent, accountId: string, ruleId
   if (body.isBusiness !== undefined)         { expressions.push('isBusiness = :biz');                                  values[':biz'] = body.isBusiness; }
   if (body.isIgnore !== undefined)           { expressions.push('isIgnore = :ignore');                                  values[':ignore'] = body.isIgnore; }
   if (body.overridesBuiltinId !== undefined) { expressions.push('overridesBuiltinId = :obid');                          values[':obid'] = body.overridesBuiltinId; }
-  if (body.projectId !== undefined)          { expressions.push('projectId = :pid');                                    values[':pid'] = body.projectId; }
   if (expressions.length === 0) throw { statusCode: 400, message: 'No fields to update' };
 
   const res = await ddb.send(new UpdateCommand({

--- a/packages/budget-domain/src/contracts.ts
+++ b/packages/budget-domain/src/contracts.ts
@@ -28,7 +28,6 @@ export interface CustomRule {
   isBusiness: boolean;            // Sets _business: true on matched transactions
   isIgnore?: boolean;             // Sets _ignore: true on matched transactions
   overridesBuiltinId?: string;    // Built-in rule ID this custom rule replaces/disables
-  projectId?: string;             // Assigns matched transactions to a project category
   learned: boolean;               // true if created via "Learn" button; false if manually authored
   createdAt: string;              // ISO 8601
 }


### PR DESCRIPTION
## What this PR does

Removes the `projectId` field from `CustomRule` in canonical contracts and the budget-rules Lambda.

## Why

Per session recon (May 17 2026):
- Field declared in `packages/budget-domain/src/contracts.ts` (one line)
- Field written in `apps/budget-tracker/functions/budget-rules/src/index.ts` (two locations: CREATE and PATCH paths)
- Zero reads anywhere in the codebase
- No UI to set the field
- No tests
- No documentation

The field's original intent (decouple project identity from category identity) conflicts with the canonical model where project identity = category identity. Removing it eliminates dead code.

## Files changed

- `packages/budget-domain/src/contracts.ts` — remove field declaration
- `apps/budget-tracker/functions/budget-rules/src/index.ts` — remove CREATE write and PATCH update target

## Data note

Existing rules in DynamoDB may have `projectId` stored from prior writes (though per recon, no UI ever wrote a value, so the field would have been undefined). After this change, the field is dormant on stored items. No migration needed.

## Cross-references

- Commit 9d42b15 — original introduction (M6 #178 repository swap)
- Recon dated 2026-05-17