### PR TITLE
M7 Bucket A' (F6): extract platform.job-results table from SA analysis-cache

### DIFF
--- a/.github/workflows/deploy-platform.yml
+++ b/.github/workflows/deploy-platform.yml
@@ -58,13 +58,13 @@ jobs:
         working-directory: infrastructure
         run: pnpm exec cdk deploy 'Transformotion-GithubActionsRole' --require-approval never
 
+      - name: CDK Deploy — PlatformTables (dev) (must precede Api — Api imports job-results table ARN via Fn::ImportValue)
+        working-directory: infrastructure
+        run: pnpm exec cdk deploy 'TransformotionDev-PlatformTables' --require-approval never
+
       - name: CDK Deploy — Platform stacks (dev)
         working-directory: infrastructure
         run: pnpm exec cdk deploy 'TransformotionDev-Storage' 'TransformotionDev-Network' 'TransformotionDev-Auth' 'TransformotionDev-AuthApi' 'TransformotionDev-Api' --require-approval never
-
-      - name: CDK Deploy — PlatformTables (must follow Api to release Fn::ImportValue)
-        working-directory: infrastructure
-        run: pnpm exec cdk deploy 'TransformotionDev-PlatformTables' --require-approval never
 
       - name: CDK Deploy — PlatformWs (dev)
         working-directory: infrastructure
@@ -99,13 +99,13 @@ jobs:
         working-directory: infrastructure
         run: pnpm exec cdk deploy 'Transformotion-GithubActionsRole' --require-approval never
 
+      - name: CDK Deploy — PlatformTables (prod) (must precede Api — Api imports job-results table ARN via Fn::ImportValue)
+        working-directory: infrastructure
+        run: pnpm exec cdk deploy 'TransformotionProd-PlatformTables' --require-approval never
+
       - name: CDK Deploy — Platform stacks (prod)
         working-directory: infrastructure
         run: pnpm exec cdk deploy 'TransformotionProd-Storage' 'TransformotionProd-Network' 'TransformotionProd-Auth' 'TransformotionProd-AuthApi' 'TransformotionProd-Api' --require-approval never
-
-      - name: CDK Deploy — PlatformTables (must follow Api to release Fn::ImportValue)
-        working-directory: infrastructure
-        run: pnpm exec cdk deploy 'TransformotionProd-PlatformTables' --require-approval never
 
       - name: CDK Deploy — PlatformWs (prod)
         working-directory: infrastructure

--- a/apps/stock-analyser/CLAUDE.md
+++ b/apps/stock-analyser/CLAUDE.md
@@ -58,7 +58,7 @@ All Stock Analyser Lambdas share the platform API Gateway and Cognito JWT author
 | `stock-analyser.watchlist-{stage}` | `accountId` | `ticker` | Watchlist items per account |
 | `stock-analyser.analysis-cache-{stage}` | `accountId` | `cacheKey` | Claude analysis cache (TTL: expiresAt) |
 
-Analysis cache is accessed via both `transformotion-claude-proxy-{stage}` (write, for the async job pattern) and `transformotion-analysis-cache-{stage}` (read/delete, for polling and cache management).
+Analysis cache is accessed by `transformotion-analysis-cache-{stage}` (read/delete). As of M7 / PR #334 (Bucket A'), async job records (`job-*` keys) are written by `claude-proxy` to `platform.job-results-{stage}` (not this table). The `analysis-cache` Lambda routes GET requests for `job-*` keys to that platform table; all other keys stay on this table.
 
 ## Authorization requirement
 

--- a/apps/stock-analyser/functions/analysis-cache/src/index.ts
+++ b/apps/stock-analyser/functions/analysis-cache/src/index.ts
@@ -13,7 +13,8 @@ import {
 } from '@transformotion/lambda-middleware';
 
 const ddb = DynamoDBDocumentClient.from(new DynamoDBClient({}));
-const TABLE = process.env.CACHE_TABLE!;
+const TABLE             = process.env.CACHE_TABLE!;
+const JOB_RESULTS_TABLE = process.env.JOB_RESULTS_TABLE!;
 
 // Special partition key used for data shared across all accounts.
 // Market analysis, recommendations, ETFs, metals, and stock analyses
