### PR TITLE
docs: correct stale references after M7 #192 and M8

### DIFF
--- a/apps/stock-analyser/contracts/DATA_CONTRACTS.md
+++ b/apps/stock-analyser/contracts/DATA_CONTRACTS.md
@@ -9,13 +9,13 @@ This document is the single source of truth for interface contracts between the 
 
 ## Architecture Rule: Mock/Real Separation
 
-The `NEXT_PUBLIC_USE_MOCK_DATA` environment variable controls whether the app uses real AWS backends or in-memory mock data.
+Provider selection uses the runtime-config pattern (per CONTRIBUTING.md §5.8): `NEXT_PUBLIC_RUNTIME_PROFILE` sets the profile (`mock` locally, `live` in deployed environments), with optional per-concern override env vars. The resolved provider for each concern is on the config object (e.g. `config.storage.provider`, `config.ai.provider`).
 
 **Critical rule for UI components:**
-- Components NEVER check `useMockData` directly
+- Components NEVER check provider flags directly
 - Components call service methods (e.g. `portfolioService.getHoldings()`) or hooks (e.g. `useClaude()`)
 - The service/hook handles mock vs real internally
-- This means the same component code runs in v0 preview (mock) and production (real AWS)
+- This means the same component code runs locally (mock profile) and in deployed environments (live profile)
 
 If a new UI feature needs new data, the pattern is:
 1. Add the field to the relevant type

