### PR TITLE
WebSocket infrastructure for async AI Review (PR 3 of 5)

### DIFF
--- a/.github/workflows/deploy-budget-tracker.yml
+++ b/.github/workflows/deploy-budget-tracker.yml
@@ -75,7 +75,20 @@ jobs:
 
       - name: CDK Deploy — Budget Tracker stacks (dev)
         working-directory: infrastructure
-        run: pnpm exec cdk deploy 'TransformotionDev-BudgetTrackerTables' 'TransformotionDev-BudgetTrackerApi' --require-approval never
+        run: pnpm exec cdk deploy 'TransformotionDev-BudgetTrackerTables' 'TransformotionDev-BudgetTrackerApi' 'TransformotionDev-BudgetTrackerWs' --require-approval never
+
+      - name: Extract WebSocket URL from CDK output
+        run: |
+          WSS_URL=$(aws cloudformation describe-stacks \
+            --stack-name TransformotionDev-BudgetTrackerWs \
+            --query "Stacks[0].Outputs[?OutputKey=='WssUrl'].OutputValue" \
+            --output text)
+          if [ -z "$WSS_URL" ]; then
+            echo "ERROR: Could not extract WssUrl from TransformotionDev-BudgetTrackerWs stack"
+            exit 1
+          fi
+          echo "NEXT_PUBLIC_BUDGET_WSS_URL=$WSS_URL" >> $GITHUB_ENV
+          echo "Extracted WSS URL: $WSS_URL"
 
       - name: Build Next.js (static export)
         working-directory: apps/budget-tracker
@@ -140,7 +153,20 @@ jobs:
 
       - name: CDK Deploy — Budget Tracker stacks (prod)
         working-directory: infrastructure
-        run: pnpm exec cdk deploy 'TransformotionProd-BudgetTrackerTables' 'TransformotionProd-BudgetTrackerApi' --require-approval never
+        run: pnpm exec cdk deploy 'TransformotionProd-BudgetTrackerTables' 'TransformotionProd-BudgetTrackerApi' 'TransformotionProd-BudgetTrackerWs' --require-approval never
+
+      - name: Extract WebSocket URL from CDK output
+        run: |
+          WSS_URL=$(aws cloudformation describe-stacks \
+            --stack-name TransformotionProd-BudgetTrackerWs \
+            --query "Stacks[0].Outputs[?OutputKey=='WssUrl'].OutputValue" \
+            --output text)
+          if [ -z "$WSS_URL" ]; then
+            echo "ERROR: Could not extract WssUrl from TransformotionProd-BudgetTrackerWs stack"
+            exit 1
+          fi
+          echo "NEXT_PUBLIC_BUDGET_WSS_URL=$WSS_URL" >> $GITHUB_ENV
+          echo "Extracted WSS URL: $WSS_URL"
 
       - name: Build Next.js (static export)
         working-directory: apps/budget-tracker

--- a/apps/budget-tracker/.env.example
+++ b/apps/budget-tracker/.env.example
@@ -167,6 +167,15 @@ NEXT_PUBLIC_RUNTIME_PROFILE=mock
 # deploy. Empty in local development (defaults to 'dev' in lib/build-info.ts).
 NEXT_PUBLIC_COMMIT_HASH=
 
+# [BUILD-INJECTED]
+# WebSocket URL for the AI Review service. Extracted from the CDK stack output
+# (TransformotionDev/Prod-BudgetTrackerWs → WssUrl) by the deploy workflow
+# immediately after CDK deploy, then written to $GITHUB_ENV so the Next.js
+# build can embed it. Not set manually — the workflow always reads the live
+# stack output, so the URL remains correct even if the WebSocket API is recreated.
+# For local development: leave empty (AI Review uses synchronous HTTP fallback).
+NEXT_PUBLIC_BUDGET_WSS_URL=
+
 # ── Cross-app navigation URLs ─────────────────────────────────────────────────
 
 # [REQUIRED]

--- a/apps/budget-tracker/functions/ai-ws-authorizer/package.json
+++ b/apps/budget-tracker/functions/ai-ws-authorizer/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@transformotion/fn-budget-ai-ws-authorizer",
+  "version": "0.0.0",
+  "private": true,
+  "main": "./src/index.ts",
+  "scripts": {
+    "build": "tsc --noEmit",
+    "typecheck": "tsc --noEmit",
+    "lint": "echo \"lint: ai-ws-authorizer\""
+  },
+  "dependencies": {
+    "jose": "^5.9.6"
+  },
+  "devDependencies": {
+    "@types/aws-lambda": "^8",
+    "@types/node": "^22",
+    "typescript": "*"
+  }
+}

