### PR TITLE
fix(infra): grant cloudfront:GetInvalidation to deploy role

### DIFF
--- a/.github/workflows/deploy-platform.yml
+++ b/.github/workflows/deploy-platform.yml
@@ -58,6 +58,10 @@ jobs:
         working-directory: infrastructure
         run: pnpm exec cdk deploy 'TransformotionDev-BudgetTrackerTables' --require-approval never
 
+      - name: CDK Deploy — GithubActionsRole (account-level, deploy once)
+        working-directory: infrastructure
+        run: pnpm exec cdk deploy 'Transformotion-GithubActionsRole' --require-approval never
+
       - name: CDK Deploy — Platform stacks (dev)
         working-directory: infrastructure
         run: pnpm exec cdk deploy 'TransformotionDev-Storage' 'TransformotionDev-Network' 'TransformotionDev-Auth' 'TransformotionDev-AuthApi' 'TransformotionDev-Api' --require-approval never
@@ -94,6 +98,10 @@ jobs:
       - name: CDK Deploy — BudgetTrackerTables (must precede Auth to drop cross-stack import)
         working-directory: infrastructure
         run: pnpm exec cdk deploy 'TransformotionProd-BudgetTrackerTables' --require-approval never
+
+      - name: CDK Deploy — GithubActionsRole (account-level, deploy once)
+        working-directory: infrastructure
+        run: pnpm exec cdk deploy 'Transformotion-GithubActionsRole' --require-approval never
 
       - name: CDK Deploy — Platform stacks (prod)
         working-directory: infrastructure

--- a/infrastructure/bin/app.ts
+++ b/infrastructure/bin/app.ts
@@ -3,12 +3,13 @@ import 'source-map-support/register';
 import * as cdk from 'aws-cdk-lib';
 
 // ── Platform stacks ───────────────────────────────────────────────────────────
-import { NetworkStack }        from '../lib/platform/network-stack';
-import { AuthStack }           from '../lib/platform/auth-stack';
-import { AuthApiStack }        from '../lib/platform/auth-api-stack';
-import { PlatformApiStack }    from '../lib/platform/platform-api-stack';
-import { PlatformTablesStack } from '../lib/platform/platform-tables-stack';
-import { StorageStack }        from '../lib/platform/storage-stack';
+import { NetworkStack }           from '../lib/platform/network-stack';
+import { AuthStack }              from '../lib/platform/auth-stack';
+import { AuthApiStack }           from '../lib/platform/auth-api-stack';
+import { PlatformApiStack }       from '../lib/platform/platform-api-stack';
+import { PlatformTablesStack }    from '../lib/platform/platform-tables-stack';
+import { StorageStack }           from '../lib/platform/storage-stack';
+import { GithubActionsRoleStack } from '../lib/platform/github-actions-role-stack';
 
 // ── Stock Analyser stacks ─────────────────────────────────────────────────────
 import { StockAnalyserApiStack }    from '../lib/stock-analyser/stock-analyser-api-stack';
@@ -28,6 +29,13 @@ const env = {
   account: '959516291617',
   region: 'ap-southeast-2',
 };
+
+// ── Account-level stacks (not stage-specific) ─────────────────────────────────
+
+new GithubActionsRoleStack(app, 'Transformotion-GithubActionsRole', {
+  env,
+  description: 'Transformotion Apps — GitHubActionsDeployRole inline IAM policies (#262, #263)',
+});
 
 // ── Dev stacks ────────────────────────────────────────────────────────────────
 

--- a/infrastructure/lib/platform/github-actions-role-stack.ts
+++ b/infrastructure/lib/platform/github-actions-role-stack.ts
@@ -1,0 +1,44 @@
+import * as cdk from 'aws-cdk-lib';
+import * as iam from 'aws-cdk-lib/aws-iam';
+import { Construct } from 'constructs';
+
+/**
+ * GithubActionsRoleStack — manages inline IAM policies on GitHubActionsDeployRole.
+ *
+ * The role itself was created out-of-band (see #263 for full CDK migration).
+ * This stack takes ownership of the TransformotionDevDeploy inline policy only.
+ *
+ * Account-level — not stage-specific. Deployed once.
+ */
+export class GithubActionsRoleStack extends cdk.Stack {
+  constructor(scope: Construct, id: string, props: cdk.StackProps) {
+    super(scope, id, props);
+
+    // CfnRolePolicy maps to PutRolePolicy (upsert) — safe to apply against
+    // the existing out-of-band policy; CloudFormation will replace the document.
+    new iam.CfnRolePolicy(this, 'TransformotionDeployPolicy', {
+      roleName:   'GitHubActionsDeployRole',
+      policyName: 'TransformotionDevDeploy',
+      policyDocument: {
+        Version: '2012-10-17',
+        Statement: [
+          {
+            Effect:   'Allow',
+            Action:   ['s3:ListBucket', 's3:GetObject', 's3:PutObject', 's3:DeleteObject'],
+            Resource: '*',
+          },
+          {
+            Effect:   'Allow',
+            Action:   ['cloudfront:CreateInvalidation', 'cloudfront:GetInvalidation'],
+            Resource: '*',
+          },
+          {
+            Effect:   'Allow',
+            Action:   'cloudformation:DescribeStacks',
+            Resource: `arn:aws:cloudformation:${this.region}:${this.account}:stack/Transformotion*`,
+          },
+        ],
+      },
+    });
+  }
+}


### PR DESCRIPTION
## What

Adds `cloudfront:GetInvalidation` to the IAM policy attached to `GitHubActionsDeployRole`, and brings that policy into CDK source as a `GithubActionsRoleStack`.

## Why

PR #259 introduced `aws cloudfront wait invalidation-completed` in deploy workflows. The wait command polls via `GetInvalidation`, which the role didn't have permission for. Every CloudFront-using deploy has been failing on the wait step since #259 merged.

Scope matches the existing `CreateInvalidation` grant — `Resource: '*'`, no widening.

## Recon finding: role not in CDK

`GitHubActionsDeployRole` and its `TransformotionDevDeploy` inline policy were created out-of-band (not tracked in CDK). This PR brings `TransformotionDevDeploy` into CDK via `CfnRolePolicy` (`GithubActionsRoleStack`). The role definition itself and `CDKAssumeBootstrapRoles` remain out-of-band — tracked in #263 for a full migration.

`CfnRolePolicy` maps to `PutRolePolicy` (upsert) — safe to apply against the existing policy; CloudFormation replaces the document in place.

## Deployment

`deploy-platform.yml` is updated to deploy `Transformotion-GithubActionsRole` in both dev and prod jobs. The stack is account-level (not stage-specific) and idempotent — deploying it in both jobs is safe.

## Verification

On merge, trigger `deploy-platform.yml` via `workflow_dispatch`. Once deployed, re-run the failed stock-analyser deploy. Subsequent launchpad and budget-tracker deploys will also be unblocked.

Closes #262
Refs #263