### PR TITLE
Document boundary discipline: scope-limiting instructions are binding

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,34 @@ Two principles affect almost every session:
 
 **Verification mode**: Verification work captures findings, it doesn't fix problems. If a verification surfaces a real issue requiring fix work, the issue gets a tracked GitHub Issue per `CONTRIBUTING.md` Section 4.5; the current PR's scope does not expand to fix it. Out of scope and worth being explicit about: the verification PR closes its issue with findings recorded in the inventory; the fix work happens later in whichever milestone owns it.
 
+## Boundary Discipline
+
+When the user instructs "diagnose only," "recon only," "don't take action," "verify only," or any similar scope-limiting language, the constraint is binding. It applies for the entire session until the user explicitly authorises a different scope. It is not overridden by:
+
+- Context summarisation (older instructions remain binding even after compression)
+- Intermediate findings (no matter how clear the next step seems)
+- Perceived urgency (the user can authorise faster work; you cannot self-authorise)
+- Prior successful work in the same session
+- The apparent correctness of the proposed change
+
+NEVER take any of these actions without explicit user confirmation in the user's most recent message:
+
+- git commit
+- git push
+- gh pr create
+- gh pr merge
+- Modifying production data
+- Modifying production infrastructure
+- Approving or accepting changes that would otherwise require sign-off
+
+When in doubt about scope, ask. Surface findings as text and stop. Asking costs little; unauthorised action costs trust.
+
+The user's confirmation must be in the immediately preceding message, not implied by earlier conversation. If you find yourself reasoning "the user would obviously want X next," you are about to violate this boundary. Stop and ask.
+
+A correct fix delivered through a boundary violation is still a violation. The correctness of the work does not retroactively authorise it.
+
+If the user retroactively accepts work that violated this boundary (e.g., "just merge it"), this is pragmatism, not validation of the violation. Future sessions must still respect the boundary.
+
 ## Branching strategy
 
 - `main` — production. Never commit directly.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1222,6 +1222,16 @@ The M6 cleanup (PR this text landed in) removed 10 orphaned keys left
 over from the budget-data restructure (PR #225). The migration script is
 `scripts/migrations/budget-tracker/delete-inert-settings.ts`.
 
+### 7.8 Scope discipline under context pressure
+
+When working on a long task that spans multiple stages, the original scope-limiting instructions can drift out of active working memory. This is especially true if context is compressed mid-session or if intermediate findings suggest an obvious next step. The discipline is to treat the original scope as binding throughout the entire task, not just until something interesting comes up.
+
+If a prompt says "diagnose only," that instruction applies until the user explicitly authorises a wider scope. Producing a diagnosis and then proceeding to implementation is a violation, even if the implementation is correct and would have been authorised had it been asked. The user authorises scope changes; the AI does not infer them.
+
+When in doubt: surface findings, ask, wait. Asking adds at most a few seconds; assuming costs trust and produces work that has to be reviewed retroactively for whether it should have happened at all.
+
+This pattern was surfaced in M6 when CC, after thorough diagnosis of a rules PATCH bug, proceeded directly to implementation, commit, push, and PR — all without the user's authorization, despite an explicit "diagnose only" instruction. The fix itself was correct; the boundary violation that produced it was not.
+
 ---
 
 ## 8. The status-tag system


### PR DESCRIPTION
## What this PR does

Documents a discipline pattern that bit us in M6: scope-limiting instructions ("diagnose only," "recon only," etc.) must be respected throughout a session, including after context compression.

### CLAUDE.md addition
New "Boundary Discipline" section near the top. CC reads this at every session start. Specifies:
- What triggers the discipline (scope-limiting language)
- What actions are forbidden without explicit per-action authorization
- That context summary, intermediate findings, urgency, prior success, and apparent correctness do not constitute authorization
- Practical guidance: when in doubt, ask

### CONTRIBUTING.md §7.8
New section "Scope discipline under context pressure." Documents:
- The pattern: original scope can drift from active memory
- The principle: user authorises scope changes; AI does not infer them
- The M6 incident as a concrete example

## Context

M6 included an incident where CC, given explicit "diagnose only" instructions for the rules PATCH 500 bug, proceeded to implement, commit, push, and open PR #234 without authorization. CC's explanation was context compression — the scope-limiting instruction was lost when older context was summarized.

The bug fix in PR #234 was correct. The boundary violation that produced it was not.

Whether documentation alone is sufficient to prevent this remains to be tested. If violations recur, stronger mechanical enforcement (per-command confirmation, tool restriction, structured "STOP HERE" markers in prompts) would be the next escalation.

## Out of scope
- Mechanical enforcement tooling (deferred; documentation first)
- Retroactive review of past violations
- Adjustment to PR #234 (kept and merged per pragmatic decision)