### PR TITLE
M7 Bucket A'': shared APPS const; unify platform WSS URL env var (#335)

### DIFF
--- a/.github/workflows/deploy-budget-tracker.yml
+++ b/.github/workflows/deploy-budget-tracker.yml
@@ -114,7 +114,7 @@ jobs:
             echo "ERROR: Could not extract WssUrl from TransformotionDev-PlatformWs stack"
             exit 1
           fi
-          echo "NEXT_PUBLIC_BUDGET_WSS_URL=$WSS_URL" >> $GITHUB_ENV
+          echo "NEXT_PUBLIC_PLATFORM_WSS_URL=$WSS_URL" >> $GITHUB_ENV
           echo "Extracted WSS URL: $WSS_URL"
 
       - name: Build Next.js (static export)
@@ -230,7 +230,7 @@ jobs:
             echo "ERROR: Could not extract WssUrl from TransformotionProd-PlatformWs stack"
             exit 1
           fi
-          echo "NEXT_PUBLIC_BUDGET_WSS_URL=$WSS_URL" >> $GITHUB_ENV
+          echo "NEXT_PUBLIC_PLATFORM_WSS_URL=$WSS_URL" >> $GITHUB_ENV
           echo "Extracted WSS URL: $WSS_URL"
 
       - name: Build Next.js (static export)

--- a/.github/workflows/deploy-stock-analyser.yml
+++ b/.github/workflows/deploy-stock-analyser.yml
@@ -112,7 +112,7 @@ jobs:
             echo "ERROR: Could not extract WssUrl from TransformotionDev-PlatformWs stack"
             exit 1
           fi
-          echo "NEXT_PUBLIC_CLAUDE_WSS_URL=$WSS_URL" >> $GITHUB_ENV
+          echo "NEXT_PUBLIC_PLATFORM_WSS_URL=$WSS_URL" >> $GITHUB_ENV
           echo "Extracted WSS URL: $WSS_URL"
 
       - name: Build Next.js (static export)
@@ -227,7 +227,7 @@ jobs:
             echo "ERROR: Could not extract WssUrl from TransformotionProd-PlatformWs stack"
             exit 1
           fi
-          echo "NEXT_PUBLIC_CLAUDE_WSS_URL=$WSS_URL" >> $GITHUB_ENV
+          echo "NEXT_PUBLIC_PLATFORM_WSS_URL=$WSS_URL" >> $GITHUB_ENV
           echo "Extracted WSS URL: $WSS_URL"
 
       - name: Build Next.js (static export)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -271,7 +271,7 @@ packages/
 ├── auth-client/           # Cognito and mock auth service implementations
 ├── budget-domain/         # Budget Tracker domain types and pure helpers
 ├── lambda-middleware/     # Shared withAuth/withAuthOnly wrappers and helpers
-├── runtime-config/        # Runtime profile + provider resolution helpers
+├── runtime-config/        # Runtime profile + provider resolution helpers; canonical app registry (APPS const)
 ├── cdk-constructs/        # Shared CDK constructs (the shared construct library)
 ├── ui/                    # UI packages, organised by concern (see below)
 └── <other-concern>/

--- a/apps/budget-tracker/.env.example
+++ b/apps/budget-tracker/.env.example
@@ -174,7 +174,7 @@ NEXT_PUBLIC_COMMIT_HASH=
 # build can embed it. Not set manually — the workflow always reads the live
 # stack output, so the URL remains correct even if the WebSocket API is recreated.
 # For local development: leave empty (mock AI provider is used instead of WebSocket flow).
-NEXT_PUBLIC_BUDGET_WSS_URL=
+NEXT_PUBLIC_PLATFORM_WSS_URL=
 
 # ── Cross-app navigation URLs ─────────────────────────────────────────────────
 

--- a/apps/budget-tracker/lib/config/index.ts
+++ b/apps/budget-tracker/lib/config/index.ts
@@ -10,6 +10,7 @@ import {
   selectProvider,
   normaliseCrossAppUrl,
   createConfig,
+  LP_AUTH_ROUTES,
   type APIConfig,
   type AuthConfig,
   type StorageConfig,
@@ -70,7 +71,7 @@ function loadConfig(): AppConfig {
         validValues: ['mock', 'claude'] as const,
       }),
       model: process.env.NEXT_PUBLIC_AI_MODEL || 'claude-3-sonnet',
-      wssUrl: process.env.NEXT_PUBLIC_BUDGET_WSS_URL || '',
+      wssUrl: process.env.NEXT_PUBLIC_PLATFORM_WSS_URL || '',
     },
     storage: {
       provider: selectProvider({
@@ -93,8 +94,8 @@ function loadConfig(): AppConfig {
       debugMode: process.env.NEXT_PUBLIC_DEBUG_MODE === 'true',
     },
     apps: {
-      signInUrl: normaliseCrossAppUrl(process.env.NEXT_PUBLIC_SIGNIN_URL, '/sign-in/'),
-      signOutUrl: normaliseCrossAppUrl(process.env.NEXT_PUBLIC_SIGNOUT_URL, '/signed-out/'),
+      signInUrl: normaliseCrossAppUrl(process.env.NEXT_PUBLIC_SIGNIN_URL, LP_AUTH_ROUTES.signIn),
+      signOutUrl: normaliseCrossAppUrl(process.env.NEXT_PUBLIC_SIGNOUT_URL, LP_AUTH_ROUTES.signedOut),
       peers: {
         'launchpad': normaliseCrossAppUrl(process.env.NEXT_PUBLIC_LAUNCHPAD_URL, '/'),
       },

--- a/apps/budget-tracker/lib/services/ai/claude-ai.ts
+++ b/apps/budget-tracker/lib/services/ai/claude-ai.ts
@@ -15,7 +15,7 @@ export class ClaudeAIService implements AIService {
     const token     = await authService.getIdToken()
     const accountId = await authService.getAccountIdForApp('budget-tracker')
 
-    if (!wssUrl)    throw new Error('WebSocket URL not configured (NEXT_PUBLIC_BUDGET_WSS_URL)')
+    if (!wssUrl)    throw new Error('WebSocket URL not configured (NEXT_PUBLIC_PLATFORM_WSS_URL)')
     if (!token)     throw new Error('No auth token available')
     if (!accountId) throw new Error('No accountId available')
 

--- a/apps/launchpad/components/launchpad/launchpad.tsx
+++ b/apps/launchpad/components/launchpad/launchpad.tsx
@@ -5,6 +5,7 @@ import { cn } from '@/lib/utils'
 import { Wordmark } from '@/components/brand/wordmark'
 import { TrendingUp, Wallet, Layers, LogOut, Settings, User as UserIcon, Check } from 'lucide-react'
 import type { User } from '@transformotion/auth-client'
+import { APP_SLUGS } from '@transformotion/runtime-config'
 
 interface App {
   id: string
@@ -201,8 +202,8 @@ function AppGrid({
   })
 
   const getLaunchHandler = (appId: string) => {
-    if (appId === 'stock-signal') return onLaunchApp
-    if (appId === 'budget-tracker') return onLaunchBudgetTracker
+    if (appId === APP_SLUGS[0]) return onLaunchApp
+    if (appId === APP_SLUGS[1]) return onLaunchBudgetTracker
     return undefined
   }
 

--- a/apps/stock-analyser/.env.example
+++ b/apps/stock-analyser/.env.example
@@ -81,7 +81,7 @@ NEXT_PUBLIC_CLAUDE_CACHE_URL=https://your-platform-api-id.execute-api.ap-southea
 # reads the live stack output, so the URL remains correct even if the
 # WebSocket API is recreated.
 # For local development: leave empty (mock AI provider is used instead).
-NEXT_PUBLIC_CLAUDE_WSS_URL=
+NEXT_PUBLIC_PLATFORM_WSS_URL=
 
 # ── Cognito authentication ────────────────────────────────────────────────────
 

--- a/apps/stock-analyser/CLAUDE.md
+++ b/apps/stock-analyser/CLAUDE.md
@@ -86,7 +86,7 @@ Key service methods defined in [contracts/DATA_CONTRACTS.md](./contracts/DATA_CO
 ### Claude AI pattern
 
 The `useClaude<T>()` hook handles the full async request cycle via the platform WebSocket:
-1. Open platform WSS (`NEXT_PUBLIC_CLAUDE_WSS_URL`) with Cognito ID token and `?app=stock-analyser`
+1. Open platform WSS (`NEXT_PUBLIC_PLATFORM_WSS_URL`) with Cognito ID token and `?app=stock-analyser`
 2. Send `{ action: 'init' }` → receive `{ type: 'connected', connectionId }`
 3. POST to `/api/claude` with prompt + `connectionId` → returns `jobId`
 4. Receive `{ type: 'job_complete' }` push on the WebSocket when the job finishes
@@ -168,7 +168,7 @@ Required env vars marked `[REQUIRED]` in `.env.example` must be set before the d
 | `NEXT_PUBLIC_COGNITO_DOMAIN` | Hosted UI domain |
 | `NEXT_PUBLIC_RUNTIME_PROFILE` | `mock` (default; local development) or `live` (deployed environments). Determines defaults for auth, data, AI, and future concerns. See root `CLAUDE.md` for the design map. |
 | `NEXT_PUBLIC_API_BASE_URL` | Platform API base URL |
-| `NEXT_PUBLIC_CLAUDE_WSS_URL` | Platform WebSocket URL for async AI job notifications — extracted from `TransformotionDev-PlatformWs` CloudFormation output at deploy time |
+| `NEXT_PUBLIC_PLATFORM_WSS_URL` | Platform WebSocket URL for async AI job notifications — extracted from `TransformotionDev-PlatformWs` CloudFormation output at deploy time |
 
 **Cognito client variable rebind:** The GitHub Actions variable `NEXT_PUBLIC_STOCK_ANALYSER_COGNITO_CLIENT_ID` is mapped to the generic runtime env var `NEXT_PUBLIC_COGNITO_CLIENT_ID` in the deploy workflow's env block. This allows each app to have its own Cognito App Client (established in sub-phase 7b.5-alpha) while the runtime code (`@transformotion/auth-client`) reads a single generic name. Local development reads `NEXT_PUBLIC_COGNITO_CLIENT_ID` directly from `.env.local`.
 

--- a/apps/stock-analyser/docs/claude-ai-pattern.md
+++ b/apps/stock-analyser/docs/claude-ai-pattern.md
@@ -5,7 +5,7 @@ This document explains how to integrate AI features using the `useClaude` hook. 
 ## Overview
 
 The Claude integration uses an **async WebSocket pattern**:
-1. Open platform WebSocket (`NEXT_PUBLIC_CLAUDE_WSS_URL`) with Cognito ID token
+1. Open platform WebSocket (`NEXT_PUBLIC_PLATFORM_WSS_URL`) with Cognito ID token
 2. POST to `/api/claude` with prompt + `connectionId` → returns `jobId`
 3. Receive `{ type: 'job_complete' }` push notification on the WebSocket
 4. Read the completed job result from the analysis-cache
@@ -75,7 +75,7 @@ NEXT_PUBLIC_RUNTIME_PROFILE=mock
 # API Endpoints
 NEXT_PUBLIC_CLAUDE_API_URL=/api/claude       # Where to POST prompt
 NEXT_PUBLIC_CLAUDE_CACHE_URL=/analysis-cache # Where to read job results
-NEXT_PUBLIC_CLAUDE_WSS_URL=wss://...         # Platform WebSocket URL for job notifications
+NEXT_PUBLIC_PLATFORM_WSS_URL=wss://...         # Platform WebSocket URL for job notifications
 ```
 
 ## Hook API
@@ -157,7 +157,7 @@ const analysis = await call({
 
 ### Production (Real Claude)
 - `NEXT_PUBLIC_RUNTIME_PROFILE=live` (set by deploy workflows)
-- Opens platform WebSocket (`NEXT_PUBLIC_CLAUDE_WSS_URL`) with Cognito ID token
+- Opens platform WebSocket (`NEXT_PUBLIC_PLATFORM_WSS_URL`) with Cognito ID token
 - Calls actual Lambda + Claude API
 - API key in Lambda (server-side only)
 

--- a/apps/stock-analyser/lib/config/index.ts
+++ b/apps/stock-analyser/lib/config/index.ts
@@ -10,6 +10,7 @@ import {
   selectProvider,
   normaliseCrossAppUrl,
   createConfig,
+  LP_AUTH_ROUTES,
   type APIConfig,
   type AuthConfig,
   type StorageConfig,
@@ -69,7 +70,7 @@ function loadConfig(): AppConfig {
         validValues: ['mock', 'claude'] as const,
       }),
       model:   process.env.NEXT_PUBLIC_AI_MODEL || 'claude-3-sonnet',
-      wssUrl:  process.env.NEXT_PUBLIC_CLAUDE_WSS_URL || '',
+      wssUrl:  process.env.NEXT_PUBLIC_PLATFORM_WSS_URL || '',
     },
     storage: {
       provider: selectProvider({
@@ -92,8 +93,8 @@ function loadConfig(): AppConfig {
       debugMode: process.env.NEXT_PUBLIC_DEBUG_MODE === 'true',
     },
     apps: {
-      signInUrl: normaliseCrossAppUrl(process.env.NEXT_PUBLIC_SIGNIN_URL, '/sign-in/'),
-      signOutUrl: normaliseCrossAppUrl(process.env.NEXT_PUBLIC_SIGNOUT_URL, '/signed-out/'),
+      signInUrl: normaliseCrossAppUrl(process.env.NEXT_PUBLIC_SIGNIN_URL, LP_AUTH_ROUTES.signIn),
+      signOutUrl: normaliseCrossAppUrl(process.env.NEXT_PUBLIC_SIGNOUT_URL, LP_AUTH_ROUTES.signedOut),
       peers: {
         'budget-tracker': normaliseCrossAppUrl(process.env.NEXT_PUBLIC_BUDGET_URL, '/budget-tracker/'),
       },

--- a/apps/stock-analyser/lib/hooks/use-claude.ts
+++ b/apps/stock-analyser/lib/hooks/use-claude.ts
@@ -165,7 +165,7 @@ async function subscribeViaWss<T>(
   wssUrl: string,
   signal: AbortSignal,
 ): Promise<T> {
-  if (!wssUrl) throw new Error('WSS URL not configured (NEXT_PUBLIC_CLAUDE_WSS_URL)')
+  if (!wssUrl) throw new Error('WSS URL not configured (NEXT_PUBLIC_PLATFORM_WSS_URL)')
 
   const token     = await authService.getIdToken()
   const accountId = (await authService.getAccountIdForApp('stock-signal')) ?? ''

--- a/docs/architecture/inventory.md
+++ b/docs/architecture/inventory.md
@@ -185,6 +185,15 @@ implemented:
   `AppsConfig`) and `createConfig<T>()` factory. Both apps' `lib/config/index.ts`
   now import sub-types and factory from the package; `AppsConfig.peers`
   replaces the per-app `budgetTrackerUrl`/`launchpadUrl` fields.
+  Extended by M7 / PR #335 (Bucket A'') to add the canonical app registry:
+  `APPS` const (slug, cognitoGroup, urlPrefix, label per app), `APP_SLUGS`
+  derived array, `AppDescriptor`/`AppSlug` types, and `LP_AUTH_ROUTES`
+  (signIn/signedOut path constants). Consumed by platform Lambdas
+  (account-provisioning, pre-token-generation, claude-proxy), CDK stacks
+  (PlatformWsStack, AuthStack, NetworkStack), launchpad, and both app
+  configs. WebSocket URL env var unified: `NEXT_PUBLIC_PLATFORM_WSS_URL`
+  replaces the per-app `NEXT_PUBLIC_CLAUDE_WSS_URL` (SA) and
+  `NEXT_PUBLIC_BUDGET_WSS_URL` (BT) in both deploy workflows and configs.
 
 `packages/cycle-engine/` was deleted in this PR. Its RSI/MACD/cycle
 scoring implementation was app-specific (Stock Analyser only), so it

--- a/infrastructure/package.json
+++ b/infrastructure/package.json
@@ -15,6 +15,7 @@
     "deploy:prod:auth": "cdk deploy TransformotionProd-Auth --require-approval never"
   },
   "dependencies": {
+    "@transformotion/runtime-config": "workspace:*",
     "aws-cdk-lib": "^2.100.0",
     "constructs": "^10.0.0",
     "source-map-support": "^0.5.21"

--- a/infrastructure/tsconfig.json
+++ b/infrastructure/tsconfig.json
@@ -7,6 +7,7 @@
     "lib": ["ES2022"],
     "baseUrl": ".",
     "paths": {
+      "@transformotion/runtime-config": ["./node_modules/@transformotion/runtime-config/src/index.ts"],
       "aws-cdk-lib": ["./node_modules/aws-cdk-lib"],
       "aws-cdk-lib/*": ["./node_modules/aws-cdk-lib/*"],
       "constructs": ["./node_modules/constructs"],

--- a/packages/runtime-config/src/apps.ts
+++ b/packages/runtime-config/src/apps.ts
@@ -1,0 +1,39 @@
+/**
+ * Canonical app registry — single source of truth for app slugs, Cognito
+ * groups, CloudFront URL prefixes, and display labels across the monorepo.
+ *
+ * Import this to eliminate hardcoded slug/group strings from platform Lambdas,
+ * CDK stacks, launchpad, and app configs.
+ *
+ * Slug values are the JWT claim key used in `accounts[slug]` and the URL
+ * prefix served by CloudFront. The `slug` for Stock Analyser is currently
+ * 'stock-signal' matching the live claim key; it will become 'stock-analyser'
+ * when issue #286 renames the URL prefix in coordination.
+ */
+
+export const APPS = [
+  {
+    slug:             'stock-signal',
+    cognitoGroup:     'stock-app-access',
+    groupDescription: 'User has access to Stock Signal',
+    urlPrefix:        '/stock-signal',
+    label:            'Stock Signal Analyser',
+  },
+  {
+    slug:             'budget-tracker',
+    cognitoGroup:     'budget-app-access',
+    groupDescription: 'User has access to Budget Tracker',
+    urlPrefix:        '/budget-tracker',
+    label:            'Budget Tracker',
+  },
+] as const;
+
+export type AppDescriptor = typeof APPS[number];
+export type AppSlug = AppDescriptor['slug'];
+export const APP_SLUGS = APPS.map(app => app.slug);
+
+/** Launchpad auth route paths (used as config fallbacks in app config files). */
+export const LP_AUTH_ROUTES = {
+  signIn:    '/sign-in/',
+  signedOut: '/signed-out/',
+} as const;

--- a/packages/runtime-config/src/index.ts
+++ b/packages/runtime-config/src/index.ts
@@ -144,6 +144,8 @@ export function selectProvider<T extends string>(args: SelectProviderArgs<T>): T
  *   // → 'https://dev.apps.transformotion.com.au/budget-tracker/' (slash added)
  *   //   or '/budget-tracker/' if env var is unset
  */
+export * from './apps'
+
 export function normaliseCrossAppUrl(
   envValue: string | undefined,
   fallback: string

--- a/platform/functions/auth/account-provisioning/package.json
+++ b/platform/functions/auth/account-provisioning/package.json
@@ -10,7 +10,8 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@transformotion/lambda-middleware": "workspace:*"
+    "@transformotion/lambda-middleware": "workspace:*",
+    "@transformotion/runtime-config": "workspace:*"
   },
   "devDependencies": {
     "@aws-sdk/client-cognito-identity-provider": "^3",

--- a/platform/functions/auth/account-provisioning/src/index.ts
+++ b/platform/functions/auth/account-provisioning/src/index.ts
@@ -3,6 +3,7 @@ import {
   CognitoIdentityProviderClient,
   AdminUpdateUserAttributesCommand,
 } from '@aws-sdk/client-cognito-identity-provider';
+import { APPS } from '@transformotion/runtime-config';
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import {
   DynamoDBDocumentClient,
@@ -26,10 +27,12 @@ const ACCOUNTS_TABLE        = process.env.ACCOUNTS_TABLE!;
 const ACCOUNT_MEMBERS_TABLE = process.env.ACCOUNT_MEMBERS_TABLE!;
 const USER_POOL_ID          = process.env.USER_POOL_ID!;
 
-const APP_CLIENT_TO_SLUG: Record<string, string> = {
-  [process.env.APP_CLIENT_STOCK_SIGNAL!]:   'stock-signal',
-  [process.env.APP_CLIENT_BUDGET_TRACKER!]: 'budget-tracker',
-};
+const APP_CLIENT_TO_SLUG: Record<string, string> = Object.fromEntries(
+  APPS.map(app => [
+    process.env[`APP_CLIENT_${app.slug.toUpperCase().replace(/-/g, '_')}`]!,
+    app.slug,
+  ])
+);
 
 /**
  * Auth setup Lambda — handles two routes:

--- a/platform/functions/auth/pre-token-generation/package.json
+++ b/platform/functions/auth/pre-token-generation/package.json
@@ -9,6 +9,9 @@
     "lint": "echo \"lint: pre-token-generation\"",
     "test": "vitest run"
   },
+  "dependencies": {
+    "@transformotion/runtime-config": "workspace:*"
+  },
   "devDependencies": {
     "@aws-sdk/client-cognito-identity-provider": "^3",
     "@aws-sdk/client-dynamodb": "^3",

--- a/platform/functions/auth/pre-token-generation/src/index.ts
+++ b/platform/functions/auth/pre-token-generation/src/index.ts
@@ -6,6 +6,7 @@ import {
 } from '@aws-sdk/client-cognito-identity-provider';
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { DynamoDBDocumentClient, QueryCommand, BatchGetCommand } from '@aws-sdk/lib-dynamodb';
+import { APPS, APP_SLUGS, type AppSlug } from '@transformotion/runtime-config';
 
 // ── Clients ───────────────────────────────────────────────────────────────────
 
@@ -17,13 +18,9 @@ const ACCOUNTS_TABLE        = process.env.ACCOUNTS_TABLE!;
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 
-const APP_SLUGS = ['stock-signal', 'budget-tracker'] as const;
-type AppSlug = (typeof APP_SLUGS)[number];
-
-const ACCESS_GROUP: Record<AppSlug, string> = {
-  'stock-signal':   'stock-app-access',
-  'budget-tracker': 'budget-app-access',
-};
+const ACCESS_GROUP = Object.fromEntries(
+  APPS.map(app => [app.slug, app.cognitoGroup])
+) as Record<AppSlug, string>;
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 

--- a/platform/functions/claude-proxy/package.json
+++ b/platform/functions/claude-proxy/package.json
@@ -10,7 +10,8 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@transformotion/lambda-middleware": "workspace:*"
+    "@transformotion/lambda-middleware": "workspace:*",
+    "@transformotion/runtime-config": "workspace:*"
   },
   "devDependencies": {
     "@aws-sdk/client-apigatewaymanagementapi": "^3",

--- a/platform/functions/claude-proxy/src/index.ts
+++ b/platform/functions/claude-proxy/src/index.ts
@@ -13,6 +13,7 @@ import {
   HttpError,
   type APIGatewayProxyEvent,
 } from '@transformotion/lambda-middleware';
+import { APP_SLUGS } from '@transformotion/runtime-config';
 
 // ── Clients (one per Lambda container) ───────────────────────────────────────
 
@@ -285,7 +286,7 @@ async function executeAsyncJob(job: AsyncJobEvent): Promise<void> {
 // ── API Gateway handler (Cognito-authenticated) ───────────────────────────────
 
 const apiGatewayHandler = withAuth(async ({ auth, account, event }) => {
-  requireAnyAppAccess(auth, ['stock-signal', 'budget-tracker']);
+  requireAnyAppAccess(auth, APP_SLUGS);
   const {
     prompt,
     system,

--- a/platform/infrastructure/auth-stack.ts
+++ b/platform/infrastructure/auth-stack.ts
@@ -8,6 +8,7 @@ import * as lambdaNodejs from 'aws-cdk-lib/aws-lambda-nodejs';
 import * as secretsmanager from 'aws-cdk-lib/aws-secretsmanager';
 import { Construct } from 'constructs';
 import { cognitoHostedUiCss } from './cognito-hosted-ui-css';
+import { APPS } from '@transformotion/runtime-config';
 
 export interface AuthStackProps extends cdk.StackProps {
   stage: 'dev' | 'prod';
@@ -259,9 +260,9 @@ export class AuthStack extends cdk.Stack {
     // ── Cognito Groups ─────────────────────────────────────────────────────
     const groups: Array<{ name: string; description: string; precedence: number }> = [
       // Target groups (7e-prep-1) — accepted by handlers after 7e-prep-2 dual-gate
-      { name: 'site-admin',        description: 'Platform administrator',          precedence: 1  },
-      { name: 'stock-app-access',  description: 'User has access to Stock Signal', precedence: 50 },
-      { name: 'budget-app-access', description: 'User has access to Budget Tracker', precedence: 60 },
+      { name: 'site-admin', description: 'Platform administrator', precedence: 1 },
+      // App-access groups sourced from APPS const — prevents cognitoGroup names from drifting
+      ...APPS.map((app, idx) => ({ name: app.cognitoGroup, description: app.groupDescription, precedence: 50 + idx * 10 })),
       // Legacy groups — removed at 7e-cleanup
       { name: 'admin',          description: 'Platform administrators — full access to all apps', precedence: 2  },
       { name: 'stock-app',      description: 'Stock Signal Analyser access',                       precedence: 10 },

--- a/platform/infrastructure/network-stack.ts
+++ b/platform/infrastructure/network-stack.ts
@@ -4,6 +4,7 @@ import * as cloudfront from 'aws-cdk-lib/aws-cloudfront';
 import * as origins from 'aws-cdk-lib/aws-cloudfront-origins';
 import * as acm from 'aws-cdk-lib/aws-certificatemanager';
 import { Construct } from 'constructs';
+import { APPS } from '@transformotion/runtime-config';
 
 export interface NetworkStackProps extends cdk.StackProps {
   stage: 'dev' | 'prod';
@@ -101,8 +102,8 @@ export class NetworkStack extends cdk.Stack {
           eventType: cloudfront.FunctionEventType.VIEWER_REQUEST,
         }],
       },
-      additionalBehaviors: {
-        '/budget-tracker/*': {
+      additionalBehaviors: Object.fromEntries(
+        APPS.map(app => [`${app.urlPrefix}/*`, {
           origin: origins.S3BucketOrigin.withOriginAccessControl(this.bucket),
           viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
           cachePolicy: cloudfront.CachePolicy.CACHING_OPTIMIZED,
@@ -111,18 +112,8 @@ export class NetworkStack extends cdk.Stack {
             function: indexRewrite,
             eventType: cloudfront.FunctionEventType.VIEWER_REQUEST,
           }],
-        },
-        '/stock-signal/*': {
-          origin: origins.S3BucketOrigin.withOriginAccessControl(this.bucket),
-          viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
-          cachePolicy: cloudfront.CachePolicy.CACHING_OPTIMIZED,
-          compress: true,
-          functionAssociations: [{
-            function: indexRewrite,
-            eventType: cloudfront.FunctionEventType.VIEWER_REQUEST,
-          }],
-        },
-      },
+        }])
+      ),
       defaultRootObject: 'index.html',
       errorResponses: [
         // SPA fallback — React Router handles 403/404

--- a/platform/infrastructure/platform-ws-stack.ts
+++ b/platform/infrastructure/platform-ws-stack.ts
@@ -9,6 +9,7 @@ import * as iam from 'aws-cdk-lib/aws-iam';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as lambdaNodejs from 'aws-cdk-lib/aws-lambda-nodejs';
 import { Construct } from 'constructs';
+import { APPS } from '@transformotion/runtime-config';
 
 export interface PlatformWsStackProps extends cdk.StackProps {
   userPool: cognito.IUserPool;
@@ -94,11 +95,8 @@ export class PlatformWsStack extends cdk.Stack {
       memorySize:   256,
       environment: {
         COGNITO_USER_POOL_ID: userPool.userPoolId,
-        APP_NAME:             'budget-tracker',
-        // 'stock-signal' matches the JWT accounts claim key (which mirrors the URL prefix).
-        // When the URL prefix rename issue (#286) lands, this becomes 'stock-analyser' in
-        // coordination with the Cognito claim key migration.
-        PERMITTED_APPS:       'budget-tracker,stock-signal',
+        APP_NAME:       'budget-tracker',
+        PERMITTED_APPS: APPS.map(app => app.slug).join(','),
       },
       bundling: {
         ...bundling,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -798,6 +798,9 @@ importers:
 
   infrastructure:
     dependencies:
+      '@transformotion/runtime-config':
+        specifier: workspace:*
+        version: link:../packages/runtime-config
       aws-cdk-lib:
         specifier: ^2.100.0
         version: 2.250.0(constructs@10.6.0)
@@ -1181,6 +1184,9 @@ importers:
       '@transformotion/lambda-middleware':
         specifier: workspace:*
         version: link:../../../../packages/lambda-middleware
+      '@transformotion/runtime-config':
+        specifier: workspace:*
+        version: link:../../../../packages/runtime-config
     devDependencies:
       '@aws-sdk/client-cognito-identity-provider':
         specifier: ^3
@@ -1245,6 +1251,10 @@ importers:
         version: 5.7.3
 
   platform/functions/auth/pre-token-generation:
+    dependencies:
+      '@transformotion/runtime-config':
+        specifier: workspace:*
+        version: link:../../../../packages/runtime-config
     devDependencies:
       '@aws-sdk/client-cognito-identity-provider':
         specifier: ^3
@@ -1273,6 +1283,9 @@ importers:
       '@transformotion/lambda-middleware':
         specifier: workspace:*
         version: link:../../../packages/lambda-middleware
+      '@transformotion/runtime-config':
+        specifier: workspace:*
+        version: link:../../../packages/runtime-config
     devDependencies:
       '@aws-sdk/client-apigatewaymanagementapi':
         specifier: ^3


### PR DESCRIPTION
## Summary

Creates `packages/runtime-config/src/apps.ts` as the canonical app registry — single source of truth for slug/cognitoGroup/urlPrefix/label — and wires it into every hardcoded site across platform Lambdas, CDK stacks, launchpad, and app configs.

Also unifies the platform WebSocket URL env var: `NEXT_PUBLIC_PLATFORM_WSS_URL` replaces the per-app `NEXT_PUBLIC_CLAUDE_WSS_URL` (SA) and `NEXT_PUBLIC_BUDGET_WSS_URL` (BT).

Resolves #335.

## Fixes included

| Finding | File | Change |
|---------|------|--------|
| F1 | `account-provisioning/src/index.ts` | `APP_CLIENT_TO_SLUG` derives from `APPS` |
| F2 | `pre-token-generation/src/index.ts` | `APP_SLUGS` + `ACCESS_GROUP` derive from `APPS` |
| F5 | `claude-proxy/src/index.ts` | `requireAnyAppAccess` uses `APP_SLUGS` |
| F7 | `platform-ws-stack.ts` | `PERMITTED_APPS` = `APPS.map(app => app.slug).join(',')` |
| F8 | `auth-stack.ts` | App-access Cognito groups iterate from `APPS.cognitoGroup` |
| F9 | `network-stack.ts` | `additionalBehaviors` paths from `APPS.urlPrefix` |
| F10 | `launchpad/launchpad.tsx` | `getLaunchHandler` uses `APP_SLUGS` |
| SW5 | `apps/stock-analyser/lib/config/index.ts` | `signInUrl`/`signOutUrl` fallbacks use `LP_AUTH_ROUTES` |
| SW9 | `apps/budget-tracker/lib/config/index.ts` | same |
| SW10 | deploy workflows + app configs + .env.example | WSS URL env var unified to `NEXT_PUBLIC_PLATFORM_WSS_URL` |

## CDK synth verification (load-bearing pre-merge check)

`cdk synth TransformotionDev-Auth` output:
- ✅ `aws:cdk:path: TransformotionDev-Auth/Group-stock-app-access` — unchanged
- ✅ `aws:cdk:path: TransformotionDev-Auth/Group-budget-app-access` — unchanged
- ✅ `GroupName: stock-app-access` / `budget-app-access` — unchanged

`cdk synth TransformotionDev-Network` output:
- ✅ `PathPattern: /stock-signal/*` — unchanged
- ✅ `PathPattern: /budget-tracker/*` — unchanged

`cdk synth TransformotionDev-PlatformWs` output:
- ✅ `PERMITTED_APPS: stock-signal,budget-tracker` — same values, now derived

No logical ID changes. No CloudFormation resource recreations.

## Normative doc updates (§2.1 discipline rule)

- `docs/architecture/inventory.md` — runtime-config entry extended with APPS const, APP_SLUGS, LP_AUTH_ROUTES, and WSS URL rename
- `CONTRIBUTING.md §3.4` — runtime-config description updated to mention app registry
- `apps/stock-analyser/CLAUDE.md` — `NEXT_PUBLIC_PLATFORM_WSS_URL` (was `NEXT_PUBLIC_CLAUDE_WSS_URL`)
- `apps/stock-analyser/docs/claude-ai-pattern.md` — same

## Smoke test checklist (post-deploy — non-negotiable)

- [ ] BT: open AI review → WebSocket connects and delivers batch results
- [ ] SA: open analyser → WebSocket connects and delivers analysis result
- [ ] Auth: sign in with a test account → Cognito token contains `accounts` claim with `stock-signal` and `budget-tracker` keys
- [ ] Launchpad: tile click routes to correct app for stock-signal and budget-tracker

🤖 Generated with [Claude Code](https://claude.com/claude-code)