### PR TITLE
feat(ci): authenticated smoke check via Cognito admin auth flow

### DIFF
--- a/.github/workflows/deploy-budget-tracker.yml
+++ b/.github/workflows/deploy-budget-tracker.yml
@@ -114,12 +114,19 @@ jobs:
             --id "$INVALIDATION_ID"
 
       - name: Verify deployment
+        env:
+          CI_COGNITO_USERNAME: ${{ secrets.CI_COGNITO_USERNAME }}
+          CI_COGNITO_PASSWORD: ${{ secrets.CI_COGNITO_PASSWORD }}
+          COGNITO_USER_POOL_ID: ${{ vars.NEXT_PUBLIC_COGNITO_USER_POOL_ID }}
+          COGNITO_APP_CLIENT_ID: ${{ vars.NEXT_PUBLIC_BUDGET_TRACKER_COGNITO_CLIENT_ID }}
+          API_BASE_URL: ${{ vars.NEXT_PUBLIC_API_URL }}
         run: |
           bash scripts/ci/verify-deploy.sh \
             "${{ vars.NEXT_PUBLIC_BUDGET_TRACKER_APP_URL }}" \
             apps/budget-tracker/.env.example \
             "${{ github.sha }}" \
-            "budget-tracker"
+            "budget-tracker" \
+            "/api/user/profile"
 
   deploy-prod:
     name: Budget Tracker → Prod
@@ -201,9 +208,16 @@ jobs:
             --id "$INVALIDATION_ID"
 
       - name: Verify deployment
+        env:
+          CI_COGNITO_USERNAME: ${{ secrets.CI_COGNITO_USERNAME }}
+          CI_COGNITO_PASSWORD: ${{ secrets.CI_COGNITO_PASSWORD }}
+          COGNITO_USER_POOL_ID: ${{ vars.NEXT_PUBLIC_COGNITO_USER_POOL_ID }}
+          COGNITO_APP_CLIENT_ID: ${{ vars.NEXT_PUBLIC_BUDGET_TRACKER_COGNITO_CLIENT_ID }}
+          API_BASE_URL: ${{ vars.NEXT_PUBLIC_API_URL }}
         run: |
           bash scripts/ci/verify-deploy.sh \
             "${{ vars.NEXT_PUBLIC_BUDGET_TRACKER_APP_URL }}" \
             apps/budget-tracker/.env.example \
             "${{ github.sha }}" \
-            "budget-tracker"
+            "budget-tracker" \
+            "/api/user/profile"

--- a/.github/workflows/deploy-stock-analyser.yml
+++ b/.github/workflows/deploy-stock-analyser.yml
@@ -99,12 +99,19 @@ jobs:
             --id "$INVALIDATION_ID"
 
       - name: Verify deployment
+        env:
+          CI_COGNITO_USERNAME: ${{ secrets.CI_COGNITO_USERNAME }}
+          CI_COGNITO_PASSWORD: ${{ secrets.CI_COGNITO_PASSWORD }}
+          COGNITO_USER_POOL_ID: ${{ vars.NEXT_PUBLIC_COGNITO_USER_POOL_ID }}
+          COGNITO_APP_CLIENT_ID: ${{ vars.NEXT_PUBLIC_STOCK_ANALYSER_COGNITO_CLIENT_ID }}
+          API_BASE_URL: ${{ vars.NEXT_PUBLIC_API_URL }}
         run: |
           bash scripts/ci/verify-deploy.sh \
             "${{ vars.NEXT_PUBLIC_APP_URL }}/stock-signal" \
             apps/stock-analyser/.env.example \
             "${{ github.sha }}" \
-            "stock-analyser"
+            "stock-analyser" \
+            "/api/user/profile"
 
   deploy-prod:
     name: Stock Analyser → Prod
@@ -172,9 +179,16 @@ jobs:
             --id "$INVALIDATION_ID"
 
       - name: Verify deployment