--- a/apps/budget-tracker/functions/ai-ws-authorizer/src/index.ts
+++ b/apps/budget-tracker/functions/ai-ws-authorizer/src/index.ts
@@ -1,0 +1,76 @@
+import * as jose from 'jose';
+
+const USER_POOL_ID = process.env.COGNITO_USER_POOL_ID!;
+const REGION       = process.env.AWS_REGION ?? 'ap-southeast-2';
+
+const JWKS_URL = `https://cognito-idp.${REGION}.amazonaws.com/${USER_POOL_ID}/.well-known/jwks.json`;
+const ISSUER   = `https://cognito-idp.${REGION}.amazonaws.com/${USER_POOL_ID}`;
+
+// Cache the JWKS set across warm invocations
+const JWKS = jose.createRemoteJWKSet(new URL(JWKS_URL));
+
+interface WsAuthorizerEvent {
+  type: 'REQUEST';
+  methodArn: string;
+  requestContext: {
+    stage: string;
+    apiId: string;
+    routeKey: string;
+  };
+  queryStringParameters?: Record<string, string | undefined>;
+}
+
+interface AuthorizerResult {
+  principalId: string;
+  policyDocument: {
+    Version: '2012-10-17';
+    Statement: Array<{
+      Action: string;
+      Effect: 'Allow' | 'Deny';
+      Resource: string;
+    }>;
+  };
+  context?: Record<string, string>;
+}
+
+function makePolicy(effect: 'Allow' | 'Deny', resource: string, principalId: string, context?: Record<string, string>): AuthorizerResult {
+  return {
+    principalId,
+    policyDocument: {
+      Version: '2012-10-17',
+      Statement: [{ Action: 'execute-api:Invoke', Effect: effect, Resource: resource }],
+    },
+    ...(context ? { context } : {}),
+  };
+}
+
+export const handler = async (event: WsAuthorizerEvent): Promise<AuthorizerResult> => {
+  const token     = event.queryStringParameters?.token;
+  const accountId = event.queryStringParameters?.accountId;
+
+  if (!token) {
+    console.log('[ai-ws-authorizer] rejected: no token in query string');
+    return makePolicy('Deny', event.methodArn, 'anonymous');
+  }
+
+  try {
+    const { payload } = await jose.jwtVerify(token, JWKS, { issuer: ISSUER });
+
+    const userId   = payload.sub as string;
+    const accounts = JSON.parse((payload['accounts'] as string | undefined) ?? '[]') as string[];
+
+    if (accountId && !accounts.includes(accountId)) {
+      console.log(`[ai-ws-authorizer] rejected: accountId ${accountId} not in user's accounts`);
+      return makePolicy('Deny', event.methodArn, userId);
+    }
+
+    console.log(`[ai-ws-authorizer] allowed: userId=${userId} accountId=${accountId ?? 'none'}`);
+    return makePolicy('Allow', event.methodArn, userId, {
+      userId,
+      accountId: accountId ?? '',
+    });
+  } catch (err) {
+    console.log('[ai-ws-authorizer] rejected: token verification failed:', (err as Error).message);
+    return makePolicy('Deny', event.methodArn, 'anonymous');
+  }
+};

--- a/apps/budget-tracker/functions/ai-ws-authorizer/tsconfig.json
+++ b/apps/budget-tracker/functions/ai-ws-authorizer/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "types": ["node", "aws-lambda"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/apps/budget-tracker/functions/ai-ws-connect/package.json
+++ b/apps/budget-tracker/functions/ai-ws-connect/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@transformotion/fn-budget-ai-ws-connect",
+  "version": "0.0.0",
+  "private": true,
+  "main": "./src/index.ts",
+  "scripts": {
+    "build": "tsc --noEmit",
+    "typecheck": "tsc --noEmit",
+    "lint": "echo \"lint: ai-ws-connect\""
+  },
+  "devDependencies": {
+    "@aws-sdk/client-dynamodb": "^3",
+    "@aws-sdk/lib-dynamodb": "^3",
+    "@types/aws-lambda": "^8",
+    "@types/node": "^22",
+    "typescript": "*"
+  }
+}

--- a/apps/budget-tracker/functions/ai-ws-connect/src/index.ts
+++ b/apps/budget-tracker/functions/ai-ws-connect/src/index.ts
@@ -1,0 +1,38 @@
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import { DynamoDBDocumentClient, PutCommand } from '@aws-sdk/lib-dynamodb';
+
+const ddb   = DynamoDBDocumentClient.from(new DynamoDBClient({}));
+const TABLE = process.env.CONNECTIONS_TABLE!;
+
+interface ConnectEvent {
+  requestContext: {
+    connectionId: string;
+    stage: string;
+    authorizer?: {
+      userId?: string;
+      accountId?: string;
+    };
+  };
+}
+
+export const handler = async (event: ConnectEvent): Promise<{ statusCode: number }> => {
+  const { connectionId, authorizer } = event.requestContext;
+  const userId    = authorizer?.userId ?? 'unknown';
+  const accountId = authorizer?.accountId ?? '';
+  const now       = Math.floor(Date.now() / 1000);
+
+  console.log(`[ai-ws-connect] connectionId=${connectionId} userId=${userId} accountId=${accountId}`);
+
+  await ddb.send(new PutCommand({
+    TableName: TABLE,
+    Item: {
+      connectionId,
+      userId,
+      accountId,
+      createdAt: new Date().toISOString(),
+      expiresAt: now + 3600,  // TTL: 1 hour; DynamoDB removes stale connections
+    },
+  }));
+
+  return { statusCode: 200 };
+};

