### PR TITLE
fix(ci): wait for CloudFront invalidation before verify

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -78,8 +78,22 @@ jobs:
         run: |
           if [ "${{ github.event.inputs.target }}" = "dev" ]; then
             aws s3 sync apps/stock-analyser/out s3://$S3_BUCKET_DEV --delete
-            aws cloudfront create-invalidation --distribution-id $CF_DIST_DEV --paths "/*"
+            INVALIDATION_ID=$(aws cloudfront create-invalidation \
+              --distribution-id $CF_DIST_DEV \
+              --paths "/*" \
+              --query 'Invalidation.Id' \
+              --output text)
+            aws cloudfront wait invalidation-completed \
+              --distribution-id $CF_DIST_DEV \
+              --id "$INVALIDATION_ID"
           else
             aws s3 sync apps/stock-analyser/out s3://${{ vars.S3_BUCKET_PROD }} --delete
-            aws cloudfront create-invalidation --distribution-id ${{ vars.CLOUDFRONT_DISTRIBUTION_ID_PROD }} --paths "/*"
+            INVALIDATION_ID=$(aws cloudfront create-invalidation \
+              --distribution-id ${{ vars.CLOUDFRONT_DISTRIBUTION_ID_PROD }} \
+              --paths "/*" \
+              --query 'Invalidation.Id' \
+              --output text)
+            aws cloudfront wait invalidation-completed \
+              --distribution-id ${{ vars.CLOUDFRONT_DISTRIBUTION_ID_PROD }} \
+              --id "$INVALIDATION_ID"
           fi

--- a/.github/workflows/deploy-budget-tracker.yml
+++ b/.github/workflows/deploy-budget-tracker.yml
@@ -98,7 +98,15 @@ jobs:
         run: aws s3 sync apps/budget-tracker/out s3://transformotion-web-dev-959516291617/budget-tracker --delete
 
       - name: Invalidate CloudFront
-        run: aws cloudfront create-invalidation --distribution-id E1128DYYBLMWYK --paths "/budget-tracker/*"
+        run: |
+          INVALIDATION_ID=$(aws cloudfront create-invalidation \
+            --distribution-id E1128DYYBLMWYK \
+            --paths "/budget-tracker/*" \
+            --query 'Invalidation.Id' \
+            --output text)
+          aws cloudfront wait invalidation-completed \
+            --distribution-id E1128DYYBLMWYK \
+            --id "$INVALIDATION_ID"
 
       - name: Verify deployment
         run: |
@@ -176,7 +184,15 @@ jobs:
         run: aws s3 sync apps/budget-tracker/out s3://transformotion-prod-bucket/budget-tracker --delete
 
       - name: Invalidate CloudFront
-        run: aws cloudfront create-invalidation --distribution-id ${{ vars.CLOUDFRONT_DISTRIBUTION_ID_PROD }} --paths "/budget-tracker/*"
+        run: |
+          INVALIDATION_ID=$(aws cloudfront create-invalidation \
+            --distribution-id ${{ vars.CLOUDFRONT_DISTRIBUTION_ID_PROD }} \
+            --paths "/budget-tracker/*" \
+            --query 'Invalidation.Id' \
+            --output text)
+          aws cloudfront wait invalidation-completed \
+            --distribution-id ${{ vars.CLOUDFRONT_DISTRIBUTION_ID_PROD }} \
+            --id "$INVALIDATION_ID"
 
       - name: Verify deployment
         run: |

--- a/.github/workflows/deploy-launchpad.yml
+++ b/.github/workflows/deploy-launchpad.yml
@@ -76,7 +76,15 @@ jobs:
         run: aws s3 sync apps/launchpad/out s3://transformotion-web-dev-959516291617 --delete --exclude "stock-signal/*" --exclude "budget-tracker/*"
 
       - name: Invalidate CloudFront