+        env:
+          CI_COGNITO_USERNAME: ${{ secrets.CI_COGNITO_USERNAME }}
+          CI_COGNITO_PASSWORD: ${{ secrets.CI_COGNITO_PASSWORD }}
+          COGNITO_USER_POOL_ID: ${{ vars.NEXT_PUBLIC_COGNITO_USER_POOL_ID }}
+          COGNITO_APP_CLIENT_ID: ${{ vars.NEXT_PUBLIC_STOCK_ANALYSER_COGNITO_CLIENT_ID }}
+          API_BASE_URL: ${{ vars.NEXT_PUBLIC_API_URL }}
         run: |
           bash scripts/ci/verify-deploy.sh \
             "${{ vars.NEXT_PUBLIC_APP_URL }}/stock-signal" \
             apps/stock-analyser/.env.example \
             "${{ github.sha }}" \
-            "stock-analyser"
+            "stock-analyser" \
+            "/api/user/profile"

--- a/infrastructure/lib/platform/auth-stack.ts
+++ b/infrastructure/lib/platform/auth-stack.ts
@@ -361,7 +361,8 @@ export class AuthStack extends cdk.Stack {
         logoutUrls:   options.logoutUrls,
       },
       supportedIdentityProviders: options.supportedIdentityProviders,
-      authFlows:            { userSrp: true },
+      // Required for #252 O17 CI smoke check; only callable via IAM (cognito-idp:AdminInitiateAuth on deploy role).
+      authFlows:            { userSrp: true, adminUserPassword: true },
       accessTokenValidity:  cdk.Duration.hours(1),
       idTokenValidity:      cdk.Duration.hours(1),
       refreshTokenValidity: cdk.Duration.days(30),

--- a/infrastructure/lib/platform/github-actions-role-stack.ts
+++ b/infrastructure/lib/platform/github-actions-role-stack.ts
@@ -37,6 +37,18 @@ export class GithubActionsRoleStack extends cdk.Stack {
             Action:   'cloudformation:DescribeStacks',
             Resource: `arn:aws:cloudformation:${this.region}:${this.account}:stack/Transformotion*`,
           },
+          {
+            // Required for #252 O17 CI smoke check (admin-initiate-auth, ADMIN_USER_PASSWORD_AUTH flow).
+            // Pool ARNs are hardcoded because GithubActionsRole deploys before AuthStack in
+            // deploy-platform.yml, so Fn::ImportValue on AuthStack exports is unavailable at
+            // first deploy. TODO(#263): migrate to cross-stack reference once deploy ordering allows.
+            Effect:   'Allow',
+            Action:   'cognito-idp:AdminInitiateAuth',
+            Resource: [
+              `arn:aws:cognito-idp:${this.region}:${this.account}:userpool/ap-southeast-2_7QhxUvefw`,
+              `arn:aws:cognito-idp:${this.region}:${this.account}:userpool/ap-southeast-2_8hHCARUWq`,
+            ],
+          },
         ],
       },
     });

--- a/scripts/ci/verify-deploy.sh
+++ b/scripts/ci/verify-deploy.sh
@@ -3,20 +3,32 @@
 #
 # Post-deploy verification: confirms the deployed frontend artefact
 # matches the commit that triggered the deploy, that every [REQUIRED]
-# NEXT_PUBLIC_* variable was substituted at build time, and that the
-# deployed URL is reachable.
+# NEXT_PUBLIC_* variable was substituted at build time, that the
+# deployed URL is reachable, and (optionally) that an authenticated
+# API call returns 2xx.
 #
 # Usage:
-#   scripts/ci/verify-deploy.sh <deployed-url> <path-to-.env.example> <expected-commit-hash> [<app-identity>]
+#   scripts/ci/verify-deploy.sh <deployed-url> <path-to-.env.example> <expected-commit-hash> [<app-identity>] [<smoke-endpoint>]
 #
 # The optional 4th argument is the expected app identity string (e.g. "launchpad",
 # "stock-analyser", "budget-tracker"). When provided, the script checks that the
 # deployed HTML's <html> element contains a matching data-app attribute.
 #
