### PR TITLE
refactor(platform): rename rate-limits table to canonical separator

### DIFF
--- a/docs/architecture/auth.md
+++ b/docs/architecture/auth.md
@@ -418,7 +418,7 @@ Five platform Lambdas have explicit permission models. Each is documented here f
 | `user` | `withAuthOnly` | None — user owns their own data | `platform.users` RW |
 | `auth/account-provisioning` | `withAuthOnly` | None — first-login flow; user has JWT but no app group memberships yet | `platform.accounts` RW + `platform.account-members` RW + `AdminUpdateUserAttributes` on user pool ARN |
 | `auth/invitations` | `withAuth` | Account-context guards | `platform.accounts` R + `platform.invitations` RW |
-| `auth/forgot-provider` | None (raw handler — pre-authentication) | None | `platform-rate-limits` RW + `AdminGetUser` on user pool ARN + SES `SendEmail` (scoped to verified sender identity ARN, pending tightening in M8) |
+| `auth/forgot-provider` | None (raw handler — pre-authentication) | None | `platform.rate-limits` RW + `AdminGetUser` on user pool ARN + SES `SendEmail` (scoped to verified sender identity ARN, pending tightening in M8) |
 
 **`accounts`, `user`, `auth/account-provisioning`, `auth/invitations`** are user-facing API endpoints. Each uses the appropriate middleware wrapper based on whether account context is required, and authorization helpers based on what the operation needs to verify.
 
@@ -632,7 +632,7 @@ The handler is pre-authentication by necessity. It uses no `withAuth` / `withAut
 
 ### Abuse-resistance posture
 
-Current state has Lambda-side IP-based rate limiting (5 requests per IP per 15 minutes, stored in `platform-rate-limits-{stage}`). The rate limiter currently fails open: if the rate-limit table is unavailable, requests proceed without limiting.
+Current state has Lambda-side IP-based rate limiting (5 requests per IP per 15 minutes, stored in `platform.rate-limits-{stage}`). The rate limiter currently fails open: if the rate-limit table is unavailable, requests proceed without limiting.
 
 The following tightenings are scheduled for M8:
 

--- a/docs/architecture/inventory.md
+++ b/docs/architecture/inventory.md
@@ -465,7 +465,7 @@ removing the dependency-cycle workaround.
 | `platform.account-members-{stage}` | accountId | userId | Has `userId-index` GSI for reverse lookup. |
 | `platform.invitations-{stage}` | invitationId | — | Used by invitation flow (M11). |
 | `platform.users-{stage}` | userId | — | |
-| `platform-rate-limits-{stage}` | pk | — | Owned by `AuthApiStack` (not PlatformTablesStack). PK: `lookup-provider#<ip>`. Used for rate-limiting by `forgot-provider` Lambda. Note: uses hyphen not dot — does NOT follow `{scope}.{entity}` convention. |
+| `platform.rate-limits-{stage}` | pk | — | Owned by `AuthApiStack` (not PlatformTablesStack). PK: `lookup-provider#<ip>`. Used for rate-limiting by `forgot-provider` Lambda. |
 | `platform.analysis-cache-{stage}` | accountId | cacheKey | Misnamed — see Section 2.7. |
 
 #### 2.10.2 Stock-analyser tables

--- a/infrastructure/lib/platform/auth-api-stack.ts
+++ b/infrastructure/lib/platform/auth-api-stack.ts
@@ -41,7 +41,7 @@ export class AuthApiStack extends cdk.Stack {
     // ── DynamoDB — rate-limit table ─────────────────────────────────────────
     // PK: "lookup-provider#<ip>", TTL attribute "ttl" enables auto-expiry
     const rateLimitTable = new dynamodb.Table(this, 'RateLimits', {
-      tableName:       `platform-rate-limits-${stage}`,
+      tableName:       `platform.rate-limits-${stage}`,
       partitionKey:    { name: 'pk', type: dynamodb.AttributeType.STRING },
       timeToLiveAttribute: 'ttl',
       billingMode:     dynamodb.BillingMode.PAY_PER_REQUEST,


### PR DESCRIPTION
## What
Renames `platform-rate-limits-${stage}` to `platform.rate-limits-${stage}` to match the canonical `{scope}.{entity}-{stage}` separator rule.

## Why
M2.1 #106 ADR. Brings rate-limits into canonical form alongside other `platform.*` tables.

## Data loss
Counter values will reset on deploy. PLAN.md §11 explicitly authorises this — counters self-heal as new requests arrive.

## Brief availability impact
The fail-closed rate-limiter blocks (rather than bypasses) requests if the table is unavailable. There will be a brief window during CDK deploy between the old table being destroyed and the new table being created where rate-limited endpoints return errors. Dev only; acceptable per PLAN.md.

## Files changed
- `infrastructure/lib/platform/auth-api-stack.ts` — tableName value
- `docs/architecture/inventory.md` — table name + removed stale "does NOT follow convention" note
- `docs/architecture/auth.md` — two table name references

Lambda env var (`RATE_LIMIT_TABLE`) is a CDK token reference — picks up the new name automatically; no Lambda code change needed.

Closes #246