### PR TITLE
chore(budget-tracker): remove dead USE_MOCK_DATA config field

### DIFF
--- a/apps/budget-tracker/CLAUDE.md
+++ b/apps/budget-tracker/CLAUDE.md
@@ -189,7 +189,7 @@ pnpm --filter @transformotion/budget-tracker dev
 # Runs on http://localhost:3002
 ```
 
-Environment: copy `apps/budget-tracker/.env.example` to `.env.local` and fill in values. Set `NEXT_PUBLIC_USE_MOCK_DATA=true` to use stub adaptors without real AWS.
+Environment: copy `apps/budget-tracker/.env.example` to `.env.local` and fill in values.
 
 ## Environment variables (relevant subset)
 
@@ -200,7 +200,6 @@ Environment: copy `apps/budget-tracker/.env.example` to `.env.local` and fill in
 | `NEXT_PUBLIC_COGNITO_USER_POOL_ID` | Shared Cognito user pool ID |
 | `NEXT_PUBLIC_COGNITO_DOMAIN` | Hosted UI domain |
 | `NEXT_PUBLIC_RUNTIME_PROFILE` | `mock` (default; local development) or `live` (deployed environments). Determines defaults for auth, data, AI, and future concerns. See root `CLAUDE.md` for the design map. |
-| `NEXT_PUBLIC_USE_MOCK_DATA` | `true` = stub adaptors, `false` = real AWS |
 | `NEXT_PUBLIC_API_BASE_URL` | Budget Tracker API base URL |
 
 **Cognito client variable rebind:** The GitHub Actions variable `NEXT_PUBLIC_BUDGET_TRACKER_COGNITO_CLIENT_ID` is mapped to the generic runtime env var `NEXT_PUBLIC_COGNITO_CLIENT_ID` in the deploy workflow's env block. This allows each app to have its own Cognito App Client (established in sub-phase 7b.5-alpha) while the runtime code (`@transformotion/auth-client`) reads a single generic name. Local development reads `NEXT_PUBLIC_COGNITO_CLIENT_ID` directly from `.env.local`.

--- a/apps/budget-tracker/lib/config/index.ts
+++ b/apps/budget-tracker/lib/config/index.ts
@@ -50,8 +50,6 @@ export interface ClaudeConfig {
 }
 
 export interface FeaturesConfig {
-  /** Use mock data instead of real API calls */
-  useMockData: boolean
   /** Enable debug logging */
   debugMode: boolean
 }
@@ -126,7 +124,6 @@ export function loadConfig(): AppConfig {
       maxPollTime: parseInt(process.env.NEXT_PUBLIC_CLAUDE_MAX_POLL_TIME || '500000', 10),
     },
     features: {
-      useMockData: process.env.NEXT_PUBLIC_USE_MOCK_DATA !== 'false', // Default to true for dev
       debugMode: process.env.NEXT_PUBLIC_DEBUG_MODE === 'true',
     },
     apps: {

--- a/docs/architecture/inventory.md
+++ b/docs/architecture/inventory.md
@@ -1050,9 +1050,6 @@ Launchpad deploy syncs to S3 root (excluding `stock-signal/*` and `budget-tracke
 Approximately 22 environment variables are exposed to the client side
 (`NEXT_PUBLIC_*`). Notable:
 
-- `NEXT_PUBLIC_USE_MOCK_DATA` — defaults to mock-mode in code,
-  reclassified as `[REQUIRED]` in PR #23. Long-term default-flip to
-  production values is in PLAN.md Section 19 (Backlog).
 - `NEXT_PUBLIC_RUNTIME_PROFILE` — profile + override pattern (M6 #189).
   Set to `mock` (default; local dev) or `live` (deployed). Per-concern
   overrides allow targeted swaps: `NEXT_PUBLIC_AUTH_OVERRIDE` (wired


### PR DESCRIPTION
## What

Removes dead `useMockData` config field and stale doc references from budget-tracker.

## Why

Per V1c recon (during PR #270's pre-flight check), budget-tracker is already on the canonical runtime-config pattern. The `useMockData` field is populated from the env var but never read. This PR removes the dead field and the references to it.

Not a migration. Pure cleanup.

## Changes

- `apps/budget-tracker/lib/config/index.ts` — remove `useMockData: boolean` from `FeaturesConfig` type; remove `NEXT_PUBLIC_USE_MOCK_DATA` population line from `loadConfig()`
- `apps/budget-tracker/CLAUDE.md` — remove stale `NEXT_PUBLIC_USE_MOCK_DATA=true` local dev instruction (line 192) and env-var table row (line 203); matches stock-analyser CLAUDE.md pattern
- `docs/architecture/inventory.md` — remove stale `NEXT_PUBLIC_USE_MOCK_DATA` bullet point

## Manual follow-up

Post-merge: delete the dev-environment GH Actions variable `NEXT_PUBLIC_USE_MOCK_DATA=false`. Will be done in this session after merge.

Closes #268