--- a/apps/budget-tracker/functions/ai-ws-connect/tsconfig.json
+++ b/apps/budget-tracker/functions/ai-ws-connect/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "types": ["node", "aws-lambda"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/apps/budget-tracker/functions/ai-ws-default/package.json
+++ b/apps/budget-tracker/functions/ai-ws-default/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@transformotion/fn-budget-ai-ws-default",
+  "version": "0.0.0",
+  "private": true,
+  "main": "./src/index.ts",
+  "scripts": {
+    "build": "tsc --noEmit",
+    "typecheck": "tsc --noEmit",
+    "lint": "echo \"lint: ai-ws-default\""
+  },
+  "devDependencies": {
+    "@types/aws-lambda": "^8",
+    "@types/node": "^22",
+    "typescript": "*"
+  }
+}

--- a/apps/budget-tracker/functions/ai-ws-default/src/index.ts
+++ b/apps/budget-tracker/functions/ai-ws-default/src/index.ts
@@ -1,0 +1,25 @@
+interface DefaultEvent {
+  requestContext: {
+    connectionId: string;
+    routeKey: string;
+  };
+  body?: string;
+}
+
+export const handler = async (event: DefaultEvent): Promise<{ statusCode: number }> => {
+  const { connectionId, routeKey } = event.requestContext;
+
+  console.log(`[ai-ws-default] connectionId=${connectionId} routeKey=${routeKey}`);
+
+  if (event.body) {
+    try {
+      const message = JSON.parse(event.body) as unknown;
+      console.log(`[ai-ws-default] message received:`, JSON.stringify(message));
+    } catch {
+      console.log(`[ai-ws-default] raw body:`, event.body);
+    }
+  }
+
+  // PR 4 will use this route for client-initiated actions (e.g. cancellation)
+  return { statusCode: 200 };
+};

--- a/apps/budget-tracker/functions/ai-ws-default/tsconfig.json
+++ b/apps/budget-tracker/functions/ai-ws-default/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "types": ["node", "aws-lambda"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/apps/budget-tracker/functions/ai-ws-disconnect/package.json
+++ b/apps/budget-tracker/functions/ai-ws-disconnect/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@transformotion/fn-budget-ai-ws-disconnect",
+  "version": "0.0.0",
+  "private": true,
+  "main": "./src/index.ts",
+  "scripts": {
+    "build": "tsc --noEmit",
+    "typecheck": "tsc --noEmit",
+    "lint": "echo \"lint: ai-ws-disconnect\""
+  },
+  "devDependencies": {
+    "@aws-sdk/client-dynamodb": "^3",
+    "@aws-sdk/lib-dynamodb": "^3",
+    "@types/aws-lambda": "^8",
+    "@types/node": "^22",
+    "typescript": "*"
+  }
+}

--- a/apps/budget-tracker/functions/ai-ws-disconnect/src/index.ts
+++ b/apps/budget-tracker/functions/ai-ws-disconnect/src/index.ts
@@ -1,0 +1,29 @@
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import { DynamoDBDocumentClient, DeleteCommand } from '@aws-sdk/lib-dynamodb';
+
+const ddb   = DynamoDBDocumentClient.from(new DynamoDBClient({}));
+const TABLE = process.env.CONNECTIONS_TABLE!;
+
+interface DisconnectEvent {
+  requestContext: {
+    connectionId: string;
+  };
+}
+
+export const handler = async (event: DisconnectEvent): Promise<{ statusCode: number }> => {
+  const { connectionId } = event.requestContext;
+
+  console.log(`[ai-ws-disconnect] connectionId=${connectionId}`);
+
+  try {
+    await ddb.send(new DeleteCommand({
+      TableName: TABLE,
+      Key: { connectionId },
+    }));
+  } catch (err) {
+    // Best-effort — connection may have already been cleaned up by TTL
+    console.warn(`[ai-ws-disconnect] delete failed (may be already gone): ${(err as Error).message}`);
+  }
+
+  return { statusCode: 200 };
+};

