### PR TITLE
feat(budget-tracker): async AI review via WebSocket

### DIFF
--- a/.github/workflows/deploy-budget-tracker.yml
+++ b/.github/workflows/deploy-budget-tracker.yml
@@ -75,7 +75,7 @@ jobs:
 
       - name: CDK Deploy — Budget Tracker stacks (dev)
         working-directory: infrastructure
-        run: pnpm exec cdk deploy 'TransformotionDev-BudgetTrackerTables' 'TransformotionDev-BudgetTrackerApi' 'TransformotionDev-BudgetTrackerWs' --require-approval never
+        run: pnpm exec cdk deploy 'TransformotionDev-BudgetTrackerTables' 'TransformotionDev-BudgetTrackerWs' 'TransformotionDev-BudgetTrackerApi' --require-approval never
 
       - name: Extract WebSocket URL from CDK output
         run: |
@@ -153,7 +153,7 @@ jobs:
 
       - name: CDK Deploy — Budget Tracker stacks (prod)
         working-directory: infrastructure
-        run: pnpm exec cdk deploy 'TransformotionProd-BudgetTrackerTables' 'TransformotionProd-BudgetTrackerApi' 'TransformotionProd-BudgetTrackerWs' --require-approval never
+        run: pnpm exec cdk deploy 'TransformotionProd-BudgetTrackerTables' 'TransformotionProd-BudgetTrackerWs' 'TransformotionProd-BudgetTrackerApi' --require-approval never
 
       - name: Extract WebSocket URL from CDK output
         run: |

--- a/apps/budget-tracker/.env.example
+++ b/apps/budget-tracker/.env.example
@@ -173,7 +173,7 @@ NEXT_PUBLIC_COMMIT_HASH=
 # immediately after CDK deploy, then written to $GITHUB_ENV so the Next.js
 # build can embed it. Not set manually — the workflow always reads the live
 # stack output, so the URL remains correct even if the WebSocket API is recreated.
-# For local development: leave empty (AI Review uses synchronous HTTP fallback).
+# For local development: leave empty (mock AI provider is used instead of WebSocket flow).
 NEXT_PUBLIC_BUDGET_WSS_URL=
 
 # ── Cross-app navigation URLs ─────────────────────────────────────────────────
@@ -214,3 +214,7 @@ NEXT_PUBLIC_BUDGET_WSS_URL=
 # TRANSACTIONS_TABLE        — DynamoDB table name for transactions
 # RULES_TABLE               — DynamoDB table name for categorisation rules
 # CLAUDE_PROXY_FUNCTION_NAME — Lambda function name for direct Claude invocation
+# AI_JOBS_TABLE             — DynamoDB table for async AI review jobs
+# WS_CONNECTIONS_TABLE      — DynamoDB table for WebSocket connection state
+# WS_API_ID                 — WebSocket API Gateway ID (for management API endpoint)
+# WS_STAGE                  — WebSocket API stage (dev | prod)

--- a/apps/budget-tracker/components/budget-tracker/tabs/review-tab.tsx
+++ b/apps/budget-tracker/components/budget-tracker/tabs/review-tab.tsx
@@ -9,6 +9,7 @@ import { getCategoryBadgeClasses } from "../data/category-colors"
 import { getActiveCategories, getActiveSubcategories, getCategoryName, getSubcategoryName } from "@/lib/categories"
 import { cn } from "@/lib/utils"
 import { getAIService } from "@/lib/services/ai"
