### PR TITLE
Hotfix: revert SW6 verify-deploy arg (stock-analyser, not stock-signal)

### DIFF
--- a/.github/workflows/deploy-stock-analyser.yml
+++ b/.github/workflows/deploy-stock-analyser.yml
@@ -145,7 +145,7 @@ jobs:
             "${{ vars.NEXT_PUBLIC_APP_URL }}/stock-signal" \
             apps/stock-analyser/.env.example \
             "${{ github.sha }}" \
-            "stock-signal" \
+            "stock-analyser" \
             "/api/user/profile"
 
   deploy-prod:
@@ -260,5 +260,5 @@ jobs:
             "${{ vars.NEXT_PUBLIC_APP_URL }}/stock-signal" \
             apps/stock-analyser/.env.example \
             "${{ github.sha }}" \
-            "stock-signal" \
+            "stock-analyser" \
             "/api/user/profile"


### PR DESCRIPTION
## Problem

#337 changed the `verify-deploy.sh` 4th argument in `deploy-stock-analyser.yml` from `"stock-analyser"` to `"stock-signal"` (the SW6 finding). This caused the SA dev deploy to fail immediately after merge:

```
FAIL: app identity marker data-app="stock-signal" NOT found in root HTML.
```

## Root cause

SW6 was misidentified. The verify-deploy.sh 4th argument is not the JWT claim key — it is the **app identity string** checked against the deployed HTML's `data-app` attribute. That attribute is set from `APP_IDENTITY` in `apps/stock-analyser/lib/build-info.ts`, which is `'stock-analyser'` (the directory/build identity).

The original `"stock-analyser"` argument was correct. The script docstring confirms:
> The optional 4th argument is the expected app identity string (e.g. "launchpad", "stock-analyser", "budget-tracker").

## Fix

Restore argument to `"stock-analyser"` in both dev and prod steps.

## Notes

- The JWT claim key / URL prefix (`stock-signal`) is a separate concept from the app's build identity
- SW6 will be removed from #333's scope retroactively (it was not a real finding)
- The actual SW6 finding (if any) may need re-investigation after #286 renames both identifiers to `stock-analyser`

🤖 Generated with [Claude Code](https://claude.com/claude-code)