### PR TITLE
fix(m7): restore SA cycle gauge tracks (Tailwind @source for ui-primitives)

### DIFF
--- a/apps/budget-tracker/app/globals.css
+++ b/apps/budget-tracker/app/globals.css
@@ -1,4 +1,5 @@
 @import 'tailwindcss';
+@source "../../../packages/ui/primitives/src/**/*.{ts,tsx}";
 @import 'tw-animate-css';
 
 @custom-variant dark (&:is(.dark *));

--- a/apps/stock-analyser/app/globals.css
+++ b/apps/stock-analyser/app/globals.css
@@ -1,4 +1,5 @@
 @import 'tailwindcss';
+@source "../../../packages/ui/primitives/src/**/*.{ts,tsx}";
 @import 'tw-animate-css';
 
 @custom-variant dark (&:is(.dark *));


### PR DESCRIPTION
## Root cause

PR #300 moved `design-system.tsx` (containing `CycleGauge` and `FullCycleGauge`) from `apps/stock-analyser/components/ui/` into `packages/ui/primitives/src/`. Tailwind v4's `@tailwindcss/postcss` scanner roots at `apps/stock-analyser/` and does not auto-scan above that directory. The package source is two levels above the app root — outside the scan.

The gauge track classes used exclusively in `design-system.tsx` were therefore never emitted:

| Component | Missing classes |
|---|---|
| `FullCycleGauge` track segments | `bg-signal-green/40`, `bg-signal-amber/40`, `bg-signal-gold/40`, `bg-signal-red/40` |
| `CycleGauge` track segments | `bg-signal-green/30`, `bg-signal-amber/30`, `bg-signal-gold/30`, `bg-signal-red/30` |

The `@theme inline` block in `globals.css` registers the `--color-signal-*` tokens (making the utilities *possible*), but Tailwind v4 still requires the class names to appear in scanned source files before it emits the CSS rules. The position dot (`bg-foreground`) and score text (`text-foreground`) remained visible because those are standard tokens scanned elsewhere — only the track segment colours were affected.

This was confirmed by inspecting the pre-fix build output: `/30` and `/40` opacity variants were absent; `/10`, `/15`, `/20` etc. (referenced in SA source files) were present.

## Fix

Add `@source` directive in each affected app's `globals.css` entrypoint, pointing at `packages/ui/primitives/src/`:

```css
@source "../../../packages/ui/primitives/src/**/*.{ts,tsx}";
```

## Apps fixed

- **`apps/stock-analyser/app/globals.css`** — primary fix (gauge regression)
- **`apps/budget-tracker/app/globals.css`** — parallel fix (BT also imports from `@transformotion/ui-primitives`; same latent bug prevented proactively)

Launchpad does not import from `@transformotion/ui-primitives` — no change needed there.

## Why this wasn't caught earlier

Tailwind silently omits classes that don't appear in scanned files — no build error, no warning. TypeScript checking doesn't touch CSS generation. The gauge appeared to render (the container bar and dot were visible) but the four coloured segments were transparent. Only visual inspection surfaced it.

## Verification

- V1: `pnpm typecheck` — pass (SA)
- V2: `pnpm build` — pass (SA and BT)
- V3: Post-fix build output (`out/_next/static/chunks/*.css`) contains all eight classes: `signal-green/30`, `signal-amber/30`, `signal-gold/30`, `signal-red/30`, `signal-green/40`, `signal-amber/40`, `signal-gold/40`, `signal-red/40` ✓
- V5: 2 files changed, 2 insertions ✓

## Smoke test

Load any analysed ticker in SA (e.g. FMG.AX), navigate to the Analyser tab. Confirm the cycle gauge track renders four coloured zones (green / amber / gold / red) beneath the position dot.

Refs M7 cycle-gauge regression. Diagnosed via CSS bundle inspection (pre-fix: `/30` and `/40` absent; post-fix: all eight present).