### PR TITLE
docs: align CONTRIBUTING §5.3 and PLAN backlog with retired flag

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -692,7 +692,7 @@ The decision of which implementation gets wired in is made at the environment la
 
 **Client-side selection: build-time config.** The build mode (`MODE` in Vite, equivalent in Next.js) determines which implementation is bundled. Production builds include only the production implementation; v0 builds include only the mock implementation. The unused implementation is tree-shaken out — production bundles do not carry mock code.
 
-The build-time config is typically driven by an environment variable like `NEXT_PUBLIC_USE_MOCK_DATA`, set per build environment. The variable is consumed at the module level where the implementation is wired into the domain interface.
+The build-time config is typically driven by an environment variable like `NEXT_PUBLIC_RUNTIME_PROFILE`, set per build environment. The variable is consumed at the module level where the implementation is wired into the domain interface. See §5.8 for the canonical pattern documentation.
 
 **Server-side selection: deployment-time config via CDK.** Lambdas receive their physical-store choice via environment variables defined in their CDK stack definition. A Lambda using `CacheService` reads (for example) `CACHE_BACKEND=dynamodb` at startup and wires the corresponding implementation.
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -1276,9 +1276,9 @@ out of the Backlog milestone.
   in a dead error state with no redirect to sign-in. Raised in
   Issue #18's comments and deferred to Phase 4 UX work.
 
-- **NEXT_PUBLIC_USE_MOCK_DATA default-flip.** Long-term flip of code
-  defaults to production values. Issue #18 short-term fix
-  reclassified as `[REQUIRED]`; this is the long-term fix.
+- **NEXT_PUBLIC_RUNTIME_PROFILE default-flip.** Long-term flip of code
+  defaults to production values (`live` profile). Issue #18 short-term
+  fix reclassified as `[REQUIRED]`; this is the long-term fix.
 
 - **Recommendations sector filter bug.** Issue #33 — the Stock Signal
   Recommendations tab computes a sector-filtered list but renders the


### PR DESCRIPTION
## What

Round-2 doc drift cleanup. Two normative-doc references missed by PR #267 are updated to reference the canonical `NEXT_PUBLIC_RUNTIME_PROFILE` pattern.

## Files

- **CONTRIBUTING.md §5.3** (line 695): variable name updated from `NEXT_PUBLIC_USE_MOCK_DATA` → `NEXT_PUBLIC_RUNTIME_PROFILE`; cross-reference to §5.8 added (§5.8 already referenced §5.3 — this completes the bidirectional link)
- **PLAN.md backlog entry** (line 1279): variable name updated; `(live profile)` added to clarify what "production values" means under the new pattern

## No deploy triggered

Both files are at the repo root, outside all `on.push.paths` filters. Per the deploy-watch rule, session ends at merge confirmation.

## Closes the cleanup trail

Trail: #192 (retire flag) → #266 (round-1 doc cleanup) → #279 (round-2 doc cleanup). After this PR, no normative document teaches the retired pattern.

Closes #279