### PR TITLE
Add config sub-types + createConfig factory to runtime-config (#293)

### DIFF
--- a/MONOREPO.md
+++ b/MONOREPO.md
@@ -45,7 +45,7 @@ transformotion-apps/
 │   ├── data-access/                       # Shared Repository<T,ID> interface + query types (@transformotion/data-access)
 │   ├── logger/                            # Shared Logger interface + ConsoleLogger (@transformotion/logger)
 │   ├── lambda-middleware/                 # Shared withAuth/withAuthOnly wrappers
-│   ├── runtime-config/                    # Runtime profile + provider resolution (@transformotion/runtime-config)
+│   ├── runtime-config/                    # Runtime profile + provider resolution + shared config sub-types + createConfig factory (@transformotion/runtime-config)
 │   └── ui/                                # Organisational directory (not itself a package; §3.4)
 │       ├── error-boundaries/              # @transformotion/ui-error-boundaries
 │       └── primitives/                    # @transformotion/ui-primitives (56 shadcn components + hooks)

--- a/apps/budget-tracker/app/page.tsx
+++ b/apps/budget-tracker/app/page.tsx
@@ -8,7 +8,7 @@ export default function Page() {
   const { signOut } = useAuthStore()
 
   const handleGoToLaunchpad = () => {
-    window.location.assign(getConfig().apps.launchpadUrl)
+    window.location.assign(getConfig().apps.peers['launchpad'])
   }
 
   const handleSignOut = async () => {

--- a/apps/budget-tracker/lib/config/index.ts
+++ b/apps/budget-tracker/lib/config/index.ts
@@ -6,61 +6,24 @@
  * Client-safe keys use NEXT_PUBLIC_ prefix.
  */
 
-import { selectProvider, normaliseCrossAppUrl } from '@transformotion/runtime-config'
+import {
+  selectProvider,
+  normaliseCrossAppUrl,
+  createConfig,
+  type APIConfig,
+  type AuthConfig,
+  type StorageConfig,
+  type LoggingConfig,
+  type ClaudeConfig,
+  type FeaturesConfig,
+  type AppsConfig,
+} from '@transformotion/runtime-config'
 
-export interface APIConfig {
-  baseURL: string
-  timeout: number
-}
-
-export interface AuthConfig {
-  provider: 'mock' | 'cognito'
-  cognitoUserPoolId?: string
-  cognitoClientId?: string
-  cognitoRegion?: string
-}
-
+// AIConfig stays per-app: BT has wssUrl which SA lacks (resolved by #295)
 export interface AIConfig {
   provider: 'mock' | 'claude'
   model: string
   wssUrl: string
-}
-
-export interface StorageConfig {
-  provider: 'local' | 'dynamo'
-  dynamoTablePrefix?: string
-  region?: string
-}
-
-export interface LoggingConfig {
-  provider: 'console' | 'cloudwatch'
-  level: 'debug' | 'info' | 'warn' | 'error'
-  cloudwatchLogGroup?: string
-}
-
-export interface ClaudeConfig {
-  /** Base URL for Claude API proxy (AWS API Gateway) */
-  apiUrl: string
-  /** Base URL for polling job status (analysis-cache Lambda) */
-  cacheUrl: string
-  /** Polling interval in ms */
-  pollInterval: number
-  /** Max polling duration in ms */
-  maxPollTime: number
-}
-
-export interface FeaturesConfig {
-  /** Enable debug logging */
-  debugMode: boolean
-}
-
-export interface AppsConfig {
-  /** URL for the Launchpad app (cross-app navigation requires full page load) */
-  launchpadUrl: string
-  /** URL for the Launchpad sign-in page; unauthenticated users are redirected here */
-  signInUrl: string
-  /** URL for the signed-out landing page after sign-out */
-  signOutUrl: string
 }
 
 export interface AppConfig {
@@ -74,11 +37,17 @@ export interface AppConfig {
   apps: AppsConfig
 }
 
-/**
- * Load configuration from environment variables.
- * Called once at app startup.
- */
-export function loadConfig(): AppConfig {
+export type {
+  APIConfig,
+  AuthConfig,
+  StorageConfig,
+  LoggingConfig,
+  ClaudeConfig,
+  FeaturesConfig,
+  AppsConfig,
+}
+
+function loadConfig(): AppConfig {
   return {
     api: {
       baseURL: process.env.NEXT_PUBLIC_API_URL || '',
@@ -127,24 +96,13 @@ export function loadConfig(): AppConfig {
       debugMode: process.env.NEXT_PUBLIC_DEBUG_MODE === 'true',
     },
     apps: {
-      launchpadUrl: normaliseCrossAppUrl(process.env.NEXT_PUBLIC_LAUNCHPAD_URL, '/'),
       signInUrl: normaliseCrossAppUrl(process.env.NEXT_PUBLIC_SIGNIN_URL, '/sign-in/'),
       signOutUrl: normaliseCrossAppUrl(process.env.NEXT_PUBLIC_SIGNOUT_URL, '/signed-out/'),
+      peers: {
+        'launchpad': normaliseCrossAppUrl(process.env.NEXT_PUBLIC_LAUNCHPAD_URL, '/'),
+      },
     },
   }
 }
 
-// Singleton config instance
-let _config: AppConfig | null = null
-
-export function getConfig(): AppConfig {
-  if (!_config) {
-    _config = loadConfig()
-  }
-  return _config
-}
-
-// Reset config (useful for testing)
-export function resetConfig(): void {
-  _config = null
-}
+export const { getConfig, resetConfig } = createConfig(loadConfig)

--- a/apps/stock-analyser/lib/config/index.ts
+++ b/apps/stock-analyser/lib/config/index.ts
@@ -6,60 +6,23 @@
  * Client-safe keys use NEXT_PUBLIC_ prefix.
  */
 
-import { selectProvider, normaliseCrossAppUrl } from '@transformotion/runtime-config'
+import {
+  selectProvider,
+  normaliseCrossAppUrl,
+  createConfig,
+  type APIConfig,
+  type AuthConfig,
+  type StorageConfig,
+  type LoggingConfig,
+  type ClaudeConfig,
+  type FeaturesConfig,
+  type AppsConfig,
+} from '@transformotion/runtime-config'
 
-export interface APIConfig {
-  baseURL: string
-  timeout: number
-}
-
-export interface AuthConfig {
-  provider: 'mock' | 'cognito'
-  cognitoUserPoolId?: string
-  cognitoClientId?: string
-  cognitoRegion?: string
-}
-
+// AIConfig stays per-app until #295 resolves the wssUrl drift between SA and BT
 export interface AIConfig {
   provider: 'mock' | 'claude'
   model: string
-}
-
-export interface StorageConfig {
-  provider: 'local' | 'dynamo'
-  dynamoTablePrefix?: string
-  region?: string
-}
-
-export interface LoggingConfig {
-  provider: 'console' | 'cloudwatch'
-  level: 'debug' | 'info' | 'warn' | 'error'
-  cloudwatchLogGroup?: string
-}
-
-export interface ClaudeConfig {
-  /** Base URL for Claude API proxy (AWS API Gateway) */
-  apiUrl: string
-  /** Base URL for polling job status (analysis-cache Lambda) */
-  cacheUrl: string
-  /** Polling interval in ms */
-  pollInterval: number
-  /** Max polling duration in ms */
-  maxPollTime: number
-}
-
-export interface FeaturesConfig {
-  /** Enable debug logging */
-  debugMode: boolean
-}
-
-export interface AppsConfig {
-  /** URL for the Budget Tracker app (cross-app navigation requires full page load) */
-  budgetTrackerUrl: string
-  /** URL for the Launchpad sign-in page; unauthenticated users are redirected here */
-  signInUrl: string
-  /** URL for the signed-out landing page; used by mock-profile signOut handler */
-  signOutUrl: string
 }
 
 export interface AppConfig {
@@ -73,11 +36,17 @@ export interface AppConfig {
   apps: AppsConfig
 }
 
-/**
- * Load configuration from environment variables.
- * Called once at app startup.
- */
-export function loadConfig(): AppConfig {
+export type {
+  APIConfig,
+  AuthConfig,
+  StorageConfig,
+  LoggingConfig,
+  ClaudeConfig,
+  FeaturesConfig,
+  AppsConfig,
+}
+
+function loadConfig(): AppConfig {
   return {
     api: {
       baseURL: process.env.NEXT_PUBLIC_API_URL || '',
@@ -125,24 +94,13 @@ export function loadConfig(): AppConfig {
       debugMode: process.env.NEXT_PUBLIC_DEBUG_MODE === 'true',
     },
     apps: {
-      budgetTrackerUrl: normaliseCrossAppUrl(process.env.NEXT_PUBLIC_BUDGET_URL, '/budget-tracker/'),
       signInUrl: normaliseCrossAppUrl(process.env.NEXT_PUBLIC_SIGNIN_URL, '/sign-in/'),
       signOutUrl: normaliseCrossAppUrl(process.env.NEXT_PUBLIC_SIGNOUT_URL, '/signed-out/'),
+      peers: {
+        'budget-tracker': normaliseCrossAppUrl(process.env.NEXT_PUBLIC_BUDGET_URL, '/budget-tracker/'),
+      },
     },
   }
 }
 
-// Singleton config instance
-let _config: AppConfig | null = null
-
-export function getConfig(): AppConfig {
-  if (!_config) {
-    _config = loadConfig()
-  }
-  return _config
-}
-
-// Reset config (useful for testing)
-export function resetConfig(): void {
-  _config = null
-}
+export const { getConfig, resetConfig } = createConfig(loadConfig)

--- a/docs/architecture/inventory.md
+++ b/docs/architecture/inventory.md
@@ -178,7 +178,12 @@ implemented:
   4 source files. Not a stub. Description corrected by M7 / PR #304.
 - `packages/runtime-config/` — `selectProvider()`, `resolveProfile()`,
   `normaliseCrossAppUrl()`, `RuntimeProfile` exports. Previously absent
-  from this section; added by M7 / PR #304.
+  from this section; added by M7 / PR #304. Extended by M7 / PR #293
+  to export 7 shared config sub-types (`APIConfig`, `AuthConfig`,
+  `StorageConfig`, `LoggingConfig`, `ClaudeConfig`, `FeaturesConfig`,
+  `AppsConfig`) and `createConfig<T>()` factory. Both apps' `lib/config/index.ts`
+  now import sub-types and factory from the package; `AppsConfig.peers`
+  replaces the per-app `budgetTrackerUrl`/`launchpadUrl` fields.
 
 `packages/cycle-engine/` was deleted in this PR. Its RSI/MACD/cycle
 scoring implementation was app-specific (Stock Analyser only), so it

--- a/packages/runtime-config/src/index.ts
+++ b/packages/runtime-config/src/index.ts
@@ -20,6 +20,73 @@
 
 export type RuntimeProfile = 'mock' | 'live'
 
+// ── Shared config sub-types ───────────────────────────────────────────────────
+
+export interface APIConfig {
+  baseURL: string
+  timeout: number
+}
+
+export interface AuthConfig {
+  provider: 'mock' | 'cognito'
+  cognitoUserPoolId?: string
+  cognitoClientId?: string
+  cognitoRegion?: string
+}
+
+export interface StorageConfig {
+  provider: 'local' | 'dynamo'
+  dynamoTablePrefix?: string
+  region?: string
+}
+
+export interface LoggingConfig {
+  provider: 'console' | 'cloudwatch'
+  level: 'debug' | 'info' | 'warn' | 'error'
+  cloudwatchLogGroup?: string
+}
+
+export interface ClaudeConfig {
+  apiUrl: string
+  cacheUrl: string
+  pollInterval: number
+  maxPollTime: number
+}
+
+export interface FeaturesConfig {
+  debugMode: boolean
+}
+
+/** Unified cross-app URL config. Use `peers[appSlug]` for peer app URLs. */
+export interface AppsConfig {
+  signInUrl: string
+  signOutUrl: string
+  peers: Record<string, string>
+}
+
+// ── Config factory ────────────────────────────────────────────────────────────
+
+/**
+ * Creates a lazy singleton config accessor.
+ * Each call to createConfig() produces an independent cache slot.
+ * resetConfig() clears the cached instance (test isolation).
+ */
+export function createConfig<T>(factory: () => T): {
+  getConfig: () => T
+  resetConfig: () => void
+} {
+  let _config: T | null = null
+  return {
+    getConfig() {
+      if (_config === null) _config = factory()
+      return _config
+    },
+    resetConfig() {
+      _config = null
+    },
+  }
+}
+
 /**
  * Resolves the active runtime profile from the environment.
  * Defaults to 'mock' if NEXT_PUBLIC_RUNTIME_PROFILE is unset or invalid —


### PR DESCRIPTION
## Summary

Extends `@transformotion/runtime-config` with shared config sub-types and a `createConfig<T>()` factory, eliminating duplicated interface declarations and module-level singleton boilerplate in both apps.

**Package additions (`packages/runtime-config/src/index.ts`):**
- 7 shared interfaces: `APIConfig`, `AuthConfig`, `StorageConfig`, `LoggingConfig`, `ClaudeConfig`, `FeaturesConfig`, `AppsConfig`
- `createConfig<T>(factory)` — lazy singleton via closure; `resetConfig()` for test isolation

**Both apps' `lib/config/index.ts` rewritten to:**
- Import shared sub-types + `createConfig` from `@transformotion/runtime-config`
- Keep `AIConfig` per-app (BT adds `wssUrl`; unification deferred to #295)
- `AppsConfig.peers: Record<string, string>` replaces `budgetTrackerUrl`/`launchpadUrl` fields
- `export const { getConfig, resetConfig } = createConfig(loadConfig)` replaces module-level `let _config`

**Callsite update:**
- `apps/budget-tracker/app/page.tsx` — `getConfig().apps.launchpadUrl` → `getConfig().apps.peers['launchpad']`

## Normative doc updates (§2.1)

- `MONOREPO.md` — `runtime-config` description updated
- `docs/architecture/inventory.md` — §1.5 `runtime-config` entry updated with new exports and `AppsConfig` migration

## Test plan

- [ ] `pnpm --filter @transformotion/runtime-config typecheck` — clean
- [ ] `pnpm --filter @transformotion/stock-analyser typecheck` — clean
- [ ] `pnpm --filter @transformotion/budget typecheck` — clean
- [ ] `config.apps.budgetTrackerUrl` / `config.apps.launchpadUrl` — no remaining references in SA or BT (launchpad app's own config is out of scope)
- [ ] BT `app/page.tsx` uses `getConfig().apps.peers['launchpad']`

Closes #293

🤖 Generated with [Claude Code](https://claude.com/claude-code)