### PR TITLE
fix(m7): hotfix #327 deploy regressions (D1 GSI grant + D2 SA app key)

### DIFF
--- a/apps/budget-tracker/infrastructure/budget-tracker-api-stack.ts
+++ b/apps/budget-tracker/infrastructure/budget-tracker-api-stack.ts
@@ -151,10 +151,12 @@ export class BudgetTrackerApiStack extends cdk.Stack {
     }));
     aiJobsTable.grantReadWriteData(aiFn);
     wsConnectionsTable.grantReadData(aiFn);
-    // grantReadData covers the table ARN only; querying the userId-index GSI needs an explicit grant
+    // grantReadData on a Table imported via fromTableName covers the base table ARN but not GSI ARNs,
+    // because CDK has no schema knowledge of imported tables. Explicit grant for the userId-index GSI
+    // used by the connectionId lookup (budget-ai-handler queries by userId to find the caller's WSS connectionId).
     aiFn.addToRolePolicy(new iam.PolicyStatement({
       actions:   ['dynamodb:Query'],
-      resources: [`arn:aws:dynamodb:${this.region}:${this.account}:table/budget-tracker.ai-connections-${stage}/index/userId-index`],
+      resources: [`arn:aws:dynamodb:${this.region}:${this.account}:table/${wsConnectionsTableName}/index/*`],
     }));
 
     // ── budget-data-handler ───────────────────────────────────────────────────

