### PR TITLE
Restore deploy order: PlatformTables before Platform stacks (#343 follow-up)

### DIFF
--- a/.github/workflows/deploy-platform.yml
+++ b/.github/workflows/deploy-platform.yml
@@ -58,13 +58,13 @@ jobs:
         working-directory: infrastructure
         run: pnpm exec cdk deploy 'Transformotion-GithubActionsRole' --require-approval never
 
+      - name: CDK Deploy — PlatformTables (dev)
+        working-directory: infrastructure
+        run: pnpm exec cdk deploy 'TransformotionDev-PlatformTables' --require-approval never
+
       - name: CDK Deploy — Platform stacks (dev)
         working-directory: infrastructure
         run: pnpm exec cdk deploy 'TransformotionDev-Storage' 'TransformotionDev-Network' 'TransformotionDev-Auth' 'TransformotionDev-AuthApi' 'TransformotionDev-Api' --require-approval never
-
-      - name: CDK Deploy — PlatformTables (dev) (must follow Platform stacks — PlatformApiStack uses Table.fromTableName(), no Fn::ImportValue dependency)
-        working-directory: infrastructure
-        run: pnpm exec cdk deploy 'TransformotionDev-PlatformTables' --require-approval never
 
       - name: CDK Deploy — PlatformWs (dev)
         working-directory: infrastructure
@@ -99,13 +99,13 @@ jobs:
         working-directory: infrastructure
         run: pnpm exec cdk deploy 'Transformotion-GithubActionsRole' --require-approval never
 
+      - name: CDK Deploy — PlatformTables (prod)
+        working-directory: infrastructure
+        run: pnpm exec cdk deploy 'TransformotionProd-PlatformTables' --require-approval never
+
       - name: CDK Deploy — Platform stacks (prod)
         working-directory: infrastructure
         run: pnpm exec cdk deploy 'TransformotionProd-Storage' 'TransformotionProd-Network' 'TransformotionProd-Auth' 'TransformotionProd-AuthApi' 'TransformotionProd-Api' --require-approval never
-
-      - name: CDK Deploy — PlatformTables (prod) (must follow Platform stacks — PlatformApiStack uses Table.fromTableName(), no Fn::ImportValue dependency)
-        working-directory: infrastructure
-        run: pnpm exec cdk deploy 'TransformotionProd-PlatformTables' --require-approval never
 
       - name: CDK Deploy — PlatformWs (prod)
         working-directory: infrastructure


### PR DESCRIPTION
## Summary

Reverts the step order introduced in #343, now that the transitional deploy has completed.

**#343 context:** The transitional deploy (Platform stacks → PlatformTables) was required to break the CloudFormation export deadlock: `TransformotionDev-Api` and `TransformotionDev-StockAnalyserApi` had live `Fn::ImportValue` references into `PlatformTables` (from PR #341). Deploying Api first dropped those imports; PlatformTables could then remove its exported outputs.

**This PR:** Now that no live stack imports from PlatformTables, the order has no CF constraint in either direction. Restoring PlatformTables-first is the correct permanent ordering:

- Tables exist before any Lambda that writes to them at runtime (greenfield correctness)
- Matches the resource-dependency mental model (infrastructure before application)
- `PlatformApiStack` uses `Table.fromTableName()` throughout — no `Fn::ImportValue` generated, order doesn't affect CF at all

## Change

Both dev and prod sections: PlatformTables → Platform stacks (Storage, Network, Auth, AuthApi, Api) → PlatformWs

Step names cleaned up — no explanatory parenthetical needed since this is the correct natural order.

## Merge when

After the platform deploy triggered post-#343 merge confirms clean (Api drops import, PlatformTables removes exports). This PR should merge immediately after that confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)