### PR TITLE
Fix AI Review: three latent bugs in budget-ai Lambda

### DIFF
--- a/apps/budget-tracker/functions/budget-ai/src/index.ts
+++ b/apps/budget-tracker/functions/budget-ai/src/index.ts
@@ -85,26 +85,46 @@ async function review(
   const categoryList = formatCategoryList(categories);
   const allResults: AiReviewResponse['results'] = [];
 
+  // Build (category name, subcategory name) → { categoryId, subcategoryId } lookup
+  const labelLookup = new Map<string, { categoryId: string; subcategoryId: string }>();
+  for (const cat of categories) {
+    for (const sub of cat.subcategories) {
+      const key = `${cat.name.toLowerCase()}::${sub.name.toLowerCase()}`;
+      labelLookup.set(key, { categoryId: cat.categoryId, subcategoryId: sub.subcategoryId });
+    }
+  }
+
   for (let i = 0; i < transactions.length; i += BATCH_REVIEW) {
     const batch = transactions.slice(i, i + BATCH_REVIEW);
     const proxyResponse = await invokeProxy(auth, accountId, {
-      model:      AI_MODEL,
-      max_tokens: 4096,
-      webSearch:  true,
-      system:     `You are a personal finance assistant helping to categorise Australian bank transactions that a fast categorisation pass could not handle.\n\nYou will be given:\n- A list of budget categories, each with allowed subcategories\n- A list of unknown or ambiguous transactions (index, description, amount)\n\nYou have access to a web_search tool. If a merchant or description is unfamiliar, you MAY search to identify the business type before categorising. Use web_search sparingly — only when the description is genuinely ambiguous.\n\nYou must:\n- Return ONLY a JSON array, one object per transaction\n- Each object has exactly: {"index": <int>, "category": <string>, "subcategory": <string>, "reason": <string>}\n- The category must be one of the provided categories exactly\n- The subcategory must be one of the subcategories listed under that category exactly\n- The reason must be a single sentence explaining your choice in plain English\n- If a transaction is genuinely uncategorisable, return it with category: "", subcategory: "", and reason explaining why\n- Do not include any text outside the JSON array\n- Do not wrap the JSON in markdown code fences`,
-      messages: [{
-        role: 'user',
-        content: `BUDGET CATEGORIES AND SUBCATEGORIES:\n${categoryList}\n\nTRANSACTIONS TO CATEGORISE (index: description — amount):\n${formatTxList(batch)}`,
-      }],
+      model:     AI_MODEL,
+      maxTokens: 4096,
+      webSearch: true,
+      system:    `You are a personal finance assistant helping to categorise Australian bank transactions that a fast categorisation pass could not handle.\n\nYou will be given:\n- A list of budget categories, each with allowed subcategories\n- A list of unknown or ambiguous transactions (index, description, amount)\n\nYou have access to a web_search tool. If a merchant or description is unfamiliar, you MAY search to identify the business type before categorising. Use web_search sparingly — only when the description is genuinely ambiguous.\n\nYou must:\n- Return ONLY a JSON array, one object per transaction\n- Each object has exactly: {"index": <int>, "category": <string>, "subcategory": <string>, "reason": <string>}\n- The category must be one of the provided categories exactly\n- The subcategory must be one of the subcategories listed under that category exactly\n- The reason must be a single sentence explaining your choice in plain English\n- If a transaction is genuinely uncategorisable, return it with category: "", subcategory: "", and reason explaining why\n- Do not include any text outside the JSON array\n- Do not wrap the JSON in markdown code fences`,
+      prompt:    `BUDGET CATEGORIES AND SUBCATEGORIES:\n${categoryList}\n\nTRANSACTIONS TO CATEGORISE (index: description — amount):\n${formatTxList(batch)}`,
     });
 
-    const content = proxyResponse['content'] as Array<{ type: string; text?: string }> | undefined;
-    const text = (content ?? []).filter(c => c.type === 'text').map(c => c.text ?? '').join('');
+    // Fix 2: proxy returns content as a plain string, not Anthropic content blocks
+    const text = (proxyResponse['content'] as string) ?? '';
 
     try {
       const clean = text.replace(/```json|```/g, '').trim();
-      const parsed = JSON.parse(clean.slice(clean.indexOf('['), clean.lastIndexOf(']') + 1)) as AiReviewResponse['results'];
-      allResults.push(...parsed);
+      const rawSuggestions = JSON.parse(
+        clean.slice(clean.indexOf('['), clean.lastIndexOf(']') + 1)
+      ) as Array<{ index: number; category: string; subcategory: string; reason: string }>;
+
+      // Fix 3: resolve Claude's name strings to canonical UUIDs
+      for (const s of rawSuggestions) {
+        const key = `${s.category.toLowerCase()}::${s.subcategory.toLowerCase()}`;
+        const ids = labelLookup.get(key);
+        if (!ids) {
+          console.warn(
+            `[budget-ai] review: could not resolve "${s.category} > ${s.subcategory}" to UUIDs; dropping suggestion at index ${s.index}`
+          );
+          continue;
+        }
+        allResults.push({ index: s.index, categoryId: ids.categoryId, subcategoryId: ids.subcategoryId, reason: s.reason });
+      }
     } catch {
       console.error('[budget-ai] review: failed to parse batch response', text.slice(0, 200));
     }
@@ -122,17 +142,14 @@ async function csvAnalysis(
   const { sampleRows } = parseBody<{ sampleRows: string[][] }>(event);
 
   const proxyResponse = await invokeProxy(auth, accountId, {
-    model:      AI_MODEL,
-    max_tokens: 1024,
-    system:     `You are a CSV format detective. Given the first few rows of a bank transaction CSV, identify which column is which.\n\nYou must return ONLY a JSON object with this exact shape:\n{\n  "dateColumn": <int>,\n  "descriptionColumn": <int>,\n  "amountColumn": <int>,\n  "debitColumn": <int>,\n  "creditColumn": <int>,\n  "dateFormat": <string>,\n  "hasHeader": <bool>,\n  "confidence": "high" | "medium" | "low",\n  "notes": <string>\n}\n\nEither amountColumn OR (debitColumn + creditColumn) must be present, not both. Columns are 0-indexed.\n\nIf you cannot determine the format with reasonable confidence, set confidence: "low" and describe the issue in notes.\n\nDo not include any text outside the JSON object.\nDo not wrap the JSON in markdown code fences.`,
-    messages: [{
-      role: 'user',
-      content: `Sample rows from uploaded CSV (each row is an array of cell values):\n${JSON.stringify(sampleRows, null, 2)}\n\nThe first row above MAY be a header row, or it may be a data row. Use the content to decide.`,
-    }],
+    model:     AI_MODEL,
+    maxTokens: 1024,
+    system:    `You are a CSV format detective. Given the first few rows of a bank transaction CSV, identify which column is which.\n\nYou must return ONLY a JSON object with this exact shape:\n{\n  "dateColumn": <int>,\n  "descriptionColumn": <int>,\n  "amountColumn": <int>,\n  "debitColumn": <int>,\n  "creditColumn": <int>,\n  "dateFormat": <string>,\n  "hasHeader": <bool>,\n  "confidence": "high" | "medium" | "low",\n  "notes": <string>\n}\n\nEither amountColumn OR (debitColumn + creditColumn) must be present, not both. Columns are 0-indexed.\n\nIf you cannot determine the format with reasonable confidence, set confidence: "low" and describe the issue in notes.\n\nDo not include any text outside the JSON object.\nDo not wrap the JSON in markdown code fences.`,
+    prompt:    `Sample rows from uploaded CSV (each row is an array of cell values):\n${JSON.stringify(sampleRows, null, 2)}\n\nThe first row above MAY be a header row, or it may be a data row. Use the content to decide.`,
   });
 
-  const content = proxyResponse['content'] as Array<{ type: string; text?: string }> | undefined;
-  const text = (content ?? []).filter(c => c.type === 'text').map(c => c.text ?? '').join('');
+  // Fix 2: proxy returns content as a plain string, not Anthropic content blocks
+  const text = (proxyResponse['content'] as string) ?? '';
 
   try {
     const clean = text.replace(/```json|```/g, '').trim();


### PR DESCRIPTION
## What this PR does

Fixes AI Review which was non-functional since the PR #224 rewire. Three latent bugs in budget-ai Lambda; surfaced when AI Review was invoked against the 69 uncategorised transactions from the Budget Data restructure.

### The bugs
1. **Request format mismatch** — budget-ai sent Anthropic SDK shape; claude-proxy expects ClaudeRequest shape (prompt, maxTokens).
2. **Response parsing mismatch** — Lambda treated proxy response as content blocks array; proxy returns string.
3. **Name → UUID resolution missing** — Lambda type-cast Claude's name strings to UUID type; frontend would have received undefined UUIDs and silently corrupted accepted transactions.

### The fixes
All three changes in `apps/budget-tracker/functions/budget-ai/src/index.ts`:
1. Both review() and csvAnalysis() send `{ prompt, maxTokens }` shape
2. Both functions read `content` as string
3. review() resolves Claude's `{ category, subcategory }` strings to canonical `{ categoryId, subcategoryId }` UUIDs via the categories array; unresolvable suggestions logged at WARN and dropped

### End-to-end verification
- Lambda returns 200 (not 500)
- Review cards render with real category names
- Accept flow categorises transactions and creates rules
- Uncategorised count decrements as expected
- No silent UUID corruption

## Out of scope
- M6 cleanup PR (separate follow-up)
- Frontend changes (review-tab.tsx already expected canonical shape; bug was Lambda-only)
- claude-proxy or Anthropic SDK changes

## Discipline note
Initial CC diagnosis identified two bugs. Verification recon caught the third name-to-UUID resolution issue. Half-fix would have prevented Lambda errors but silently corrupted accepted transactions. Three-fix chain is complete.

## Cross-references
- PR #224 — AI substrate rewire (bug origin)
- Issue #200 — Rules import (independent; complete)