### PR TITLE
docs: correct cdk.md gateway description for budget-tracker

### DIFF
--- a/docs/architecture/cdk.md
+++ b/docs/architecture/cdk.md
@@ -52,9 +52,7 @@ Deployed by `deploy-budget-tracker.yml`. Source in `infrastructure/lib/budget-tr
 | Stack name | Class | Contents |
 |---|---|---|
 | `Transformotion{Stage}-BudgetTrackerTables` | `BudgetTrackerTablesStack` | `budget-tracker.accounts`, `budget-tracker.transactions`, `budget-tracker.rules`, `budget-tracker.settings` |
-| `Transformotion{Stage}-BudgetTrackerApi` | `BudgetTrackerApiStack` | Budget Tracker Lambda functions + its own API Gateway (`budget-tracker-api-{stage}`) |
-
-> **Note:** Budget Tracker has its own API Gateway rather than sharing the platform gateway. This is an architectural divergence from the intended model. It is functional and not blocking; consolidation to the platform gateway is tracked as sub-phase 7f (optional).
+| `Transformotion{Stage}-BudgetTrackerApi` | `BudgetTrackerApiStack` | Budget Tracker Lambda functions + routes on the shared platform API Gateway |
 
 ---
 
@@ -116,7 +114,9 @@ Stacks receive constructs via `props` in `bin/app.ts`. Cross-stack references ge
 | `PlatformApiStack` | `AuthStack` | `userPool` (construct) |
 | `PlatformApiStack` | `StockAnalyserTablesStack` | `analysisCacheTable` (construct) |
 | `StockAnalyserApiStack` | `PlatformApiStack` | `api` and `authoriser` (constructs) |
-| `BudgetTrackerApiStack` | `AuthStack` | `userPool` (construct — for its own authoriser) |
+| `BudgetTrackerApiStack` | `PlatformApiStack` | `api`, `authoriser`, `apiResource` (constructs — mounts onto the shared platform gateway) |
+| `BudgetTrackerApiStack` | `BudgetTrackerTablesStack` | `budgetDataTableName`, `aiJobsTableName` (strings) |
+| `BudgetTrackerApiStack` | `BudgetTrackerWsStack` | `wsConnectionsTableName`, `wsApiId` (strings) |
 
 ---
 


### PR DESCRIPTION
## Summary

Corrects three stale items in `docs/architecture/cdk.md` that described budget-tracker as having its own API Gateway. The gateway consolidation landed in M5 via PR #171 (issue #150) — `BudgetTrackerApiStack` has mounted on the shared platform gateway at `/api/budget/v1` since then.

**Items corrected:**
- Stack inventory row: `BudgetTrackerApiStack` description updated from "its own API Gateway (`budget-tracker-api-{stage}`)" to "routes on the shared platform API Gateway"
- Stale note block removed: the "architectural divergence" + sub-phase 7f consolidation-tracking note was describing a completed migration as future work
- Cross-stack dependency table: replaces stale `BudgetTrackerApiStack → AuthStack (userPool)` row with the three correct rows: `PlatformApiStack` (api/authoriser/apiResource), `BudgetTrackerTablesStack` (budgetDataTableName/aiJobsTableName), `BudgetTrackerWsStack` (wsConnectionsTableName/wsApiId)

Phrasing aligns with the correction note already present in `apps/budget-tracker/CLAUDE.md`.

This is a §2.1 discipline rule miss from PR #171 — `cdk.md` is on the normative document list (CONTRIBUTING.md §2.3 line 149) and should have been updated when the gateway consolidation merged.

Surfaced by #252 Phase 2 (O17) recon.

Closes #282

## Deploy impact

No deploy triggered — `docs/architecture/cdk.md` is outside all `on.push.paths` filters.