### PR TITLE
fix(ci): narrow deploy workflow path filters to per-app deps (#239 Shape A)

### DIFF
--- a/.github/workflows/deploy-budget-tracker.yml
+++ b/.github/workflows/deploy-budget-tracker.yml
@@ -6,7 +6,12 @@ on:
     paths:
       - 'apps/budget-tracker/**'
       - 'infrastructure/lib/budget-tracker/**'
-      - 'packages/**'
+      - 'packages/api-client/**'
+      - 'packages/ui/**'
+      - 'packages/auth-client/**'
+      - 'packages/runtime-config/**'
+      - 'packages/lambda-middleware/**'
+      - 'packages/budget-domain/**'
   workflow_dispatch:
     inputs:
       target:

--- a/.github/workflows/deploy-launchpad.yml
+++ b/.github/workflows/deploy-launchpad.yml
@@ -5,7 +5,8 @@ on:
     branches: [develop, main]
     paths:
       - 'apps/launchpad/**'
-      - 'packages/**'
+      - 'packages/auth-client/**'
+      - 'packages/runtime-config/**'
   workflow_dispatch:
     inputs:
       target:

--- a/.github/workflows/deploy-stock-analyser.yml
+++ b/.github/workflows/deploy-stock-analyser.yml
@@ -6,8 +6,11 @@ on:
     paths:
       - 'apps/stock-analyser/**'
       - 'infrastructure/lib/stock-analyser/**'
-      - 'packages/**'
-      - 'functions/**'
+      - 'packages/api-client/**'
+      - 'packages/ui/**'
+      - 'packages/auth-client/**'
+      - 'packages/runtime-config/**'
+      - 'packages/lambda-middleware/**'
   workflow_dispatch:
     inputs:
       target:


### PR DESCRIPTION
## Summary

Replaces the broad `packages/**` catch-all (and `functions/**` in stock-analyser) in all three deploy workflow `on.push.paths` filters with explicit per-app workspace dependency paths.

**Before:** Any change to any package (or any platform function in stock-analyser's case) triggered all three deploy workflows simultaneously.

**After:** Each workflow only triggers on changes to packages that app actually depends on.

Per-app dep mapping (derived from each app's `package.json`):
- **launchpad**: `auth-client`, `runtime-config`
- **stock-analyser**: `api-client`, `ui`, `auth-client`, `runtime-config`, `lambda-middleware`
- **budget-tracker**: `api-client`, `ui`, `auth-client`, `runtime-config`, `lambda-middleware`, `budget-domain`

`functions/**` removed from stock-analyser — stock-analyser has no dependency on platform functions.

Closes #239 (Shape A — workflow path filter narrowing)

Shape B (CI guard against future drift) tracked in #265.

## Test plan

- [ ] CI passes (typecheck, lint, build, infra-synth)
- [ ] Diff confirms only `on.push.paths` blocks changed — no other workflow content modified
- [ ] Verified `on.push.branches` unchanged in all three files
- [ ] `budget-domain` present in budget-tracker paths (used by both frontend and Lambda functions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)