### PR TITLE
docs: document BT WebSocket AI infrastructure (#302)

### DIFF
--- a/MONOREPO.md
+++ b/MONOREPO.md
@@ -60,7 +60,8 @@ transformotion-apps/
 │       │   └── stock-analyser-tables-stack.ts
 │       └── budget-tracker/                # Budget Tracker-specific stacks
 │           ├── budget-tracker-api-stack.ts
-│           └── budget-tracker-tables-stack.ts
+│           ├── budget-tracker-tables-stack.ts
+│           └── budget-tracker-ws-stack.ts
 │
 ├── platform/                              # Platform-owned deployable artefacts
 │   └── functions/                         # Platform Lambda source (shared across apps)

--- a/apps/budget-tracker/CLAUDE.md
+++ b/apps/budget-tracker/CLAUDE.md
@@ -37,6 +37,7 @@ React + TypeScript + Tailwind CSS + shadcn/ui.
 |---|---|
 | `Transformotion{Stage}-BudgetTrackerTables` | `budget-tracker.accounts`, `budget-tracker.transactions`, `budget-tracker.rules`, `budget-tracker.settings` |
 | `Transformotion{Stage}-BudgetTrackerApi` | All Budget Tracker Lambda functions, mounted on the shared platform API Gateway |
+| `Transformotion{Stage}-BudgetTrackerWs` | WebSocket API Gateway `budget-tracker-ai-ws-{stage}`, custom Lambda authoriser (Cognito ID token via `?token=`), 4 WS Lambdas, `budget-tracker.ai-connections-{stage}` table |
 
 Source: `infrastructure/lib/budget-tracker/`
 
@@ -54,6 +55,17 @@ Source: `infrastructure/lib/budget-tracker/`
 | `budget-ai-csv-analysis-handler-{stage}` | `POST /api/budget/v1/ai/csv-analysis` |
 | `budget-export-handler-{stage}` | `GET /api/budget/v1/business-export` |
 
+## WebSocket Lambda functions
+
+API Gateway v2 WebSocket (`budget-tracker-ai-ws-{stage}`). Uses a custom Lambda authoriser on `$connect`; does not use the platform Cognito JWT authoriser.
+
+| Lambda | Route / trigger |
+|---|---|
+| `budget-ai-ws-authorizer-{stage}` | Custom authoriser for `$connect`; validates Cognito ID token from `?token=` query string |
+| `budget-ai-ws-connect-{stage}` | `$connect` — writes `{ connectionId, userId, accountId, expiresAt }` to `budget-tracker.ai-connections-{stage}` |
+| `budget-ai-ws-disconnect-{stage}` | `$disconnect` — deletes connection record |
+| `budget-ai-ws-default-{stage}` | `$default` — receives client messages; has `execute-api:ManageConnections` IAM grant |
+
 ## DynamoDB tables
 
 | Table | PK | SK | Purpose |
@@ -62,6 +74,7 @@ Source: `infrastructure/lib/budget-tracker/`
 | `budget-tracker.transactions-{stage}` | `accountId` | `transactionId` | Transactions; GSI: `accountId-dateIso-index` |
 | `budget-tracker.rules-{stage}` | `accountId` | `ruleId` | Custom categorisation rules |
 | `budget-tracker.settings-{stage}` | `accountId` | `settingKey` | Per-account settings (key-value) |
+| `budget-tracker.ai-connections-{stage}` | `connectionId` | — | Active WS connections; GSI: `userId-index`; TTL: `expiresAt` |
 
 ## Authorization requirement
 

--- a/docs/architecture/cdk.md
+++ b/docs/architecture/cdk.md
@@ -53,6 +53,7 @@ Deployed by `deploy-budget-tracker.yml`. Source in `infrastructure/lib/budget-tr
 |---|---|---|
 | `Transformotion{Stage}-BudgetTrackerTables` | `BudgetTrackerTablesStack` | `budget-tracker.accounts`, `budget-tracker.transactions`, `budget-tracker.rules`, `budget-tracker.settings` |
 | `Transformotion{Stage}-BudgetTrackerApi` | `BudgetTrackerApiStack` | Budget Tracker Lambda functions + routes on the shared platform API Gateway |
+| `Transformotion{Stage}-BudgetTrackerWs` | `BudgetTrackerWsStack` | WebSocket API Gateway `budget-tracker-ai-ws-{stage}`, 4 WS Lambdas, `budget-tracker.ai-connections-{stage}` table |
 
 ---
 
@@ -102,6 +103,17 @@ Deployed by `deploy-budget-tracker.yml`. Source in `infrastructure/lib/budget-tr
 | `budget-export-handler-{stage}` | Budget Tracker export Lambda | `GET /api/budget/v1/business-export` |
 | `budget-migrate-handler-{stage}` | Budget Tracker migrate Lambda | `POST /api/budget/v1/migrate-from-localstorage` |
 
+### Budget Tracker WS Lambda functions (`Transformotion{Stage}-BudgetTrackerWs`)
+
+API Gateway v2 WebSocket — does not use `CognitoUserPoolsAuthorizer`; uses a custom Lambda authoriser instead.
+
+| Function name | Handler | Route / trigger |
+|---|---|---|
+| `budget-ai-ws-authorizer-{stage}` | `apps/budget-tracker/functions/ai-ws-authorizer` | Custom Lambda authoriser for `$connect`; validates Cognito ID token from `?token=` query string; identity source: `route.request.querystring.token` |
+| `budget-ai-ws-connect-{stage}` | `apps/budget-tracker/functions/ai-ws-connect` | `$connect` route — writes `{ connectionId, userId, accountId, expiresAt }` to `budget-tracker.ai-connections-{stage}` |
+| `budget-ai-ws-disconnect-{stage}` | `apps/budget-tracker/functions/ai-ws-disconnect` | `$disconnect` route — deletes connection record |
+| `budget-ai-ws-default-{stage}` | `apps/budget-tracker/functions/ai-ws-default` | `$default` route — receives client messages; has `execute-api:ManageConnections` IAM grant |
+
 ---
 
 ## Cross-stack dependencies
@@ -116,6 +128,7 @@ Stacks receive constructs via `props` in `bin/app.ts`. Cross-stack references ge
 | `StockAnalyserApiStack` | `PlatformApiStack` | `api` and `authoriser` (constructs) |
 | `BudgetTrackerApiStack` | `PlatformApiStack` | `api`, `authoriser`, `apiResource` (constructs — mounts onto the shared platform gateway) |
 | `BudgetTrackerApiStack` | `BudgetTrackerTablesStack` | `budgetDataTableName`, `aiJobsTableName` (strings) |
+| `BudgetTrackerWsStack` | `AuthStack` | `userPool` (construct — for custom authoriser JWKS validation) |
 | `BudgetTrackerApiStack` | `BudgetTrackerWsStack` | `wsConnectionsTableName`, `wsApiId` (strings) |
 
 ---
@@ -161,6 +174,13 @@ Platform Lambda environment variables:
 | `ANTHROPIC_SECRET_NAME` | claude-proxy | `{stage}/anthropic/api-key` (Secrets Manager) |
 | `USER_POOL_ID` | account-provisioning, pre-token-generation | Cognito user pool ID |
 | `ACCOUNTS_TABLE` | pre-token-generation | `platform.accounts-{stage}` (read for appSlug resolution) |
+
+Budget Tracker WS Lambda environment variables:
+
+| Variable | Lambda | Value |
+|---|---|---|
+| `COGNITO_USER_POOL_ID` | `budget-ai-ws-authorizer-{stage}` | Cognito user pool ID (for JWKS verification) |
+| `CONNECTIONS_TABLE` | `budget-ai-ws-connect-{stage}`, `budget-ai-ws-disconnect-{stage}` | `budget-tracker.ai-connections-{stage}` |
 
 ---
 

--- a/docs/architecture/inventory.md
+++ b/docs/architecture/inventory.md
@@ -512,6 +512,9 @@ during v4 inventory production.
 | `budget-tracker.transactions-{stage}` | accountId | transactionId |
 | `budget-tracker.rules-{stage}` | accountId | ruleId |
 | `budget-tracker.settings-{stage}` | accountId | settingKey |
+| `budget-tracker.ai-connections-{stage}` | connectionId | — |
+
+`budget-tracker.ai-connections-{stage}` is owned by `BudgetTrackerWsStack` (not `BudgetTrackerTablesStack`). PK: `connectionId` (STRING); GSI: `userId-index` (PK: `userId`); TTL attribute: `expiresAt`. Added by M7 / PR #302.
 
 Categories, subcategories, and budget amounts are stored as a single
 `budgetData` value in the settings table (key: `budgetData`), with
@@ -1030,6 +1033,13 @@ CDK stacks under `infrastructure/lib/`:
 - `budget-tracker-api-stack.ts` — defines the BudgetTrackerApi gateway
   (the workaround per Section 2.9; M5 retires)
 - `budget-tracker-tables-stack.ts`
+- `budget-tracker-ws-stack.ts` — `BudgetTrackerWsStack`; WebSocket API
+  Gateway v2 (`budget-tracker-ai-ws-{stage}`), custom Lambda authoriser
+  (Cognito ID token via `?token=` query string), 4 WS Lambdas
+  (`budget-ai-ws-authorizer`, `budget-ai-ws-connect`,
+  `budget-ai-ws-disconnect`, `budget-ai-ws-default`),
+  `budget-tracker.ai-connections-{stage}` DynamoDB table. Added by
+  M7 / PR #302.
 
 There is no `MonitoringStack` despite `infrastructure/lib/README.md`
 declaring one. M13 creates it.


### PR DESCRIPTION
## Summary

§2.1 discipline rule correction — `BudgetTrackerWsStack` was deployed without same-PR normative document updates.

Documents the existing BT WebSocket AI infrastructure across four normative files:

- **`docs/architecture/cdk.md`** — added `Transformotion{Stage}-BudgetTrackerWs` stack row to Budget Tracker stacks table; added "Budget Tracker WS Lambda functions" section with 4 Lambda entries; added `BudgetTrackerWsStack → AuthStack` cross-stack dep row; added WS Lambda env vars (`COGNITO_USER_POOL_ID`, `CONNECTIONS_TABLE`)
- **`docs/architecture/inventory.md`** — added `budget-tracker.ai-connections-{stage}` to §2.10.3 BT tables; added `budget-tracker-ws-stack.ts` entry to §5.6 CDK stack topology
- **`MONOREPO.md`** — added `budget-tracker-ws-stack.ts` to BT stack listing in directory tree
- **`apps/budget-tracker/CLAUDE.md`** — added `BudgetTrackerWs` row to CDK stacks table; added "WebSocket Lambda functions" section; added `budget-tracker.ai-connections-{stage}` to DynamoDB tables

No code changes. No deploy triggered (documentation-only).

Closes #302.

## Test plan

- [ ] All four changed files render correctly in GitHub
- [ ] cdk.md WSS Lambda table matches `infrastructure/lib/budget-tracker/budget-tracker-ws-stack.ts` source
- [ ] No deploy workflow triggered (changed paths are docs only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)