### PR TITLE
fix(m7): claude-proxy WSS push IAM resource ARN

### DIFF
--- a/platform/infrastructure/platform-api-stack.ts
+++ b/platform/infrastructure/platform-api-stack.ts
@@ -179,7 +179,11 @@ export class PlatformApiStack extends cdk.Stack {
     if (wsApiEndpoint && wsApiId) {
       claudeProxyFn.addToRolePolicy(new iam.PolicyStatement({
         actions:   ['execute-api:ManageConnections'],
-        resources: [`arn:aws:execute-api:${this.region}:${this.account}:${wsApiId}/${stage}/@connections/*`],
+        // Resource pattern matches all method+route combinations under the stage.
+        // The @connections management API is reached via POST /<stage>/@connections/{connectionId},
+        // so the pattern must cover the HTTP method segment.
+        // Matches the same pattern used by budget-ai-handler in budget-tracker-api-stack.ts.
+        resources: [`arn:aws:execute-api:${this.region}:${this.account}:${wsApiId}/${stage}/*`],
       }));
     }
 


### PR DESCRIPTION
## Summary

Third IAM/ARN bug in the #327 lineage, surfaced during dev smoke-test verification after #328 merged.

---

### Diagnostic finding

SA's WSS connection established correctly after #328 (`app=stock-signal` aligned). The Claude job runs to completion (41 s, `status: complete` confirmed in DynamoDB). But claude-proxy's attempt to push `{ type: 'job_complete', jobId }` back to the SA client fails every time with 403:

```
WARN [claude-proxy] WSS push failed (connection may be stale):
User: .../TransformotionDev-Api-ClaudeProxyFnServiceRole3C29C.../transformotion-claude-proxy-dev
is not authorized to perform: execute-api:ManageConnections
on resource: arn:aws:execute-api:...:gwbzk4zvdl/dev/POST/@connections/{connectionId}
because no identity-based policy allows the execute-api:ManageConnections action
```

The live IAM policy on the role grants:
```
"Resource": "arn:aws:execute-api:...:gwbzk4zvdl/dev/@connections/*"
```

The actual resource IAM evaluates at runtime is:
```
arn:aws:execute-api:...:gwbzk4zvdl/dev/POST/@connections/{connectionId}
```

The pattern `dev/@connections/*` does not match `dev/POST/@connections/{connectionId}` — the HTTP method segment `POST/` appears between the stage and `@connections/`, and the old pattern had no wildcard to absorb it.

**Fix:** `dev/@connections/*` → `dev/*`. The `*` covers all method+route combinations under the stage, including `POST/@connections/{connectionId}`.

---

### Why it was latent pre-#327

- SA used polling before #327 — claude-proxy never needed to push to a WebSocket.
- BT AI review uses `budget-ai-handler` for its WSS push, not claude-proxy. `budget-ai-handler`'s equivalent grant already uses `/${stage}/*` (the correct broader pattern). Claude-proxy's grant was never exercised.
- #327 introduced claude-proxy's first live WSS push for SA. The latent ARN bug was exposed.

---

### Pattern parity with budget-ai-handler

`budget-tracker-api-stack.ts` (correct, working):
```typescript
resources: [`arn:aws:execute-api:${this.region}:${this.account}:${wsApiId}/${stage}/*`]
```

`platform-api-stack.ts` before this PR (broken):
```typescript
resources: [`arn:aws:execute-api:${this.region}:${this.account}:${wsApiId}/${stage}/@connections/*`]
```

After this PR: identical pattern.

---

### Verification

- `pnpm typecheck` — 47/47 pass (cached)
- `pnpm cdk synth` — 25 stacks; synthesized `ClaudeProxyFnServiceRoleDefaultPolicy230B1217` now shows `ManageConnections` resource resolving to `<Fn::ImportValue PlatformWsApi>/<stage>/*`
- `git diff --stat` — 1 file changed (platform-api-stack.ts)

---

### Post-merge

Platform deploy only — no SA or BT frontend rebuild needed. The IAM policy update applies when CloudFormation updates the Lambda's role policy. Once `TransformotionDev-Api` reaches `UPDATE_COMPLETE`, SA market analysis should push the `job_complete` notification and surface results.

---

*Third IAM/ARN bug in the #327 lineage (D1: GSI table name, D2: app identifier, D3: ManageConnections ARN pattern). A cross-cutting IAM recon of all WSS-related grants is planned as a follow-up.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)