### PR TITLE
docs: add stores/ to canonical per-app structure (#305)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -221,6 +221,7 @@ apps/<app>/
 ├── app/                   # Next.js routing
 ├── components/            # App-specific React components
 ├── lib/                   # App-specific TypeScript modules
+├── stores/                # App-specific Zustand stores (auth, domain state)
 ├── functions/             # App-specific Lambda handlers
 ├── infrastructure/        # App-specific CDK stacks
 ├── contracts/             # Forbidden — see Section 2.3 (contracts root only)


### PR DESCRIPTION
Adds `stores/` to the canonical per-app directory structure in CONTRIBUTING.md §3.2.

## Decision

Architecture decision ratified in #305: `stores/` is a canonical per-app concern at app root, sitting alongside `components/`, `lib/`, and `functions/`. Zustand stores are architecturally distinct from business logic modules and warrant their own top-level entry in the canonical structure.

Framing (a) was ratified in the issue — no file relocation needed in any app. All three apps already have `stores/` at app root; this PR documents the canonical location.

## Changes

- `CONTRIBUTING.md §3.2`: one line added to the per-app structure tree

No code changes. No deploys triggered (CONTRIBUTING.md outside all path filters).

Closes #305