-# The [REQUIRED] var substitution check (check 4) reads each var's value
-# from the current shell environment. In CI the job-level env block
-# provides all NEXT_PUBLIC_* vars automatically. Locally, export them
-# before running this script.
+# The optional 5th argument is the smoke-check API endpoint path (e.g.
+# "/api/user/profile"). When provided, the script performs an additional
+# authenticated call [5/5] to confirm the backend is reachable post-deploy.
+# When omitted (e.g. launchpad, which has no backend), [5/5] is skipped.
+#
+# Required environment variables for the smoke check (only when 5th arg is set):
+#   CI_COGNITO_USERNAME   — CI test user username (from GitHub Secrets)
+#   CI_COGNITO_PASSWORD   — CI test user password (from GitHub Secrets)
+#   COGNITO_USER_POOL_ID  — Cognito user pool ID
+#   COGNITO_APP_CLIENT_ID — Cognito app client ID for this app
+#   API_BASE_URL          — Platform API Gateway base URL (no trailing slash)
+#
+# The [REQUIRED] var substitution check reads each var's value from the current
+# shell environment. In CI the job-level env block provides all NEXT_PUBLIC_* vars
+# automatically. Locally, export them before running this script.
 #
 # Exits 0 if all checks pass; 1 with a detailed report otherwise.
 
@@ -26,6 +38,14 @@ DEPLOYED_URL="${1:?first arg must be deployed URL (e.g. https://dev.apps.transfo
 ENV_EXAMPLE="${2:?second arg must be path to .env.example}"
 EXPECTED_HASH="${3:?third arg must be expected commit hash}"
 EXPECTED_APP="${4:-}"
+SMOKE_ENDPOINT="${5:-}"
+
+# Total checks depends on whether a smoke endpoint was provided.
+if [[ -n "$SMOKE_ENDPOINT" ]]; then
+  TOTAL_CHECKS=5
+else
+  TOTAL_CHECKS=4
+fi
 
 # Strip trailing slash from URL if present.
 DEPLOYED_URL="${DEPLOYED_URL%/}"
@@ -40,7 +60,7 @@ echo "Expected commit hash: $EXPECTED_HASH"
 echo
 
 # ── Check 1: root document returns 200 ────────────────────────────────────────
-echo "[1/4] Probing root document..."
+echo "[1/${TOTAL_CHECKS}] Probing root document..."
 root_code=$(curl -s -o /dev/null -w "%{http_code}" "$DEPLOYED_URL/")
 if [[ "$root_code" != "200" ]]; then
   echo "FAIL: root document returned HTTP $root_code (expected 200)" >&2
@@ -74,7 +94,7 @@ echo "[info] All $chunk_count chunks reachable"
 echo
 
 # ── Check 2: app identity marker present in root HTML ─────────────────────────
-echo "[2/4] Checking app identity marker..."
+echo "[2/${TOTAL_CHECKS}] Checking app identity marker..."
 if [[ -n "$EXPECTED_APP" ]]; then
   if (set +o pipefail; echo "$root_html" | grep -qF "data-app=\"$EXPECTED_APP\""); then
     echo "      OK: data-app=\"$EXPECTED_APP\" found in root HTML"
@@ -102,7 +122,7 @@ fi
 echo
 
 # ── Check 3: commit hash present in the deployed artefact ─────────────────────
-echo "[3/4] Checking commit hash presence..."
+echo "[3/${TOTAL_CHECKS}] Checking commit hash presence..."
 # Run in a subshell with pipefail disabled: when grep -q finds a match early it
 # exits 0 and closes the pipe, causing echo/printf to receive SIGPIPE (exit 141).
 # With pipefail the pipeline would return 141 even on a successful match.
@@ -128,7 +148,7 @@ fi
 echo
 
 # ── Check 4: every [REQUIRED] NEXT_PUBLIC_* var was substituted ───────────────
-echo "[4/4] Checking [REQUIRED] var substitution in bundle..."
+echo "[4/${TOTAL_CHECKS}] Checking [REQUIRED] var substitution in bundle..."
 
 required_vars=()
 current_tag=""
@@ -155,7 +175,7 @@ done < "$ENV_EXAMPLE"
 echo "      Checking ${#required_vars[@]} [REQUIRED] NEXT_PUBLIC_* vars in initial-load chunks"
 echo "      NOTE: only checks the $chunk_count chunks referenced from the index page."
 echo "            API client vars in lazy-loaded route chunks may not appear here —"
