### PR TITLE
Fix SA deploy: break Fn::ImportValue cross-stack refs on platform.job-results (#341 hotfix)

### DIFF
--- a/infrastructure/bin/app.ts
+++ b/infrastructure/bin/app.ts
@@ -68,7 +68,7 @@ new AuthApiStack(app, 'TransformotionDev-AuthApi', {
   appUrl:      'https://dev.apps.transformotion.com.au',
 });
 
-const devPlatformTables = new PlatformTablesStack(app, 'TransformotionDev-PlatformTables', {
+new PlatformTablesStack(app, 'TransformotionDev-PlatformTables', {
   env,
   stage:       'dev',
   description: 'Transformotion Apps — Dev platform DynamoDB tables (users, accounts, invitations)',
@@ -94,7 +94,7 @@ const devPlatformApi = new PlatformApiStack(app, 'TransformotionDev-Api', {
   userPool:                 devAuth.userPool,
   stockSignalAppClientId:   devAuth.stockAnalyserAppClient.userPoolClientId,
   budgetTrackerAppClientId: devAuth.budgetTrackerAppClient.userPoolClientId,
-  jobResultsTable:          devPlatformTables.jobResultsTable,
+  jobResultsTableName:      'platform.job-results-dev',
   wsApiEndpoint:            devPlatformWs.wsApiEndpoint,
   wsApiId:                  devPlatformWs.webSocketApi.apiId,
 });
@@ -105,7 +105,7 @@ new StockAnalyserApiStack(app, 'TransformotionDev-StockAnalyserApi', {
   description:         'Transformotion Apps — Dev Stock Analyser API routes',
   api:                 devPlatformApi.api,
   authoriser:          devPlatformApi.authoriser,
-  jobResultsTableName: devPlatformTables.jobResultsTable.tableName,
+  jobResultsTableName: 'platform.job-results-dev',
 });
 
 const devBudgetTrackerTables = new BudgetTrackerTablesStack(app, 'TransformotionDev-BudgetTrackerTables', {
@@ -165,7 +165,7 @@ new AuthApiStack(app, 'TransformotionProd-AuthApi', {
   appUrl:      'https://apps.transformotion.com.au',
 });
 
-const prodPlatformTables = new PlatformTablesStack(app, 'TransformotionProd-PlatformTables', {
+new PlatformTablesStack(app, 'TransformotionProd-PlatformTables', {
   env,
   stage:       'prod',
   description: 'Transformotion Apps — Prod platform DynamoDB tables (users, accounts, invitations)',
@@ -191,7 +191,7 @@ const prodPlatformApi = new PlatformApiStack(app, 'TransformotionProd-Api', {
   userPool:                 prodAuth.userPool,
   stockSignalAppClientId:   prodAuth.stockAnalyserAppClient.userPoolClientId,
   budgetTrackerAppClientId: prodAuth.budgetTrackerAppClient.userPoolClientId,
-  jobResultsTable:          prodPlatformTables.jobResultsTable,
+  jobResultsTableName:      'platform.job-results-prod',
   wsApiEndpoint:            prodPlatformWs.wsApiEndpoint,
   wsApiId:                  prodPlatformWs.webSocketApi.apiId,
 });
@@ -202,7 +202,7 @@ new StockAnalyserApiStack(app, 'TransformotionProd-StockAnalyserApi', {
   description:         'Transformotion Apps — Prod Stock Analyser API routes',
   api:                 prodPlatformApi.api,
   authoriser:          prodPlatformApi.authoriser,
-  jobResultsTableName: prodPlatformTables.jobResultsTable.tableName,
+  jobResultsTableName: 'platform.job-results-prod',
 });
 
 const prodBudgetTrackerTables = new BudgetTrackerTablesStack(app, 'TransformotionProd-BudgetTrackerTables', {

--- a/platform/infrastructure/platform-api-stack.ts
+++ b/platform/infrastructure/platform-api-stack.ts
@@ -16,8 +16,8 @@ export interface PlatformApiStackProps extends cdk.StackProps {
   /** Imported from AuthStack — used by account-provisioning to map aud → appSlug */
   stockSignalAppClientId: string;
   budgetTrackerAppClientId: string;
-  /** Imported from PlatformTablesStack — claude-proxy writes async job records here */
-  jobResultsTable: dynamodb.ITable;
+  /** Table name for platform.job-results-{stage} — claude-proxy writes async job records here */
+  jobResultsTableName: string;
   /** Imported from PlatformWsStack — enables claude-proxy to push WSS notifications */
   wsApiEndpoint?: string;
   /** Imported from PlatformWsStack — used for execute-api:ManageConnections IAM resource */
@@ -55,7 +55,9 @@ export class PlatformApiStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props: PlatformApiStackProps) {
     super(scope, id, props);
 
-    const { stage, userPool, stockSignalAppClientId, budgetTrackerAppClientId, jobResultsTable, wsApiEndpoint, wsApiId } = props;
+    const { stage, userPool, stockSignalAppClientId, budgetTrackerAppClientId, jobResultsTableName, wsApiEndpoint, wsApiId } = props;
+
+    const jobResultsTable = dynamodb.Table.fromTableName(this, 'JobResultsTable', jobResultsTableName);
 
     // ── REST API ─────────────────────────────────────────────────────────────
     this.api = new apigateway.RestApi(this, 'Api', {


### PR DESCRIPTION
## Summary

Hotfix for a deploy failure introduced by #341.

When #341 passed `devPlatformTables.jobResultsTable` (a CDK `ITable` object) to `PlatformApiStack` and `StockAnalyserApiStack`, CDK generated `Fn::ImportValue` from both stacks into `TransformotionDev-PlatformTables`. The SA deploy workflow picked up the dependency and tried to redeploy PlatformTables — but the platform workflow had already executed that changeset, producing `InvalidChangeSetStatusException: EXECUTE_COMPLETE`.

**Fix:** both stacks now accept `jobResultsTableName: string` and call `Table.fromTableName()` internally. The table name follows the known naming convention (`platform.job-results-{stage}`) so no cross-stack CDK token is needed. The ARN is inlined as a literal in each CloudFormation template; zero `Fn::ImportValue` generated.

**Verified by synth:** `grep "PlatformTables" TransformotionDev-Api.template.json TransformotionDev-StockAnalyserApi.template.json` → no matches.

## Test plan

- [x] `pnpm --filter @transformotion/infra typecheck` — clean
- [x] CDK synth — zero `Fn::ImportValue` from PlatformTables in Api or StockAnalyserApi templates
- [ ] SA deploy completes without `InvalidChangeSetStatusException`
- [ ] SA market analysis smoke test

🤖 Generated with [Claude Code](https://claude.com/claude-code)