@@ -86,6 +87,17 @@ export const handler = withAuth(async ({ auth, account, event }) => {
 
   // ── GET /analysis-cache/{key} ─────────────────────────────────────────────
   if (event.httpMethod === 'GET') {
+    // job-* keys are platform-owned async job records written by claude-proxy.
+    // They live in the platform.job-results table keyed by accountId + cacheKey.
+    if (cacheKey.startsWith('job-')) {
+      const res = await ddb.send(new GetCommand({
+        TableName: JOB_RESULTS_TABLE,
+        Key: { accountId, cacheKey },
+      }));
+      if (!res.Item) throw notFound(`Job '${cacheKey}' not found`);
+      return ok(normaliseItem(res.Item as Record<string, unknown>));
+    }
+
     // Check SHARED partition first (benefits all users), then fall back to
     // the account-specific partition (legacy items written before SHARED was introduced).
     let res = await ddb.send(new GetCommand({

--- a/apps/stock-analyser/infrastructure/stock-analyser-api-stack.ts
+++ b/apps/stock-analyser/infrastructure/stock-analyser-api-stack.ts
@@ -12,6 +12,8 @@ export interface StockAnalyserApiStackProps extends cdk.StackProps {
   api: apigateway.RestApi;
   /** Shared JWT authoriser from PlatformApiStack. */
   authoriser: apigateway.CognitoUserPoolsAuthorizer;
+  /** From PlatformTablesStack — analysis-cache Lambda reads job-* keys from here. */
+  jobResultsTableName: string;
 }
 
 /**
@@ -33,7 +35,7 @@ export class StockAnalyserApiStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props: StockAnalyserApiStackProps) {
     super(scope, id, props);
 
-    const { stage, api, authoriser } = props;
+    const { stage, api, authoriser, jobResultsTableName } = props;
     const auth = authMethodOptions(authoriser);
 
     // ── /portfolio — Portfolio Lambda ─────────────────────────────────────
@@ -88,6 +90,10 @@ export class StockAnalyserApiStack extends cdk.Stack {
     );
 
     // ── /analysis-cache/{key} — Analysis Cache Lambda ─────────────────────
+    const jobResultsTable = dynamodb.Table.fromTableName(
+      this, 'JobResultsTable', jobResultsTableName,
+    );
+
     const cacheFn = new lambdaNodejs.NodejsFunction(this, 'CacheFn', {
       functionName: `transformotion-analysis-cache-${stage}`,
       entry:        path.join(__dirname, '../functions/analysis-cache/src/index.ts'),
@@ -95,11 +101,15 @@ export class StockAnalyserApiStack extends cdk.Stack {
       runtime:      lambda.Runtime.NODEJS_20_X,
       timeout:      cdk.Duration.seconds(15),
       memorySize:   256,
-      environment:  { CACHE_TABLE: analysisCacheTable.tableName },
+      environment: {
+        CACHE_TABLE:       analysisCacheTable.tableName,
+        JOB_RESULTS_TABLE: jobResultsTable.tableName,
+      },
       bundling:     { externalModules: ['@aws-sdk/*'], minify: true, sourceMap: false, forceDockerBundling: false },
     });
 
     analysisCacheTable.grantReadWriteData(cacheFn);
+    jobResultsTable.grantReadData(cacheFn);
 
     const cacheIntegration = new apigateway.LambdaIntegration(cacheFn, { proxy: true });
     const cacheKey = api.root

--- a/docs/architecture/inventory.md
+++ b/docs/architecture/inventory.md
@@ -527,6 +527,7 @@ removing the dependency-cycle workaround.
 | `platform.users-{stage}` | userId | — | |
 | `platform.rate-limits-{stage}` | pk | — | Owned by `AuthApiStack` (not PlatformTablesStack). PK: `lookup-provider#<ip>`. Used for rate-limiting by `forgot-provider` Lambda. |
 | `platform.analysis-cache-{stage}` | accountId | cacheKey | Misnamed — see Section 2.7. |
+| `platform.job-results-{stage}` | accountId | cacheKey | Added M7 / PR #334 (Bucket A'). Platform-owned async AI job state (pending → retrying → complete/error). Written by `claude-proxy`, read by `analysis-cache` Lambda via `job-*` key prefix routing. TTL: 2h. |
 
 #### 2.10.2 Stock-analyser tables
 
@@ -615,6 +616,13 @@ The handler distinguishes two event shapes:
 2. **Async job path** — event has `__asyncJob: true`. Routes to
    `executeAsyncJob()`, which carries no auth check. This path is only
    reachable via the proxy self-invoking itself (see IAM boundary below).
+
+#### DynamoDB grants
+
+As of M7 / PR #334 (Bucket A'), `claude-proxy` writes async job records to
+`platform.job-results-{stage}` (PlatformTablesStack) and has **no IAM
+access** to `stock-analyser.analysis-cache-{stage}`. The prior coupling
+(writing job records to SA's table) was resolved by this PR.
 
 #### IAM trust boundary
 

--- a/infrastructure/bin/app.ts
+++ b/infrastructure/bin/app.ts
@@ -68,13 +68,13 @@ new AuthApiStack(app, 'TransformotionDev-AuthApi', {
   appUrl:      'https://dev.apps.transformotion.com.au',
 });
 
-new PlatformTablesStack(app, 'TransformotionDev-PlatformTables', {
+const devPlatformTables = new PlatformTablesStack(app, 'TransformotionDev-PlatformTables', {
   env,
   stage:       'dev',
   description: 'Transformotion Apps — Dev platform DynamoDB tables (users, accounts, invitations)',
 });
 
-const devStockAnalyserTables = new StockAnalyserTablesStack(app, 'TransformotionDev-StockAnalyserTables', {
+new StockAnalyserTablesStack(app, 'TransformotionDev-StockAnalyserTables', {
   env,
   stage:       'dev',
   description: 'Transformotion Apps — Dev Stock Analyser DynamoDB tables',
@@ -94,17 +94,18 @@ const devPlatformApi = new PlatformApiStack(app, 'TransformotionDev-Api', {
   userPool:                 devAuth.userPool,
   stockSignalAppClientId:   devAuth.stockAnalyserAppClient.userPoolClientId,
   budgetTrackerAppClientId: devAuth.budgetTrackerAppClient.userPoolClientId,
-  analysisCacheTable:       devStockAnalyserTables.analysisCacheTable,
+  jobResultsTable:          devPlatformTables.jobResultsTable,
   wsApiEndpoint:            devPlatformWs.wsApiEndpoint,
   wsApiId:                  devPlatformWs.webSocketApi.apiId,
 });
 
 new StockAnalyserApiStack(app, 'TransformotionDev-StockAnalyserApi', {
   env,
-  stage:       'dev',
-  description: 'Transformotion Apps — Dev Stock Analyser API routes',
-  api:         devPlatformApi.api,
-  authoriser:  devPlatformApi.authoriser,
+  stage:               'dev',
+  description:         'Transformotion Apps — Dev Stock Analyser API routes',
+  api:                 devPlatformApi.api,
+  authoriser:          devPlatformApi.authoriser,
+  jobResultsTableName: devPlatformTables.jobResultsTable.tableName,
 });
 
 const devBudgetTrackerTables = new BudgetTrackerTablesStack(app, 'TransformotionDev-BudgetTrackerTables', {
@@ -164,13 +165,13 @@ new AuthApiStack(app, 'TransformotionProd-AuthApi', {
   appUrl:      'https://apps.transformotion.com.au',
 });
 
-new PlatformTablesStack(app, 'TransformotionProd-PlatformTables', {
+const prodPlatformTables = new PlatformTablesStack(app, 'TransformotionProd-PlatformTables', {
   env,
   stage:       'prod',
   description: 'Transformotion Apps — Prod platform DynamoDB tables (users, accounts, invitations)',
 });
 
-const prodStockAnalyserTables = new StockAnalyserTablesStack(app, 'TransformotionProd-StockAnalyserTables', {
+new StockAnalyserTablesStack(app, 'TransformotionProd-StockAnalyserTables', {
   env,
   stage:       'prod',
   description: 'Transformotion Apps — Prod Stock Analyser DynamoDB tables',
@@ -190,17 +191,18 @@ const prodPlatformApi = new PlatformApiStack(app, 'TransformotionProd-Api', {
   userPool:                 prodAuth.userPool,
   stockSignalAppClientId:   prodAuth.stockAnalyserAppClient.userPoolClientId,
   budgetTrackerAppClientId: prodAuth.budgetTrackerAppClient.userPoolClientId,
-  analysisCacheTable:       prodStockAnalyserTables.analysisCacheTable,
+  jobResultsTable:          prodPlatformTables.jobResultsTable,
   wsApiEndpoint:            prodPlatformWs.wsApiEndpoint,
   wsApiId:                  prodPlatformWs.webSocketApi.apiId,
 });
 
 new StockAnalyserApiStack(app, 'TransformotionProd-StockAnalyserApi', {
   env,
-  stage:       'prod',
-  description: 'Transformotion Apps — Prod Stock Analyser API routes',
-  api:         prodPlatformApi.api,
-  authoriser:  prodPlatformApi.authoriser,
+  stage:               'prod',
+  description:         'Transformotion Apps — Prod Stock Analyser API routes',
+  api:                 prodPlatformApi.api,
+  authoriser:          prodPlatformApi.authoriser,
+  jobResultsTableName: prodPlatformTables.jobResultsTable.tableName,
 });
 
 const prodBudgetTrackerTables = new BudgetTrackerTablesStack(app, 'TransformotionProd-BudgetTrackerTables', {

--- a/platform/CLAUDE.md
+++ b/platform/CLAUDE.md
@@ -72,6 +72,16 @@ The `ws-authorizer` reads `?app=` from the query string (defaults to `budget-tra
 |---|---|---|---|---|
 | `platform.ws-connections-{stage}` | `connectionId` | `userId-index` | `expiresAt` (1h) | Active WebSocket connections for all apps |
 
+## Platform job results table (`PlatformTablesStack`)
+
+`platform.job-results-{stage}` — platform-owned async AI job state. Added M7 / PR #334 (Bucket A').
+
+| Table | PK | SK | TTL | Purpose |
+|---|---|---|---|---|
+| `platform.job-results-{stage}` | `accountId` | `cacheKey` | `expiresAt` (2h) | Async AI job records written by `claude-proxy`, read by `analysis-cache` Lambda via `job-*` key prefix |
+
+`claude-proxy` writes `cacheKey: job-{jobId}` records here (pending → retrying → complete/error). SA's `analysis-cache` Lambda routes GET requests for keys starting with `job-` to this table; all other keys continue to read from `stock-analyser.analysis-cache-{stage}`.
+
 ## Adding a new app's WebSocket flow
 
 1. Pass `?app=<appSlug>` in the WebSocket URL when connecting

--- a/platform/functions/claude-proxy/src/index.ts
+++ b/platform/functions/claude-proxy/src/index.ts
@@ -21,7 +21,7 @@ const sm           = new SecretsManagerClient({});
 const lambdaClient = new LambdaClient({});
 const ddb          = DynamoDBDocumentClient.from(new DynamoDBClient({}));
 
-const CACHE_TABLE     = process.env.CACHE_TABLE ?? '';
+const JOB_RESULTS_TABLE = process.env.JOB_RESULTS_TABLE ?? '';
 const WS_API_ENDPOINT = process.env.WS_API_ENDPOINT ?? '';
 const JOB_TTL_SECONDS = 2 * 60 * 60; // 2 hours
 
@@ -205,7 +205,7 @@ async function executeAsyncJob(job: AsyncJobEvent): Promise<void> {
   const writeJob = async (payload: Record<string, unknown>) => {
     const now = new Date().toISOString();
     await ddb.send(new PutCommand({
-      TableName: CACHE_TABLE,
+      TableName: JOB_RESULTS_TABLE,
       Item: {
         accountId: job.accountId,
         cacheKey:  `job-${job.jobId}`,
@@ -220,7 +220,7 @@ async function executeAsyncJob(job: AsyncJobEvent): Promise<void> {
     '[claude-proxy] Step 1 (async job): jobId:', job.jobId,
     'accountId:', job.accountId,
     'webSearch:', job.webSearch,
-    'CACHE_TABLE:', CACHE_TABLE,
+    'JOB_RESULTS_TABLE:', JOB_RESULTS_TABLE,
     'promptLength:', job.prompt.length,
   );
 
@@ -310,13 +310,13 @@ const apiGatewayHandler = withAuth(async ({ auth, account, event }) => {
       '[claude-proxy] Step 1 (trigger): asyncMode=true, jobId:', jobId,
       'accountId:', account.accountId,
       'webSearch:', webSearch,
-      'CACHE_TABLE:', CACHE_TABLE,
+      'JOB_RESULTS_TABLE:', JOB_RESULTS_TABLE,
       'fnName:', process.env.AWS_LAMBDA_FUNCTION_NAME,
     );
 
     // Write pending state so the frontend knows the job started
     await ddb.send(new PutCommand({
-      TableName: CACHE_TABLE,
+      TableName: JOB_RESULTS_TABLE,
       Item: {
         accountId: account.accountId,
         cacheKey:  `job-${jobId}`,

--- a/platform/infrastructure/platform-api-stack.ts
+++ b/platform/infrastructure/platform-api-stack.ts
@@ -16,8 +16,8 @@ export interface PlatformApiStackProps extends cdk.StackProps {
   /** Imported from AuthStack — used by account-provisioning to map aud → appSlug */
   stockSignalAppClientId: string;
   budgetTrackerAppClientId: string;
-  /** Imported from StockAnalyserTablesStack */
-  analysisCacheTable: dynamodb.ITable;
+  /** Imported from PlatformTablesStack — claude-proxy writes async job records here */
+  jobResultsTable: dynamodb.ITable;
   /** Imported from PlatformWsStack — enables claude-proxy to push WSS notifications */
   wsApiEndpoint?: string;
   /** Imported from PlatformWsStack — used for execute-api:ManageConnections IAM resource */
@@ -55,7 +55,7 @@ export class PlatformApiStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props: PlatformApiStackProps) {
     super(scope, id, props);
 
-    const { stage, userPool, stockSignalAppClientId, budgetTrackerAppClientId, analysisCacheTable, wsApiEndpoint, wsApiId } = props;
+    const { stage, userPool, stockSignalAppClientId, budgetTrackerAppClientId, jobResultsTable, wsApiEndpoint, wsApiId } = props;
 
     // ── REST API ─────────────────────────────────────────────────────────────
     this.api = new apigateway.RestApi(this, 'Api', {
@@ -162,14 +162,14 @@ export class PlatformApiStack extends cdk.Stack {
       memorySize:   512,
       environment: {
         ANTHROPIC_SECRET_NAME: anthropicSecret.secretName,
-        CACHE_TABLE:           analysisCacheTable.tableName,
+        JOB_RESULTS_TABLE:     jobResultsTable.tableName,
         ...(wsApiEndpoint ? { WS_API_ENDPOINT: wsApiEndpoint } : {}),
       },
       bundling: { externalModules: ['@aws-sdk/*'], minify: true, sourceMap: false, forceDockerBundling: false },
     });
 
     anthropicSecret.grantRead(claudeProxyFn);
-    analysisCacheTable.grantReadWriteData(claudeProxyFn);
+    jobResultsTable.grantReadWriteData(claudeProxyFn);
     claudeProxyFn.addToRolePolicy(new iam.PolicyStatement({
       actions:   ['lambda:InvokeFunction'],
       resources: [

--- a/platform/infrastructure/platform-tables-stack.ts
+++ b/platform/infrastructure/platform-tables-stack.ts
@@ -22,6 +22,7 @@ export class PlatformTablesStack extends cdk.Stack {
   public readonly accountsTable:       dynamodb.Table;
   public readonly accountMembersTable: dynamodb.Table;
   public readonly invitationsTable:    dynamodb.Table;
+  public readonly jobResultsTable:     dynamodb.Table;
 
   constructor(scope: Construct, id: string, props: PlatformTablesStackProps) {
     super(scope, id, props);
@@ -80,6 +81,20 @@ export class PlatformTablesStack extends cdk.Stack {
       projectionType: dynamodb.ProjectionType.ALL,
     });
 
+    // ── platform.job-results ──────────────────────────────────────────────
+    // PK: accountId  SK: cacheKey
+    // Stores async AI job state (pending → retrying → complete/error).
+    // Owned by platform (written by claude-proxy, read by SA/BT via analysis-cache).
+    // TTL: 2 hours — job records are transient.
+    this.jobResultsTable = new dynamodb.Table(this, 'JobResultsTable', {
+      tableName:           `platform.job-results-${stage}`,
+      partitionKey:        { name: 'accountId', type: dynamodb.AttributeType.STRING },
+      sortKey:             { name: 'cacheKey',  type: dynamodb.AttributeType.STRING },
+      billingMode:         dynamodb.BillingMode.PAY_PER_REQUEST,
+      timeToLiveAttribute: 'expiresAt',
+      removalPolicy:       removal,
+    });
+
     // ── Outputs ───────────────────────────────────────────────────────────
     const out = (id: string, table: dynamodb.Table, hint: string) => {
       new cdk.CfnOutput(this, id, {
@@ -93,5 +108,6 @@ export class PlatformTablesStack extends cdk.Stack {
     out('AccountsTableArn',       this.accountsTable,       'platform.accounts table ARN');
     out('AccountMembersTableArn', this.accountMembersTable, 'platform.account-members table ARN');
     out('InvitationsTableArn',    this.invitationsTable,    'platform.invitations table ARN');
+    out('JobResultsTableArn',     this.jobResultsTable,     'platform.job-results table ARN');
   }
 }


### PR DESCRIPTION
## Summary

Resolves finding F6 from the M7 recon: `claude-proxy` was writing async AI job records to `stock-analyser.analysis-cache-{stage}` — an SA-owned table. This PR separates the two concerns with a clean platform-owned table.

- New `platform.job-results-{stage}` DynamoDB table in `PlatformTablesStack` (PK accountId, SK cacheKey, TTL 2h)
- `claude-proxy` writes `job-*` records to the new platform table; IAM grant on SA's analysis-cache table removed
- SA `analysis-cache` Lambda routes GET requests for `job-*` keys to the platform table; all other keys unchanged
- `StockAnalyserApiStack` gains `jobResultsTableName` prop; read-only IAM grant wired for `analysis-cache` Lambda
- `PlatformApiStack` prop: `analysisCacheTable` → `jobResultsTable` (from `PlatformTablesStack`, not SA tables stack)
- `app.ts`: `PlatformTablesStack` assigned to variable; threaded to both `PlatformApiStack` and `StockAnalyserApiStack` (dev + prod)
- Docs: `inventory.md`, `platform/CLAUDE.md`, `apps/stock-analyser/CLAUDE.md`

## Deploy ordering

Platform deploys first (new table + claude-proxy env change). SA deploys second (analysis-cache routing). Between the two deploys frontend polling of `job-*` keys will 404 briefly — this is the documented window from the issue spec. The deploy workflow's wait-loop pattern handles sequencing.

## Smoke test

- `platform-ws-authorizer-dev` unchanged (no env change to this Lambda)
- After platform deploy: confirm `transformotion-claude-proxy-dev` env shows `JOB_RESULTS_TABLE` (not `CACHE_TABLE`)
- After SA deploy: run SA market analysis end-to-end — async job polling must complete successfully

## Test plan

- [x] `pnpm --filter @transformotion/infra typecheck` — clean
- [x] `pnpm --filter @transformotion/fn-claude-proxy typecheck` — clean
- [x] `pnpm --filter @transformotion/fn-analysis-cache typecheck` — clean
- [ ] Deploy to dev and verify `platform.job-results-dev` table created in DynamoDB
- [ ] Verify `transformotion-claude-proxy-dev` Lambda env: `JOB_RESULTS_TABLE` set, no `CACHE_TABLE`
- [ ] SA market analysis end-to-end smoke test

Closes #334

🤖 Generated with [Claude Code](https://claude.com/claude-code)