-        run: aws cloudfront create-invalidation --distribution-id E1128DYYBLMWYK --paths "/*"
+        run: |
+          INVALIDATION_ID=$(aws cloudfront create-invalidation \
+            --distribution-id E1128DYYBLMWYK \
+            --paths "/*" \
+            --query 'Invalidation.Id' \
+            --output text)
+          aws cloudfront wait invalidation-completed \
+            --distribution-id E1128DYYBLMWYK \
+            --id "$INVALIDATION_ID"
 
       - name: Verify deployment
         run: |
@@ -133,7 +141,15 @@ jobs:
         run: aws s3 sync apps/launchpad/out s3://transformotion-prod-bucket --delete --exclude "stock-signal/*" --exclude "budget-tracker/*"
 
       - name: Invalidate CloudFront
-        run: aws cloudfront create-invalidation --distribution-id ${{ vars.CLOUDFRONT_DISTRIBUTION_ID_PROD }} --paths "/*"
+        run: |
+          INVALIDATION_ID=$(aws cloudfront create-invalidation \
+            --distribution-id ${{ vars.CLOUDFRONT_DISTRIBUTION_ID_PROD }} \
+            --paths "/*" \
+            --query 'Invalidation.Id' \
+            --output text)
+          aws cloudfront wait invalidation-completed \
+            --distribution-id ${{ vars.CLOUDFRONT_DISTRIBUTION_ID_PROD }} \
+            --id "$INVALIDATION_ID"
 
       - name: Verify deployment
         run: |

--- a/.github/workflows/deploy-stock-analyser.yml
+++ b/.github/workflows/deploy-stock-analyser.yml
@@ -86,7 +86,15 @@ jobs:
         run: aws s3 sync apps/stock-analyser/out s3://transformotion-web-dev-959516291617/stock-signal --delete
 
       - name: Invalidate CloudFront
-        run: aws cloudfront create-invalidation --distribution-id E1128DYYBLMWYK --paths "/*"
+        run: |
+          INVALIDATION_ID=$(aws cloudfront create-invalidation \
+            --distribution-id E1128DYYBLMWYK \
+            --paths "/*" \
+            --query 'Invalidation.Id' \
+            --output text)
+          aws cloudfront wait invalidation-completed \
+            --distribution-id E1128DYYBLMWYK \
+            --id "$INVALIDATION_ID"
 
       - name: Verify deployment
         run: |
@@ -151,7 +159,15 @@ jobs:
         run: aws s3 sync apps/stock-analyser/out s3://transformotion-prod-bucket/stock-signal --delete
 
       - name: Invalidate CloudFront
-        run: aws cloudfront create-invalidation --distribution-id ${{ vars.CLOUDFRONT_DISTRIBUTION_ID_PROD }} --paths "/*"
+        run: |
+          INVALIDATION_ID=$(aws cloudfront create-invalidation \
+            --distribution-id ${{ vars.CLOUDFRONT_DISTRIBUTION_ID_PROD }} \
+            --paths "/*" \
+            --query 'Invalidation.Id' \
+            --output text)
+          aws cloudfront wait invalidation-completed \
+            --distribution-id ${{ vars.CLOUDFRONT_DISTRIBUTION_ID_PROD }} \
+            --id "$INVALIDATION_ID"
 
       - name: Verify deployment
         run: |


### PR DESCRIPTION
## What
Replaces fire-and-forget CloudFront invalidation with capture-and-wait in all deploy workflows.

## Why
Verify step was polling stale cached content during invalidation propagation window, producing false-negative CI failures.

## Workflows affected
- `.github/workflows/deploy-launchpad.yml` (dev + prod jobs)
- `.github/workflows/deploy-stock-analyser.yml` (dev + prod jobs)
- `.github/workflows/deploy-budget-tracker.yml` (dev + prod jobs)
- `.github/workflows/cd.yml` (dev + prod branches of if/else)

8 invalidation calls total converted from single-line fire-and-forget to capture-and-wait. No other changes to any workflow.

Closes #238