### PR TITLE
feat(ci): verify deployed app identity via data-app marker

### DIFF
--- a/.github/workflows/deploy-budget-tracker.yml
+++ b/.github/workflows/deploy-budget-tracker.yml
@@ -118,7 +118,8 @@ jobs:
           bash scripts/ci/verify-deploy.sh \
             "${{ vars.NEXT_PUBLIC_BUDGET_TRACKER_APP_URL }}" \
             apps/budget-tracker/.env.example \
-            "${{ github.sha }}"
+            "${{ github.sha }}" \
+            "budget-tracker"
 
   deploy-prod:
     name: Budget Tracker → Prod
@@ -204,4 +205,5 @@ jobs:
           bash scripts/ci/verify-deploy.sh \
             "${{ vars.NEXT_PUBLIC_BUDGET_TRACKER_APP_URL }}" \
             apps/budget-tracker/.env.example \
-            "${{ github.sha }}"
+            "${{ github.sha }}" \
+            "budget-tracker"

--- a/.github/workflows/deploy-launchpad.yml
+++ b/.github/workflows/deploy-launchpad.yml
@@ -92,7 +92,8 @@ jobs:
           bash scripts/ci/verify-deploy.sh \
             "https://dev.apps.transformotion.com.au/" \
             apps/launchpad/.env.example \
-            "${{ github.sha }}"
+            "${{ github.sha }}" \
+            "launchpad"
 
   deploy-prod:
     name: Launchpad → Prod
@@ -157,4 +158,5 @@ jobs:
           bash scripts/ci/verify-deploy.sh \
             "https://apps.transformotion.com.au/" \
             apps/launchpad/.env.example \
-            "${{ github.sha }}"
+            "${{ github.sha }}" \
+            "launchpad"

--- a/.github/workflows/deploy-stock-analyser.yml
+++ b/.github/workflows/deploy-stock-analyser.yml
@@ -103,7 +103,8 @@ jobs:
           bash scripts/ci/verify-deploy.sh \
             "${{ vars.NEXT_PUBLIC_APP_URL }}/stock-signal" \
             apps/stock-analyser/.env.example \
-            "${{ github.sha }}"
+            "${{ github.sha }}" \
+            "stock-analyser"
 
   deploy-prod:
     name: Stock Analyser → Prod
@@ -175,4 +176,5 @@ jobs:
           bash scripts/ci/verify-deploy.sh \
             "${{ vars.NEXT_PUBLIC_APP_URL }}/stock-signal" \
             apps/stock-analyser/.env.example \
-            "${{ github.sha }}"
+            "${{ github.sha }}" \
+            "stock-analyser"

--- a/apps/budget-tracker/app/layout.tsx
+++ b/apps/budget-tracker/app/layout.tsx
@@ -1,6 +1,6 @@
 import type { Metadata, Viewport } from 'next'
 import { Inter, Geist_Mono } from 'next/font/google'
