### PR TITLE
Fix: exclude infrastructure/ from app tsconfig (follow-up to #324)

### DIFF
--- a/apps/budget-tracker/tsconfig.json
+++ b/apps/budget-tracker/tsconfig.json
@@ -25,5 +25,5 @@
     ".next/types/**/*.ts",
     ".next/dev/types/**/*.ts"
   ],
-  "exclude": ["node_modules", "functions"]
+  "exclude": ["node_modules", "functions", "infrastructure"]
 }

--- a/apps/stock-analyser/tsconfig.json
+++ b/apps/stock-analyser/tsconfig.json
@@ -37,6 +37,7 @@
   ],
   "exclude": [
     "node_modules",
-    "components/budget-tracker"
+    "components/budget-tracker",
+    "infrastructure"
   ]
 }


### PR DESCRIPTION
## Summary

Follow-up fix for PR #324. After moving CDK stacks into `apps/budget-tracker/infrastructure/` and `apps/stock-analyser/infrastructure/`, the Next.js `**/*.ts` glob in each app's `tsconfig.json` picks up the CDK stack files. These import `aws-cdk-lib` which is not an app dependency, causing `next build` and `pnpm typecheck` to fail in CI.

**Fix:** Add `"infrastructure"` to the `exclude` array in both app tsconfigs. This mirrors the existing `"functions"` exclusion (Lambda source is already excluded for the same reason).

## Verification

- `pnpm typecheck` — 47/47 pass ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)