+import type { ReviewResult as AIReviewResult } from "@/lib/services/ai"
 import type { MatchingRule } from "@transformotion/budget-domain"
 
 interface ReviewResult {
@@ -44,34 +45,39 @@ export function ReviewTab() {
   const handleAIReview = async () => {
     setLoading(true)
     setError(null)
+    setReviewResults([])
     try {
-      const batch = uncategorizedTransactions.slice(0, 20)
+      const batch = uncategorizedTransactions.slice(0, 100)
       const indexedTxs = batch.map((t, i) => ({
         index: i,
         description: t.description,
         amount: String(t.amount),
       }))
 
-      const result = await getAIService().reviewTransactions({
+      await getAIService().reviewTransactions({
         transactions: indexedTxs,
         categories,
+        onBatch: (batchResults: AIReviewResult[]) => {
+          const formatted: ReviewResult[] = batchResults.flatMap(r => {
+            const tx = batch[r.index]
+            if (!tx?.transactionId) return []
+            return [{
+              transactionId: tx.transactionId,
+              description: tx.description,
+              suggestedCategoryId: r.categoryId,
+              suggestedSubcategoryId: r.subcategoryId,
+              suggestedCategoryName: getCategoryName(categories, r.categoryId),
+              suggestedSubcategoryName: getSubcategoryName(categories, r.subcategoryId),
+              reason: r.reason,
+              status: "pending" as const,
+            }]
+          })
+          setReviewResults(prev => {
+            const existing = new Set(prev.map(r => r.transactionId))
+            return [...prev, ...formatted.filter(r => !existing.has(r.transactionId))]
+          })
+        },
       })
-
-      const formatted: ReviewResult[] = result.results.map(r => {
-        const tx = batch[r.index]
-        return {
-          transactionId: tx?.transactionId ?? '',
-          description: tx?.description ?? '',
-          suggestedCategoryId: r.categoryId,
-          suggestedSubcategoryId: r.subcategoryId,
-          suggestedCategoryName: getCategoryName(categories, r.categoryId),
-          suggestedSubcategoryName: getSubcategoryName(categories, r.subcategoryId),
-          reason: r.reason,
-          status: "pending" as const,
-        }
-      }).filter(r => r.transactionId)
-
-      setReviewResults(formatted)
     } catch (err) {
       setError(err instanceof Error ? err : new Error("AI review failed"))
     } finally {

--- a/apps/budget-tracker/functions/ai-ws-connect/package.json
+++ b/apps/budget-tracker/functions/ai-ws-connect/package.json
@@ -9,6 +9,7 @@
     "lint": "echo \"lint: ai-ws-connect\""
   },
   "devDependencies": {
+    "@aws-sdk/client-apigatewaymanagementapi": "^3",
     "@aws-sdk/client-dynamodb": "^3",
     "@aws-sdk/lib-dynamodb": "^3",
     "@types/aws-lambda": "^8",

--- a/apps/budget-tracker/functions/ai-ws-connect/src/index.ts
+++ b/apps/budget-tracker/functions/ai-ws-connect/src/index.ts
@@ -1,5 +1,6 @@
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { DynamoDBDocumentClient, PutCommand } from '@aws-sdk/lib-dynamodb';
+import { ApiGatewayManagementApiClient, PostToConnectionCommand } from '@aws-sdk/client-apigatewaymanagementapi';
 
 const ddb   = DynamoDBDocumentClient.from(new DynamoDBClient({}));
 const TABLE = process.env.CONNECTIONS_TABLE!;
@@ -8,6 +9,7 @@ interface ConnectEvent {
   requestContext: {
     connectionId: string;
     stage: string;
+    domainName: string;
     authorizer?: {
       userId?: string;
       accountId?: string;
@@ -16,7 +18,7 @@ interface ConnectEvent {
 }
 
 export const handler = async (event: ConnectEvent): Promise<{ statusCode: number }> => {
-  const { connectionId, authorizer } = event.requestContext;
+  const { connectionId, stage, domainName, authorizer } = event.requestContext;
   const userId    = authorizer?.userId ?? 'unknown';
   const accountId = authorizer?.accountId ?? '';
   const now       = Math.floor(Date.now() / 1000);
@@ -30,9 +32,23 @@ export const handler = async (event: ConnectEvent): Promise<{ statusCode: number
       userId,
       accountId,
       createdAt: new Date().toISOString(),
-      expiresAt: now + 3600,  // TTL: 1 hour; DynamoDB removes stale connections
+      expiresAt: now + 3600,
     },
   }));
+
+  // Push connectionId back to the client immediately after connect
+  const mgmt = new ApiGatewayManagementApiClient({
+    endpoint: `https://${domainName}/${stage}`,
+  });
+
+  try {
+    await mgmt.send(new PostToConnectionCommand({
+      ConnectionId: connectionId,
+      Data: Buffer.from(JSON.stringify({ type: 'connected', connectionId })),
+    }));
+  } catch (err) {
+    console.warn(`[ai-ws-connect] failed to push connected message: ${(err as Error).message}`);
+  }
 
   return { statusCode: 200 };
 };

--- a/apps/budget-tracker/functions/budget-ai/package.json
+++ b/apps/budget-tracker/functions/budget-ai/package.json
@@ -13,6 +13,7 @@
     "@transformotion/lambda-middleware": "workspace:*"
   },
   "devDependencies": {
+    "@aws-sdk/client-apigatewaymanagementapi": "^3",
     "@aws-sdk/client-dynamodb": "^3",
     "@aws-sdk/lib-dynamodb": "^3",
     "@aws-sdk/client-lambda": "^3",

--- a/apps/budget-tracker/functions/budget-ai/src/csv-analysis.ts
+++ b/apps/budget-tracker/functions/budget-ai/src/csv-analysis.ts
@@ -1,0 +1,33 @@
+import { ok } from '@transformotion/lambda-middleware';
+import type { AuthClaims } from '@transformotion/lambda-middleware';
+import { parseBody } from '@transformotion/lambda-middleware';
+import type { AiCsvAnalysisResponse } from '@transformotion/budget-domain';
+import { invokeProxy } from './proxy';
+
+const AI_MODEL = 'claude-sonnet-4-20250514';
+
+export async function csvAnalysis(
+  auth: AuthClaims,
+  accountId: string,
+  event: Parameters<typeof parseBody>[0],
+) {
+  const { sampleRows } = parseBody<{ sampleRows: string[][] }>(event);
+
+  const proxyResponse = await invokeProxy(auth, accountId, {
+    model:     AI_MODEL,
+    maxTokens: 1024,
+    system:    `You are a CSV format detective. Given the first few rows of a bank transaction CSV, identify which column is which.\n\nYou must return ONLY a JSON object with this exact shape:\n{\n  "dateColumn": <int>,\n  "descriptionColumn": <int>,\n  "amountColumn": <int>,\n  "debitColumn": <int>,\n  "creditColumn": <int>,\n  "dateFormat": <string>,\n  "hasHeader": <bool>,\n  "confidence": "high" | "medium" | "low",\n  "notes": <string>\n}\n\nEither amountColumn OR (debitColumn + creditColumn) must be present, not both. Columns are 0-indexed.\n\nIf you cannot determine the format with reasonable confidence, set confidence: "low" and describe the issue in notes.\n\nDo not include any text outside the JSON object.\nDo not wrap the JSON in markdown code fences.`,
+    prompt:    `Sample rows from uploaded CSV (each row is an array of cell values):\n${JSON.stringify(sampleRows, null, 2)}\n\nThe first row above MAY be a header row, or it may be a data row. Use the content to decide.`,
+  });
+
+  const text = (proxyResponse['content'] as string) ?? '';
+
+  try {
+    const clean = text.replace(/```json|```/g, '').trim();
+    const result = JSON.parse(clean) as AiCsvAnalysisResponse;
+    return ok(result);
+  } catch {
+    console.error('[budget-ai] csv-analysis: failed to parse response', text.slice(0, 200));
+    throw { statusCode: 502, message: 'Failed to parse AI response for CSV analysis' };
+  }
+}

--- a/apps/budget-tracker/functions/budget-ai/src/index.ts
+++ b/apps/budget-tracker/functions/budget-ai/src/index.ts
@@ -1,174 +1,32 @@
-import { LambdaClient, InvokeCommand } from '@aws-sdk/client-lambda';
-import { withAuth, parseBody, ok, requireAppAccess, requireAccountAccess } from '@transformotion/lambda-middleware';
-import type { AuthClaims } from '@transformotion/lambda-middleware';
-import type {
-  Category,
-  AiReviewResponse,
-  AiCsvAnalysisResponse,
-} from '@transformotion/budget-domain';
-
-const lambdaClient = new LambdaClient({});
-const PROXY_FN     = process.env.CLAUDE_PROXY_FUNCTION_NAME!;
-const AI_MODEL     = 'claude-sonnet-4-20250514';
-const BATCH_REVIEW = 20;
-
-// ── Invoke the shared claude-proxy Lambda ─────────────────────────────────────
-// Formats a minimal API Gateway proxy event so the proxy's withAuth middleware
-// can extract claims without requiring a raw JWT token.
-async function invokeProxy(
-  auth: AuthClaims,
-  accountId: string,
-  body: object
-): Promise<Record<string, unknown>> {
-  const fakeEvent = {
-    httpMethod: 'POST',
-    path: '/api/claude',
-    headers: { 'x-account-id': accountId },
-    queryStringParameters: null,
-    pathParameters: null,
-    requestContext: {
-      authorizer: {
-        claims: {
-          sub:              auth.userId,
-          email:            auth.email,
-          'cognito:groups': auth.groups.join(' '),
-          apps:             JSON.stringify(auth.apps),
-          accounts:         JSON.stringify(auth.accounts),
-          site_admin:       String(auth.siteAdmin),
-        },
-      },
-    },
-    body: JSON.stringify(body),
-    isBase64Encoded: false,
-  };
-
-  const result = await lambdaClient.send(new InvokeCommand({
-    FunctionName: PROXY_FN,
-    Payload:      Buffer.from(JSON.stringify(fakeEvent)),
-  }));
-
-  const response = JSON.parse(Buffer.from(result.Payload!).toString()) as {
-    statusCode: number;
-    body: string;
-  };
-
-  if (response.statusCode !== 200) {
-    const err = JSON.parse(response.body || '{}');
-    throw { statusCode: response.statusCode, message: err.error ?? 'Claude proxy error' };
-  }
-
-  return JSON.parse(response.body) as Record<string, unknown>;
-}
-
-function formatCategoryList(categories: Category[]): string {
-  return categories
-    .filter(cat => !cat.deleted)
-    .map(cat => `${cat.name}: ${cat.subcategories.filter(sub => !sub.deleted).map(sub => sub.name).join(', ')}`)
-    .join('\n');
-}
-
-function formatTxList(txs: Array<{ index: number; description: string; amount: string }>): string {
-  return txs.map(t => `${t.index}: ${t.description} — ${t.amount}`).join('\n');
-}
-
-// ── POST /api/budget/v1/ai/review ─────────────────────────────────────────────
-async function review(
-  auth: AuthClaims,
-  accountId: string,
-  event: Parameters<typeof parseBody>[0]
-) {
-  const { transactions, categories } = parseBody<{
-    transactions: Array<{ index: number; description: string; amount: string }>;
-    categories: Category[];
-  }>(event);
-
-  const categoryList = formatCategoryList(categories);
-  const allResults: AiReviewResponse['results'] = [];
-
-  // Build (category name, subcategory name) → { categoryId, subcategoryId } lookup
-  const labelLookup = new Map<string, { categoryId: string; subcategoryId: string }>();
-  for (const cat of categories) {
-    for (const sub of cat.subcategories) {
-      const key = `${cat.name.toLowerCase()}::${sub.name.toLowerCase()}`;
-      labelLookup.set(key, { categoryId: cat.categoryId, subcategoryId: sub.subcategoryId });
-    }
-  }
-
-  for (let i = 0; i < transactions.length; i += BATCH_REVIEW) {
-    const batch = transactions.slice(i, i + BATCH_REVIEW);
-    const proxyResponse = await invokeProxy(auth, accountId, {
-      model:     AI_MODEL,
-      maxTokens: 4096,
-      webSearch: true,
-      system:    `You are a personal finance assistant helping to categorise Australian bank transactions that a fast categorisation pass could not handle.\n\nYou will be given:\n- A list of budget categories, each with allowed subcategories\n- A list of unknown or ambiguous transactions (index, description, amount)\n\nYou have access to a web_search tool. If a merchant or description is unfamiliar, you MAY search to identify the business type before categorising. Use web_search sparingly — only when the description is genuinely ambiguous.\n\nYou must:\n- Return ONLY a JSON array, one object per transaction\n- Each object has exactly: {"index": <int>, "category": <string>, "subcategory": <string>, "reason": <string>}\n- The category must be one of the provided categories exactly\n- The subcategory must be one of the subcategories listed under that category exactly\n- The reason must be a single sentence explaining your choice in plain English\n- If a transaction is genuinely uncategorisable, return it with category: "", subcategory: "", and reason explaining why\n- Do not include any text outside the JSON array\n- Do not wrap the JSON in markdown code fences`,
-      prompt:    `BUDGET CATEGORIES AND SUBCATEGORIES:\n${categoryList}\n\nTRANSACTIONS TO CATEGORISE (index: description — amount):\n${formatTxList(batch)}`,
-    });
-
-    // Fix 2: proxy returns content as a plain string, not Anthropic content blocks
-    const text = (proxyResponse['content'] as string) ?? '';
-
-    try {
-      const clean = text.replace(/```json|```/g, '').trim();
-      const rawSuggestions = JSON.parse(
-        clean.slice(clean.indexOf('['), clean.lastIndexOf(']') + 1)
-      ) as Array<{ index: number; category: string; subcategory: string; reason: string }>;
-
-      // Fix 3: resolve Claude's name strings to canonical UUIDs
-      for (const s of rawSuggestions) {
-        const key = `${s.category.toLowerCase()}::${s.subcategory.toLowerCase()}`;
-        const ids = labelLookup.get(key);
-        if (!ids) {
-          console.warn(
-            `[budget-ai] review: could not resolve "${s.category} > ${s.subcategory}" to UUIDs; dropping suggestion at index ${s.index}`
-          );
-          continue;
-        }
-        allResults.push({ index: s.index, categoryId: ids.categoryId, subcategoryId: ids.subcategoryId, reason: s.reason });
-      }
-    } catch {
-      console.error('[budget-ai] review: failed to parse batch response', text.slice(0, 200));
-    }
-  }
-
-  return ok({ results: allResults });
-}
-
-// ── POST /api/budget/v1/ai/csv-analysis ──────────────────────────────────────
-async function csvAnalysis(
-  auth: AuthClaims,
-  accountId: string,
-  event: Parameters<typeof parseBody>[0]
-) {
-  const { sampleRows } = parseBody<{ sampleRows: string[][] }>(event);
-
-  const proxyResponse = await invokeProxy(auth, accountId, {
-    model:     AI_MODEL,
-    maxTokens: 1024,
-    system:    `You are a CSV format detective. Given the first few rows of a bank transaction CSV, identify which column is which.\n\nYou must return ONLY a JSON object with this exact shape:\n{\n  "dateColumn": <int>,\n  "descriptionColumn": <int>,\n  "amountColumn": <int>,\n  "debitColumn": <int>,\n  "creditColumn": <int>,\n  "dateFormat": <string>,\n  "hasHeader": <bool>,\n  "confidence": "high" | "medium" | "low",\n  "notes": <string>\n}\n\nEither amountColumn OR (debitColumn + creditColumn) must be present, not both. Columns are 0-indexed.\n\nIf you cannot determine the format with reasonable confidence, set confidence: "low" and describe the issue in notes.\n\nDo not include any text outside the JSON object.\nDo not wrap the JSON in markdown code fences.`,
-    prompt:    `Sample rows from uploaded CSV (each row is an array of cell values):\n${JSON.stringify(sampleRows, null, 2)}\n\nThe first row above MAY be a header row, or it may be a data row. Use the content to decide.`,
-  });
-
-  // Fix 2: proxy returns content as a plain string, not Anthropic content blocks
-  const text = (proxyResponse['content'] as string) ?? '';
-
-  try {
-    const clean = text.replace(/```json|```/g, '').trim();
-    const result = JSON.parse(clean) as AiCsvAnalysisResponse;
-    return ok(result);
-  } catch {
-    console.error('[budget-ai] csv-analysis: failed to parse response', text.slice(0, 200));
-    throw { statusCode: 502, message: 'Failed to parse AI response for CSV analysis' };
-  }
-}
+import { withAuth, requireAppAccess, requireAccountAccess } from '@transformotion/lambda-middleware';
+import { reviewStart } from './review-start';
+import { runReviewWorker, type ReviewWorkerPayload } from './review-worker';
+import { csvAnalysis } from './csv-analysis';
 
 // ── Handler ───────────────────────────────────────────────────────────────────
-export const handler = withAuth(async ({ auth, account, event }) => {
-  requireAppAccess(auth, 'budget-tracker');
-  requireAccountAccess(auth, 'budget-tracker', account.accountId);
-  const resource = event.resource ?? '';
+//
+// Two entry modes:
+//   1. HTTP via API Gateway — normal withAuth flow
+//   2. Async worker — invoked directly by reviewStart with { __asyncJob: 'review-worker' }
+//      The event is a ReviewWorkerPayload, not an API Gateway proxy event.
 
-  if (resource === '/api/budget/v1/ai/review')        return review(auth, account.accountId, event);
-  if (resource === '/api/budget/v1/ai/csv-analysis')  return csvAnalysis(auth, account.accountId, event);
+export const handler = async (event: unknown) => {
+  // Detect async worker invocation
+  const maybeWorker = event as Partial<ReviewWorkerPayload>;
+  if (maybeWorker.__asyncJob === 'review-worker') {
+    await runReviewWorker(maybeWorker as ReviewWorkerPayload);
+    return;
+  }
 
-  throw { statusCode: 400, message: `Unrecognised route: ${event.httpMethod} ${resource}` };
-});
+  // Normal HTTP path
+  return withAuth(async ({ auth, account, event: apiEvent }) => {
+    requireAppAccess(auth, 'budget-tracker');
+    requireAccountAccess(auth, 'budget-tracker', account.accountId);
+    const resource = apiEvent.resource ?? '';
+
+    if (resource === '/api/budget/v1/ai/review')       return reviewStart(auth, account.accountId, apiEvent);
+    if (resource === '/api/budget/v1/ai/csv-analysis') return csvAnalysis(auth, account.accountId, apiEvent);
+
+    throw { statusCode: 400, message: `Unrecognised route: ${apiEvent.httpMethod} ${resource}` };
+  })(event as Parameters<ReturnType<typeof withAuth>>[0]);
+};

--- a/apps/budget-tracker/functions/budget-ai/src/proxy.ts
+++ b/apps/budget-tracker/functions/budget-ai/src/proxy.ts
@@ -1,0 +1,50 @@
+import { LambdaClient, InvokeCommand } from '@aws-sdk/client-lambda';
+import type { AuthClaims } from '@transformotion/lambda-middleware';
+
+const lambdaClient = new LambdaClient({});
+const PROXY_FN     = process.env.CLAUDE_PROXY_FUNCTION_NAME!;
+
+export async function invokeProxy(
+  auth: AuthClaims,
+  accountId: string,
+  body: object,
+): Promise<Record<string, unknown>> {
+  const fakeEvent = {
+    httpMethod: 'POST',
+    path: '/api/claude',
+    headers: { 'x-account-id': accountId },
+    queryStringParameters: null,
+    pathParameters: null,
+    requestContext: {
+      authorizer: {
+        claims: {
+          sub:              auth.userId,
+          email:            auth.email,
+          'cognito:groups': auth.groups.join(' '),
+          apps:             JSON.stringify(auth.apps),
+          accounts:         JSON.stringify(auth.accounts),
+          site_admin:       String(auth.siteAdmin),
+        },
+      },
+    },
+    body: JSON.stringify(body),
+    isBase64Encoded: false,
+  };
+
+  const result = await lambdaClient.send(new InvokeCommand({
+    FunctionName: PROXY_FN,
+    Payload:      Buffer.from(JSON.stringify(fakeEvent)),
+  }));
+
+  const response = JSON.parse(Buffer.from(result.Payload!).toString()) as {
+    statusCode: number;
+    body: string;
+  };
+
+  if (response.statusCode !== 200) {
+    const err = JSON.parse(response.body || '{}');
+    throw { statusCode: response.statusCode, message: err.error ?? 'Claude proxy error' };
+  }
+
+  return JSON.parse(response.body) as Record<string, unknown>;
+}

--- a/apps/budget-tracker/functions/budget-ai/src/review-start.ts
+++ b/apps/budget-tracker/functions/budget-ai/src/review-start.ts
@@ -1,0 +1,79 @@
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import { DynamoDBDocumentClient, PutCommand, GetCommand } from '@aws-sdk/lib-dynamodb';
+import { LambdaClient, InvokeCommand } from '@aws-sdk/client-lambda';
+import { ok, parseBody } from '@transformotion/lambda-middleware';
+import type { AuthClaims } from '@transformotion/lambda-middleware';
+import type { Category } from '@transformotion/budget-domain';
+import type { ReviewWorkerPayload } from './review-worker';
+
+const ddb         = DynamoDBDocumentClient.from(new DynamoDBClient({}));
+const lambdaClient = new LambdaClient({});
+
+const JOBS_TABLE  = process.env.AI_JOBS_TABLE!;
+const CONN_TABLE  = process.env.WS_CONNECTIONS_TABLE!;
+const SELF_FN     = process.env.AWS_LAMBDA_FUNCTION_NAME!;
+
+export async function reviewStart(
+  auth: AuthClaims,
+  accountId: string,
+  event: Parameters<typeof parseBody>[0],
+): Promise<ReturnType<typeof ok>> {
+  const { connectionId, transactions, categories, settings } = parseBody<{
+    connectionId: string;
+    transactions: Array<{ index: number; description: string; amount: string }>;
+    categories: Category[];
+    settings?: { batchSize?: number; parallelLimit?: number; confidenceThreshold?: 'low' | 'medium' };
+  }>(event);
+
+  // Verify the connectionId belongs to this user
+  const connItem = await ddb.send(new GetCommand({
+    TableName: CONN_TABLE,
+    Key: { connectionId },
+  }));
+  if (!connItem.Item || connItem.Item['userId'] !== auth.userId) {
+    throw { statusCode: 400, message: 'Invalid or expired WebSocket connection' };
+  }
+
+  const jobId    = crypto.randomUUID();
+  const now      = Math.floor(Date.now() / 1000);
+  const expiresAt = now + 86400; // 24h TTL
+
+  await ddb.send(new PutCommand({
+    TableName: JOBS_TABLE,
+    Item: {
+      jobId,
+      userId:    auth.userId,
+      accountId,
+      status:    'pending',
+      createdAt: new Date().toISOString(),
+      expiresAt,
+    },
+  }));
+
+  const batchSize            = Math.min(Math.max(settings?.batchSize ?? 5, 1), 20);
+  const parallelLimit        = Math.min(Math.max(settings?.parallelLimit ?? 4, 1), 10);
+  const confidenceThreshold  = settings?.confidenceThreshold ?? 'low';
+
+  const workerPayload: ReviewWorkerPayload = {
+    __asyncJob: 'review-worker',
+    jobId,
+    userId: auth.userId,
+    accountId,
+    connectionId,
+    transactions,
+    categories,
+    batchSize,
+    parallelLimit,
+    confidenceThreshold,
+    auth,
+  };
+
+  // Dispatch worker asynchronously — fire and forget
+  await lambdaClient.send(new InvokeCommand({
+    FunctionName:   SELF_FN,
+    InvocationType: 'Event',
+    Payload:        Buffer.from(JSON.stringify(workerPayload)),
+  }));
+
+  return ok({ jobId });
+}

--- a/apps/budget-tracker/functions/budget-ai/src/review-worker.ts
+++ b/apps/budget-tracker/functions/budget-ai/src/review-worker.ts
@@ -1,0 +1,160 @@
+import type { AuthClaims } from '@transformotion/lambda-middleware';
+import type { Category, WsMessageBatchResult, WsMessageComplete, WsMessageError } from '@transformotion/budget-domain';
+import { invokeProxy } from './proxy';
+import { pushToConnection, processWithConcurrency, buildLabelLookup, formatCategoryList, formatTxList } from './shared';
+
+const AI_MODEL = 'claude-sonnet-4-20250514';
+
+export interface ReviewWorkerPayload {
+  __asyncJob:    'review-worker';
+  jobId:         string;
+  userId:        string;
+  accountId:     string;
+  connectionId:  string;
+  transactions:  Array<{ index: number; description: string; amount: string }>;
+  categories:    Category[];
+  batchSize:     number;
+  parallelLimit: number;
+  confidenceThreshold: 'low' | 'medium';
+  auth:          AuthClaims;
+}
+
+type BatchResult = {
+  index: number;
+  categoryId: string;
+  subcategoryId: string;
+  reason: string;
+  confidence: 'high' | 'medium' | 'low';
+};
+
+const CONFIDENCE_ORDER: Record<string, number> = { high: 2, medium: 1, low: 0 };
+
+function meetsThreshold(confidence: string, threshold: 'low' | 'medium'): boolean {
+  return CONFIDENCE_ORDER[confidence] >= CONFIDENCE_ORDER[threshold];
+}
+
+async function runBatch(
+  auth: AuthClaims,
+  accountId: string,
+  batch: Array<{ index: number; description: string; amount: string }>,
+  categoryList: string,
+  labelLookup: Map<string, { categoryId: string; subcategoryId: string }>,
+  webSearch: boolean,
+): Promise<BatchResult[]> {
+  const proxyResponse = await invokeProxy(auth, accountId, {
+    model:     AI_MODEL,
+    maxTokens: 4096,
+    webSearch,
+    system:    `You are a personal finance assistant helping to categorise Australian bank transactions.\n\nYou will be given:\n- A list of budget categories, each with allowed subcategories\n- A list of transactions (index, description, amount)\n\n${webSearch ? 'You have access to a web_search tool. If a merchant or description is unfamiliar, you MAY search to identify the business type. Use web_search sparingly.' : ''}\n\nYou must:\n- Return ONLY a JSON array, one object per transaction\n- Each object has exactly: {"index": <int>, "category": <string>, "subcategory": <string>, "reason": <string>, "confidence": "high"|"medium"|"low"}\n- The category must be one of the provided categories exactly\n- The subcategory must be one of the subcategories listed under that category exactly\n- "confidence" reflects how certain you are: "high" = clear match, "medium" = reasonable inference, "low" = best guess\n- The reason must be a single sentence explaining your choice in plain English\n- If a transaction is genuinely uncategorisable, return it with category: "", subcategory: "", confidence: "low", and reason explaining why\n- Do not include any text outside the JSON array\n- Do not wrap the JSON in markdown code fences`,
+    prompt:    `BUDGET CATEGORIES AND SUBCATEGORIES:\n${categoryList}\n\nTRANSACTIONS TO CATEGORISE (index: description — amount):\n${formatTxList(batch)}`,
+  });
+
+  const text = (proxyResponse['content'] as string) ?? '';
+  const results: BatchResult[] = [];
+
+  try {
+    const clean = text.replace(/```json|```/g, '').trim();
+    const rawSuggestions = JSON.parse(
+      clean.slice(clean.indexOf('['), clean.lastIndexOf(']') + 1)
+    ) as Array<{ index: number; category: string; subcategory: string; reason: string; confidence: string }>;
+
+    for (const s of rawSuggestions) {
+      const key = `${s.category.toLowerCase()}::${s.subcategory.toLowerCase()}`;
+      const ids = labelLookup.get(key);
+      if (!ids) {
+        console.warn(`[budget-ai] review-worker: could not resolve "${s.category} > ${s.subcategory}" at index ${s.index}`);
+        continue;
+      }
+      results.push({
+        index:         s.index,
+        categoryId:    ids.categoryId,
+        subcategoryId: ids.subcategoryId,
+        reason:        s.reason,
+        confidence:    (s.confidence as 'high' | 'medium' | 'low') ?? 'low',
+      });
+    }
+  } catch {
+    console.error('[budget-ai] review-worker: failed to parse batch', text.slice(0, 200));
+  }
+
+  return results;
+}
+
+export async function runReviewWorker(payload: ReviewWorkerPayload): Promise<void> {
+  const { jobId, connectionId, transactions, categories, batchSize, parallelLimit, confidenceThreshold, auth, accountId } = payload;
+
+  const categoryList = formatCategoryList(categories);
+  const labelLookup  = buildLabelLookup(categories);
+
+  const pass1Results = new Map<number, BatchResult>();
+  const totalCount   = transactions.length;
+  let completedCount = 0;
+
+  // ── Pass 1: fast, no webSearch ────────────────────────────────────────────
+
+  const batches1: Array<typeof transactions> = [];
+  for (let i = 0; i < transactions.length; i += batchSize) {
+    batches1.push(transactions.slice(i, i + batchSize));
+  }
+
+  try {
+    await processWithConcurrency(batches1, parallelLimit, async (batch) => {
+      const batchResults = await runBatch(auth, accountId, batch, categoryList, labelLookup, false);
+      for (const r of batchResults) pass1Results.set(r.index, r);
+
+      completedCount += batch.length;
+      const msg: WsMessageBatchResult = {
+        type:           'batch_result',
+        jobId,
+        pass:           1,
+        results:        batchResults,
+        completedCount,
+        totalCount,
+      };
+      await pushToConnection(connectionId, msg);
+    });
+
+    // ── Pass 2: web search for low-confidence results ─────────────────────
+
+    const needsPass2 = transactions.filter(tx => {
+      const r = pass1Results.get(tx.index);
+      return !r || !meetsThreshold(r.confidence, confidenceThreshold);
+    });
+
+    if (needsPass2.length > 0) {
+      const batches2: Array<typeof transactions> = [];
+      for (let i = 0; i < needsPass2.length; i += batchSize) {
+        batches2.push(needsPass2.slice(i, i + batchSize));
+      }
+
+      let pass2Completed = 0;
+      await processWithConcurrency(batches2, parallelLimit, async (batch) => {
+        const batchResults = await runBatch(auth, accountId, batch, categoryList, labelLookup, true);
+        for (const r of batchResults) pass1Results.set(r.index, r);
+
+        pass2Completed += batch.length;
+        const msg: WsMessageBatchResult = {
+          type:           'batch_result',
+          jobId,
+          pass:           2,
+          results:        batchResults,
+          completedCount: pass2Completed,
+          totalCount:     needsPass2.length,
+        };
+        await pushToConnection(connectionId, msg);
+      });
+    }
+
+    const complete: WsMessageComplete = { type: 'complete', jobId };
+    await pushToConnection(connectionId, complete);
+
+  } catch (err) {
+    console.error('[budget-ai] review-worker: fatal error', err);
+    const errorMsg: WsMessageError = {
+      type:    'error',
+      jobId,
+      message: (err as Error).message ?? 'Internal error during AI review',
+    };
+    await pushToConnection(connectionId, errorMsg);
+  }
+}

--- a/apps/budget-tracker/functions/budget-ai/src/shared.ts
+++ b/apps/budget-tracker/functions/budget-ai/src/shared.ts
@@ -1,0 +1,75 @@
+import { ApiGatewayManagementApiClient, PostToConnectionCommand } from '@aws-sdk/client-apigatewaymanagementapi';
+import type { Category } from '@transformotion/budget-domain';
+
+// ── WebSocket push ────────────────────────────────────────────────────────────
+
+let _wsClient: ApiGatewayManagementApiClient | undefined;
+
+function getWsClient(): ApiGatewayManagementApiClient {
+  if (!_wsClient) {
+    const apiId  = process.env.WS_API_ID!;
+    const stage  = process.env.WS_STAGE!;
+    const region = process.env.AWS_REGION_NAME ?? process.env.AWS_REGION!;
+    _wsClient = new ApiGatewayManagementApiClient({
+      endpoint: `https://${apiId}.execute-api.${region}.amazonaws.com/${stage}`,
+      region,
+    });
+  }
+  return _wsClient;
+}
+
+export async function pushToConnection(connectionId: string, payload: unknown): Promise<void> {
+  try {
+    await getWsClient().send(new PostToConnectionCommand({
+      ConnectionId: connectionId,
+      Data:         Buffer.from(JSON.stringify(payload)),
+    }));
+  } catch (err) {
+    console.warn(`[budget-ai] pushToConnection failed for ${connectionId}:`, (err as Error).message);
+  }
+}
+
+// ── Concurrency limiter ───────────────────────────────────────────────────────
+
+export async function processWithConcurrency<T, R>(
+  items: T[],
+  concurrency: number,
+  fn: (item: T) => Promise<R>,
+): Promise<R[]> {
+  const results: R[] = [];
+  let idx = 0;
+
+  async function worker() {
+    while (idx < items.length) {
+      const i = idx++;
+      results[i] = await fn(items[i]);
+    }
+  }
+
+  await Promise.all(Array.from({ length: Math.min(concurrency, items.length) }, worker));
+  return results;
+}
+
+// ── Category label lookup ─────────────────────────────────────────────────────
+
+export function buildLabelLookup(categories: Category[]): Map<string, { categoryId: string; subcategoryId: string }> {
+  const map = new Map<string, { categoryId: string; subcategoryId: string }>();
+  for (const cat of categories) {
+    for (const sub of cat.subcategories) {
+      const key = `${cat.name.toLowerCase()}::${sub.name.toLowerCase()}`;
+      map.set(key, { categoryId: cat.categoryId, subcategoryId: sub.subcategoryId });
+    }
+  }
+  return map;
+}
+
+export function formatCategoryList(categories: Category[]): string {
+  return categories
+    .filter(cat => !cat.deleted)
+    .map(cat => `${cat.name}: ${cat.subcategories.filter(sub => !sub.deleted).map(sub => sub.name).join(', ')}`)
+    .join('\n');
+}
+
+export function formatTxList(txs: Array<{ index: number; description: string; amount: string }>): string {
+  return txs.map(t => `${t.index}: ${t.description} — ${t.amount}`).join('\n');
+}

--- a/apps/budget-tracker/functions/budget-settings/src/index.ts
+++ b/apps/budget-tracker/functions/budget-settings/src/index.ts
@@ -6,12 +6,18 @@ import type { BudgetSettings } from '@transformotion/budget-domain';
 const ddb = DynamoDBDocumentClient.from(new DynamoDBClient({}));
 const TABLE = process.env.SETTINGS_TABLE!;
 
-// BudgetSettings now contains only csvFormatMappings.
-// All budget/category state moved to budget-tracker.budget-data table.
-const SETTING_KEYS: Array<keyof BudgetSettings> = ['csvFormatMappings'];
+const SETTING_KEYS: Array<keyof BudgetSettings> = [
+  'csvFormatMappings',
+  'aiReviewBatchSize',
+  'aiReviewParallelLimit',
+  'aiReviewConfidenceThreshold',
+];
 
 const DEFAULT_SETTINGS: BudgetSettings = {
   csvFormatMappings: {},
+  aiReviewBatchSize: 5,
+  aiReviewParallelLimit: 4,
+  aiReviewConfidenceThreshold: 'low',
 };
 
 async function getSettings(accountId: string) {

--- a/apps/budget-tracker/lib/config/index.ts
+++ b/apps/budget-tracker/lib/config/index.ts
@@ -23,6 +23,7 @@ export interface AuthConfig {
 export interface AIConfig {
   provider: 'mock' | 'claude'
   model: string
+  wssUrl: string
 }
 
 export interface StorageConfig {
@@ -102,6 +103,7 @@ export function loadConfig(): AppConfig {
         validValues: ['mock', 'claude'] as const,
       }),
       model: process.env.NEXT_PUBLIC_AI_MODEL || 'claude-3-sonnet',
+      wssUrl: process.env.NEXT_PUBLIC_BUDGET_WSS_URL || '',
     },
     storage: {
       provider: selectProvider({

--- a/apps/budget-tracker/lib/services/ai/claude-ai.ts
+++ b/apps/budget-tracker/lib/services/ai/claude-ai.ts
@@ -1,22 +1,78 @@
-import type { AiReviewResponse, AiCsvAnalysisResponse } from '@transformotion/budget-domain'
-import type { AIService, ReviewTransactionsInput, AnalyseCsvFormatInput } from './index'
+import type { AiCsvAnalysisResponse, WsMessageBatchResult, WsMessageComplete, WsMessageError, WsMessageConnected } from '@transformotion/budget-domain'
+import type { AIService, ReviewTransactionsInput, AnalyseCsvFormatInput, ReviewTransactionsResult } from './index'
 import { getBudgetHttp } from '@/lib/api'
+import { authService } from '@/lib/services/auth'
+import { getConfig } from '@/lib/config'
 
-const REVIEW_URL = '/api/budget/v1/ai/review'
+const REVIEW_URL      = '/api/budget/v1/ai/review'
 const CSV_ANALYSIS_URL = '/api/budget/v1/ai/csv-analysis'
 
+type WsMessage = WsMessageConnected | WsMessageBatchResult | WsMessageComplete | WsMessageError
+
 export class ClaudeAIService implements AIService {
-  async reviewTransactions(input: ReviewTransactionsInput): Promise<AiReviewResponse> {
+  async reviewTransactions(input: ReviewTransactionsInput): Promise<ReviewTransactionsResult> {
+    const wssUrl   = getConfig().ai.wssUrl
+    const token    = await authService.getIdToken()
+    const accountId = await authService.getAccountIdForApp('budget-tracker')
+
+    if (!wssUrl)    throw new Error('WebSocket URL not configured (NEXT_PUBLIC_BUDGET_WSS_URL)')
+    if (!token)     throw new Error('No auth token available')
+    if (!accountId) throw new Error('No accountId available')
+
+    // Connect to the WebSocket server
+    const ws = new WebSocket(`${wssUrl}?token=${encodeURIComponent(token)}&accountId=${encodeURIComponent(accountId)}`)
+
+    const connectionId = await new Promise<string>((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error('WebSocket connect timeout')), 10_000)
+      ws.onmessage = (event) => {
+        const msg = JSON.parse(event.data as string) as WsMessage
+        if (msg.type === 'connected') {
+          clearTimeout(timer)
+          resolve(msg.connectionId)
+        }
+      }
+      ws.onerror = () => { clearTimeout(timer); reject(new Error('WebSocket connection error')) }
+      ws.onclose = (e) => { clearTimeout(timer); if (!e.wasClean) reject(new Error('WebSocket closed unexpectedly')) }
+    })
+
+    // Start streaming listener before calling HTTP so we don't miss early messages
     const http = getBudgetHttp()
-    const body = {
+    const { jobId } = await http.post<{ jobId: string }>(REVIEW_URL, {
+      connectionId,
       transactions: input.transactions,
-      categories: input.categories,
-    }
-    const result = await http.post<AiReviewResponse>(REVIEW_URL, body)
-    if (input.onBatch) {
-      input.onBatch(result.results)
-    }
-    return result
+      categories:   input.categories,
+      settings:     input.settings,
+    })
+
+    // Listen for WS messages until complete or error
+    await new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        ws.close()
+        reject(new Error('AI review timed out after 5 minutes'))
+      }, 5 * 60 * 1000)
+
+      ws.onmessage = (event) => {
+        const msg = JSON.parse(event.data as string) as WsMessage
+        if (msg.type === 'batch_result') {
+          input.onBatch?.(msg.results, msg.pass)
+        } else if (msg.type === 'complete') {
+          clearTimeout(timer)
+          ws.close()
+          resolve()
+        } else if (msg.type === 'error') {
+          clearTimeout(timer)
+          ws.close()
+          reject(new Error(msg.message))
+        }
+      }
+      ws.onerror = () => { clearTimeout(timer); reject(new Error('WebSocket error during review')) }
+      ws.onclose = (e) => {
+        clearTimeout(timer)
+        if (!e.wasClean) reject(new Error('WebSocket closed unexpectedly during review'))
+      }
+    })
+
+    return { jobId }
   }
 
   async analyseCsvFormat(input: AnalyseCsvFormatInput): Promise<AiCsvAnalysisResponse> {

--- a/apps/budget-tracker/lib/services/ai/index.ts
+++ b/apps/budget-tracker/lib/services/ai/index.ts
@@ -1,13 +1,16 @@
 import type {
   Category,
-  AiReviewResponse,
   AiCsvAnalysisResponse,
+  WsMessageBatchResult,
 } from '@transformotion/budget-domain'
+
+export type ReviewResult = WsMessageBatchResult['results'][number]
 
 export interface ReviewTransactionsInput {
   transactions: Array<{ index: number; description: string; amount: string }>
   categories: Category[]
-  onBatch?: (batchResults: AiReviewResponse['results']) => void
+  settings?: { batchSize?: number; parallelLimit?: number; confidenceThreshold?: 'low' | 'medium' }
+  onBatch?: (results: ReviewResult[], pass: 1 | 2) => void
 }
 
 export interface AnalyseCsvFormatInput {
@@ -15,8 +18,12 @@ export interface AnalyseCsvFormatInput {
   possibleHeaders?: string[]
 }
 
+export interface ReviewTransactionsResult {
+  jobId: string
+}
+
 export interface AIService {
-  reviewTransactions(input: ReviewTransactionsInput): Promise<AiReviewResponse>
+  reviewTransactions(input: ReviewTransactionsInput): Promise<ReviewTransactionsResult>
   analyseCsvFormat(input: AnalyseCsvFormatInput): Promise<AiCsvAnalysisResponse>
 }
 

--- a/apps/budget-tracker/lib/services/ai/mock-ai.ts
+++ b/apps/budget-tracker/lib/services/ai/mock-ai.ts
@@ -1,60 +1,70 @@
-import type { AiReviewResponse, AiCsvAnalysisResponse } from '@transformotion/budget-domain'
-import type { AIService, ReviewTransactionsInput, AnalyseCsvFormatInput } from './index'
+import type { AiCsvAnalysisResponse } from '@transformotion/budget-domain'
+import type { AIService, ReviewTransactionsInput, AnalyseCsvFormatInput, ReviewResult, ReviewTransactionsResult } from './index'
 
 export class MockAIService implements AIService {
-  async reviewTransactions(input: ReviewTransactionsInput): Promise<AiReviewResponse> {
-    await simulateDelay()
+  async reviewTransactions(input: ReviewTransactionsInput): Promise<ReviewTransactionsResult> {
+    const jobId = crypto.randomUUID()
+    const batchSize = input.settings?.batchSize ?? 5
 
-    const results: AiReviewResponse['results'] = input.transactions.map(tx => {
-      const desc = tx.description.toLowerCase()
+    // Simulate async batch streaming with a slight delay per batch
+    const run = async () => {
+      for (let i = 0; i < input.transactions.length; i += batchSize) {
+        await simulateDelay()
+        const batch = input.transactions.slice(i, i + batchSize)
+        const results: ReviewResult[] = batch.map(tx => {
+          const desc = tx.description.toLowerCase()
 
-      // Try to find a matching category/subcategory by keyword
-      let matchedCategoryId = ''
-      let matchedSubcategoryId = ''
+          let matchedCategoryId = ''
+          let matchedSubcategoryId = ''
 
-      const keywords: Array<{ pattern: RegExp; catName: string; subName: string }> = [
-        { pattern: /woolworths|coles|aldi|supermarket/, catName: 'Groceries', subName: 'Supermarket' },
-        { pattern: /salary|payroll|pay|income/, catName: 'Income', subName: 'Your take-home pay' },
-        { pattern: /netflix|spotify|disney|streaming/, catName: 'Eating-out & Entertainment', subName: 'Movies shows & music' },
-        { pattern: /restaurant|cafe|coffee/, catName: 'Eating-out & Entertainment', subName: 'Restaurants' },
-        { pattern: /transfer|tfr/, catName: 'Financial & Insurance', subName: 'Transfer' },
-      ]
+          const keywords: Array<{ pattern: RegExp; catName: string; subName: string }> = [
+            { pattern: /woolworths|coles|aldi|supermarket/, catName: 'Groceries', subName: 'Supermarket' },
+            { pattern: /salary|payroll|pay|income/, catName: 'Income', subName: 'Your take-home pay' },
+            { pattern: /netflix|spotify|disney|streaming/, catName: 'Eating-out & Entertainment', subName: 'Movies shows & music' },
+            { pattern: /restaurant|cafe|coffee/, catName: 'Eating-out & Entertainment', subName: 'Restaurants' },
+            { pattern: /transfer|tfr/, catName: 'Financial & Insurance', subName: 'Transfer' },
+          ]
 
-      for (const { pattern, catName, subName } of keywords) {
-        if (!pattern.test(desc)) continue
-        const cat = input.categories.find(c => c.name === catName)
-        if (!cat) continue
-        const sub = cat.subcategories.find(s => s.name === subName)
-        if (sub) {
-          matchedCategoryId = cat.categoryId
-          matchedSubcategoryId = sub.subcategoryId
-          break
-        }
-        // fall back to first subcategory in that category
-        if (cat.subcategories.length > 0) {
-          matchedCategoryId = cat.categoryId
-          matchedSubcategoryId = cat.subcategories[0].subcategoryId
-          break
-        }
+          for (const { pattern, catName, subName } of keywords) {
+            if (!pattern.test(desc)) continue
+            const cat = input.categories.find(c => c.name === catName)
+            if (!cat) continue
+            const sub = cat.subcategories.find(s => s.name === subName)
+            if (sub) {
+              matchedCategoryId = cat.categoryId
+              matchedSubcategoryId = sub.subcategoryId
+              break
+            }
+            if (cat.subcategories.length > 0) {
+              matchedCategoryId = cat.categoryId
+              matchedSubcategoryId = cat.subcategories[0].subcategoryId
+              break
+            }
+          }
+
+          if (!matchedCategoryId && input.categories.length > 0) {
+            const cat = input.categories[0]
+            matchedCategoryId = cat.categoryId
+            matchedSubcategoryId = cat.subcategories[0]?.subcategoryId ?? ''
+          }
+
+          return {
+            index: tx.index,
+            categoryId: matchedCategoryId,
+            subcategoryId: matchedSubcategoryId,
+            reason: `Mock categorisation based on description keywords for "${tx.description}".`,
+            confidence: 'high' as const,
+          }
+        })
+
+        input.onBatch?.(results, 1)
       }
+    }
 
-      // Default: first available category/subcategory
-      if (!matchedCategoryId && input.categories.length > 0) {
-        const cat = input.categories[0]
-        matchedCategoryId = cat.categoryId
-        matchedSubcategoryId = cat.subcategories[0]?.subcategoryId ?? ''
-      }
+    // Fire and forget — caller receives jobId immediately
+    run().catch(console.error)
 
-      return {
-        index: tx.index,
-        categoryId: matchedCategoryId,
-        subcategoryId: matchedSubcategoryId,
-        reason: `Mock categorisation based on description keywords for "${tx.description}".`,
-      }
-    })
-
-    input.onBatch?.(results)
-    return { results }
+    return { jobId }
   }
 
   async analyseCsvFormat(_input: AnalyseCsvFormatInput): Promise<AiCsvAnalysisResponse> {
@@ -76,5 +86,5 @@ export function createMockAIService(): MockAIService {
 }
 
 async function simulateDelay(): Promise<void> {
-  await new Promise(resolve => setTimeout(resolve, 600 + Math.random() * 600))
+  await new Promise(resolve => setTimeout(resolve, 400 + Math.random() * 400))
 }

--- a/infrastructure/bin/app.ts
+++ b/infrastructure/bin/app.ts
@@ -96,21 +96,24 @@ const devBudgetTrackerTables = new BudgetTrackerTablesStack(app, 'Transformotion
   description: 'Transformotion Apps — Dev Budget Tracker DynamoDB tables',
 });
 
-new BudgetTrackerApiStack(app, 'TransformotionDev-BudgetTrackerApi', {
-  env,
-  stage:               'dev',
-  description:         'Transformotion Apps — Dev Budget Tracker API routes',
-  api:                 devPlatformApi.api,
-  authoriser:          devPlatformApi.authoriser,
-  apiResource:         devPlatformApi.apiResource,
-  budgetDataTableName: devBudgetTrackerTables.budgetDataTable.tableName,
-});
-
-new BudgetTrackerWsStack(app, 'TransformotionDev-BudgetTrackerWs', {
+const devBudgetTrackerWs = new BudgetTrackerWsStack(app, 'TransformotionDev-BudgetTrackerWs', {
   env,
   stage:       'dev',
   description: 'Transformotion Apps — Dev Budget Tracker WebSocket API (AI Review)',
   userPool:    devAuth.userPool,
+});
+
+new BudgetTrackerApiStack(app, 'TransformotionDev-BudgetTrackerApi', {
+  env,
+  stage:                  'dev',
+  description:            'Transformotion Apps — Dev Budget Tracker API routes',
+  api:                    devPlatformApi.api,
+  authoriser:             devPlatformApi.authoriser,
+  apiResource:            devPlatformApi.apiResource,
+  budgetDataTableName:    devBudgetTrackerTables.budgetDataTable.tableName,
+  aiJobsTableName:        devBudgetTrackerTables.aiJobsTable.tableName,
+  wsConnectionsTableName: devBudgetTrackerWs.connectionsTable.tableName,
+  wsApiId:                devBudgetTrackerWs.webSocketApi.apiId,
 });
 
 new MigrationsApiStack(app, 'TransformotionDev-MigrationsApi', {
@@ -187,21 +190,24 @@ const prodBudgetTrackerTables = new BudgetTrackerTablesStack(app, 'Transformotio
   description: 'Transformotion Apps — Prod Budget Tracker DynamoDB tables',
 });
 
-new BudgetTrackerApiStack(app, 'TransformotionProd-BudgetTrackerApi', {
-  env,
-  stage:               'prod',
-  description:         'Transformotion Apps — Prod Budget Tracker API routes',
-  api:                 prodPlatformApi.api,
-  authoriser:          prodPlatformApi.authoriser,
-  apiResource:         prodPlatformApi.apiResource,
-  budgetDataTableName: prodBudgetTrackerTables.budgetDataTable.tableName,
-});
-
-new BudgetTrackerWsStack(app, 'TransformotionProd-BudgetTrackerWs', {
+const prodBudgetTrackerWs = new BudgetTrackerWsStack(app, 'TransformotionProd-BudgetTrackerWs', {
   env,
   stage:       'prod',
   description: 'Transformotion Apps — Prod Budget Tracker WebSocket API (AI Review)',
   userPool:    prodAuth.userPool,
+});
+
+new BudgetTrackerApiStack(app, 'TransformotionProd-BudgetTrackerApi', {
+  env,
+  stage:                  'prod',
+  description:            'Transformotion Apps — Prod Budget Tracker API routes',
+  api:                    prodPlatformApi.api,
+  authoriser:             prodPlatformApi.authoriser,
+  apiResource:            prodPlatformApi.apiResource,
+  budgetDataTableName:    prodBudgetTrackerTables.budgetDataTable.tableName,
+  aiJobsTableName:        prodBudgetTrackerTables.aiJobsTable.tableName,
+  wsConnectionsTableName: prodBudgetTrackerWs.connectionsTable.tableName,
+  wsApiId:                prodBudgetTrackerWs.webSocketApi.apiId,
 });
 
 new MigrationsApiStack(app, 'TransformotionProd-MigrationsApi', {

--- a/infrastructure/lib/budget-tracker/budget-tracker-api-stack.ts
+++ b/infrastructure/lib/budget-tracker/budget-tracker-api-stack.ts
@@ -17,6 +17,12 @@ export interface BudgetTrackerApiStackProps extends cdk.StackProps {
   apiResource: apigateway.Resource;
   /** budget-data table name — passed in to avoid cross-stack dependency issues. */
   budgetDataTableName: string;
+  /** AI jobs table name from BudgetTrackerTablesStack. */
+  aiJobsTableName: string;
+  /** WebSocket connections table name from BudgetTrackerWsStack. */
+  wsConnectionsTableName: string;
+  /** WebSocket API ID from BudgetTrackerWsStack (used to build the management API endpoint). */
+  wsApiId: string;
 }
 
 /**
@@ -42,7 +48,7 @@ export class BudgetTrackerApiStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props: BudgetTrackerApiStackProps) {
     super(scope, id, props);
 
-    const { stage, authoriser, apiResource: platformApiResource, budgetDataTableName } = props;
+    const { stage, authoriser, apiResource: platformApiResource, budgetDataTableName, aiJobsTableName, wsConnectionsTableName, wsApiId } = props;
 
     const auth = authMethodOptions(authoriser);
 
@@ -56,10 +62,12 @@ export class BudgetTrackerApiStack extends cdk.Stack {
     cdk.Tags.of(this).add('environment', stage);
 
     // ── Import shared tables by name ──────────────────────────────────────────
-    const txTable         = dynamodb.Table.fromTableName(this, 'TxTable',         `budget-tracker.transactions-${stage}`);
-    const rulesTable      = dynamodb.Table.fromTableName(this, 'RulesTable',      `budget-tracker.rules-${stage}`);
-    const settingsTable   = dynamodb.Table.fromTableName(this, 'SettingsTable',   `budget-tracker.settings-${stage}`);
-    const budgetDataTable = dynamodb.Table.fromTableName(this, 'BudgetDataTable', budgetDataTableName);
+    const txTable           = dynamodb.Table.fromTableName(this, 'TxTable',           `budget-tracker.transactions-${stage}`);
+    const rulesTable        = dynamodb.Table.fromTableName(this, 'RulesTable',        `budget-tracker.rules-${stage}`);
+    const settingsTable     = dynamodb.Table.fromTableName(this, 'SettingsTable',     `budget-tracker.settings-${stage}`);
+    const budgetDataTable   = dynamodb.Table.fromTableName(this, 'BudgetDataTable',   budgetDataTableName);
+    const aiJobsTable       = dynamodb.Table.fromTableName(this, 'AiJobsTable',       aiJobsTableName);
+    const wsConnectionsTable = dynamodb.Table.fromTableName(this, 'WsConnectionsTable', wsConnectionsTableName);
 
     const claudeProxyFnName = `transformotion-claude-proxy-${stage}`;
 
@@ -111,21 +119,38 @@ export class BudgetTrackerApiStack extends cdk.Stack {
     });
     settingsTable.grantReadWriteData(settingsFn);
 
-    // ── budget-ai-handler (categorise + review + csv-analysis) ───────────────
+    // ── budget-ai-handler (categorise + review-start + review-worker + csv-analysis) ──
+    const aiFnName = `budget-ai-handler-${stage}`;
     const aiFn = new lambdaNodejs.NodejsFunction(this, 'AiFn', {
-      functionName: `budget-ai-handler-${stage}`,
+      functionName: aiFnName,
       entry:        path.join(fnDir, 'budget-ai/src/index.ts'),
       handler:      'handler',
       runtime:      lambda.Runtime.NODEJS_20_X,
       timeout:      cdk.Duration.seconds(300),
       memorySize:   512,
-      environment:  { CLAUDE_PROXY_FUNCTION_NAME: claudeProxyFnName },
+      environment:  {
+        CLAUDE_PROXY_FUNCTION_NAME: claudeProxyFnName,
+        AI_JOBS_TABLE:              aiJobsTableName,
+        WS_CONNECTIONS_TABLE:       wsConnectionsTableName,
+        WS_API_ID:                  wsApiId,
+        WS_STAGE:                   stage,
+        AWS_REGION_NAME:            this.region,
+      },
       bundling,
     });
     aiFn.addToRolePolicy(new iam.PolicyStatement({
       actions:   ['lambda:InvokeFunction'],
-      resources: [`arn:aws:lambda:${this.region}:${this.account}:function:${claudeProxyFnName}`],
+      resources: [
+        `arn:aws:lambda:${this.region}:${this.account}:function:${claudeProxyFnName}`,
+        `arn:aws:lambda:${this.region}:${this.account}:function:${aiFnName}`,
+      ],
     }));
+    aiFn.addToRolePolicy(new iam.PolicyStatement({
+      actions:   ['execute-api:ManageConnections'],
+      resources: [`arn:aws:execute-api:${this.region}:${this.account}:${wsApiId}/${stage}/*`],
+    }));
+    aiJobsTable.grantReadWriteData(aiFn);
+    wsConnectionsTable.grantReadData(aiFn);
 
     // ── budget-data-handler ───────────────────────────────────────────────────
     const budgetDataFn = new lambdaNodejs.NodejsFunction(this, 'BudgetDataFn', {

--- a/infrastructure/lib/budget-tracker/budget-tracker-tables-stack.ts
+++ b/infrastructure/lib/budget-tracker/budget-tracker-tables-stack.ts
@@ -24,6 +24,7 @@ export class BudgetTrackerTablesStack extends cdk.Stack {
   public readonly rulesTable:        dynamodb.Table;
   public readonly settingsTable:     dynamodb.Table;
   public readonly budgetDataTable:   dynamodb.Table;
+  public readonly aiJobsTable:       dynamodb.Table;
 
   constructor(scope: Construct, id: string, props: BudgetTrackerTablesStackProps) {
     super(scope, id, props);
@@ -82,6 +83,23 @@ export class BudgetTrackerTablesStack extends cdk.Stack {
       removalPolicy:        cdk.RemovalPolicy.RETAIN,
     });
 
+    // ── budget-tracker.ai-jobs ────────────────────────────────────────────────
+    // Tracks async AI review jobs. PK: jobId. GSI: userId-index for user queries.
+    // TTL: expiresAt (24h after creation) for automatic cleanup.
+    this.aiJobsTable = new dynamodb.Table(this, 'AiJobsTable', {
+      tableName:           `budget-tracker.ai-jobs-${stage}`,
+      partitionKey:        { name: 'jobId', type: dynamodb.AttributeType.STRING },
+      billingMode:         dynamodb.BillingMode.PAY_PER_REQUEST,
+      timeToLiveAttribute: 'expiresAt',
+      removalPolicy:       removal,
+    });
+
+    this.aiJobsTable.addGlobalSecondaryIndex({
+      indexName:    'userId-index',
+      partitionKey: { name: 'userId', type: dynamodb.AttributeType.STRING },
+      projectionType: dynamodb.ProjectionType.ALL,
+    });
+
     // ── Outputs ───────────────────────────────────────────────────────────────
     const out = (id: string, value: string, description: string) =>
       new cdk.CfnOutput(this, id, { value, description, exportName: `Transformotion-${stage}-${id}` });
@@ -90,5 +108,6 @@ export class BudgetTrackerTablesStack extends cdk.Stack {
     out('BTRulesTableArn',        this.rulesTable.tableArn,        'budget-tracker.rules table ARN');
     out('BTSettingsTableArn',     this.settingsTable.tableArn,     'budget-tracker.settings table ARN');
     out('BTBudgetDataTableArn',   this.budgetDataTable.tableArn,   'budget-tracker.budget-data table ARN');
+    out('BTAiJobsTableArn',       this.aiJobsTable.tableArn,       'budget-tracker.ai-jobs table ARN');
   }
 }

--- a/infrastructure/lib/budget-tracker/budget-tracker-ws-stack.ts
+++ b/infrastructure/lib/budget-tracker/budget-tracker-ws-stack.ts
@@ -5,6 +5,7 @@ import * as integrations from 'aws-cdk-lib/aws-apigatewayv2-integrations';
 import * as authorizers from 'aws-cdk-lib/aws-apigatewayv2-authorizers';
 import * as cognito from 'aws-cdk-lib/aws-cognito';
 import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
+import * as iam from 'aws-cdk-lib/aws-iam';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as lambdaNodejs from 'aws-cdk-lib/aws-lambda-nodejs';
 import { Construct } from 'constructs';
@@ -162,6 +163,12 @@ export class BudgetTrackerWsStack extends cdk.Stack {
       stageName:    stage,
       autoDeploy:   true,
     });
+
+    // Allow $connect to push the 'connected' message back to the new client
+    connectFn.addToRolePolicy(new iam.PolicyStatement({
+      actions:   ['execute-api:ManageConnections'],
+      resources: [`arn:aws:execute-api:${this.region}:${this.account}:${this.webSocketApi.apiId}/${stage}/*`],
+    }));
 
     // ── Stack outputs ─────────────────────────────────────────────────────────
 

--- a/packages/budget-domain/src/contracts.ts
+++ b/packages/budget-domain/src/contracts.ts
@@ -68,6 +68,9 @@ export interface MatchingRule {
 
 export interface BudgetSettings {
   csvFormatMappings: Record<string, CSVMapping>;
+  aiReviewBatchSize?: number;
+  aiReviewParallelLimit?: number;
+  aiReviewConfidenceThreshold?: 'low' | 'medium';
 }
 
 export interface CSVMapping {
@@ -128,12 +131,38 @@ export interface AccountMember {
 // ── AI response schemas ───────────────────────────────────────────────────────
 
 export interface AiReviewResponse {
+  jobId: string;
+}
+
+export interface WsMessageConnected {
+  type: 'connected';
+  connectionId: string;
+}
+
+export interface WsMessageBatchResult {
+  type: 'batch_result';
+  jobId: string;
+  pass: 1 | 2;
   results: Array<{
     index: number;
     categoryId: string;
     subcategoryId: string;
     reason: string;
+    confidence: 'high' | 'medium' | 'low';
   }>;
+  completedCount: number;
+  totalCount: number;
+}
+
+export interface WsMessageComplete {
+  type: 'complete';
+  jobId: string;
+}
+
+export interface WsMessageError {
+  type: 'error';
+  jobId: string;
+  message: string;
 }
 
 export interface AiCsvAnalysisResponse {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -256,6 +256,9 @@ importers:
 
   apps/budget-tracker/functions/ai-ws-connect:
     devDependencies:
+      '@aws-sdk/client-apigatewaymanagementapi':
+        specifier: ^3
+        version: 3.1049.0
       '@aws-sdk/client-dynamodb':
         specifier: ^3
         version: 3.1032.0
@@ -311,6 +314,9 @@ importers:
         specifier: workspace:*
         version: link:../../../../packages/lambda-middleware
     devDependencies:
+      '@aws-sdk/client-apigatewaymanagementapi':
+        specifier: ^3
+        version: 3.1049.0
       '@aws-sdk/client-dynamodb':
         specifier: ^3
         version: 3.1032.0
@@ -1220,6 +1226,10 @@ packages:
   '@aws-crypto/util@5.2.0':
     resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
 
+  '@aws-sdk/client-apigatewaymanagementapi@3.1049.0':
+    resolution: {integrity: sha512-H9rRdYHo7MF5CgXLZY0IBjEGhIV1IvhlV/GOD07j+PxhbxxzbcPNq55fVYzMjI8jfXWH45W7TFfOm2eayXuhkw==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/client-cognito-identity-provider@3.1032.0':
     resolution: {integrity: sha512-sdoZosLkiA9EHYg3nOTNrbiyNQaZfDXPIegznlxe7faF0xfLLecMuBZzlwGFSO6b4L4369RbJIx19+eCQ5mmzw==}
     engines: {node: '>=20.0.0'}
@@ -1260,6 +1270,10 @@ packages:
     resolution: {integrity: sha512-gy/gffKz0zaHDaqRiLCdIvgHmaAL/HXuAtMcBP7euYSFx4BsbsdlfmUBJag+Gqe62z6/XuloKyQyaiH+kS3Vrg==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/core@3.974.12':
+    resolution: {integrity: sha512-qrqgioqYFjwR6LatVNS1L2Vk++EwRIxqSQXPKNv5Ofux2D8UNgqMQ1znnMyEImXquVPTtbf71fc128pvmU6y9A==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/core@3.974.8':
     resolution: {integrity: sha512-njR2qoG6ZuB0kvAS2FyICsFZJ6gmCcf2X/7JcD14sUvGDm26wiZ5BrA6LOiUxKFEF+IVe7kdroxyE00YlkiYsw==}
     engines: {node: '>=20.0.0'}
@@ -1268,36 +1282,36 @@ packages:
     resolution: {integrity: sha512-QUagVVBbC8gODCF6e1aV0mE2TXWB9Opz4k8EJFdNrujUVQm5R4AjJa1mpOqzwOuROBzqJU9zawzig7M96L8Ejg==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-env@3.972.27':
-    resolution: {integrity: sha512-xfUt2CUZDC+Tf16A6roD1b4pk/nrXdkoLY3TEhv198AXDtBo5xUJP1zd0e8SmuKLN4PpIBX96OizZbmMlcI6oQ==}
-    engines: {node: '>=20.0.0'}
-
   '@aws-sdk/credential-provider-env@3.972.34':
     resolution: {integrity: sha512-XT0jtf8Fw9JE6ppsQeoNnZRiG+jqRixMT1v1ZR17G60UvVdsQmTG8nbEyHuEPfMxDXEhfdARaM/XiEhca4lGHQ==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-http@3.972.29':
-    resolution: {integrity: sha512-hjNeYb6oLyHgMihra83ie0J/T2y9om3cy1qC90h9DRgvYXEoN4BCFf8bHguZjKhXunnv7YkmZRuYL5Mkk77eCA==}
+  '@aws-sdk/credential-provider-env@3.972.38':
+    resolution: {integrity: sha512-m3WjZEgPtioMhPmwqUt+DhlTJ2i9ufR6DhfkyXojb9puEvfR+ur2U5shavu5/Cc9WHHsDCvALi6UFHgcqjhQ5w==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-http@3.972.36':
     resolution: {integrity: sha512-DPoGWfy7J7RKxvbf5kOKIGQkD2ek3dbKgzKIGrnLuvZBz5myU+Im/H6pmc14QcnFbqHMqxvtWSgRDSJW3qXLQg==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-ini@3.972.31':
-    resolution: {integrity: sha512-PuQ7e8WYzAPpzvFcajxf8c0LqSzakVHVlKw8M0oubk8Kf347YOCCqT1seQrHs5AdZuIh2RD9LX4O+Xa5ImEBfQ==}
+  '@aws-sdk/credential-provider-http@3.972.40':
+    resolution: {integrity: sha512-D78L/m2Dr6cJnnSvWoAudPhQmCwmJ7j6APXsPYmFpPaKfQTfCSu0rdm8j14Np+VmXF9z8Aj8HE3xFpsrwtfgeg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-ini@3.972.38':
     resolution: {integrity: sha512-oDzUBu2MGJFgoar05sPMCwSrhw44ASyccrHzj66vO69OZqi7I6hZZxXfuPLC8OCzW7C+sU+bI73XHij41yekgQ==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-login@3.972.31':
-    resolution: {integrity: sha512-bBmWDmtSpmLOZR6a0kmowBcVL1hiL8Vlap/RXeMpFd7JbWl87YcwqL6T9LH/0oBVEZXu1dUZAtojgSuZgMO5xw==}
+  '@aws-sdk/credential-provider-ini@3.972.42':
+    resolution: {integrity: sha512-Mu5ESvFXeinafVM8jTIvRqcvK2Ehj4kz3auT39yUcHwu1Vfxo6xRlmUafdKLW4tusjAJukQwK09sCSMgOm7OKg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-login@3.972.38':
     resolution: {integrity: sha512-g1NosS8qe4OF++G2UFCM5ovSkgipC7YYor5KCWatG0UoMSO5YFj9C8muePlyVmOBV/WTI16Jo3/s1NUo/o1Bww==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.42':
+    resolution: {integrity: sha512-O6WkZga3kf0yqyJYd1dbeJqVhEgJx/x1UaLgtbR+XuL/YP+K5y6QTxQKL7ka9z3jnQASESKGAPnRyt4D5hQrxA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-node@3.972.32':
@@ -1308,28 +1322,32 @@ packages:
     resolution: {integrity: sha512-HEswDQyxUtadoZ/bJsPPENHg7R0Lzym5LuMksJeHvqhCOpP+rtkDLKI4/ZChH4w3cf5kG8n6bZuI8PzajoiqMg==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-process@3.972.27':
-    resolution: {integrity: sha512-1CZvfb1WzudWWIFAVQkd1OI/T1RxPcSvNWzNsb2BMBVsBJzBtB8dV5f2nymHVU4UqwxipdVt/DAbgdDRf33JDg==}
+  '@aws-sdk/credential-provider-node@3.972.43':
+    resolution: {integrity: sha512-D/DJmbrWRP5BXEO3FH+ar4el+2n6OlGofiud7dQun2jES+AQEJjczenp1jBb4MBN7CpGpS8nsWGQLtuzc9tQbA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-process@3.972.34':
     resolution: {integrity: sha512-T3IFs4EVmVi1dVN5RciFnklCANSzvrQd/VuHY9ThHSQmYkTogjcGkoJEr+oNUPQZnso52183088NqysMPji1/Q==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-sso@3.972.31':
-    resolution: {integrity: sha512-x8Mx18S48XMl9bEEpYwmXDTvjWGPIfDadReN37Lc099/DUrlL4Zs9T9rwwggo6DkKS1aev6v+MTUx7JTa87TZQ==}
+  '@aws-sdk/credential-provider-process@3.972.38':
+    resolution: {integrity: sha512-EnbYVajGgbkb24s0K1eo4VNAPV5mHIET7LSvirTaFCwkfrfaOJxtSE+wY/tJdKDS21cEYkZs2ruCaAm+W4iblg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-sso@3.972.38':
     resolution: {integrity: sha512-5ZxG+t0+3Q3QPh8KEjX6syskhgNf7I0MN7oGioTf6Lm1NTjfP7sIcYGNsthXC2qR8vcD3edNZwCr2ovfSSWuRA==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-web-identity@3.972.31':
-    resolution: {integrity: sha512-zfuNMIkGfjYsHis9qytYf74Bcmq6Ji9Xwf4w53baRCI/b2otTwZv3SW1uRiJ5Di7999QzRGhHZ96+eUeo3gSOA==}
+  '@aws-sdk/credential-provider-sso@3.972.42':
+    resolution: {integrity: sha512-RVV/9NbFwI8ZHEH5dn39lGyFmSbSVj1+orZdr6QsOe1mW9DCglmlen0cFaNZmCcqkqc7erNRHNBduxbeZuHAnw==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-web-identity@3.972.38':
     resolution: {integrity: sha512-lYHFF30DGI20jZcYX8cm6Ns0V7f1dDN6g/MBDLTyD/5iw+bXs3yBr2iAiHDkx4RFU5JgsnZvCHYKiRVPRdmOgw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.42':
+    resolution: {integrity: sha512-/67fXX0ddllD4u2Nujc5PvT4byHgpMUfz6+RxIKi/0nFIckeorm7JvXgzBuDyVKw0s58EbofmETDWUf9vTEuHQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/dynamodb-codec@3.973.1':
@@ -1398,8 +1416,8 @@ packages:
     resolution: {integrity: sha512-iz+B29TXcAZsJpwB+AwG/TTGA5l/VnmMZ2UxtiySOZjI6gCdmviXPwdgzcmuazMy16rXoPY4mYCGe7zdNKfx5A==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/nested-clients@3.996.21':
-    resolution: {integrity: sha512-Me3d/ua2lb2G0bQfFmvCeQQp3+nN6GSPqMxDmi/IQlQ8CrlpQ5C0JJHpz2AnOUkEFI0lBNrAL3Vnt29l44ndkA==}
+  '@aws-sdk/nested-clients@3.997.10':
+    resolution: {integrity: sha512-FtQ/Bt327peZJuyo4WZSOLVUTw9ujRxntepiC7L65FxA2P82Xlq0g14T22BuqBUeMjDoxa9nvwiMHjLIfP3eUg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/nested-clients@3.997.6':
@@ -1422,12 +1440,16 @@ packages:
     resolution: {integrity: sha512-+CMIt3e1VzlklAECmG+DtP1sV8iKq25FuA0OKpnJ4KA0kxUtd7CgClY7/RU6VzJBQwbN4EJ9Ue6plvqx1qGadw==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/token-providers@3.1032.0':
-    resolution: {integrity: sha512-n+PU8Z+gll7p3wDrH+Wo6fkt8sPrVnq30YYM6Ryga95oJlEneNMEbDHj0iqjMX3V7gaGdJo/hJWyPo4lscP+mA==}
+  '@aws-sdk/signature-v4-multi-region@3.996.27':
+    resolution: {integrity: sha512-0Phbz4t6HI3D3skxvG2uI+VWU034/nSIw1T8d+FPzzQG9EQTrw94o9mOKO2Gv3n3Oc8P7JD7RAUxkoneLWv5Eg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/token-providers@3.1041.0':
     resolution: {integrity: sha512-Th7kPI6YPtvJUcdznooXJMy+9rQWjmEF81LxaJssngBzuysK4a/x+l8kjm1zb7nYsUPbndnBdUnwng/3PLvtGw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1049.0':
+    resolution: {integrity: sha512-r7+d0lQMTHKypkmaF5jRTBYLYHCUHzt3gaVoN9SidLhQeWhCmHk3AKrboDTpPF5b7Pt7vKu3+oeMjznM2Eu1ow==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/types@3.973.8':
@@ -1477,12 +1499,12 @@ packages:
       aws-crt:
         optional: true
 
-  '@aws-sdk/xml-builder@3.972.18':
-    resolution: {integrity: sha512-BMDNVG1ETXRhl1tnisQiYBef3RShJ1kfZA7x7afivTFMLirfHNTb6U71K569HNXhSXbQZsweHvSDZ6euBw8hPA==}
-    engines: {node: '>=20.0.0'}
-
   '@aws-sdk/xml-builder@3.972.22':
     resolution: {integrity: sha512-PMYKKtJd70IsSG0yHrdAbxBr+ZWBKLvzFZfD3/urxgf6hXVMzuU5M+3MJ5G67RpOmLBu1fAUN65SbWuKUCOlAA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/xml-builder@3.972.24':
+    resolution: {integrity: sha512-V8z5YcDPfsvzrBlj0xR1vhRtocblhYbqdreCJB/voGd4Sr5zjNAeWxexbnqVtskTJe0vFb5KMqbSL++ePl+zRw==}
     engines: {node: '>=20.0.0'}
 
   '@aws/lambda-invoke-store@0.2.4':
@@ -3144,8 +3166,16 @@ packages:
     resolution: {integrity: sha512-x7BlLbUFL8NWCGjMF9C+1N5cVCxcPa7g6Tv9B4A2luWx3be3oU8hQ96wIwxe/s7OhIzvoJH73HAUSg5JXVlEtQ==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/core@3.24.3':
+    resolution: {integrity: sha512-Ep/7tPamGY8mgESE3LyLKtxJyy6U52WWAqr/3wial47Sj4u3PiIF73AOGI27UyLy9duTkhZbgzodOfLV4TduZg==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/credential-provider-imds@4.2.14':
     resolution: {integrity: sha512-Au28zBN48ZAoXdooGUHemuVBrkE+Ie6RPmGNIAJsFqj33Vhb6xAgRifUydZ2aY+M+KaMAETAlKk5NC5h1G7wpg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.3.3':
+    resolution: {integrity: sha512-I2Bti0DKFo2IJyN28ijCsx51BAumEYR4/1yZ1FXyBygy9MqbnMqCev4JPth/MbpRfBSRAX35hITSnAdJRo1u5w==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/eventstream-codec@4.2.14':
@@ -3170,6 +3200,10 @@ packages:
 
   '@smithy/fetch-http-handler@5.3.17':
     resolution: {integrity: sha512-bXOvQzaSm6MnmLaWA1elgfQcAtN4UP3vXqV97bHuoOrHQOJiLT3ds6o9eo5bqd0TJfRFpzdGnDQdW3FACiAVdw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.4.3':
+    resolution: {integrity: sha512-F+DRf8IJazRJgYog2A/yJK7eYVc0rqTlRzO+5ZxjJd4WkZoKz0IJRncf7G6t1pdVT3kryJcwuTFhN1c5m6N47A==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/hash-blob-browser@4.2.15':
@@ -3251,6 +3285,10 @@ packages:
     resolution: {integrity: sha512-iB+orM4x3xrr57X3YaXazfKnntl0LHlZB1kcXSGzMV1Tt0+YwEjGlbjk/44qEGtBzXAz6yFDzkYTKSV6Pj2HUg==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/node-http-handler@4.7.3':
+    resolution: {integrity: sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/property-provider@4.2.14':
     resolution: {integrity: sha512-WuM31CgfsnQ/10i7NYr0PyxqknD72Y5uMfUMVSniPjbEPceiTErb4eIqJQ+pdxNEAUEWrewrGjIRjVbVHsxZiQ==}
     engines: {node: '>=18.0.0'}
@@ -3283,6 +3321,10 @@ packages:
     resolution: {integrity: sha512-1D9Y/nmlVjCeSivCbhZ7hgEpmHyY1h0GvpSZt3l0xcD9JjmjVC1CHOozS6+Gh+/ldMH8JuJ6cujObQqfayAVFA==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/signature-v4@5.4.3':
+    resolution: {integrity: sha512-53+75QuPl6DL+ct6vVEB51FDO5oulXr20TPV46VvJZg76lIlXNWfxi8j+G2V/t0I2qxCBOa3vX/8bmjrpFVo9g==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/smithy-client@4.12.11':
     resolution: {integrity: sha512-wzz/Wa1CH/Tlhxh0s4DQPEcXSxSVfJ59AZcUh9Gu0c6JTlKuwGf4o/3P2TExv0VbtPFt8odIBG+eQGK2+vTECg==}
     engines: {node: '>=18.0.0'}
@@ -3301,6 +3343,10 @@ packages:
 
   '@smithy/types@4.14.1':
     resolution: {integrity: sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.14.2':
+    resolution: {integrity: sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/url-parser@4.2.14':
@@ -4346,12 +4392,15 @@ packages:
   fast-xml-builder@1.1.5:
     resolution: {integrity: sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==}
 
-  fast-xml-parser@5.5.8:
-    resolution: {integrity: sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==}
-    hasBin: true
+  fast-xml-builder@1.2.0:
+    resolution: {integrity: sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==}
 
   fast-xml-parser@5.7.2:
     resolution: {integrity: sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==}
+    hasBin: true
+
+  fast-xml-parser@5.7.3:
+    resolution: {integrity: sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==}
     hasBin: true
 
   fdir@6.5.0:
@@ -5342,6 +5391,10 @@ packages:
     resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
     engines: {node: '>=18'}
 
+  xml-naming@0.1.0:
+    resolution: {integrity: sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==}
+    engines: {node: '>=16.0.0'}
+
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
@@ -5539,6 +5592,19 @@ snapshots:
     dependencies:
       '@aws-sdk/types': 3.973.8
       '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-sdk/client-apigatewaymanagementapi@3.1049.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.12
+      '@aws-sdk/credential-provider-node': 3.972.43
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.3
+      '@smithy/fetch-http-handler': 5.4.3
+      '@smithy/node-http-handler': 4.7.3
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@aws-sdk/client-cognito-identity-provider@3.1032.0':
@@ -5969,7 +6035,7 @@ snapshots:
   '@aws-sdk/core@3.974.1':
     dependencies:
       '@aws-sdk/types': 3.973.8
-      '@aws-sdk/xml-builder': 3.972.18
+      '@aws-sdk/xml-builder': 3.972.22
       '@smithy/core': 3.23.17
       '@smithy/node-config-provider': 4.3.14
       '@smithy/property-provider': 4.2.14
@@ -5980,6 +6046,17 @@ snapshots:
       '@smithy/util-base64': 4.3.2
       '@smithy/util-middleware': 4.2.14
       '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@aws-sdk/core@3.974.12':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/xml-builder': 3.972.24
+      '@aws/lambda-invoke-store': 0.2.4
+      '@smithy/core': 3.24.3
+      '@smithy/signature-v4': 5.4.3
+      '@smithy/types': 4.14.1
+      bowser: 2.14.1
       tslib: 2.8.1
 
   '@aws-sdk/core@3.974.8':
@@ -6004,14 +6081,6 @@ snapshots:
       '@smithy/types': 4.14.1
       tslib: 2.8.1
 
-  '@aws-sdk/credential-provider-env@3.972.27':
-    dependencies:
-      '@aws-sdk/core': 3.974.8
-      '@aws-sdk/types': 3.973.8
-      '@smithy/property-provider': 4.2.14
-      '@smithy/types': 4.14.1
-      tslib: 2.8.1
-
   '@aws-sdk/credential-provider-env@3.972.34':
     dependencies:
       '@aws-sdk/core': 3.974.8
@@ -6020,17 +6089,12 @@ snapshots:
       '@smithy/types': 4.14.1
       tslib: 2.8.1
 
-  '@aws-sdk/credential-provider-http@3.972.29':
+  '@aws-sdk/credential-provider-env@3.972.38':
     dependencies:
-      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/core': 3.974.12
       '@aws-sdk/types': 3.973.8
-      '@smithy/fetch-http-handler': 5.3.17
-      '@smithy/node-http-handler': 4.6.1
-      '@smithy/property-provider': 4.2.14
-      '@smithy/protocol-http': 5.3.14
-      '@smithy/smithy-client': 4.12.13
+      '@smithy/core': 3.24.3
       '@smithy/types': 4.14.1
-      '@smithy/util-stream': 4.5.23
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-http@3.972.36':
@@ -6046,24 +6110,15 @@ snapshots:
       '@smithy/util-stream': 4.5.25
       tslib: 2.8.1
 
-  '@aws-sdk/credential-provider-ini@3.972.31':
+  '@aws-sdk/credential-provider-http@3.972.40':
     dependencies:
-      '@aws-sdk/core': 3.974.8
-      '@aws-sdk/credential-provider-env': 3.972.27
-      '@aws-sdk/credential-provider-http': 3.972.29
-      '@aws-sdk/credential-provider-login': 3.972.31
-      '@aws-sdk/credential-provider-process': 3.972.27
-      '@aws-sdk/credential-provider-sso': 3.972.31
-      '@aws-sdk/credential-provider-web-identity': 3.972.31
-      '@aws-sdk/nested-clients': 3.996.21
+      '@aws-sdk/core': 3.974.12
       '@aws-sdk/types': 3.973.8
-      '@smithy/credential-provider-imds': 4.2.14
-      '@smithy/property-provider': 4.2.14
-      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/core': 3.24.3
+      '@smithy/fetch-http-handler': 5.4.3
+      '@smithy/node-http-handler': 4.7.3
       '@smithy/types': 4.14.1
       tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
 
   '@aws-sdk/credential-provider-ini@3.972.38':
     dependencies:
@@ -6084,18 +6139,21 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/credential-provider-login@3.972.31':
+  '@aws-sdk/credential-provider-ini@3.972.42':
     dependencies:
-      '@aws-sdk/core': 3.974.8
-      '@aws-sdk/nested-clients': 3.996.21
+      '@aws-sdk/core': 3.974.12
+      '@aws-sdk/credential-provider-env': 3.972.38
+      '@aws-sdk/credential-provider-http': 3.972.40
+      '@aws-sdk/credential-provider-login': 3.972.42
+      '@aws-sdk/credential-provider-process': 3.972.38
+      '@aws-sdk/credential-provider-sso': 3.972.42
+      '@aws-sdk/credential-provider-web-identity': 3.972.42
+      '@aws-sdk/nested-clients': 3.997.10
       '@aws-sdk/types': 3.973.8
-      '@smithy/property-provider': 4.2.14
-      '@smithy/protocol-http': 5.3.14
-      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/core': 3.24.3
+      '@smithy/credential-provider-imds': 4.3.3
       '@smithy/types': 4.14.1
       tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
 
   '@aws-sdk/credential-provider-login@3.972.38':
     dependencies:
@@ -6110,14 +6168,23 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/credential-provider-login@3.972.42':
+    dependencies:
+      '@aws-sdk/core': 3.974.12
+      '@aws-sdk/nested-clients': 3.997.10
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.3
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-node@3.972.32':
     dependencies:
-      '@aws-sdk/credential-provider-env': 3.972.27
-      '@aws-sdk/credential-provider-http': 3.972.29
-      '@aws-sdk/credential-provider-ini': 3.972.31
-      '@aws-sdk/credential-provider-process': 3.972.27
-      '@aws-sdk/credential-provider-sso': 3.972.31
-      '@aws-sdk/credential-provider-web-identity': 3.972.31
+      '@aws-sdk/credential-provider-env': 3.972.34
+      '@aws-sdk/credential-provider-http': 3.972.36
+      '@aws-sdk/credential-provider-ini': 3.972.38
+      '@aws-sdk/credential-provider-process': 3.972.34
+      '@aws-sdk/credential-provider-sso': 3.972.38
+      '@aws-sdk/credential-provider-web-identity': 3.972.38
       '@aws-sdk/types': 3.973.8
       '@smithy/credential-provider-imds': 4.2.14
       '@smithy/property-provider': 4.2.14
@@ -6144,12 +6211,17 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/credential-provider-process@3.972.27':
+  '@aws-sdk/credential-provider-node@3.972.43':
     dependencies:
-      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/credential-provider-env': 3.972.38
+      '@aws-sdk/credential-provider-http': 3.972.40
+      '@aws-sdk/credential-provider-ini': 3.972.42
+      '@aws-sdk/credential-provider-process': 3.972.38
+      '@aws-sdk/credential-provider-sso': 3.972.42
+      '@aws-sdk/credential-provider-web-identity': 3.972.42
       '@aws-sdk/types': 3.973.8
-      '@smithy/property-provider': 4.2.14
-      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/core': 3.24.3
+      '@smithy/credential-provider-imds': 4.3.3
       '@smithy/types': 4.14.1
       tslib: 2.8.1
 
@@ -6162,18 +6234,13 @@ snapshots:
       '@smithy/types': 4.14.1
       tslib: 2.8.1
 
-  '@aws-sdk/credential-provider-sso@3.972.31':
+  '@aws-sdk/credential-provider-process@3.972.38':
     dependencies:
-      '@aws-sdk/core': 3.974.8
-      '@aws-sdk/nested-clients': 3.996.21
-      '@aws-sdk/token-providers': 3.1032.0
+      '@aws-sdk/core': 3.974.12
       '@aws-sdk/types': 3.973.8
-      '@smithy/property-provider': 4.2.14
-      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/core': 3.24.3
       '@smithy/types': 4.14.1
       tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
 
   '@aws-sdk/credential-provider-sso@3.972.38':
     dependencies:
@@ -6188,17 +6255,15 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/credential-provider-web-identity@3.972.31':
+  '@aws-sdk/credential-provider-sso@3.972.42':
     dependencies:
-      '@aws-sdk/core': 3.974.8
-      '@aws-sdk/nested-clients': 3.996.21
+      '@aws-sdk/core': 3.974.12
+      '@aws-sdk/nested-clients': 3.997.10
+      '@aws-sdk/token-providers': 3.1049.0
       '@aws-sdk/types': 3.973.8
-      '@smithy/property-provider': 4.2.14
-      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/core': 3.24.3
       '@smithy/types': 4.14.1
       tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
 
   '@aws-sdk/credential-provider-web-identity@3.972.38':
     dependencies:
@@ -6211,6 +6276,15 @@ snapshots:
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
+
+  '@aws-sdk/credential-provider-web-identity@3.972.42':
+    dependencies:
+      '@aws-sdk/core': 3.974.12
+      '@aws-sdk/nested-clients': 3.997.10
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.3
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
 
   '@aws-sdk/dynamodb-codec@3.973.1':
     dependencies:
@@ -6318,7 +6392,7 @@ snapshots:
       '@smithy/types': 4.14.1
       '@smithy/util-config-provider': 4.2.2
       '@smithy/util-middleware': 4.2.14
-      '@smithy/util-stream': 4.5.23
+      '@smithy/util-stream': 4.5.25
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
@@ -6367,48 +6441,18 @@ snapshots:
       '@smithy/util-retry': 4.3.8
       tslib: 2.8.1
 
-  '@aws-sdk/nested-clients@3.996.21':
+  '@aws-sdk/nested-clients@3.997.10':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.974.8
-      '@aws-sdk/middleware-host-header': 3.972.10
-      '@aws-sdk/middleware-logger': 3.972.10
-      '@aws-sdk/middleware-recursion-detection': 3.972.11
-      '@aws-sdk/middleware-user-agent': 3.972.38
-      '@aws-sdk/region-config-resolver': 3.972.13
+      '@aws-sdk/core': 3.974.12
+      '@aws-sdk/signature-v4-multi-region': 3.996.27
       '@aws-sdk/types': 3.973.8
-      '@aws-sdk/util-endpoints': 3.996.8
-      '@aws-sdk/util-user-agent-browser': 3.972.10
-      '@aws-sdk/util-user-agent-node': 3.973.24
-      '@smithy/config-resolver': 4.4.17
-      '@smithy/core': 3.23.17
-      '@smithy/fetch-http-handler': 5.3.17
-      '@smithy/hash-node': 4.2.14
-      '@smithy/invalid-dependency': 4.2.14
-      '@smithy/middleware-content-length': 4.2.14
-      '@smithy/middleware-endpoint': 4.4.32
-      '@smithy/middleware-retry': 4.5.7
-      '@smithy/middleware-serde': 4.2.20
-      '@smithy/middleware-stack': 4.2.14
-      '@smithy/node-config-provider': 4.3.14
-      '@smithy/node-http-handler': 4.6.1
-      '@smithy/protocol-http': 5.3.14
-      '@smithy/smithy-client': 4.12.13
+      '@smithy/core': 3.24.3
+      '@smithy/fetch-http-handler': 5.4.3
+      '@smithy/node-http-handler': 4.7.3
       '@smithy/types': 4.14.1
-      '@smithy/url-parser': 4.2.14
-      '@smithy/util-base64': 4.3.2
-      '@smithy/util-body-length-browser': 4.2.2
-      '@smithy/util-body-length-node': 4.2.3
-      '@smithy/util-defaults-mode-browser': 4.3.49
-      '@smithy/util-defaults-mode-node': 4.2.54
-      '@smithy/util-endpoints': 3.4.2
-      '@smithy/util-middleware': 4.2.14
-      '@smithy/util-retry': 4.3.8
-      '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
 
   '@aws-sdk/nested-clients@3.997.6':
     dependencies:
@@ -6488,17 +6532,13 @@ snapshots:
       '@smithy/types': 4.14.1
       tslib: 2.8.1
 
-  '@aws-sdk/token-providers@3.1032.0':
+  '@aws-sdk/signature-v4-multi-region@3.996.27':
     dependencies:
-      '@aws-sdk/core': 3.974.8
-      '@aws-sdk/nested-clients': 3.996.21
       '@aws-sdk/types': 3.973.8
-      '@smithy/property-provider': 4.2.14
-      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/core': 3.24.3
+      '@smithy/signature-v4': 5.4.3
       '@smithy/types': 4.14.1
       tslib: 2.8.1
-    transitivePeerDependencies:
-      - aws-crt
 
   '@aws-sdk/token-providers@3.1041.0':
     dependencies:
@@ -6511,6 +6551,15 @@ snapshots:
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
+
+  '@aws-sdk/token-providers@3.1049.0':
+    dependencies:
+      '@aws-sdk/core': 3.974.12
+      '@aws-sdk/nested-clients': 3.997.10
+      '@aws-sdk/types': 3.973.8
+      '@smithy/core': 3.24.3
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
 
   '@aws-sdk/types@3.973.8':
     dependencies:
@@ -6571,17 +6620,18 @@ snapshots:
       '@smithy/util-config-provider': 4.2.2
       tslib: 2.8.1
 
-  '@aws-sdk/xml-builder@3.972.18':
-    dependencies:
-      '@smithy/types': 4.14.1
-      fast-xml-parser: 5.5.8
-      tslib: 2.8.1
-
   '@aws-sdk/xml-builder@3.972.22':
     dependencies:
       '@nodable/entities': 2.1.0
       '@smithy/types': 4.14.1
       fast-xml-parser: 5.7.2
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.24':
+    dependencies:
+      '@nodable/entities': 2.1.0
+      '@smithy/types': 4.14.1
+      fast-xml-parser: 5.7.3
       tslib: 2.8.1
 
   '@aws/lambda-invoke-store@0.2.4': {}
@@ -8006,12 +8056,24 @@ snapshots:
       '@smithy/uuid': 1.1.2
       tslib: 2.8.1
 
+  '@smithy/core@3.24.3':
+    dependencies:
+      '@aws-crypto/crc32': 5.2.0
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
   '@smithy/credential-provider-imds@4.2.14':
     dependencies:
       '@smithy/node-config-provider': 4.3.14
       '@smithy/property-provider': 4.2.14
       '@smithy/types': 4.14.1
       '@smithy/url-parser': 4.2.14
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.3.3':
+    dependencies:
+      '@smithy/core': 3.24.3
+      '@smithy/types': 4.14.2
       tslib: 2.8.1
 
   '@smithy/eventstream-codec@4.2.14':
@@ -8050,6 +8112,12 @@ snapshots:
       '@smithy/querystring-builder': 4.2.14
       '@smithy/types': 4.14.1
       '@smithy/util-base64': 4.3.2
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.4.3':
+    dependencies:
+      '@smithy/core': 3.24.3
+      '@smithy/types': 4.14.2
       tslib: 2.8.1
 
   '@smithy/hash-blob-browser@4.2.15':
@@ -8195,6 +8263,12 @@ snapshots:
       '@smithy/types': 4.14.1
       tslib: 2.8.1
 
+  '@smithy/node-http-handler@4.7.3':
+    dependencies:
+      '@smithy/core': 3.24.3
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
   '@smithy/property-provider@4.2.14':
     dependencies:
       '@smithy/types': 4.14.1
@@ -8240,6 +8314,12 @@ snapshots:
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
+  '@smithy/signature-v4@5.4.3':
+    dependencies:
+      '@smithy/core': 3.24.3
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
   '@smithy/smithy-client@4.12.11':
     dependencies:
       '@smithy/core': 3.23.17
@@ -8269,6 +8349,10 @@ snapshots:
       tslib: 2.8.1
 
   '@smithy/types@4.14.1':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/types@4.14.2':
     dependencies:
       tslib: 2.8.1
 
@@ -9370,16 +9454,22 @@ snapshots:
     dependencies:
       path-expression-matcher: 1.5.0
 
-  fast-xml-parser@5.5.8:
+  fast-xml-builder@1.2.0:
     dependencies:
-      fast-xml-builder: 1.1.5
       path-expression-matcher: 1.5.0
-      strnum: 2.2.3
+      xml-naming: 0.1.0
 
   fast-xml-parser@5.7.2:
     dependencies:
       '@nodable/entities': 2.1.0
       fast-xml-builder: 1.1.5
+      path-expression-matcher: 1.5.0
+      strnum: 2.2.3
+
+  fast-xml-parser@5.7.3:
+    dependencies:
+      '@nodable/entities': 2.1.0
+      fast-xml-builder: 1.2.0
       path-expression-matcher: 1.5.0
       strnum: 2.2.3
 
@@ -10332,6 +10422,8 @@ snapshots:
       ansi-styles: 6.2.3
       string-width: 7.2.0
       strip-ansi: 7.2.0
+
+  xml-naming@0.1.0: {}
 
   yallist@3.1.1: {}
 


### PR DESCRIPTION
## Summary

- Replaces synchronous `POST /ai/review` with async WebSocket-based flow
- Client connects to WS, gets `connectionId`, starts job via HTTP, receives streaming batch results
- Infrastructure: new `ai-jobs` DynamoDB table, IAM wiring for `budget-ai` Lambda (self-invoke + ManageConnections)
- Lambda split into 5 files: `index.ts` (router), `review-start.ts`, `review-worker.ts`, `csv-analysis.ts`, `shared.ts`
- Pass 1 (no web search) → Pass 2 (web search for low-confidence results)
- `BudgetSettings` extended with `aiReviewBatchSize`, `aiReviewParallelLimit`, `aiReviewConfidenceThreshold`
- `$connect` Lambda now pushes `{ type: 'connected', connectionId }` back to client
- Frontend AI service layer updated: `MockAIService` simulates streaming; `ClaudeAIService` manages full WS lifecycle

## Deployed to dev

- `TransformotionDev-BudgetTrackerTables` — updated (ai-jobs table added)
- `TransformotionDev-BudgetTrackerWs` — updated (connectFn IAM grant added)
- `TransformotionDev-BudgetTrackerApi` — updated (new env vars + IAM)

## Test plan

- [ ] Typecheck passes: `pnpm turbo typecheck --filter="@transformotion/fn-budget-*"`
- [ ] Budget tracker build passes: `cd apps/budget-tracker && pnpm build`
- [ ] CDK synth: `cdk synth TransformotionDev-BudgetTrackerTables TransformotionDev-BudgetTrackerWs TransformotionDev-BudgetTrackerApi`
- [ ] End-to-end: connect via `wscat`, call review-start, observe streaming batch results

🤖 Generated with [Claude Code](https://claude.com/claude-code)