### PR TITLE
Review tab, rules matcher, AI Review fixes and features

### DIFF
--- a/apps/budget-tracker/components/budget-tracker/tabs/review-tab.tsx
+++ b/apps/budget-tracker/components/budget-tracker/tabs/review-tab.tsx
@@ -2,6 +2,8 @@
 
 import { useState } from "react"
 import { useBudgetStore } from "@/stores/budget-tracker/use-budget-store"
+import { useReviewStore } from "@/stores/budget-tracker/use-review-store"
+import type { ReviewResult } from "@/stores/budget-tracker/use-review-store"
 import { useAuthStore, selectCurrentAccount } from "@/stores/auth/use-auth-store"
 import { PageHeader, Card, PrimaryButton, EmptyState } from "@/components/ui/design-system"
 import { Sparkles, Check, X, ChevronRight, Pencil, AlertCircle, RefreshCw } from "lucide-react"
@@ -11,21 +13,6 @@ import { cn } from "@/lib/utils"
 import { getAIService } from "@/lib/services/ai"
 import type { ReviewResult as AIReviewResult } from "@/lib/services/ai"
 import type { MatchingRule } from "@transformotion/budget-domain"
-
-type ReviewState = 'idle' | 'reviewing' | 'complete' | 'error'
-
-interface ReviewResult {
-  transactionId: string
-  description: string
-  suggestedCategoryId: string
-  suggestedSubcategoryId: string
-  suggestedCategoryName: string
-  suggestedSubcategoryName: string
-  reason: string
-  confidence: 'high' | 'medium' | 'low'
-  pass: 1 | 2
-  status: "pending" | "accepted" | "rejected"
-}
 
 function ConfidenceBadge({ confidence }: { confidence: 'high' | 'medium' | 'low' }) {
   const cls = {
@@ -49,16 +36,21 @@ export function ReviewTab() {
   const settings = useBudgetStore((s) => s.settings)
   const currentAccount = useAuthStore(selectCurrentAccount)
 
-  const categories = budgetData.categories
+  // Persistent across tab navigation (Zustand)
+  const reviewState    = useReviewStore((s) => s.reviewState)
+  const error          = useReviewStore((s) => s.error)
+  const reviewResults  = useReviewStore((s) => s.reviewResults)
+  const progress       = useReviewStore((s) => s.progress)
+  const { setReviewState, setError, setReviewResults, setProgress, updateProgress, updateResultStatus } = useReviewStore.getState()
 
-  const [reviewState, setReviewState] = useState<ReviewState>('idle')
-  const [error, setError] = useState<string | null>(null)
+  // Ephemeral interaction state (local — intentionally lost on navigation)
   const [editingId, setEditingId] = useState<string | null>(null)
   const [editCategoryId, setEditCategoryId] = useState("")
   const [editSubcategoryId, setEditSubcategoryId] = useState("")
-  const [reviewResults, setReviewResults] = useState<ReviewResult[]>([])
-  const [progress, setProgress] = useState({ completed: 0, total: 0 })
+  const [acceptError, setAcceptError] = useState<string | null>(null)
+  const [acceptAllProgress, setAcceptAllProgress] = useState<{ current: number; total: number } | null>(null)
 
+  const categories = budgetData.categories
   const uncategorizedTransactions = transactions.filter(t => !t.categoryId && !t.category)
 
   function mergeResults(prev: ReviewResult[], incoming: AIReviewResult[], pass: 1 | 2, batch: typeof uncategorizedTransactions): ReviewResult[] {
@@ -76,7 +68,7 @@ export function ReviewTab() {
         reason: r.reason,
         confidence: r.confidence,
         pass,
-        status: "pending",
+        status: 'pending',
       }
       const idx = next.findIndex(x => x.transactionId === tx.transactionId)
       if (idx >= 0) {
@@ -92,6 +84,7 @@ export function ReviewTab() {
   const handleAIReview = async () => {
     setReviewState('reviewing')
     setError(null)
+    setAcceptError(null)
     setReviewResults([])
     const batch = uncategorizedTransactions.slice(0, 100)
     setProgress({ completed: 0, total: batch.length })
@@ -107,68 +100,79 @@ export function ReviewTab() {
         transactions: indexedTxs,
         categories,
         settings: {
-          batchSize:            settings.aiReviewBatchSize,
-          parallelLimit:        settings.aiReviewParallelLimit,
-          confidenceThreshold:  settings.aiReviewConfidenceThreshold,
+          batchSize:           settings.aiReviewBatchSize,
+          parallelLimit:       settings.aiReviewParallelLimit,
+          confidenceThreshold: settings.aiReviewConfidenceThreshold,
         },
         onBatch: (batchResults: AIReviewResult[], pass: 1 | 2) => {
           setReviewResults(prev => mergeResults(prev, batchResults, pass, batch))
           if (pass === 1) {
-            setProgress(p => ({ ...p, completed: Math.min(p.completed + batchResults.length, p.total) }))
+            updateProgress(p => ({ ...p, completed: Math.min(p.completed + batchResults.length, p.total) }))
           }
         },
       })
       setReviewState('complete')
     } catch (err) {
       setReviewState('error')
-      setError(err instanceof Error ? err.message : "AI review failed")
+      setError(err instanceof Error ? err.message : 'AI review failed')
     }
   }
 
   const acceptResult = async (result: ReviewResult, categoryId: string, subcategoryId: string) => {
-    await updateTransaction(result.transactionId, {
-      categoryId,
-      subcategoryId,
-      _manual: true,
-    })
+    await updateTransaction(result.transactionId, { categoryId, subcategoryId, _manual: true })
     if (currentAccount && result.description && categoryId && subcategoryId) {
       const rule: MatchingRule = {
-        ruleId: crypto.randomUUID(),
-        accountId: currentAccount.id,
-        name: result.description,
-        match: result.description,
-        matchType: 'contains',
+        ruleId:       crypto.randomUUID(),
+        accountId:    currentAccount.id,
+        name:         result.description,
+        match:        result.description,
+        matchType:    'contains',
         categoryId,
         subcategoryId,
-        isBusiness: false,
-        learned: true,
-        enabled: true,
-        priority: Date.now(),
-        createdAt: new Date().toISOString(),
+        isBusiness:   false,
+        learned:      true,
+        enabled:      true,
+        priority:     Date.now(),
+        createdAt:    new Date().toISOString(),
       }
       await addMatchingRule(rule)
     }
-    setReviewResults(prev =>
-      prev.map(r => r.transactionId === result.transactionId ? { ...r, status: "accepted" } : r)
-    )
+    updateResultStatus(result.transactionId, 'accepted')
   }
 
-  const handleAccept = (transactionId: string) => {
+  const handleAccept = async (transactionId: string) => {
     const result = reviewResults.find(r => r.transactionId === transactionId)
-    if (result) acceptResult(result, result.suggestedCategoryId, result.suggestedSubcategoryId)
+    if (!result) return
+    setAcceptError(null)
+    try {
+      await acceptResult(result, result.suggestedCategoryId, result.suggestedSubcategoryId)
+    } catch (err) {
+      setAcceptError(err instanceof Error ? err.message : 'Failed to save — check your connection and try again')
+    }
   }
 
-  const handleAcceptAll = () => {
-    const pending = reviewResults.filter(r => r.status === "pending")
-    for (const result of pending) {
-      acceptResult(result, result.suggestedCategoryId, result.suggestedSubcategoryId)
+  const handleAcceptAll = async () => {
+    const pending = reviewResults.filter(r => r.status === 'pending')
+    if (pending.length === 0) return
+    setAcceptError(null)
+    setAcceptAllProgress({ current: 0, total: pending.length })
+    let failCount = 0
+    for (let i = 0; i < pending.length; i++) {
+      setAcceptAllProgress({ current: i + 1, total: pending.length })
+      try {
+        await acceptResult(pending[i], pending[i].suggestedCategoryId, pending[i].suggestedSubcategoryId)
+      } catch {
+        failCount++
+      }
+    }
+    setAcceptAllProgress(null)
+    if (failCount > 0) {
+      setAcceptError(`${failCount} suggestion${failCount !== 1 ? 's' : ''} could not be saved — check your connection and try again`)
     }
   }
 
   const handleReject = (transactionId: string) => {
-    setReviewResults(prev =>
-      prev.map(r => r.transactionId === transactionId ? { ...r, status: "rejected" } : r)
-    )
+    updateResultStatus(transactionId, 'rejected')
   }
 
   const startEdit = (result: ReviewResult) => {
@@ -177,17 +181,27 @@ export function ReviewTab() {
     setEditSubcategoryId(result.suggestedSubcategoryId)
   }
 
-  const acceptEdited = (result: ReviewResult) => {
-    acceptResult(result, editCategoryId, editSubcategoryId)
-    setEditingId(null)
+  const acceptEdited = async (result: ReviewResult) => {
+    setAcceptError(null)
+    try {
+      await acceptResult(result, editCategoryId, editSubcategoryId)
+      setEditingId(null)
+    } catch (err) {
+      setAcceptError(err instanceof Error ? err.message : 'Failed to save — check your connection and try again')
+    }
   }
 
   const editingCategory = getActiveCategories(categories).find(c => c.categoryId === editCategoryId)
 
-  const pendingResults = reviewResults.filter(r => r.status === "pending")
-  const completedResults = reviewResults.filter(r => r.status !== "pending")
-  const progressPct = progress.total > 0 ? Math.round((progress.completed / progress.total) * 100) : 0
-  const isReviewing = reviewState === 'reviewing'
+  const pendingResults   = reviewResults.filter(r => r.status === 'pending')
+  const completedResults = reviewResults.filter(r => r.status !== 'pending')
+  const progressPct      = progress.total > 0 ? Math.round((progress.completed / progress.total) * 100) : 0
+  const isReviewing      = reviewState === 'reviewing'
+  const isAcceptingAll   = acceptAllProgress !== null
+
+  const bannerText = pendingResults.length > 0
+    ? `Review complete — ${pendingResults.length} suggestion${pendingResults.length !== 1 ? 's' : ''} remaining`
+    : 'Review complete — all suggestions processed'
 
   return (
     <div className="p-4 space-y-4 overflow-hidden">
@@ -209,7 +223,7 @@ export function ReviewTab() {
 
         <PrimaryButton
           onClick={handleAIReview}
-          disabled={uncategorizedCount === 0 || isReviewing}
+          disabled={uncategorizedCount === 0 || isReviewing || isAcceptingAll}
           className="w-full"
         >
           {isReviewing ? (
@@ -225,7 +239,7 @@ export function ReviewTab() {
           )}
         </PrimaryButton>
 
-        {/* Progress bar */}
+        {/* AI Review progress bar */}
         {isReviewing && progress.total > 0 && (
           <div className="mt-3">
             <div className="flex items-center justify-between mb-1">
@@ -243,11 +257,26 @@ export function ReviewTab() {
           </div>
         )}
 
+        {/* Accept All progress */}
+        {isAcceptingAll && acceptAllProgress && (
+          <div className="mt-3">
+            <div className="flex items-center justify-between mb-1">
+              <span className="text-xs text-muted-foreground">
+                Accepting... {acceptAllProgress.current} of {acceptAllProgress.total}
+              </span>
+            </div>
+            <div className="h-1.5 bg-surface2 rounded-full overflow-hidden">
+              <div
+                className="h-full bg-signal-green rounded-full transition-all duration-300"
+                style={{ width: `${Math.round((acceptAllProgress.current / acceptAllProgress.total) * 100)}%` }}
+              />
+            </div>
+          </div>
+        )}
+
         {reviewState === 'complete' && reviewResults.length > 0 && (
           <div className="mt-3 p-2.5 rounded-lg bg-signal-green/10 border border-signal-green/20">
-            <p className="text-xs text-signal-green font-medium">
-              Review complete — {reviewResults.length} suggestion{reviewResults.length !== 1 ? 's' : ''} ready
-            </p>
+            <p className="text-xs text-signal-green font-medium">{bannerText}</p>
           </div>
         )}
 
@@ -258,6 +287,14 @@ export function ReviewTab() {
           </div>
         )}
       </Card>
+
+      {/* Accept error (separate from AI review error) */}
+      {acceptError && (
+        <div className="p-3 rounded-lg bg-signal-red/10 border border-signal-red/20 flex items-start gap-2">
+          <AlertCircle className="size-4 text-signal-red mt-0.5 shrink-0" />
+          <div className="text-sm text-signal-red">{acceptError}</div>
+        </div>
+      )}
 
       {uncategorizedCount === 0 && reviewResults.length === 0 && (
         <EmptyState
@@ -276,9 +313,10 @@ export function ReviewTab() {
             </h3>
             <button
               onClick={handleAcceptAll}
-              className="text-xs text-primary hover:text-primary/80 transition-colors"
+              disabled={isAcceptingAll}
+              className="text-xs text-primary hover:text-primary/80 transition-colors disabled:opacity-50"
             >
-              Accept all
+              {isAcceptingAll ? 'Accepting...' : 'Accept all'}
             </button>
           </div>
 
@@ -381,14 +419,16 @@ export function ReviewTab() {
                       </button>
                       <button
                         onClick={() => handleAccept(result.transactionId)}
-                        className="size-8 rounded-lg bg-signal-green/15 text-signal-green hover:bg-signal-green/25 flex items-center justify-center transition-colors"
+                        disabled={isAcceptingAll}
+                        className="size-8 rounded-lg bg-signal-green/15 text-signal-green hover:bg-signal-green/25 flex items-center justify-center transition-colors disabled:opacity-50"
                         title="Accept"
                       >
                         <Check className="size-4" />
                       </button>
                       <button
                         onClick={() => handleReject(result.transactionId)}
-                        className="size-8 rounded-lg bg-signal-red/15 text-signal-red hover:bg-signal-red/25 flex items-center justify-center transition-colors"
+                        disabled={isAcceptingAll}
+                        className="size-8 rounded-lg bg-signal-red/15 text-signal-red hover:bg-signal-red/25 flex items-center justify-center transition-colors disabled:opacity-50"
                         title="Reject"
                       >
                         <X className="size-4" />
@@ -406,8 +446,8 @@ export function ReviewTab() {
         <div className="space-y-2">
           <h3 className="text-sm font-semibold text-muted-foreground">Completed</h3>
           <p className="text-xs text-muted-foreground">
-            {completedResults.filter(r => r.status === "accepted").length} accepted,{" "}
-            {completedResults.filter(r => r.status === "rejected").length} rejected
+            {completedResults.filter(r => r.status === 'accepted').length} accepted,{" "}
+            {completedResults.filter(r => r.status === 'rejected').length} rejected
           </p>
         </div>
       )}

--- a/apps/budget-tracker/components/budget-tracker/tabs/review-tab.tsx
+++ b/apps/budget-tracker/components/budget-tracker/tabs/review-tab.tsx
@@ -44,6 +44,8 @@ export function ReviewTab() {
   const { setReviewState, setError, setReviewResults, setProgress, updateProgress, updateResultStatus } = useReviewStore.getState()
 
   // Ephemeral interaction state (local — intentionally lost on navigation)
+  // forceFullSearch is local (resets per page session) — a per-run override, not a setting
+  const [forceFullSearch, setForceFullSearch] = useState(false)
   const [editingId, setEditingId] = useState<string | null>(null)
   const [editCategoryId, setEditCategoryId] = useState("")
   const [editSubcategoryId, setEditSubcategoryId] = useState("")
@@ -104,6 +106,7 @@ export function ReviewTab() {
           parallelLimit:       settings.aiReviewParallelLimit,
           confidenceThreshold: settings.aiReviewConfidenceThreshold,
         },
+        forceFullSearch,
         onBatch: (batchResults: AIReviewResult[], pass: 1 | 2) => {
           setReviewResults(prev => mergeResults(prev, batchResults, pass, batch))
           if (pass === 1) {
@@ -238,6 +241,20 @@ export function ReviewTab() {
             </>
           )}
         </PrimaryButton>
+
+        {/* Full search toggle — per-run override; does not modify Settings */}
+        <label className="flex items-center gap-2 mt-2 cursor-pointer select-none">
+          <input
+            type="checkbox"
+            checked={forceFullSearch}
+            onChange={(e) => setForceFullSearch(e.target.checked)}
+            disabled={isReviewing || isAcceptingAll}
+            className="rounded border-border disabled:opacity-50"
+          />
+          <span className="text-xs text-muted-foreground">
+            Full search (slower, more accurate — uses web search for every transaction)
+          </span>
+        </label>
 
         {/* AI Review progress bar */}
         {isReviewing && progress.total > 0 && (

--- a/apps/budget-tracker/components/budget-tracker/tabs/rules-tab.tsx
+++ b/apps/budget-tracker/components/budget-tracker/tabs/rules-tab.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useRef, useMemo, useEffect } from "react"
 import { useBudgetStore } from "@/stores/budget-tracker/use-budget-store"
+import { useAuthStore, selectCurrentAccount } from "@/stores/auth/use-auth-store"
 import { PageHeader, Card, PrimaryButton, SecondaryButton } from "@/components/ui/design-system"
 import { Search, Plus, RotateCcw, ChevronDown, Check, X, Pencil, Trash2, Ban, HelpCircle } from "lucide-react"
 import { applyRules, previewRuleMatches } from "@transformotion/budget-domain"
@@ -13,9 +14,11 @@ import { cn } from "@/lib/utils"
 export function RulesTab() {
   const matchingRules = useBudgetStore((s) => s.matchingRules)
   const setMatchingRules = useBudgetStore((s) => s.setMatchingRules)
+  const addMatchingRule = useBudgetStore((s) => s.addMatchingRule)
   const transactions = useBudgetStore((s) => s.transactions)
   const setTransactions = useBudgetStore((s) => s.setTransactions)
   const budgetData = useBudgetStore((s) => s.budgetData)
+  const currentAccount = useAuthStore(selectCurrentAccount)
 
   const categories = budgetData.categories
 
@@ -25,6 +28,7 @@ export function RulesTab() {
   const [testInput, setTestInput] = useState("")
   const [showRules, setShowRules] = useState(true)
   const [reapplyFeedback, setReapplyFeedback] = useState<string | null>(null)
+  const [ruleAddError, setRuleAddError] = useState<string | null>(null)
   const [editingRule, setEditingRule] = useState<string | null>(null)
   const [viewingRule, setViewingRule] = useState<string | null>(null)
   const [addingRule, setAddingRule] = useState(false)
@@ -80,28 +84,37 @@ export function RulesTab() {
     setTimeout(() => setReapplyFeedback(null), 3000)
   }
 
-  const addNewRule = () => {
+  const addNewRule = async () => {
     if (!newRule.name.trim() || !newRule.pattern.trim()) return
     if (!newRule.categoryId || !newRule.subcategoryId) return
+    if (!currentAccount) {
+      setRuleAddError('Cannot create rule: no account loaded. Try signing out and back in.')
+      return
+    }
+    setRuleAddError(null)
 
     const rule: MatchingRule = {
-      ruleId: crypto.randomUUID(),
-      accountId: "",
-      name: newRule.name.trim(),
-      match: newRule.pattern.trim(),
-      matchType: newRule.matchType,
-      categoryId: newRule.categoryId,
+      ruleId:       crypto.randomUUID(),
+      accountId:    currentAccount.id,
+      name:         newRule.name.trim(),
+      match:        newRule.pattern.trim(),
+      matchType:    newRule.matchType,
+      categoryId:   newRule.categoryId,
       subcategoryId: newRule.subcategoryId,
-      isBusiness: newRule.isBusiness,
-      enabled: true,
-      priority: Date.now(),
-      learned: false,
-      createdAt: new Date().toISOString(),
+      isBusiness:   newRule.isBusiness,
+      enabled:      true,
+      priority:     Date.now(),
+      learned:      false,
+      createdAt:    new Date().toISOString(),
     }
 
-    setMatchingRules([...matchingRules, rule])
-    setNewRule({ name: "", pattern: "", matchType: "contains", categoryId: "", subcategoryId: "", isBusiness: false })
-    setAddingRule(false)
+    try {
+      await addMatchingRule(rule)
+      setNewRule({ name: "", pattern: "", matchType: "contains", categoryId: "", subcategoryId: "", isBusiness: false })
+      setAddingRule(false)
+    } catch (err) {
+      setRuleAddError(err instanceof Error ? err.message : 'Failed to create rule — check your connection and try again')
+    }
   }
 
   const deleteRule = (id: string) => {
@@ -208,6 +221,12 @@ export function RulesTab() {
       {reapplyFeedback && (
         <div className="p-3 bg-signal-green/10 border border-signal-green/30 rounded-lg">
           <p className="text-sm text-signal-green">{reapplyFeedback}</p>
+        </div>
+      )}
+
+      {ruleAddError && (
+        <div className="p-3 bg-signal-red/10 border border-signal-red/30 rounded-lg flex items-start gap-2">
+          <span className="text-sm text-signal-red">{ruleAddError}</span>
         </div>
       )}
 

--- a/apps/budget-tracker/components/budget-tracker/tabs/settings-tab.tsx
+++ b/apps/budget-tracker/components/budget-tracker/tabs/settings-tab.tsx
@@ -18,7 +18,7 @@ export function SettingsTab() {
 
   const [batchSize, setBatchSize] = useState(String(settings.aiReviewBatchSize ?? DEFAULT_AI_SETTINGS.aiReviewBatchSize))
   const [parallelLimit, setParallelLimit] = useState(String(settings.aiReviewParallelLimit ?? DEFAULT_AI_SETTINGS.aiReviewParallelLimit))
-  const [confidenceThreshold, setConfidenceThreshold] = useState<'low' | 'medium'>(
+  const [confidenceThreshold, setConfidenceThreshold] = useState<'low' | 'medium' | 'high'>(
     settings.aiReviewConfidenceThreshold ?? DEFAULT_AI_SETTINGS.aiReviewConfidenceThreshold
   )
   const [saving, setSaving] = useState(false)
@@ -142,14 +142,15 @@ export function SettingsTab() {
             </label>
             <select
               value={confidenceThreshold}
-              onChange={(e) => { setSaved(false); setConfidenceThreshold(e.target.value as 'low' | 'medium') }}
+              onChange={(e) => { setSaved(false); setConfidenceThreshold(e.target.value as 'low' | 'medium' | 'high') }}
               className="w-full h-9 px-3 rounded-lg bg-surface2 border border-border text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-primary"
             >
               <option value="low">Low — only re-run low-confidence results</option>
               <option value="medium">Medium — re-run low and medium-confidence results</option>
+              <option value="high">High — re-run everything except high-confidence results (slowest, highest API cost)</option>
             </select>
             <p className="text-[11px] text-muted-foreground mt-1">
-              Which confidence levels trigger re-categorisation with web search. &apos;Low&apos; is faster; &apos;Medium&apos; is more thorough.
+              Which confidence levels trigger web-search re-categorisation. &apos;Low&apos; is fastest; &apos;High&apos; uses web search for almost all transactions.
             </p>
           </div>
         </div>

--- a/apps/budget-tracker/components/budget-tracker/tabs/transactions-tab.tsx
+++ b/apps/budget-tracker/components/budget-tracker/tabs/transactions-tab.tsx
@@ -2,10 +2,11 @@
 
 import { useState, useMemo, useRef } from "react"
 import { useBudgetStore } from "@/stores/budget-tracker/use-budget-store"
+import { useAuthStore, selectCurrentAccount } from "@/stores/auth/use-auth-store"
 import { PageHeader, Card, PrimaryButton, SecondaryButton, EmptyState } from "@/components/ui/design-system"
 import {
   Upload, Receipt, Filter, Download, Briefcase, X,
-  RotateCcw, Check, BookOpen, Search, FileText
+  RotateCcw, Check, BookOpen, Search, FileText, AlertCircle
 } from "lucide-react"
 import { CATEGORY_COLORS } from "../data/category-colors"
 import { applyRules } from "@transformotion/budget-domain"
@@ -90,6 +91,7 @@ export function TransactionsTab() {
   const uncategorizedCount = useBudgetStore((s) => s.uncategorizedCount)
   const filters = useBudgetStore((s) => s.filters)
   const setFilters = useBudgetStore((s) => s.setFilters)
+  const currentAccount = useAuthStore(selectCurrentAccount)
 
   const categories = budgetData.categories
 
@@ -104,6 +106,7 @@ export function TransactionsTab() {
   const [editSubcategoryId, setEditSubcategoryId] = useState("")
   const [searchQuery, setSearchQuery] = useState("")
 
+  const [learnError, setLearnError] = useState<string | null>(null)
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
   const [bulkCategoryId, setBulkCategoryId] = useState("")
   const [bulkSubcategoryId, setBulkSubcategoryId] = useState("")
@@ -229,23 +232,34 @@ export function TransactionsTab() {
     if (editingId === null) return
     const tx = transactions.find(t => t.transactionId === editingId)
     if (!tx) return
+    if (!currentAccount) {
+      setLearnError('Cannot create rule: no account loaded. Try signing out and back in.')
+      return
+    }
+    setLearnError(null)
 
     const words = tx.description.split(/\s+/).slice(0, 3).join(" ")
     const newMatchingRule: MatchingRule = {
-      ruleId: crypto.randomUUID(),
-      accountId: "",
-      name: words,
-      match: words,
-      matchType: 'contains',
-      categoryId: editCategoryId,
+      ruleId:       crypto.randomUUID(),
+      accountId:    currentAccount.id,
+      name:         words,
+      match:        words,
+      matchType:    'contains',
+      categoryId:   editCategoryId,
       subcategoryId: editSubcategoryId,
-      isBusiness: false,
-      enabled: true,
-      priority: Date.now(),
-      learned: true,
-      createdAt: new Date().toISOString(),
+      isBusiness:   false,
+      enabled:      true,
+      priority:     Date.now(),
+      learned:      true,
+      createdAt:    new Date().toISOString(),
     }
-    await addMatchingRule(newMatchingRule)
+
+    try {
+      await addMatchingRule(newMatchingRule)
+    } catch (err) {
+      setLearnError(err instanceof Error ? err.message : 'Failed to save rule — check your connection and try again')
+      return
+    }
 
     const allRules = [...matchingRules, newMatchingRule]
     setTransactions(transactions.map(t => {
@@ -323,6 +337,13 @@ export function TransactionsTab() {
           : "Import and manage your transactions"
         }
       />
+
+      {learnError && (
+        <div className="p-3 rounded-lg bg-signal-red/10 border border-signal-red/20 flex items-start gap-2">
+          <AlertCircle className="size-4 text-signal-red mt-0.5 shrink-0" />
+          <span className="text-sm text-signal-red">{learnError}</span>
+        </div>
+      )}
 
       {/* Action Bar */}
       <div className="flex items-center gap-2">

--- a/apps/budget-tracker/functions/budget-ai/src/review-start.ts
+++ b/apps/budget-tracker/functions/budget-ai/src/review-start.ts
@@ -20,10 +20,11 @@ export async function reviewStart(
 ): Promise<ReturnType<typeof ok>> {
   requireAccountAccess(auth, 'budget-tracker', accountId);
 
-  const { transactions, categories, settings } = parseBody<{
+  const { transactions, categories, settings, forceFullSearch } = parseBody<{
     transactions: Array<{ index: number; description: string; amount: string }>;
     categories: Category[];
-    settings?: { batchSize?: number; parallelLimit?: number; confidenceThreshold?: 'low' | 'medium' };
+    settings?: { batchSize?: number; parallelLimit?: number; confidenceThreshold?: 'low' | 'medium' | 'high' };
+    forceFullSearch?: boolean;
   }>(event);
 
   // Resolve connectionId from the connections table by userId (most recent active connection)
@@ -71,6 +72,7 @@ export async function reviewStart(
     batchSize,
     parallelLimit,
     confidenceThreshold,
+    forceFullSearch: forceFullSearch === true,
     auth,
   };
 

--- a/apps/budget-tracker/functions/budget-ai/src/review-worker.ts
+++ b/apps/budget-tracker/functions/budget-ai/src/review-worker.ts
@@ -15,7 +15,8 @@ export interface ReviewWorkerPayload {
   categories:    Category[];
   batchSize:     number;
   parallelLimit: number;
-  confidenceThreshold: 'low' | 'medium';
+  confidenceThreshold: 'low' | 'medium' | 'high';
+  forceFullSearch: boolean;
   auth:          AuthClaims;
 }
 
@@ -29,7 +30,7 @@ type BatchResult = {
 
 const CONFIDENCE_ORDER: Record<string, number> = { high: 2, medium: 1, low: 0 };
 
-function meetsThreshold(confidence: string, threshold: 'low' | 'medium'): boolean {
+function meetsThreshold(confidence: string, threshold: 'low' | 'medium' | 'high'): boolean {
   return CONFIDENCE_ORDER[confidence] >= CONFIDENCE_ORDER[threshold];
 }
 
@@ -45,7 +46,7 @@ async function runBatch(
     model:     AI_MODEL,
     maxTokens: 4096,
     webSearch,
-    system:    `You are a personal finance assistant helping to categorise Australian bank transactions.\n\nYou will be given:\n- A list of budget categories, each with allowed subcategories\n- A list of transactions (index, description, amount)\n\n${webSearch ? 'You have access to a web_search tool. If a merchant or description is unfamiliar, you MAY search to identify the business type. Use web_search sparingly.' : ''}\n\nYou must:\n- Return ONLY a JSON array, one object per transaction\n- Each object has exactly: {"index": <int>, "category": <string>, "subcategory": <string>, "reason": <string>, "confidence": "high"|"medium"|"low"}\n- The category must be one of the provided categories exactly\n- The subcategory must be one of the subcategories listed under that category exactly\n- "confidence" reflects how certain you are: "high" = clear match, "medium" = reasonable inference, "low" = best guess\n- The reason must be a single sentence explaining your choice in plain English\n- If a transaction is genuinely uncategorisable, return it with category: "", subcategory: "", confidence: "low", and reason explaining why\n- Do not include any text outside the JSON array\n- Do not wrap the JSON in markdown code fences`,
+    system:    `You are a personal finance assistant helping to categorise Australian bank transactions.\n\nYou will be given:\n- A list of budget categories, each with allowed subcategories\n- A list of transactions (index, description, amount)\n\n${webSearch ? 'You have access to a web_search tool. If a merchant or description is unfamiliar, you MAY search to identify the business type. Use web_search sparingly.' : ''}\n\nWhen a merchant could plausibly belong to multiple categories, use the transaction amount as a disambiguating signal. Smaller amounts at hospitality venues (pubs, bars, cafes) typically indicate drinks or snacks; larger amounts typically indicate meals. Smaller amounts at petrol stations may indicate convenience-store items; larger amounts indicate fuel. Smaller amounts at supermarkets may indicate a quick convenience purchase; larger amounts indicate a full grocery shop. Use your judgement based on typical Australian prices.\n\nYou must:\n- Return ONLY a JSON array, one object per transaction\n- Each object has exactly: {"index": <int>, "category": <string>, "subcategory": <string>, "reason": <string>, "confidence": "high"|"medium"|"low"}\n- The category must be one of the provided categories exactly\n- The subcategory must be one of the subcategories listed under that category exactly\n- "confidence" reflects how certain you are: "high" = clear match, "medium" = reasonable inference, "low" = best guess\n- The reason must be a single sentence explaining your choice in plain English, and should mention the amount where it influenced the decision\n- If a transaction is genuinely uncategorisable, return it with category: "", subcategory: "", confidence: "low", and reason explaining why\n- Do not include any text outside the JSON array\n- Do not wrap the JSON in markdown code fences`,
     prompt:    `BUDGET CATEGORIES AND SUBCATEGORIES:\n${categoryList}\n\nTRANSACTIONS TO CATEGORISE (index: description — amount):\n${formatTxList(batch)}`,
   });
 
@@ -81,7 +82,9 @@ async function runBatch(
 }
 
 export async function runReviewWorker(payload: ReviewWorkerPayload): Promise<void> {
-  const { jobId, connectionId, transactions, categories, batchSize, parallelLimit, confidenceThreshold, auth, accountId } = payload;
+  const { jobId, connectionId, transactions, categories, batchSize, parallelLimit, auth, accountId, forceFullSearch } = payload;
+  // forceFullSearch overrides the user's stored threshold for this run only
+  const confidenceThreshold: 'low' | 'medium' | 'high' = forceFullSearch ? 'high' : payload.confidenceThreshold;
 
   const categoryList = formatCategoryList(categories);
   const labelLookup  = buildLabelLookup(categories);

--- a/apps/budget-tracker/lib/services/ai/claude-ai.ts
+++ b/apps/budget-tracker/lib/services/ai/claude-ai.ts
@@ -60,9 +60,10 @@ export class ClaudeAIService implements AIService {
     // Step 3: start job — server resolves connectionId from userId via connections table
     const http = getBudgetHttp()
     const { jobId } = await http.post<{ jobId: string }>(REVIEW_URL, {
-      transactions: input.transactions,
-      categories:   input.categories,
-      settings:     input.settings,
+      transactions:    input.transactions,
+      categories:      input.categories,
+      settings:        input.settings,
+      forceFullSearch: input.forceFullSearch ?? false,
     })
 
     // Step 4: wait for streaming to complete

--- a/apps/budget-tracker/lib/services/ai/index.ts
+++ b/apps/budget-tracker/lib/services/ai/index.ts
@@ -9,7 +9,8 @@ export type ReviewResult = WsMessageBatchResult['results'][number]
 export interface ReviewTransactionsInput {
   transactions: Array<{ index: number; description: string; amount: string }>
   categories: Category[]
-  settings?: { batchSize?: number; parallelLimit?: number; confidenceThreshold?: 'low' | 'medium' }
+  settings?: { batchSize?: number; parallelLimit?: number; confidenceThreshold?: 'low' | 'medium' | 'high' }
+  forceFullSearch?: boolean
   onBatch?: (results: ReviewResult[], pass: 1 | 2) => void
 }
 

--- a/apps/budget-tracker/stores/budget-tracker/use-review-store.ts
+++ b/apps/budget-tracker/stores/budget-tracker/use-review-store.ts
@@ -1,0 +1,64 @@
+import { create } from 'zustand'
+
+export type ReviewState = 'idle' | 'reviewing' | 'complete' | 'error'
+
+export interface ReviewResult {
+  transactionId: string
+  description: string
+  suggestedCategoryId: string
+  suggestedSubcategoryId: string
+  suggestedCategoryName: string
+  suggestedSubcategoryName: string
+  reason: string
+  confidence: 'high' | 'medium' | 'low'
+  pass: 1 | 2
+  status: 'pending' | 'accepted' | 'rejected'
+}
+
+interface ReviewStoreState {
+  reviewState: ReviewState
+  error: string | null
+  reviewResults: ReviewResult[]
+  progress: { completed: number; total: number }
+
+  setReviewState: (state: ReviewState) => void
+  setError: (error: string | null) => void
+  setReviewResults: (results: ReviewResult[] | ((prev: ReviewResult[]) => ReviewResult[])) => void
+  setProgress: (progress: { completed: number; total: number }) => void
+  updateProgress: (fn: (prev: { completed: number; total: number }) => { completed: number; total: number }) => void
+  updateResultStatus: (transactionId: string, status: 'accepted' | 'rejected') => void
+  resetReview: () => void
+}
+
+export const useReviewStore = create<ReviewStoreState>()((set) => ({
+  reviewState: 'idle',
+  error: null,
+  reviewResults: [],
+  progress: { completed: 0, total: 0 },
+
+  setReviewState: (reviewState) => set({ reviewState }),
+  setError: (error) => set({ error }),
+  setReviewResults: (resultsOrUpdater) => set((s) => ({
+    reviewResults: typeof resultsOrUpdater === 'function'
+      ? resultsOrUpdater(s.reviewResults)
+      : resultsOrUpdater,
+  })),
+  setProgress: (progress) => set({ progress }),
+  updateProgress: (fn) => set((s) => ({ progress: fn(s.progress) })),
+  updateResultStatus: (transactionId, status) => set((s) => ({
+    reviewResults: s.reviewResults.map((r) =>
+      r.transactionId === transactionId ? { ...r, status } : r
+    ),
+  })),
+  resetReview: () => set({
+    reviewState: 'idle',
+    error: null,
+    reviewResults: [],
+    progress: { completed: 0, total: 0 },
+  }),
+}))
+
+export const selectReviewState = (s: ReviewStoreState) => s.reviewState
+export const selectReviewResults = (s: ReviewStoreState) => s.reviewResults
+export const selectReviewError = (s: ReviewStoreState) => s.error
+export const selectReviewProgress = (s: ReviewStoreState) => s.progress

--- a/apps/budget-tracker/stores/index.ts
+++ b/apps/budget-tracker/stores/index.ts
@@ -10,3 +10,12 @@ export {
   selectUncategorizedCount,
   selectActiveTab,
 } from './budget-tracker/use-budget-store'
+
+export {
+  useReviewStore,
+  selectReviewState,
+  selectReviewResults,
+  selectReviewError,
+  selectReviewProgress,
+} from './budget-tracker/use-review-store'
+export type { ReviewResult, ReviewState } from './budget-tracker/use-review-store'

--- a/packages/budget-domain/src/__tests__/rules.test.ts
+++ b/packages/budget-domain/src/__tests__/rules.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { applyRules } from "../rules.js";
+import { applyRules, previewRuleMatches } from "../rules.js";
 import type { MatchingRule } from "../contracts.js";
 
 function makeRule(overrides: Partial<MatchingRule> & { match: string; categoryId: string; subcategoryId: string }): MatchingRule {
@@ -83,5 +83,58 @@ describe("applyRules", () => {
     });
     const result = applyRules("WOOLWORTHS KAWANA", [disabledRule, ...sampleRules]);
     expect(result).toMatchObject({ categoryId: groceryCatId, subcategoryId: supermarketSubId });
+  });
+});
+
+describe("buildRegex whitespace normalisation", () => {
+  const catId = "cat-food";
+  const subId = "sub-dining";
+
+  it("multi-space pattern matches single-space input", () => {
+    const rule = makeRule({ match: "SQ *MYSTICA BURGERS       Noosa", categoryId: catId, subcategoryId: subId });
+    expect(applyRules("SQ *MYSTICA BURGERS Noosa", [rule])).toMatchObject({ categoryId: catId });
+  });
+
+  it("single-space pattern matches multi-space input (bank raw description)", () => {
+    const rule = makeRule({ match: "SQ *MYSTICA BURGERS Noosa", categoryId: catId, subcategoryId: subId });
+    expect(applyRules("SQ *MYSTICA BURGERS       Noosa", [rule])).toMatchObject({ categoryId: catId });
+  });
+
+  it("tab-separated pattern matches space-separated input", () => {
+    const rule = makeRule({ match: "foo\tbar", categoryId: catId, subcategoryId: subId });
+    expect(applyRules("foo bar baz", [rule])).toMatchObject({ categoryId: catId });
+  });
+
+  it("pattern with no internal whitespace continues to match normally", () => {
+    const rule = makeRule({ match: "woolworths", categoryId: catId, subcategoryId: subId });
+    expect(applyRules("WOOLWORTHS MAROOCHYDORE", [rule])).toMatchObject({ categoryId: catId });
+  });
+
+  it("regex matchType is unaffected — exact pattern is used as-is", () => {
+    const rule = makeRule({ match: "WOOLWORTHS\\s{2,}MAROOCHYDORE", matchType: "regex", categoryId: catId, subcategoryId: subId });
+    // Multi-space matches the explicit \s{2,}
+    expect(applyRules("WOOLWORTHS  MAROOCHYDORE", [rule])).toMatchObject({ categoryId: catId });
+    // Single space does NOT match \s{2,}
+    expect(applyRules("WOOLWORTHS MAROOCHYDORE", [rule])).toBeNull();
+  });
+
+  it("escapeRegex still neutralises regex special characters in patterns", () => {
+    // The * in "SQ *MYSTICA" must be treated as a literal asterisk, not a quantifier
+    const rule = makeRule({ match: "SQ *MYSTICA", categoryId: catId, subcategoryId: subId });
+    expect(applyRules("SQ *MYSTICA BURGERS", [rule])).toMatchObject({ categoryId: catId });
+    // A raw asterisk-as-quantifier would throw or behave incorrectly — this confirms it's escaped
+    expect(() => applyRules("SQ MYSTICA BURGERS", [rule])).not.toThrow();
+  });
+
+  it("startsWith matchType also normalises whitespace", () => {
+    const rule = makeRule({ match: "SQ *MYSTICA  BURGERS", matchType: "startsWith", categoryId: catId, subcategoryId: subId });
+    expect(applyRules("SQ *MYSTICA BURGERS NOOSA", [rule])).toMatchObject({ categoryId: catId });
+  });
+
+  it("previewRuleMatches uses the same normalised matching", () => {
+    const rule = makeRule({ match: "BLI BLI  HOTEL", categoryId: catId, subcategoryId: subId });
+    const matches = previewRuleMatches("BLI BLI HOTEL RESTAURANT", [rule]);
+    expect(matches).toHaveLength(1);
+    expect(matches[0].isWinner).toBe(true);
   });
 });

--- a/packages/budget-domain/src/contracts.ts
+++ b/packages/budget-domain/src/contracts.ts
@@ -70,7 +70,7 @@ export interface BudgetSettings {
   csvFormatMappings: Record<string, CSVMapping>;
   aiReviewBatchSize?: number;
   aiReviewParallelLimit?: number;
-  aiReviewConfidenceThreshold?: 'low' | 'medium';
+  aiReviewConfidenceThreshold?: 'low' | 'medium' | 'high';
 }
 
 export interface CSVMapping {

--- a/packages/budget-domain/src/rules.ts
+++ b/packages/budget-domain/src/rules.ts
@@ -4,10 +4,18 @@ function escapeRegex(s: string): string {
   return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
+function normalisePattern(pattern: string): string {
+  // Collapse whitespace runs to \s+ so multi-space bank descriptions match
+  // single-space user input (and vice-versa). Applies after escapeRegex so
+  // the literal space characters in the escaped string are safe to replace.
+  return escapeRegex(pattern).replace(/\s+/g, "\\s+");
+}
+
 function buildRegex(matchType: string, pattern: string): RegExp {
   if (matchType === "regex") return new RegExp(pattern, "i");
-  if (matchType === "startsWith") return new RegExp(`^${escapeRegex(pattern)}`, "i");
-  return new RegExp(escapeRegex(pattern), "i");
+  const p = normalisePattern(pattern);
+  if (matchType === "startsWith") return new RegExp(`^${p}`, "i");
+  return new RegExp(p, "i");
 }
 
 // Priority ASC, then createdAt DESC (newer wins equal-priority ties)


### PR DESCRIPTION
## What this PR does

Consolidated fix PR addressing multiple bugs and feature gaps in the AI Review flow and rules engine, based on staged recon work.

### Bug fixes

- **Rules matcher whitespace handling** — `buildRegex` now collapses any whitespace run to `\s+` so multi-space bank descriptions (e.g. `"SQ *MYSTICA BURGERS       Noosa"` with 7 spaces) match user-typed single-space test input and vice-versa. Applies to all non-regex matchTypes; regex matchType is intentionally unchanged.
- **Review tab state survives tab navigation** — `reviewState`, `error`, `reviewResults`, and `progress` lifted from `useState` to a new `useReviewStore` (Zustand). State survives tab navigation but not page refresh (refresh-survival is a separate concern requiring server-side caching).
- **Banner count reflects pending suggestions** — was showing `reviewResults.length` (total including accepted), now shows `pendingResults.length`. Text reads "N suggestions remaining" and decrements as suggestions are accepted.
- **Accept handlers await and surface errors** — `handleAccept`, `acceptEdited`, and the Accept All loop all called `acceptResult` without `await`. Errors were silently swallowed. Fixed: all three now `await`, wrap in `try/catch`, and surface failures via an inline error banner. Card stays visible on failure.
- **Accept All is now sequential** — was concurrent fire-and-forget (66+ parallel PATCH+GET pairs). Now sequential with a green progress bar showing "Accepting X of Y". Failure count reported at end.
- **`accountId: ""` fix** — `addNewRule` (Rules tab) and `saveAndLearn` (Transactions tab) both created rules with `accountId: ""`. Rules were stored under the empty-string partition key, appeared locally, and were silently lost on next `listRules`. Now uses `currentAccount.id` matching the pattern in `acceptResult`. Guards: if `currentAccount` is null, shows error instead of creating a broken rule.

### Features

- **Pass 2 'high' threshold** — `aiReviewConfidenceThreshold` now accepts `'high'`. When set, Pass 2 (web search) fires for every transaction that wasn't already high-confidence in Pass 1 — effectively "always do a web search." Settings tab exposes the option with cost-warning help text. Default remains `'low'`.
- **Per-run full search toggle** — "Full search" checkbox on the Review tab overrides the threshold to `'high'` for that run only. Does not modify the persisted Settings value. Toggle is local state (resets on page refresh, not on tab navigation).
- **Amount-aware AI reasoning** — system prompt updated to instruct the model to use transaction amount as a disambiguating signal (pub $12 vs $45 → drinks vs meal; petrol station $8 vs $80 → convenience vs fuel). Applied to both passes. Reason field asked to mention amount where it influenced the decision.

### Out of scope (tracked separately)

- Rules list priority UI and priority data model fix (learned rules get `Date.now()` as priority; manual rules get 100; separate work)
- Server-side caching of AI Review suggestions across page refresh
- v0 repo app code sync (143+ stale references)
- Deploy workflow race condition fix
- "Re-apply all rules" 500s: CloudWatch found 0 Lambda errors matching the described scenario post-PR #234; root cause could not be corroborated server-side

### Design decisions made

- **`useReviewStore` vs extending `useBudgetStore`**: Created a separate store per prompt recommendation. Keeps budget domain data and AI review state separate.
- **Accept All sequential vs parallel**: Sequential chosen per prompt recommendation; bounded and predictable; avoids 66+ concurrent PATCH/GET pairs. Can revisit if perceived slowness is reported.
- **`forceFullSearch` reset on refresh**: Local state (not persisted). Per-run override analogous to Stock Analyser Live mode; persisting would create surprise API costs.
- **`addNewRule` switched from `setMatchingRules` to `addMatchingRule`**: `setMatchingRules` re-PATCHes every rule on each call. `addMatchingRule` only saves the new rule then reloads. Matches the pattern used in `acceptResult`.

### Recon trail

- Original recon: review-tab state, banner, accept path, currentAccount
- Continuation recon: rule test vs list (name/match divergence), AI quality regression
- Final recon: matcher whitespace root cause (multi-space bank descriptions); 500 errors reconciled (PR #234 resolved ConditionalCheckFailedException; later observation could not be corroborated server-side)

### Component tests

The budget-tracker Next.js app has no test runner configured (no vitest/jest). Unit tests for `useReviewStore` and the updated components were not possible without first setting up a test framework — out of scope for this PR. `packages/budget-domain` tests cover the whitespace normalization in `buildRegex` (8 new test cases, 50 total passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)