### PR TITLE
Fix deploy order: Platform stacks before PlatformTables (CF export deadlock)

### DIFF
--- a/.github/workflows/deploy-platform.yml
+++ b/.github/workflows/deploy-platform.yml
@@ -58,13 +58,13 @@ jobs:
         working-directory: infrastructure
         run: pnpm exec cdk deploy 'Transformotion-GithubActionsRole' --require-approval never
 
-      - name: CDK Deploy — PlatformTables (dev) (must precede Api — Api imports job-results table ARN via Fn::ImportValue)
-        working-directory: infrastructure
-        run: pnpm exec cdk deploy 'TransformotionDev-PlatformTables' --require-approval never
-
       - name: CDK Deploy — Platform stacks (dev)
         working-directory: infrastructure
         run: pnpm exec cdk deploy 'TransformotionDev-Storage' 'TransformotionDev-Network' 'TransformotionDev-Auth' 'TransformotionDev-AuthApi' 'TransformotionDev-Api' --require-approval never
+
+      - name: CDK Deploy — PlatformTables (dev) (must follow Platform stacks — PlatformApiStack uses Table.fromTableName(), no Fn::ImportValue dependency)
+        working-directory: infrastructure
+        run: pnpm exec cdk deploy 'TransformotionDev-PlatformTables' --require-approval never
 
       - name: CDK Deploy — PlatformWs (dev)
         working-directory: infrastructure
@@ -99,13 +99,13 @@ jobs:
         working-directory: infrastructure
         run: pnpm exec cdk deploy 'Transformotion-GithubActionsRole' --require-approval never
 
-      - name: CDK Deploy — PlatformTables (prod) (must precede Api — Api imports job-results table ARN via Fn::ImportValue)
-        working-directory: infrastructure
-        run: pnpm exec cdk deploy 'TransformotionProd-PlatformTables' --require-approval never
-
       - name: CDK Deploy — Platform stacks (prod)
         working-directory: infrastructure
         run: pnpm exec cdk deploy 'TransformotionProd-Storage' 'TransformotionProd-Network' 'TransformotionProd-Auth' 'TransformotionProd-AuthApi' 'TransformotionProd-Api' --require-approval never
+
+      - name: CDK Deploy — PlatformTables (prod) (must follow Platform stacks — PlatformApiStack uses Table.fromTableName(), no Fn::ImportValue dependency)
+        working-directory: infrastructure
+        run: pnpm exec cdk deploy 'TransformotionProd-PlatformTables' --require-approval never
 
       - name: CDK Deploy — PlatformWs (prod)
         working-directory: infrastructure


### PR DESCRIPTION
## Problem

After PR #341 merged and deployed, the platform deploy now fails with:

```
Cannot delete export Transformotion-dev-JobResultsTableArn as it is in use by
TransformotionDev-Api and TransformotionDev-StockAnalyserApi
```

**Root cause:** #341 deployed live CF stacks with `Fn::ImportValue` pointing from `TransformotionDev-Api` and `TransformotionDev-StockAnalyserApi` into `PlatformTables`. PR #342 removed those imports at the code level (switched to `Table.fromTableName()` with literal strings), but the live stacks still have the old `Fn::ImportValue` references. CF won't let `PlatformTables` remove its exported outputs while they're still in use.

**Resolution:** Deploy `TransformotionDev-Api` (Platform stacks step) before `TransformotionDev-PlatformTables`. When Api deploys with #342's code, it drops its `Fn::ImportValue` from PlatformTables. Then PlatformTables can safely remove its `Fn::ImportValue`-backed outputs.

## Change

Reorder `deploy-platform.yml` steps (dev and prod):

**Before:**
1. GithubActionsRole
2. PlatformTables ← deadlocked here
3. Platform stacks (Storage, Network, Auth, AuthApi, Api)
4. PlatformWs

**After:**
1. GithubActionsRole
2. Platform stacks (Storage, Network, Auth, AuthApi, Api) ← Api deploys, drops its Fn::ImportValue
3. PlatformTables ← can now remove exports safely
4. PlatformWs

This order is permanently correct: `PlatformApiStack` now uses `Table.fromTableName()` (no cross-stack CDK token), so PlatformTables has no CF dependency on Api. The old comment ("must precede Api — Api imports job-results table ARN via Fn::ImportValue") is replaced with the new reality.

## Manual deploy sequence required after merge

1. Trigger SA deploy first (`deploy-stock-analyser.yml --field target=dev`) — drops `StockAnalyserApi`'s `Fn::ImportValue` from PlatformTables
2. After SA deploy succeeds, trigger platform deploy (`deploy-platform.yml --field target=dev`) — Api step drops Api's import, then PlatformTables can remove exports

## Related

- Fixes deadlock introduced by #341 (platform job-results table extraction)
- Completes fix started in #342 (cross-stack CDK reference removal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)