--- a/apps/stock-analyser/docs/claude-ai-pattern.md
+++ b/apps/stock-analyser/docs/claude-ai-pattern.md
@@ -69,10 +69,10 @@ async function categorizeTransactions() {
 Set environment variables to control behavior:
 
 ```env
-# Mock or Real API
-NEXT_PUBLIC_USE_MOCK_DATA=true              # true = mock, false = real
+# Provider profile: mock (default, local dev) or live (deployed environments)
+NEXT_PUBLIC_RUNTIME_PROFILE=mock
 
-# API Endpoints (change when deploying to real Lambda)
+# API Endpoints
 NEXT_PUBLIC_CLAUDE_API_URL=/api/claude      # Where to POST prompt
 NEXT_PUBLIC_CLAUDE_CACHE_URL=/analysis-cache # Where to poll results
 
@@ -155,13 +155,13 @@ const analysis = await call({
 ## Development vs. Production
 
 ### Development (Mock Mode)
-- `NEXT_PUBLIC_USE_MOCK_DATA=true`
+- `NEXT_PUBLIC_RUNTIME_PROFILE=mock` (default; no env var needed locally)
 - Simulates the async polling pattern
 - Instant results with small delay
 - No API keys needed
 
 ### Production (Real Claude)
-- `NEXT_PUBLIC_USE_MOCK_DATA=false`
+- `NEXT_PUBLIC_RUNTIME_PROFILE=live` (set by deploy workflows)
 - Calls actual Lambda + Claude API
 - Requires real polling
 - API key in Lambda (server-side only)
@@ -197,13 +197,13 @@ abort()
 
 ## Implementation Details
 
-### Mock Implementation (`NEXT_PUBLIC_USE_MOCK_DATA=true`)
+### Mock Implementation (`config.ai.provider === 'mock'`)
 1. Simulates `POST /api/claude` immediately with a mock jobId
 2. Simulates `GET /analysis-cache/job-{jobId}` polling
 3. Returns result after a short delay
 
-### Real Implementation (`NEXT_PUBLIC_USE_MOCK_DATA=false`)
-1. `POST /api/claude` with prompt (your Lambda proxy endpoint)
+### Real Implementation (`config.ai.provider === 'claude'`)
+1. `POST /api/claude` with prompt (Lambda proxy endpoint)
 2. Lambda returns `{ jobId }`
 3. Polls `GET /analysis-cache/job-{jobId}` (analysis-cache Lambda)
 4. When complete, returns typed result
@@ -239,8 +239,8 @@ const result = await call({ prompt })
 
 ## Next Steps
 
-When developers take over:
+When integrating with a deployed Claude backend:
 1. Create a Lambda function that calls Anthropic Claude API
 2. Expose it via API Gateway at `NEXT_PUBLIC_CLAUDE_API_URL`
-3. Set `NEXT_PUBLIC_USE_MOCK_DATA=false`
+3. Deploy with `NEXT_PUBLIC_RUNTIME_PROFILE=live` (already set in deploy workflows)
 4. All component code stays the same ✨

--- a/apps/stock-analyser/lib/hooks/use-claude.ts
+++ b/apps/stock-analyser/lib/hooks/use-claude.ts
@@ -1,15 +1,14 @@
 /**
  * useClaude Hook
- * 
+ *
  * Async Claude API integration with polling pattern.
- * 
+ *
  * Flow:
  * 1. POST /api/claude { prompt, asyncMode: true } -> { jobId }
  * 2. Poll GET /analysis-cache/job-{jobId} every 2.5s
  * 3. When complete, return parsed JSON content
- * 
- * Current: Mock implementation for development
- * Future: Real AWS Lambda proxy with DynamoDB polling
+ *
+ * Provider selected via config.ai.provider: 'mock' (local) or 'claude' (deployed).
  */
 
 import { useState, useCallback, useRef } from 'react'
@@ -26,7 +25,7 @@ export interface ClaudeRequest {
   /**
    * DynamoDB cache key (e.g. 'MARKET#ASX', 'ANALYSIS#CBA.AX').
    * When provided: checks DynamoDB before calling Claude, saves result after.
-   * Cache is always checked regardless of useMockData flag.
+   * Cache is always checked regardless of AI provider.
    */
   cacheKey?: string
   /**

--- a/docs/architecture/auth.md
+++ b/docs/architecture/auth.md
@@ -632,14 +632,13 @@ The handler is pre-authentication by necessity. It uses no `withAuth` / `withAut
 
 ### Abuse-resistance posture
 
-Current state has Lambda-side IP-based rate limiting (5 requests per IP per 15 minutes, stored in `platform.rate-limits-{stage}`). The rate limiter currently fails open: if the rate-limit table is unavailable, requests proceed without limiting.
+Lambda-side IP-based rate limiting (5 requests per IP per 15 minutes, stored in `platform.rate-limits-{stage}`). The rate limiter fails closed: if the rate-limit table is unavailable, requests are blocked rather than bypassed. The availability trade-off is accepted for this endpoint — it is not critical-path for active users; legitimate users can retry after DDB recovers; the abuse window stays closed during outages.
 
-The following tightenings are scheduled for M8:
+M8 deployed the following additional tightenings (all active):
 
-- **SES grant scoping.** Current grant is `ses:SendEmail` on `Resource: ['*']` — broader than necessary. M8 scopes the grant to the specific verified sender identity ARN.
-- **API Gateway throttling.** A second layer independent of the Lambda's DDB-based limiter. Specific throttle parameters decided during M8 implementation.
-- **CORS allowlist.** Current configuration is `ALL_ORIGINS`; M8 restricts to the sign-in page origin so browser-based requests from other origins are blocked.
-- **Rate-limiter fail-closed.** The current fail-open behaviour is changed to fail-closed: if the rate-limit table is unavailable, requests are blocked rather than bypassed. The availability trade-off is accepted for this endpoint — it is not critical-path for active users; legitimate users can retry after DDB recovers; the abuse window stays closed during outages.
+- **SES grant scoped** to the specific verified sender identity ARN (no longer `Resource: ['*']`).
+- **API Gateway throttling** active as a second layer independent of the Lambda's DDB-based limiter.
+- **CORS allowlist** restricts to the sign-in page origin (no longer `ALL_ORIGINS`).
 
 **Known limitation:** For federated users, `AdminGetUser(Username=email)` fails because their Cognito username is `Google_{sub}` (not email). The fix using `ListUsersCommand` resolves this. See sub-phase `7e-forgot-provider-fix` in `docs/sub-phase-7e-plan.md`.
 


### PR DESCRIPTION
## What

Corrects four stale doc/comment references after completed milestone work.

## Drift sources

- **auth.md:635** — fail-open description survived M8 closure despite M8 deploying fail-closed behaviour. Normative doc, §2.1 discipline rule applied at the time but was missed.
- **contracts/DATA_CONTRACTS.md** — USE_MOCK_DATA reference survived PR #261 (closed #192) despite the flag being retired. Normative doc, §2.1 discipline rule applied at the time but was missed.
- **apps/stock-analyser/docs/claude-ai-pattern.md** — USE_MOCK_DATA reference; non-normative app doc.
- **apps/stock-analyser/lib/hooks/use-claude.ts:29** — stale comment; code itself is correct.

## Process note

Two of the four were §2.1 discipline-rule misses. This PR corrects them after the fact. The pattern is worth noting (parked, not actionable here): the PR templates / prompts that produced #261 and the M8 closure did not explicitly enumerate which normative documents would be affected by the change. If that pattern recurs in M7's remaining work, the prompt template likely needs an explicit "which normative docs does this change touch" recon step.

Closes #266