### PR TITLE
docs: list runtime-config + correct auth-client (#304)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -268,8 +268,10 @@ separate packages rather than accumulating into omnibus packages.
 ```
 packages/
 ├── api-client/            # Typed HTTP client for the platform API gateway
+├── auth-client/           # Cognito and mock auth service implementations
 ├── budget-domain/         # Budget Tracker domain types and pure helpers
 ├── lambda-middleware/     # Shared withAuth/withAuthOnly wrappers and helpers
+├── runtime-config/        # Runtime profile + provider resolution helpers
 ├── cdk-constructs/        # Shared CDK constructs (the shared construct library)
 ├── ui/                    # UI packages, organised by concern (see below)
 └── <other-concern>/

--- a/MONOREPO.md
+++ b/MONOREPO.md
@@ -39,9 +39,10 @@ transformotion-apps/
 │
 ├── packages/                              # Shared code consumed by 2+ apps
 │   ├── api-client/                        # Typed HTTP client (@transformotion/api-client)
-│   ├── auth-client/                       # Auth type definitions (stub — single file)
+│   ├── auth-client/                       # Cognito + mock auth service implementations (@transformotion/auth-client)
 │   ├── budget-domain/                     # Budget Tracker domain types and helpers
 │   ├── lambda-middleware/                 # Shared withAuth/withAuthOnly wrappers
+│   ├── runtime-config/                    # Runtime profile + provider resolution (@transformotion/runtime-config)
 │   └── ui/                                # Shared UI components (stub — minimal)
 │
 ├── infrastructure/                        # AWS CDK
@@ -276,8 +277,7 @@ organisational, not itself a package.
   `platform.` prefix it is functionally stock-analyser data; M2.1
   ratifies the reclassification as a Stage 0b decision.
 
-- **Stub packages.** `packages/auth-client/` and `packages/ui/` are
-  minimal stubs. Their disposition (build out, retire as orphans, or
-  leave as type-only contracts) is unresolved; consider before importing
-  anything substantive from them. `packages/cycle-engine/` was deleted
-  in this PR — its implementation migrated to `apps/stock-analyser/lib/cycle/`.
+- **Stub packages.** `packages/ui/` is a minimal stub. Its disposition
+  (build out or retire as orphan) is unresolved; consider before importing
+  anything substantive from it. `packages/cycle-engine/` was deleted —
+  its implementation migrated to `apps/stock-analyser/lib/cycle/`.

--- a/docs/architecture/inventory.md
+++ b/docs/architecture/inventory.md
@@ -47,9 +47,9 @@ The repository contains the following top-level directories:
 
 - `apps/` — four subdirectories: `budget-tracker/`, `launchpad/`,
   `stock-analyser/`, `web/` (0-LOC shell, M3 cleanup)
-- `packages/` — five subdirectories: `api-client/`, `auth-client/` (stub),
-  `budget-domain/`, `lambda-middleware/`, `ui/` (stub). `cycle-engine/`
-  was removed in this PR — see Section 1.5.
+- `packages/` — six subdirectories: `api-client/`, `auth-client/`,
+  `budget-domain/`, `lambda-middleware/`, `runtime-config/`, `ui/` (stub).
+  `cycle-engine/` was removed — see Section 1.5.
 - `infrastructure/` — CDK app with `bin/app.ts` entrypoint and
   `lib/{platform,stock-analyser,budget-tracker}/` per-scope subdirs
 - `platform/functions/` — platform Lambda source: `accounts/`, `auth/` (with
@@ -128,11 +128,20 @@ frontend, persistence, contracts, and build pipeline.
 
 **Status: Confirmed (updated by M7 cycle-data PR)**
 
-Two packages remain in `packages/` as stubs:
+One package remains in `packages/` as a stub:
 
-- `packages/auth-client/` — single `src/index.ts`, type definitions
-  only, no dependencies beyond TypeScript
-- `packages/ui/` — minimal stub
+- `packages/ui/` — minimal stub (single `@transformotion/ui` package;
+  §3.4-compliant split into sub-packages tracked in M7 #298)
+
+Two packages were previously described as stubs but are fully
+implemented:
+
+- `packages/auth-client/` — full `CognitoAuthService` +
+  `createMockAuthService` implementations; `aws-amplify ^6` dependency;
+  4 source files. Not a stub. Description corrected by M7 / PR #304.
+- `packages/runtime-config/` — `selectProvider()`, `resolveProfile()`,
+  `normaliseCrossAppUrl()`, `RuntimeProfile` exports. Previously absent
+  from this section; added by M7 / PR #304.
 
 `packages/cycle-engine/` was deleted in this PR. Its RSI/MACD/cycle
 scoring implementation was app-specific (Stock Analyser only), so it


### PR DESCRIPTION
Corrects stale descriptions in three normative documents. All changes are documentation-only.

## Problems fixed

- `packages/auth-client/` was described as "stub — single file, type definitions only, no dependencies." In reality it contains a full `CognitoAuthService` + `createMockAuthService` implementation with `aws-amplify ^6` dependency (4 source files).
- `packages/runtime-config/` was absent from CONTRIBUTING.md §3.4, MONOREPO.md, and `inventory.md §1.5` despite being a live package used by both apps.

## Changes

- `CONTRIBUTING.md §3.4` — add `auth-client/` and `runtime-config/` to packages tree
- `MONOREPO.md` — correct `auth-client/` description; add `runtime-config/`; remove `auth-client/` from stub warning (only `ui/` is still a stub)
- `docs/architecture/inventory.md §1.5` — update packages count (5→6); correct `auth-client/` description; add `runtime-config/`; clarify only `ui/` remains a stub

No code changes. No deploys triggered.

Closes #304