--- a/apps/stock-analyser/lib/hooks/use-claude.ts
+++ b/apps/stock-analyser/lib/hooks/use-claude.ts
@@ -172,8 +172,11 @@ async function subscribeViaWss<T>(
 
   if (!token) throw new Error('No authentication token available')
 
+  // 'stock-signal' matches the JWT accounts claim key (which mirrors the URL prefix).
+  // When the URL prefix rename issue (#286) lands, this becomes 'stock-analyser' in
+  // coordination with the Cognito claim key migration.
   const ws = new WebSocket(
-    `${wssUrl}?token=${encodeURIComponent(token)}&app=stock-analyser&accountId=${encodeURIComponent(accountId)}`
+    `${wssUrl}?token=${encodeURIComponent(token)}&app=stock-signal&accountId=${encodeURIComponent(accountId)}`
   )
 
   // Phase 1: open connection and get connectionId via init handshake

--- a/platform/infrastructure/platform-ws-stack.ts
+++ b/platform/infrastructure/platform-ws-stack.ts
@@ -95,7 +95,10 @@ export class PlatformWsStack extends cdk.Stack {
       environment: {
         COGNITO_USER_POOL_ID: userPool.userPoolId,
         APP_NAME:             'budget-tracker',
-        PERMITTED_APPS:       'budget-tracker,stock-analyser',
+        // 'stock-signal' matches the JWT accounts claim key (which mirrors the URL prefix).
+        // When the URL prefix rename issue (#286) lands, this becomes 'stock-analyser' in
+        // coordination with the Cognito claim key migration.
+        PERMITTED_APPS:       'budget-tracker,stock-signal',
       },
       bundling: {
         ...bundling,


### PR DESCRIPTION
## Summary

Two regressions surfaced during dev deploy verification of #327 (SA polling → WSS migration). Both failures were caught before prod; prod is unaffected (still on pre-#327 state).

---

### D1 — BT POST /api/budget/v1/ai/review → 500

**Root cause:** An explicit `dynamodb:Query` IAM statement for the WSS connections GSI already existed in `budget-tracker-api-stack.ts` — but it was still referencing `budget-tracker.ai-connections-{stage}/index/userId-index` (the old orphaned table) instead of the new `platform.ws-connections-{stage}/index/*`. The ARN was stale from before the #327 WSS migration; the grant existed but pointed at the wrong table.

The `grantReadData` call above it correctly referenced the platform table via `wsConnectionsTableName` prop (and `Fn::ImportValue`), but the parallel explicit GSI grant had a hardcoded old table name that was missed during migration. Result: `budget-ai-handler` could not query the `userId-index` GSI to look up the caller's WebSocket `connectionId`.

**The CDK footgun:** `grantReadData` on a table imported via `fromTableName` generates a policy covering the base table ARN only. CDK has no schema knowledge of imported tables, so it cannot enumerate GSI ARNs. Any `Query` against a GSI requires an explicit additional statement. This was already known (hence the explicit grant existed), but the grant's ARN was stale.

**Fix:** Changed the explicit `dynamodb:Query` statement's resource ARN from the hardcoded old table name to `arn:aws:dynamodb:...:table/${wsConnectionsTableName}/index/*`, resolving via `Fn::ImportValue` to the platform table at deploy time — consistent with every other cross-stack reference in this stack.

---

### D2 — SA WSS handshake rejected at authoriser

**Root cause:** SA's WSS connect URL sent `?app=stock-analyser`, but the JWT `accounts` claim is keyed by `'stock-signal'` (matching the URL prefix, which is how the claim was populated when accounts were provisioned). The authoriser checks `accountsRaw[requestedApp]` — `accountsRaw['stock-analyser']` returned `undefined`, so the account membership check always failed.

**The two-name reality:** The Stock Analyser has two identifiers in use:
- `stock-signal` — the URL prefix (`/stock-signal/*`), used as the JWT claim key and in HTTP auth middleware (`requireAppAccess(auth, 'stock-signal')`)
- `stock-analyser` — the directory/codebase name, the `?app=` value SA was incorrectly sending

These need to be aligned. The minimal fix (this PR) aligns the WSS layer to `'stock-signal'` to match the existing claim structure. The proper alignment to `'stock-analyser'` is the scope of the existing rename issue.

**Fix:**
- `use-claude.ts`: `&app=stock-analyser` → `&app=stock-signal`
- `platform-ws-stack.ts`: `PERMITTED_APPS: 'budget-tracker,stock-analyser'` → `PERMITTED_APPS: 'budget-tracker,stock-signal'`

Both sites carry an inline comment explaining why `'stock-signal'` is used and referencing #286 for the future migration.

---

### D3 — Issue #286 scope expansion

Added a comment on issue #286 (Rename `/stock-signal/` URL prefix to `/stock-analyser/`) documenting the additional scope items that must be coordinated when the rename lands: Cognito claim key migration, HTTP auth middleware appSlug constants, `authService.getAccountIdForApp()` lookup key, WSS `?app=` value, `PERMITTED_APPS` env var, and the token-validity migration window.

---

### D4 — SA Lambdas GSI check

Confirmed: no SA Lambda queries the `platform.ws-connections-*` table via the `userId-index` GSI. SA's pattern is client-sends-connectionId (the `connectionId` is embedded in the POST body to `/api/claude` after the WSS handshake). Only `budget-ai-handler` does server-side GSI lookup.

---

## Verification

- `pnpm typecheck` — 47/47 pass
- `pnpm cdk synth` — 25 stacks synthesised; `AiFnServiceRoleDefaultPolicyBB1C2288` contains `dynamodb:Query` on `...table/<Fn::ImportValue PlatformWs ConnectionsTable>/index/*`; authoriser Lambda env shows `PERMITTED_APPS: budget-tracker,stock-signal`
- `pnpm build` — 36/36 pass
- `git diff --stat` — exactly 3 files changed

## Post-merge watch

Three deploy workflows trigger:

1. **Platform deploy** (PlatformWs CDK change — `PERMITTED_APPS` update) — redeploys the platform WS authoriser Lambda with the new env var. **This must be confirmed live before SA AI review can work**, even if the SA deploy finishes first. The `PERMITTED_APPS` change is a Lambda env update; it takes effect only after the Lambda is redeployed, not at SA build time.
2. **BT deploy** (BudgetTrackerApi CDK change — IAM fix) — redeploys the BT API stack with corrected IAM. Smoke test: BT AI review → POST `/api/budget/v1/ai/review` should return 200, not 500.
3. **SA deploy** (use-claude.ts change) — rebuilds SA frontend with `?app=stock-signal`. Smoke test: SA WSS handshake → authoriser allows connection → AI review completes. Only meaningful after the Platform deploy above is confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)