### PR TITLE
Remove stale NEXT_PUBLIC_USE_MOCK_DATA from ci.yml stock-analyser build step (#269)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,6 @@ jobs:
           NEXT_PUBLIC_CLAUDE_CACHE_URL: https://placeholder.execute-api.ap-southeast-2.amazonaws.com/dev/analysis-cache
           NEXT_PUBLIC_CALLBACK_URL: http://localhost:3000/callback
           NEXT_PUBLIC_APP_URL: http://localhost:3000
-          NEXT_PUBLIC_USE_MOCK_DATA: 'true'
         run: pnpm build
 
   infra-synth:


### PR DESCRIPTION
## Summary

- Removes `NEXT_PUBLIC_USE_MOCK_DATA: 'true'` from the stock-analyser build step env block in `ci.yml` (line 96)
- Stock-analyser retired this variable in PR #261 (closed #192); `config.features.useMockData` no longer exists in stock-analyser config
- `NEXT_PUBLIC_RUNTIME_PROFILE: mock` already provides the intended mock behaviour; the removed line was a no-op creating false signal

Closes #269.

## Verification

- **V1**: Issue #268 filed for budget-tracker migration (M7) — budget-tracker still reads `NEXT_PUBLIC_USE_MOCK_DATA`, but ci.yml does not inject it for budget-tracker
- **V2**: All other `.md` references classified:
  - `apps/budget-tracker/CLAUDE.md:192,203` — budget-tracker-legitimate (#268)
  - `CONTRIBUTING.md:695` — intentional illustrative example (architectural doc explaining the pattern concept)
  - `docs/architecture/inventory.md:1053` — inventory reference, still accurate while budget-tracker is unretired
  - `PLAN.md:1279` — backlog default-flip item, still accurate while budget-tracker is unretired
  - None are stock-analyser stale missed by #267

## Scope

One line deleted. No other files changed.

## Test plan

- [ ] CI passes on this branch (stock-analyser build uses `NEXT_PUBLIC_RUNTIME_PROFILE: mock` which is sufficient)
- [ ] No other `NEXT_PUBLIC_USE_MOCK_DATA` injections in ci.yml

🤖 Generated with [Claude Code](https://claude.com/claude-code)