### PR TITLE
fix(launchpad): correct NEXT_PUBLIC_STOCK_URL in .env.example

### DIFF
--- a/apps/launchpad/.env.example
+++ b/apps/launchpad/.env.example
@@ -107,20 +107,17 @@ NEXT_PUBLIC_APP_URL=https://dev.apps.transformotion.com.au
 # tile navigates here. Falls back to http://localhost:3000 in code for
 # local dev convenience only — a deployed launchpad with this var unset
 # would point users at localhost and break tile navigation.
-# For dev:   https://dev.apps.transformotion.com.au
-# For prod:  https://apps.transformotion.com.au
-NEXT_PUBLIC_STOCK_URL=https://dev.apps.transformotion.com.au
+# For dev:   https://dev.apps.transformotion.com.au/stock-signal/
+# For prod:  https://apps.transformotion.com.au/stock-signal/
+NEXT_PUBLIC_STOCK_URL=https://dev.apps.transformotion.com.au/stock-signal/
 
 # [REQUIRED]
 # URL of the deployed Budget Tracker app. The launchpad's Budget Tracker
 # tile navigates here. Falls back to http://localhost:3002 in code for
 # local dev convenience only — a deployed launchpad with this var unset
 # would point users at localhost and break tile navigation.
-# For dev:   the Budget Tracker is currently embedded inside the Stock
-#            Analyser app at <NEXT_PUBLIC_STOCK_URL>/budget-tracker
-#            (see Issue #17 for the consolidation plan). Once Issue #17
-#            is complete and the Budget Tracker has its own deployment,
-#            this will point to its own URL.
+# For dev:   https://dev.apps.transformotion.com.au/budget-tracker/
+# For prod:  https://apps.transformotion.com.au/budget-tracker/
 NEXT_PUBLIC_BUDGET_URL=https://dev.apps.transformotion.com.au/budget-tracker/
 
 # ── Build-injected ────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Corrects `NEXT_PUBLIC_STOCK_URL` value and comments in `apps/launchpad/.env.example` to include the `/stock-signal/` basePath suffix added in M6
- Removes stale comment on `NEXT_PUBLIC_BUDGET_URL` that referenced the old Issue #17 embedded-app architecture; replaces with accurate dev/prod URL format matching the surrounding comment style

## Fix scope

`apps/launchpad/.env.example` only. No runtime impact — the deploy workflow already has the correct value with `/stock-signal/` suffix. This is a documentation-only fix.

## Discovery

Surfaced during M7 #251 verification recon (Check A — URL references). Issue filed at time of discovery per CLAUDE.md discipline rule.

Closes #256