### PR TITLE
fix(ci): verify-deploy step checks /stock-signal basePath URL

### DIFF
--- a/.github/workflows/deploy-stock-analyser.yml
+++ b/.github/workflows/deploy-stock-analyser.yml
@@ -98,7 +98,7 @@ jobs:
       - name: Verify deployment
         run: |
           bash scripts/ci/verify-deploy.sh \
-            "${{ vars.NEXT_PUBLIC_APP_URL }}" \
+            "${{ vars.NEXT_PUBLIC_APP_URL }}/stock-signal" \
             apps/stock-analyser/.env.example \
             "${{ github.sha }}"
 
@@ -170,6 +170,6 @@ jobs:
       - name: Verify deployment
         run: |
           bash scripts/ci/verify-deploy.sh \
-            "${{ vars.NEXT_PUBLIC_APP_URL }}" \
+            "${{ vars.NEXT_PUBLIC_APP_URL }}/stock-signal" \
             apps/stock-analyser/.env.example \
             "${{ github.sha }}"


### PR DESCRIPTION
## What

Appends `/stock-signal` to the URL passed to `verify-deploy.sh` in `deploy-stock-analyser.yml` (dev and prod jobs, lines 101 and 172).

## Why

The verify step was fetching the base domain (launchpad's HTML) instead of `/stock-signal/` (stock-analyser's HTML). It accidentally passed on coordinated deploys because every app's bundle carries the same `github.sha`. It fails on isolated deploys.

Diagnosis surfaced this when stock-analyser was redeployed via `workflow_dispatch` after the PR #264 IAM fix unblocked the `cloudfront:GetInvalidation` step.

## Bug lifetime

The bug has existed since the `/stock-signal/` basePath was introduced (commit cb8aef3). Masked by coordinated-deploy false positives until now.

## Related

Issue #252 will harden `verify-deploy.sh` with an app-identity marker check, making this class of bug impossible to mask.

Closes #273