-echo "            that does NOT indicate substitution failure. Check 2 (commit hash)"
+echo "            that does NOT indicate substitution failure. Check 3 (commit hash)"
 echo "            is the definitive proof that the correct bundle was deployed."
 echo
 
@@ -197,6 +217,69 @@ if [[ ${#not_in_initial[@]} -gt 0 ]]; then
 fi
 echo
 
+# ── Check 5: authenticated API smoke check ────────────────────────────────────
+if [[ -n "$SMOKE_ENDPOINT" ]]; then
+  echo "[5/5] Smoke check — authenticated API call to ${API_BASE_URL}${SMOKE_ENDPOINT}..."
+
+  : "${CI_COGNITO_USERNAME:?CI_COGNITO_USERNAME must be set for the smoke check}"
+  : "${CI_COGNITO_PASSWORD:?CI_COGNITO_PASSWORD must be set for the smoke check}"
+  : "${COGNITO_USER_POOL_ID:?COGNITO_USER_POOL_ID must be set for the smoke check}"
+  : "${COGNITO_APP_CLIENT_ID:?COGNITO_APP_CLIENT_ID must be set for the smoke check}"
+  : "${API_BASE_URL:?API_BASE_URL must be set for the smoke check}"
+
+  echo "      Acquiring Cognito token (ADMIN_USER_PASSWORD_AUTH)..."
+  auth_response=$(aws cognito-idp admin-initiate-auth \
+    --auth-flow ADMIN_USER_PASSWORD_AUTH \
+    --client-id "$COGNITO_APP_CLIENT_ID" \
+    --user-pool-id "$COGNITO_USER_POOL_ID" \
+    --auth-parameters "USERNAME=${CI_COGNITO_USERNAME},PASSWORD=${CI_COGNITO_PASSWORD}" \
+    --output json 2>&1)
+
+  if ! echo "$auth_response" | grep -q '"IdToken"'; then
+    cat >&2 <<EOF
+
+FAIL: Cognito token acquisition failed.
+
+Response: $auth_response
+
+Possible causes:
+  - CI_COGNITO_USERNAME / CI_COGNITO_PASSWORD secrets are not set or incorrect
+  - Test user does not exist in pool $COGNITO_USER_POOL_ID
+  - ADMIN_USER_PASSWORD_AUTH flow not enabled on app client $COGNITO_APP_CLIENT_ID
+  - cognito-idp:AdminInitiateAuth not granted to the deploy role
+
+EOF
+    exit 1
+  fi
+
+  id_token=$(echo "$auth_response" | grep -o '"IdToken": *"[^"]*"' | sed 's/"IdToken": *"//' | tr -d '"')
+  echo "      Token acquired."
+
+  echo "      Calling ${API_BASE_URL}${SMOKE_ENDPOINT}..."
+  smoke_code=$(curl -s -o /dev/null -w "%{http_code}" \
+    -H "Authorization: Bearer ${id_token}" \
+    "${API_BASE_URL}${SMOKE_ENDPOINT}")
+
+  if [[ "${smoke_code:0:1}" != "2" ]]; then
+    cat >&2 <<EOF
+
+FAIL: smoke check returned HTTP $smoke_code (expected 2xx).
+
+Endpoint: ${API_BASE_URL}${SMOKE_ENDPOINT}
+
+Possible causes:
+  - Test user (${CI_COGNITO_USERNAME}) is not in the required Cognito groups
+  - API Gateway is not deployed / route does not exist
+  - Lambda function failed to start (check CloudWatch logs)
+  - API_BASE_URL is incorrect
+
+EOF
+    exit 1
+  fi
+  echo "      OK: smoke check returned HTTP $smoke_code"
+  echo
+fi
+
 # ── Summary ───────────────────────────────────────────────────────────────────
 echo "=============================================="
 echo "DEPLOY VERIFICATION PASSED"
@@ -204,4 +287,7 @@ echo "  URL:     $DEPLOYED_URL"
 echo "  Commit:  $EXPECTED_HASH"
 echo "  Chunks:  $chunk_count"
 echo "  REQUIRED vars confirmed in initial chunks: ${#confirmed_vars[@]}/${#required_vars[@]}"
+if [[ -n "$SMOKE_ENDPOINT" ]]; then
+  echo "  Smoke:   ${API_BASE_URL}${SMOKE_ENDPOINT} → HTTP $smoke_code"
+fi
 echo "=============================================="


### PR DESCRIPTION
## What changes

- **auth-stack.ts**: adds `adminUserPassword: true` to `authFlows` in `createAppClient()`, enabling `ADMIN_USER_PASSWORD_AUTH` on all three app clients. This flow requires IAM (`cognito-idp:AdminInitiateAuth`) to invoke — it is not accessible from browsers.
- **github-actions-role-stack.ts**: adds `cognito-idp:AdminInitiateAuth` to the `TransformotionDevDeploy` inline policy, scoped to the dev and prod user pool ARNs. ARNs are hardcoded because `GithubActionsRole` deploys before `AuthStack` in `deploy-platform.yml`, making `Fn::ImportValue` unavailable on first deploy. TODO(#263): migrate to cross-stack reference once deploy ordering allows.
- **verify-deploy.sh**: accepts an optional 5th positional arg `SMOKE_ENDPOINT`. When set, adds a `[5/5]` check: acquires a Cognito token via `ADMIN_USER_PASSWORD_AUTH` then calls `GET $API_BASE_URL$SMOKE_ENDPOINT`, asserting 2xx. Check numbering scales to `/5` when the arg is provided, stays `/4` when omitted (launchpad). Required env vars (`CI_COGNITO_USERNAME`, `CI_COGNITO_PASSWORD`, `COGNITO_USER_POOL_ID`, `COGNITO_APP_CLIENT_ID`, `API_BASE_URL`) documented in the script header.
- **deploy-stock-analyser.yml** (dev + prod Verify steps): passes `"/api/user/profile"` as 5th arg; adds step-level `env:` block mapping smoke check credentials and config from secrets/vars.
- **deploy-budget-tracker.yml** (dev + prod Verify steps): same shape.
- **deploy-launchpad.yml**: unchanged — no 5th arg means `[5/5]` is skipped; launchpad has no backend API.

## Why

Closes O17 of #252. O15 (app-identity marker) landed in PR #281. This PR completes the issue.

Smoke endpoint `GET /api/user/profile` was chosen because it uses `withAuthOnly` middleware (JWT only, no `X-Account-Id` required), making it the simplest authenticated endpoint that exercises the full API Gateway → Cognito JWT authoriser → Lambda path.

Shape A+ (ADMIN_USER_PASSWORD_AUTH via IAM) was selected over stored refresh tokens (30-day rotation burden) and Lambda direct invoke (bypasses API Gateway). See #252 O17 recon in PR conversation for the full shape comparison.

## Security posture

`adminUserPassword: true` enables the admin auth flow on app clients, but the flow can only be triggered by an IAM principal with `cognito-idp:AdminInitiateAuth`. Browser/SPA callers cannot use it. The CI deploy role is the only IAM principal with this permission, scoped to the two pool ARNs.

## Post-merge sequence (required before smoke check is live)

This PR is safe to merge before the test user exists — if `CI_COGNITO_USERNAME`/`CI_COGNITO_PASSWORD` secrets are unset, the smoke check step will fail with a clear error. Bootstrap must happen after CDK deploys, before the next triggered verify run.

1. **Watch `deploy-platform.yml`** — auto-triggered by CDK changes in this PR. Confirm both `Transformotion-GithubActionsRole` and `TransformotionDev-Auth` deploy successfully.
2. **Bootstrap CI test user** — create `ci-smoke-test` in Cognito, add to `stock-app-access` and `budget-app-access` groups, store credentials as `CI_COGNITO_USERNAME` / `CI_COGNITO_PASSWORD` GitHub Secrets.
3. **Validate** — manually trigger `deploy-stock-analyser.yml` and `deploy-budget-tracker.yml` and confirm `[5/5] Smoke check` passes in both.

Closes #252