-import { BUILD_COMMIT_HASH } from '@/lib/build-info'
+import { BUILD_COMMIT_HASH, APP_IDENTITY } from '@/lib/build-info'
 import './globals.css'
 
 const inter = Inter({
@@ -37,7 +37,7 @@ export default function RootLayout({
   children,
 }: Readonly<{ children: React.ReactNode }>) {
   return (
-    <html lang="en" data-commit={BUILD_COMMIT_HASH} className={`${inter.variable} ${geistMono.variable} bg-background`}>
+    <html lang="en" data-commit={BUILD_COMMIT_HASH} data-app={APP_IDENTITY} className={`${inter.variable} ${geistMono.variable} bg-background`}>
       <body className="font-sans antialiased min-h-screen bg-background text-foreground">
         {children}
       </body>

--- a/apps/budget-tracker/lib/build-info.ts
+++ b/apps/budget-tracker/lib/build-info.ts
@@ -1,1 +1,2 @@
 export const BUILD_COMMIT_HASH = process.env.NEXT_PUBLIC_COMMIT_HASH ?? 'dev';
+export const APP_IDENTITY = 'budget-tracker';

--- a/apps/launchpad/app/layout.tsx
+++ b/apps/launchpad/app/layout.tsx
@@ -1,7 +1,7 @@
 import type { Metadata, Viewport } from 'next'
 import { Inter, Geist_Mono, Bebas_Neue } from 'next/font/google'
 import { Analytics } from '@vercel/analytics/next'
-import { BUILD_COMMIT_HASH } from '@/lib/build-info'
+import { BUILD_COMMIT_HASH, APP_IDENTITY } from '@/lib/build-info'
 import './globals.css'
 
 const inter = Inter({
@@ -40,6 +40,7 @@ export default function RootLayout({
     <html
       lang="en"
       data-commit={BUILD_COMMIT_HASH}
+      data-app={APP_IDENTITY}
       className={`${inter.variable} ${geistMono.variable} ${bebasNeue.variable} bg-background`}
     >
       <body className="font-sans antialiased min-h-screen bg-background text-foreground">

--- a/apps/launchpad/lib/build-info.ts
+++ b/apps/launchpad/lib/build-info.ts
@@ -1,1 +1,2 @@
 export const BUILD_COMMIT_HASH = process.env.NEXT_PUBLIC_COMMIT_HASH ?? 'dev';
+export const APP_IDENTITY = 'launchpad';

--- a/apps/stock-analyser/app/layout.tsx
+++ b/apps/stock-analyser/app/layout.tsx
@@ -2,7 +2,7 @@ import type { Metadata, Viewport } from 'next'
 import { Inter, Geist_Mono, Bebas_Neue } from 'next/font/google'
 import { Analytics } from '@vercel/analytics/next'
 import { AmplifyProvider } from '@/components/providers/amplify-provider'
-import { BUILD_COMMIT_HASH } from '@/lib/build-info'
+import { BUILD_COMMIT_HASH, APP_IDENTITY } from '@/lib/build-info'
 import './globals.css'
 
 const inter = Inter({ 
@@ -57,7 +57,7 @@ export default function RootLayout({
   children: React.ReactNode
 }>) {
   return (
-    <html lang="en" data-commit={BUILD_COMMIT_HASH} className={`${inter.variable} ${geistMono.variable} ${bebasNeue.variable} bg-background`}>
+    <html lang="en" data-commit={BUILD_COMMIT_HASH} data-app={APP_IDENTITY} className={`${inter.variable} ${geistMono.variable} ${bebasNeue.variable} bg-background`}>
       <body className="font-sans antialiased min-h-screen bg-background text-foreground">
         <AmplifyProvider>
           {children}

--- a/apps/stock-analyser/lib/build-info.ts
+++ b/apps/stock-analyser/lib/build-info.ts
@@ -1,1 +1,2 @@
 export const BUILD_COMMIT_HASH = process.env.NEXT_PUBLIC_COMMIT_HASH ?? 'dev';
+export const APP_IDENTITY = 'stock-analyser';

--- a/scripts/ci/verify-deploy.sh
+++ b/scripts/ci/verify-deploy.sh
@@ -7,9 +7,13 @@
 # deployed URL is reachable.
 #
 # Usage:
-#   scripts/ci/verify-deploy.sh <deployed-url> <path-to-.env.example> <expected-commit-hash>
+#   scripts/ci/verify-deploy.sh <deployed-url> <path-to-.env.example> <expected-commit-hash> [<app-identity>]
 #
-# The [REQUIRED] var substitution check (check 3) reads each var's value
+# The optional 4th argument is the expected app identity string (e.g. "launchpad",
+# "stock-analyser", "budget-tracker"). When provided, the script checks that the
+# deployed HTML's <html> element contains a matching data-app attribute.
+#
+# The [REQUIRED] var substitution check (check 4) reads each var's value
 # from the current shell environment. In CI the job-level env block
 # provides all NEXT_PUBLIC_* vars automatically. Locally, export them
 # before running this script.
@@ -21,6 +25,7 @@ set -euo pipefail
 DEPLOYED_URL="${1:?first arg must be deployed URL (e.g. https://dev.apps.transformotion.com.au)}"
 ENV_EXAMPLE="${2:?second arg must be path to .env.example}"
 EXPECTED_HASH="${3:?third arg must be expected commit hash}"
+EXPECTED_APP="${4:-}"
 
 # Strip trailing slash from URL if present.
 DEPLOYED_URL="${DEPLOYED_URL%/}"
@@ -35,7 +40,7 @@ echo "Expected commit hash: $EXPECTED_HASH"
 echo
 
 # ── Check 1: root document returns 200 ────────────────────────────────────────
-echo "[1/3] Probing root document..."
+echo "[1/4] Probing root document..."
 root_code=$(curl -s -o /dev/null -w "%{http_code}" "$DEPLOYED_URL/")
 if [[ "$root_code" != "200" ]]; then
   echo "FAIL: root document returned HTTP $root_code (expected 200)" >&2
@@ -68,8 +73,36 @@ done <<< "$chunk_paths"
 echo "[info] All $chunk_count chunks reachable"
 echo
 
-# ── Check 2: commit hash present in the deployed artefact ─────────────────────
-echo "[2/3] Checking commit hash presence..."
+# ── Check 2: app identity marker present in root HTML ─────────────────────────
+echo "[2/4] Checking app identity marker..."
+if [[ -n "$EXPECTED_APP" ]]; then
+  if (set +o pipefail; echo "$root_html" | grep -qF "data-app=\"$EXPECTED_APP\""); then
+    echo "      OK: data-app=\"$EXPECTED_APP\" found in root HTML"
+  else
+    cat >&2 <<EOF
+
+FAIL: app identity marker data-app="$EXPECTED_APP" NOT found in root HTML.
+
+This means the deployed HTML came from a different app, or the marker
+was not injected during the build. URL fetched: $DEPLOYED_URL/
+
+Possible causes:
+  - The verify-deploy.sh URL arg points at the wrong app's endpoint
+  - The APP_IDENTITY constant in lib/build-info.ts does not match
+    the expected value "$EXPECTED_APP"
+  - The data-app attribute was not added to the <html> element in
+    app/layout.tsx
+
+EOF
+    exit 1
+  fi
+else
+  echo "      SKIP: no expected app identity provided (4th arg empty)"
+fi
+echo
+
+# ── Check 3: commit hash present in the deployed artefact ─────────────────────
+echo "[3/4] Checking commit hash presence..."
 # Run in a subshell with pipefail disabled: when grep -q finds a match early it
 # exits 0 and closes the pipe, causing echo/printf to receive SIGPIPE (exit 141).
 # With pipefail the pipeline would return 141 even on a successful match.
@@ -94,8 +127,8 @@ EOF
 fi
 echo
 
-# ── Check 3: every [REQUIRED] NEXT_PUBLIC_* var was substituted ───────────────
-echo "[3/3] Checking [REQUIRED] var substitution in bundle..."
+# ── Check 4: every [REQUIRED] NEXT_PUBLIC_* var was substituted ───────────────
+echo "[4/4] Checking [REQUIRED] var substitution in bundle..."
 
 required_vars=()
 current_tag=""


### PR DESCRIPTION
## What

Adds an app-identity marker check to verify-deploy.sh that asserts the deployed HTML at a given URL came from the expected app, not some other app that happens to be reachable at the URL.

## Why

PR #274 demonstrated that the existing commit-hash check can pass on a wrong-URL fetch when coordinated multi-app deploys mean every bundle carries the same `github.sha`. The app-identity check breaks that false-positive class.

## Mechanism

Parallel to the existing data-commit pattern:
- `APP_IDENTITY` hardcoded constant exported from each app's `lib/build-info.ts`
- Set as `data-app` attribute on the `<html>` element in `app/layout.tsx`
- Expected value passed as 4th argument to verify-deploy.sh from each deploy workflow's `Verify deployment` step
- verify-deploy.sh grep-checks root HTML for `data-app="<expected>"`

Check sequence renumbered: [1/4] HTTP 200, [2/4] App identity, [3/4] Commit hash, [4/4] Required env vars.

## Identity strings

Codebase-aligned, not URL-aligned:
- launchpad → `"launchpad"`
- stock-analyser → `"stock-analyser"` (NOT `"stock-signal"`; identity follows source directory, URL prefix is separate future work)
- budget-tracker → `"budget-tracker"`

## Closes only the O15 half of #252

Issue stays open after merge. O17 (repository-operations authenticated smoke check) is the remaining half and will be addressed in a separate session.

## First parallel-deploy test of deploy-watch rule

This PR touches all three apps. On merge, deploy-launchpad, deploy-stock-analyser, and deploy-budget-tracker all trigger simultaneously.

Closes O15 of #252 (issue remains open for O17)