--- a/apps/budget-tracker/functions/ai-ws-disconnect/tsconfig.json
+++ b/apps/budget-tracker/functions/ai-ws-disconnect/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "types": ["node", "aws-lambda"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/infrastructure/bin/app.ts
+++ b/infrastructure/bin/app.ts
@@ -17,6 +17,7 @@ import { StockAnalyserTablesStack } from '../lib/stock-analyser/stock-analyser-t
 // ── Budget Tracker stacks ─────────────────────────────────────────────────────
 import { BudgetTrackerTablesStack } from '../lib/budget-tracker/budget-tracker-tables-stack';
 import { BudgetTrackerApiStack }    from '../lib/budget-tracker/budget-tracker-api-stack';
+import { BudgetTrackerWsStack }     from '../lib/budget-tracker/budget-tracker-ws-stack';
 
 // ── Migration Utilities stacks ────────────────────────────────────────────────
 import { MigrationsApiStack } from '../../migration-utilities/infrastructure/lib/migrations-api-stack';
@@ -105,6 +106,13 @@ new BudgetTrackerApiStack(app, 'TransformotionDev-BudgetTrackerApi', {
   budgetDataTableName: devBudgetTrackerTables.budgetDataTable.tableName,
 });
 
+new BudgetTrackerWsStack(app, 'TransformotionDev-BudgetTrackerWs', {
+  env,
+  stage:       'dev',
+  description: 'Transformotion Apps — Dev Budget Tracker WebSocket API (AI Review)',
+  userPool:    devAuth.userPool,
+});
+
 new MigrationsApiStack(app, 'TransformotionDev-MigrationsApi', {
   env,
   stage:       'dev',
@@ -187,6 +195,13 @@ new BudgetTrackerApiStack(app, 'TransformotionProd-BudgetTrackerApi', {
   authoriser:          prodPlatformApi.authoriser,
   apiResource:         prodPlatformApi.apiResource,
   budgetDataTableName: prodBudgetTrackerTables.budgetDataTable.tableName,
+});
+
+new BudgetTrackerWsStack(app, 'TransformotionProd-BudgetTrackerWs', {
+  env,
+  stage:       'prod',
+  description: 'Transformotion Apps — Prod Budget Tracker WebSocket API (AI Review)',
+  userPool:    prodAuth.userPool,
 });
 
 new MigrationsApiStack(app, 'TransformotionProd-MigrationsApi', {

--- a/infrastructure/lib/budget-tracker/budget-tracker-ws-stack.ts
+++ b/infrastructure/lib/budget-tracker/budget-tracker-ws-stack.ts
@@ -1,0 +1,180 @@
+import * as path from 'path';
+import * as cdk from 'aws-cdk-lib';
+import * as apigatewayv2 from 'aws-cdk-lib/aws-apigatewayv2';
+import * as integrations from 'aws-cdk-lib/aws-apigatewayv2-integrations';
+import * as authorizers from 'aws-cdk-lib/aws-apigatewayv2-authorizers';
+import * as cognito from 'aws-cdk-lib/aws-cognito';
+import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import * as lambdaNodejs from 'aws-cdk-lib/aws-lambda-nodejs';
+import { Construct } from 'constructs';
+
+export interface BudgetTrackerWsStackProps extends cdk.StackProps {
+  userPool: cognito.IUserPool;
+  stage: 'dev' | 'prod';
+}
+
+/**
+ * BudgetTrackerWsStack — WebSocket API Gateway for the async AI Review service.
+ *
+ * Routes:
+ *   $connect    — custom Lambda authoriser validates Cognito ID token from query string
+ *   $disconnect — cleans up connection state
+ *   $default    — receives client-sent messages (PR 4 will use for cancellation)
+ *
+ * DynamoDB table:
+ *   budget-tracker.ai-connections-{stage}
+ *   PK: connectionId
+ *   GSI: userId-index (for cleanup queries)
+ *   TTL: expiresAt (stale connection cleanup)
+ *
+ * Output:
+ *   WssUrl — wss:// URL for the deployed stage (consumed by CI to build frontend)
+ */
+export class BudgetTrackerWsStack extends cdk.Stack {
+  public readonly webSocketApi: apigatewayv2.WebSocketApi;
+  public readonly webSocketStage: apigatewayv2.WebSocketStage;
+  public readonly connectionsTable: dynamodb.Table;
+
+  constructor(scope: Construct, id: string, props: BudgetTrackerWsStackProps) {
+    super(scope, id, props);
+
+    const { stage, userPool } = props;
+
+    cdk.Tags.of(this).add('app',         'budget-tracker');
+    cdk.Tags.of(this).add('environment', stage);
+
+    // ── Connection state table ────────────────────────────────────────────────
+
+    this.connectionsTable = new dynamodb.Table(this, 'AiConnectionsTable', {
+      tableName:     `budget-tracker.ai-connections-${stage}`,
+      partitionKey:  { name: 'connectionId', type: dynamodb.AttributeType.STRING },
+      billingMode:   dynamodb.BillingMode.PAY_PER_REQUEST,
+      timeToLiveAttribute: 'expiresAt',
+      removalPolicy: stage === 'prod' ? cdk.RemovalPolicy.RETAIN : cdk.RemovalPolicy.DESTROY,
+    });
+
+    this.connectionsTable.addGlobalSecondaryIndex({
+      indexName:    'userId-index',
+      partitionKey: { name: 'userId', type: dynamodb.AttributeType.STRING },
+      projectionType: dynamodb.ProjectionType.ALL,
+    });
+
+    // ── Bundling options shared across all WS Lambdas ─────────────────────────
+
+    const bundling: lambdaNodejs.BundlingOptions = {
+      externalModules: ['@aws-sdk/*'],
+      minify: true,
+      sourceMap: false,
+      forceDockerBundling: false,
+    };
+
+    const fnDir = path.join(__dirname, '../../../apps/budget-tracker/functions');
+
+    // ── Custom authoriser — validates Cognito ID token from query string ──────
+    //
+    // API Gateway v2 WebSocket does not support CognitoUserPoolsAuthorizer.
+    // A custom Lambda authoriser reads ?token= and ?accountId= from the
+    // $connect query string, verifies the JWT against Cognito JWKS, and
+    // returns an IAM policy.
+
+    const authorizerFn = new lambdaNodejs.NodejsFunction(this, 'AuthorizerFn', {
+      functionName: `budget-ai-ws-authorizer-${stage}`,
+      entry:        path.join(fnDir, 'ai-ws-authorizer/src/index.ts'),
+      handler:      'handler',
+      runtime:      lambda.Runtime.NODEJS_20_X,
+      timeout:      cdk.Duration.seconds(10),
+      memorySize:   256,
+      environment: {
+        COGNITO_USER_POOL_ID: userPool.userPoolId,
+      },
+      bundling: {
+        ...bundling,
+        // jose must be bundled — it is not available in the Lambda runtime
+        externalModules: ['@aws-sdk/*'],
+      },
+    });
+
+    const wsAuthorizer = new authorizers.WebSocketLambdaAuthorizer('WsAuthorizer', authorizerFn, {
+      identitySource: ['route.request.querystring.token'],
+    });
+
+    // ── $connect Lambda ───────────────────────────────────────────────────────
+
+    const connectFn = new lambdaNodejs.NodejsFunction(this, 'ConnectFn', {
+      functionName: `budget-ai-ws-connect-${stage}`,
+      entry:        path.join(fnDir, 'ai-ws-connect/src/index.ts'),
+      handler:      'handler',
+      runtime:      lambda.Runtime.NODEJS_20_X,
+      timeout:      cdk.Duration.seconds(10),
+      memorySize:   256,
+      environment:  { CONNECTIONS_TABLE: this.connectionsTable.tableName },
+      bundling,
+    });
+    this.connectionsTable.grantReadWriteData(connectFn);
+
+    // ── $disconnect Lambda ────────────────────────────────────────────────────
+
+    const disconnectFn = new lambdaNodejs.NodejsFunction(this, 'DisconnectFn', {
+      functionName: `budget-ai-ws-disconnect-${stage}`,
+      entry:        path.join(fnDir, 'ai-ws-disconnect/src/index.ts'),
+      handler:      'handler',
+      runtime:      lambda.Runtime.NODEJS_20_X,
+      timeout:      cdk.Duration.seconds(10),
+      memorySize:   256,
+      environment:  { CONNECTIONS_TABLE: this.connectionsTable.tableName },
+      bundling,
+    });
+    this.connectionsTable.grantReadWriteData(disconnectFn);
+
+    // ── $default Lambda ───────────────────────────────────────────────────────
+
+    const defaultFn = new lambdaNodejs.NodejsFunction(this, 'DefaultFn', {
+      functionName: `budget-ai-ws-default-${stage}`,
+      entry:        path.join(fnDir, 'ai-ws-default/src/index.ts'),
+      handler:      'handler',
+      runtime:      lambda.Runtime.NODEJS_20_X,
+      timeout:      cdk.Duration.seconds(10),
+      memorySize:   256,
+      environment:  { CONNECTIONS_TABLE: this.connectionsTable.tableName },
+      bundling,
+    });
+    this.connectionsTable.grantReadData(defaultFn);
+
+    // ── WebSocket API + routes ────────────────────────────────────────────────
+
+    this.webSocketApi = new apigatewayv2.WebSocketApi(this, 'AiWebSocketApi', {
+      apiName: `budget-tracker-ai-ws-${stage}`,
+      connectRouteOptions: {
+        integration: new integrations.WebSocketLambdaIntegration('ConnectInt', connectFn),
+        authorizer:  wsAuthorizer,
+      },
+      disconnectRouteOptions: {
+        integration: new integrations.WebSocketLambdaIntegration('DisconnectInt', disconnectFn),
+      },
+      defaultRouteOptions: {
+        integration: new integrations.WebSocketLambdaIntegration('DefaultInt', defaultFn),
+      },
+    });
+
+    this.webSocketStage = new apigatewayv2.WebSocketStage(this, 'AiWebSocketStage', {
+      webSocketApi: this.webSocketApi,
+      stageName:    stage,
+      autoDeploy:   true,
+    });
+
+    // ── Stack outputs ─────────────────────────────────────────────────────────
+
+    new cdk.CfnOutput(this, 'WssUrl', {
+      value:       this.webSocketStage.url,
+      description: 'WebSocket URL for the AI Review service (used by frontend)',
+      exportName:  `BudgetTrackerWss-${stage}-Url`,
+    });
+
+    new cdk.CfnOutput(this, 'ConnectionsTableName', {
+      value:       this.connectionsTable.tableName,
+      description: 'DynamoDB table for WebSocket connection state',
+      exportName:  `BudgetTrackerWss-${stage}-ConnectionsTableName`,
+    });
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -238,6 +238,70 @@ importers:
         specifier: 5.7.3
         version: 5.7.3
 
+  apps/budget-tracker/functions/ai-ws-authorizer:
+    dependencies:
+      jose:
+        specifier: ^5.9.6
+        version: 5.10.0
+    devDependencies:
+      '@types/aws-lambda':
+        specifier: ^8
+        version: 8.10.161
+      '@types/node':
+        specifier: ^22
+        version: 22.19.17
+      typescript:
+        specifier: '*'
+        version: 5.7.3
+
+  apps/budget-tracker/functions/ai-ws-connect:
+    devDependencies:
+      '@aws-sdk/client-dynamodb':
+        specifier: ^3
+        version: 3.1032.0
+      '@aws-sdk/lib-dynamodb':
+        specifier: ^3
+        version: 3.1032.0(@aws-sdk/client-dynamodb@3.1032.0)
+      '@types/aws-lambda':
+        specifier: ^8
+        version: 8.10.161
+      '@types/node':
+        specifier: ^22
+        version: 22.19.17
+      typescript:
+        specifier: '*'
+        version: 5.7.3
+
+  apps/budget-tracker/functions/ai-ws-default:
+    devDependencies:
+      '@types/aws-lambda':
+        specifier: ^8
+        version: 8.10.161
+      '@types/node':
+        specifier: ^22
+        version: 22.19.17
+      typescript:
+        specifier: '*'
+        version: 5.7.3
+
+  apps/budget-tracker/functions/ai-ws-disconnect:
+    devDependencies:
+      '@aws-sdk/client-dynamodb':
+        specifier: ^3
+        version: 3.1032.0
+      '@aws-sdk/lib-dynamodb':
+        specifier: ^3
+        version: 3.1032.0(@aws-sdk/client-dynamodb@3.1032.0)
+      '@types/aws-lambda':
+        specifier: ^8
+        version: 8.10.161
+      '@types/node':
+        specifier: ^22
+        version: 22.19.17
+      typescript:
+        specifier: '*'
+        version: 5.7.3
+
   apps/budget-tracker/functions/budget-ai:
     dependencies:
       '@transformotion/budget-domain':
@@ -4466,6 +4530,9 @@ packages:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
 
+  jose@5.10.0:
+    resolution: {integrity: sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==}
+
   js-cookie@3.0.5:
     resolution: {integrity: sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==}
     engines: {node: '>=14'}
@@ -5903,12 +5970,12 @@ snapshots:
     dependencies:
       '@aws-sdk/types': 3.973.8
       '@aws-sdk/xml-builder': 3.972.18
-      '@smithy/core': 3.23.15
+      '@smithy/core': 3.23.17
       '@smithy/node-config-provider': 4.3.14
       '@smithy/property-provider': 4.2.14
       '@smithy/protocol-http': 5.3.14
       '@smithy/signature-v4': 5.3.14
-      '@smithy/smithy-client': 4.12.11
+      '@smithy/smithy-client': 4.12.13
       '@smithy/types': 4.14.1
       '@smithy/util-base64': 4.3.2
       '@smithy/util-middleware': 4.2.14
@@ -6280,13 +6347,13 @@ snapshots:
 
   '@aws-sdk/middleware-user-agent@3.972.31':
     dependencies:
-      '@aws-sdk/core': 3.974.1
+      '@aws-sdk/core': 3.974.8
       '@aws-sdk/types': 3.973.8
-      '@aws-sdk/util-endpoints': 3.996.7
-      '@smithy/core': 3.23.15
+      '@aws-sdk/util-endpoints': 3.996.8
+      '@smithy/core': 3.23.17
       '@smithy/protocol-http': 5.3.14
       '@smithy/types': 4.14.1
-      '@smithy/util-retry': 4.3.2
+      '@smithy/util-retry': 4.3.8
       tslib: 2.8.1
 
   '@aws-sdk/middleware-user-agent@3.972.38':
@@ -6390,7 +6457,7 @@ snapshots:
   '@aws-sdk/region-config-resolver@3.972.12':
     dependencies:
       '@aws-sdk/types': 3.973.8
-      '@smithy/config-resolver': 4.4.16
+      '@smithy/config-resolver': 4.4.17
       '@smithy/node-config-provider': 4.3.14
       '@smithy/types': 4.14.1
       tslib: 2.8.1
@@ -6464,7 +6531,7 @@ snapshots:
       '@aws-sdk/types': 3.973.8
       '@smithy/types': 4.14.1
       '@smithy/url-parser': 4.2.14
-      '@smithy/util-endpoints': 3.4.1
+      '@smithy/util-endpoints': 3.4.2
       tslib: 2.8.1
 
   '@aws-sdk/util-endpoints@3.996.8':
@@ -6488,7 +6555,7 @@ snapshots:
 
   '@aws-sdk/util-user-agent-node@3.973.17':
     dependencies:
-      '@aws-sdk/middleware-user-agent': 3.972.31
+      '@aws-sdk/middleware-user-agent': 3.972.38
       '@aws-sdk/types': 3.973.8
       '@smithy/node-config-provider': 4.3.14
       '@smithy/types': 4.14.1
@@ -7900,7 +7967,7 @@ snapshots:
       '@smithy/node-config-provider': 4.3.14
       '@smithy/types': 4.14.1
       '@smithy/util-config-provider': 4.2.2
-      '@smithy/util-endpoints': 3.4.1
+      '@smithy/util-endpoints': 3.4.2
       '@smithy/util-middleware': 4.2.14
       tslib: 2.8.1
 
@@ -8042,8 +8109,8 @@ snapshots:
 
   '@smithy/middleware-endpoint@4.4.30':
     dependencies:
-      '@smithy/core': 3.23.15
-      '@smithy/middleware-serde': 4.2.18
+      '@smithy/core': 3.23.17
+      '@smithy/middleware-serde': 4.2.20
       '@smithy/node-config-provider': 4.3.14
       '@smithy/shared-ini-file-loader': 4.4.9
       '@smithy/types': 4.14.1
@@ -8064,14 +8131,14 @@ snapshots:
 
   '@smithy/middleware-retry@4.5.3':
     dependencies:
-      '@smithy/core': 3.23.15
+      '@smithy/core': 3.23.17
       '@smithy/node-config-provider': 4.3.14
       '@smithy/protocol-http': 5.3.14
       '@smithy/service-error-classification': 4.2.14
-      '@smithy/smithy-client': 4.12.11
+      '@smithy/smithy-client': 4.12.13
       '@smithy/types': 4.14.1
       '@smithy/util-middleware': 4.2.14
-      '@smithy/util-retry': 4.3.2
+      '@smithy/util-retry': 4.3.8
       '@smithy/uuid': 1.1.2
       tslib: 2.8.1
 
@@ -8090,7 +8157,7 @@ snapshots:
 
   '@smithy/middleware-serde@4.2.18':
     dependencies:
-      '@smithy/core': 3.23.15
+      '@smithy/core': 3.23.17
       '@smithy/protocol-http': 5.3.14
       '@smithy/types': 4.14.1
       tslib: 2.8.1
@@ -8175,8 +8242,8 @@ snapshots:
 
   '@smithy/smithy-client@4.12.11':
     dependencies:
-      '@smithy/core': 3.23.15
-      '@smithy/middleware-endpoint': 4.4.30
+      '@smithy/core': 3.23.17
+      '@smithy/middleware-endpoint': 4.4.32
       '@smithy/middleware-stack': 4.2.14
       '@smithy/protocol-http': 5.3.14
       '@smithy/types': 4.14.1
@@ -8253,7 +8320,7 @@ snapshots:
   '@smithy/util-defaults-mode-browser@4.3.47':
     dependencies:
       '@smithy/property-provider': 4.2.14
-      '@smithy/smithy-client': 4.12.11
+      '@smithy/smithy-client': 4.12.13
       '@smithy/types': 4.14.1
       tslib: 2.8.1
 
@@ -8266,11 +8333,11 @@ snapshots:
 
   '@smithy/util-defaults-mode-node@4.2.52':
     dependencies:
-      '@smithy/config-resolver': 4.4.16
+      '@smithy/config-resolver': 4.4.17
       '@smithy/credential-provider-imds': 4.2.14
       '@smithy/node-config-provider': 4.3.14
       '@smithy/property-provider': 4.2.14
-      '@smithy/smithy-client': 4.12.11
+      '@smithy/smithy-client': 4.12.13
       '@smithy/types': 4.14.1
       tslib: 2.8.1
 
@@ -8324,7 +8391,7 @@ snapshots:
   '@smithy/util-stream@4.5.23':
     dependencies:
       '@smithy/fetch-http-handler': 5.3.17
-      '@smithy/node-http-handler': 4.5.3
+      '@smithy/node-http-handler': 4.6.1
       '@smithy/types': 4.14.1
       '@smithy/util-base64': 4.3.2
       '@smithy/util-buffer-from': 4.2.2
@@ -9447,6 +9514,8 @@ snapshots:
   isexe@2.0.0: {}
 
   jiti@2.6.1: {}
+
+  jose@5.10.0: {}
 
   js-cookie@3.0.5: {}
 


### PR DESCRIPTION
## What this PR does

PR 3 of 5 in M6 close sequence. New WebSocket API Gateway infrastructure for the upcoming async AI Review. No app logic changes — just the plumbing.

## New infrastructure

### BudgetTrackerWsStack
Separate CDK stack at `infrastructure/lib/budget-tracker/budget-tracker-ws-stack.ts`. Contains all WebSocket resources; isolated from the existing REST API stack.

### DynamoDB connection state table
`budget-tracker.ai-connections-{stage}`
- PK: `connectionId`
- GSI: `userId-index` (for cleanup queries when a user disconnects mid-job)
- TTL: `expiresAt` (DynamoDB removes stale connections after 1 hour automatically)

### Lambda functions (4 new)
| Function | Purpose |
|---|---|
| `budget-ai-ws-authorizer-{stage}` | Validates Cognito ID token from `?token=` query string; returns IAM policy |
| `budget-ai-ws-connect-{stage}` | Writes `{ connectionId, userId, accountId, createdAt, expiresAt }` to connections table |
| `budget-ai-ws-disconnect-{stage}` | Deletes connection row (best-effort; TTL handles stragglers) |
| `budget-ai-ws-default-{stage}` | Logs client-sent messages; PR 4 wires cancellation here |

### Auth pattern
API Gateway v2 WebSocket does not support `CognitoUserPoolsAuthorizer`. Custom Lambda authoriser:
- Reads `?token=` (Cognito ID token) and `?accountId=` from `$connect` query string
- Verifies JWT against Cognito JWKS endpoint using `jose` library (bundled by esbuild)
- Validates `accountId` is in user's `accounts` token claim
- Returns IAM policy: Allow on the `$connect` route; or Deny if invalid

### Stack outputs
- `WssUrl`: `wss://5orhtpnmej.execute-api.ap-southeast-2.amazonaws.com/dev`
- `ConnectionsTableName`: `budget-tracker.ai-connections-dev`

## CI/CD changes

**deploy-budget-tracker.yml:**
- CDK deploy now includes `TransformotionDev/Prod-BudgetTrackerWs`
- New step after CDK deploy: `aws cloudformation describe-stacks` → extracts `WssUrl` → writes `NEXT_PUBLIC_BUDGET_WSS_URL` to `$GITHUB_ENV`
- Next.js build runs after, embedding the URL

**IAM:**
- Added `cloudformation:DescribeStacks` (scoped to `Transformotion*` stacks) to `GitHubActionsDeployRole` via `TransformotionDevDeploy` inline policy. Needed for the `describe-stacks` step — CDK uses assumed CDK roles for its own CloudFormation work; the CLI step runs as the GitHub Actions role directly.

**`.env.example`:**
- `NEXT_PUBLIC_BUDGET_WSS_URL` added as `[BUILD-INJECTED]` — extracted dynamically from CDK output on every deploy, not hardcoded as a GitHub Actions variable.

## Sequencing context
PR 3 of 5:
1. PR #229 — AI Review three latent bug fixes (merged)
2. PR #230 — M6 cleanup (merged)
3. **THIS PR** — WebSocket infrastructure
4. Async AI Review logic (budget-ai Lambda refactor: parallel batching, confidence tiers, WS push)
5. Frontend integration (WebSocket client, progress UI, settings tab)

## Verification
- CDK synth: 1 DynamoDB table, 4 Lambda functions, 1 WebSocket API, 3 routes, 1 authoriser, 1 stage — all present
- `pnpm turbo typecheck`: 39/39 tasks pass (4 new Lambda packages included)
- Stack deployed: `TransformotionDev-BudgetTrackerWs` CREATE_COMPLETE, 27/27 resources
- WSS URL extraction: `aws cloudformation describe-stacks` returns `wss://5orhtpnmej.execute-api.ap-southeast-2.amazonaws.com/dev`

## Out of scope
- Worker Lambda for parallel AI Review batches (PR 4)
- Pushing results to WebSocket connections (PR 4)
- Settings keys for AI Review parameters (PR 4)
- Frontend WebSocket client (PR 5)
- Progressive Review UI (PR 5)
- Settings tab UI (PR 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)