### PR TITLE
fix: use full npx ts-node form in CDK --app flag (fixes exit 126)

### DIFF
--- a/.github/workflows/deploy-budget-tracker.yml
+++ b/.github/workflows/deploy-budget-tracker.yml
@@ -95,7 +95,7 @@ jobs:
 
       - name: CDK Deploy — Budget Tracker stacks (dev)
         working-directory: infrastructure
-        run: pnpm exec cdk deploy --app 'bin/budget-tracker.ts' 'TransformotionDev-BudgetTrackerTables' 'TransformotionDev-BudgetTrackerApi' --require-approval never
+        run: pnpm exec cdk deploy --app 'npx ts-node --prefer-ts-exts bin/budget-tracker.ts' 'TransformotionDev-BudgetTrackerTables' 'TransformotionDev-BudgetTrackerApi' --require-approval never
 
       - name: Extract WebSocket URL from CDK output
         run: |
@@ -211,7 +211,7 @@ jobs:
 
       - name: CDK Deploy — Budget Tracker stacks (prod)
         working-directory: infrastructure
-        run: pnpm exec cdk deploy --app 'bin/budget-tracker.ts' 'TransformotionProd-BudgetTrackerTables' 'TransformotionProd-BudgetTrackerApi' --require-approval never
+        run: pnpm exec cdk deploy --app 'npx ts-node --prefer-ts-exts bin/budget-tracker.ts' 'TransformotionProd-BudgetTrackerTables' 'TransformotionProd-BudgetTrackerApi' --require-approval never
 
       - name: Extract WebSocket URL from CDK output
         run: |

--- a/.github/workflows/deploy-migration-utilities.yml
+++ b/.github/workflows/deploy-migration-utilities.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: CDK Deploy — Migration Utilities stack (dev)
         working-directory: infrastructure
-        run: pnpm exec cdk deploy --app 'bin/migration-utilities.ts' 'TransformotionDev-MigrationsApi' --require-approval never
+        run: pnpm exec cdk deploy --app 'npx ts-node --prefer-ts-exts bin/migration-utilities.ts' 'TransformotionDev-MigrationsApi' --require-approval never
 
   deploy-prod:
     name: Migration Utilities → Prod
@@ -83,4 +83,4 @@ jobs:
 
       - name: CDK Deploy — Migration Utilities stack (prod)
         working-directory: infrastructure
-        run: pnpm exec cdk deploy --app 'bin/migration-utilities.ts' 'TransformotionProd-MigrationsApi' --require-approval never
+        run: pnpm exec cdk deploy --app 'npx ts-node --prefer-ts-exts bin/migration-utilities.ts' 'TransformotionProd-MigrationsApi' --require-approval never

--- a/.github/workflows/deploy-platform.yml
+++ b/.github/workflows/deploy-platform.yml
@@ -56,19 +56,19 @@ jobs:
 
       - name: CDK Deploy — GithubActionsRole (account-level, deploy once)
         working-directory: infrastructure
-        run: pnpm exec cdk deploy --app 'bin/platform.ts' 'Transformotion-GithubActionsRole' --require-approval never
+        run: pnpm exec cdk deploy --app 'npx ts-node --prefer-ts-exts bin/platform.ts' 'Transformotion-GithubActionsRole' --require-approval never
 
       - name: CDK Deploy — PlatformTables (dev)
         working-directory: infrastructure
-        run: pnpm exec cdk deploy --app 'bin/platform.ts' 'TransformotionDev-PlatformTables' --require-approval never
+        run: pnpm exec cdk deploy --app 'npx ts-node --prefer-ts-exts bin/platform.ts' 'TransformotionDev-PlatformTables' --require-approval never
 
       - name: CDK Deploy — Platform stacks (dev)
         working-directory: infrastructure
-        run: pnpm exec cdk deploy --app 'bin/platform.ts' 'TransformotionDev-Storage' 'TransformotionDev-Network' 'TransformotionDev-Auth' 'TransformotionDev-AuthApi' 'TransformotionDev-Api' --require-approval never
+        run: pnpm exec cdk deploy --app 'npx ts-node --prefer-ts-exts bin/platform.ts' 'TransformotionDev-Storage' 'TransformotionDev-Network' 'TransformotionDev-Auth' 'TransformotionDev-AuthApi' 'TransformotionDev-Api' --require-approval never
 
       - name: CDK Deploy — PlatformWs (dev)
         working-directory: infrastructure
-        run: pnpm exec cdk deploy --app 'bin/platform.ts' 'TransformotionDev-PlatformWs' --require-approval never
+        run: pnpm exec cdk deploy --app 'npx ts-node --prefer-ts-exts bin/platform.ts' 'TransformotionDev-PlatformWs' --require-approval never
 
   deploy-prod:
     name: Platform → Prod
@@ -97,16 +97,16 @@ jobs:
 
       - name: CDK Deploy — GithubActionsRole (account-level, deploy once)
         working-directory: infrastructure
-        run: pnpm exec cdk deploy --app 'bin/platform.ts' 'Transformotion-GithubActionsRole' --require-approval never
+        run: pnpm exec cdk deploy --app 'npx ts-node --prefer-ts-exts bin/platform.ts' 'Transformotion-GithubActionsRole' --require-approval never
 
       - name: CDK Deploy — PlatformTables (prod)
         working-directory: infrastructure
-        run: pnpm exec cdk deploy --app 'bin/platform.ts' 'TransformotionProd-PlatformTables' --require-approval never
+        run: pnpm exec cdk deploy --app 'npx ts-node --prefer-ts-exts bin/platform.ts' 'TransformotionProd-PlatformTables' --require-approval never
 
       - name: CDK Deploy — Platform stacks (prod)
         working-directory: infrastructure
-        run: pnpm exec cdk deploy --app 'bin/platform.ts' 'TransformotionProd-Storage' 'TransformotionProd-Network' 'TransformotionProd-Auth' 'TransformotionProd-AuthApi' 'TransformotionProd-Api' --require-approval never
+        run: pnpm exec cdk deploy --app 'npx ts-node --prefer-ts-exts bin/platform.ts' 'TransformotionProd-Storage' 'TransformotionProd-Network' 'TransformotionProd-Auth' 'TransformotionProd-AuthApi' 'TransformotionProd-Api' --require-approval never
 
       - name: CDK Deploy — PlatformWs (prod)
         working-directory: infrastructure
-        run: pnpm exec cdk deploy --app 'bin/platform.ts' 'TransformotionProd-PlatformWs' --require-approval never
+        run: pnpm exec cdk deploy --app 'npx ts-node --prefer-ts-exts bin/platform.ts' 'TransformotionProd-PlatformWs' --require-approval never

--- a/.github/workflows/deploy-stock-analyser.yml
+++ b/.github/workflows/deploy-stock-analyser.yml
@@ -72,7 +72,7 @@ jobs:
 
       - name: CDK Deploy — Stock Analyser stacks (dev)
         working-directory: infrastructure
-        run: pnpm exec cdk deploy --app 'bin/stock-analyser.ts' 'TransformotionDev-StockAnalyserApi' --require-approval never
+        run: pnpm exec cdk deploy --app 'npx ts-node --prefer-ts-exts bin/stock-analyser.ts' 'TransformotionDev-StockAnalyserApi' --require-approval never
 
       - name: Wait for PlatformWs stack (handles first-deploy race; see #295)
         run: |
@@ -187,7 +187,7 @@ jobs:
 
       - name: CDK Deploy — Stock Analyser stacks (prod)
         working-directory: infrastructure
-        run: pnpm exec cdk deploy --app 'bin/stock-analyser.ts' 'TransformotionProd-StockAnalyserTables' 'TransformotionProd-StockAnalyserApi' --require-approval never
+        run: pnpm exec cdk deploy --app 'npx ts-node --prefer-ts-exts bin/stock-analyser.ts' 'TransformotionProd-StockAnalyserTables' 'TransformotionProd-StockAnalyserApi' --require-approval never
 
       - name: Wait for PlatformWs stack (handles first-deploy race; see #295)
         run: |


### PR DESCRIPTION
## Problem

PR #348 added `--app 'bin/{entrypoint}.ts'` to all CDK deploy steps. The `--app` flag overrides the `"app"` key in `infrastructure/cdk.json`. `cdk.json` contains the full command:

```
"app": "npx ts-node --prefer-ts-exts bin/platform.ts"
```

Providing only the path as `--app 'bin/platform.ts'` tells CDK to execute `bin/platform.ts` directly as a binary. The OS rejects this with exit code 126 (Permission denied) because `.ts` files have no execute permission.

Observed in platform deploy run after PR #348 merged:
```
/bin/sh: 1: bin/platform.ts: Permission denied
bin/platform.ts: Subprocess exited with error 126
```

## Fix

Changed all `--app 'bin/{entrypoint}.ts'` to `--app 'npx ts-node --prefer-ts-exts bin/{entrypoint}.ts'` — the full form matching the `cdk.json` pattern.

Affects 14 CDK deploy steps across four workflows:
- `deploy-platform.yml` — 8 steps (4 dev + 4 prod)
- `deploy-stock-analyser.yml` — 2 steps
- `deploy-budget-tracker.yml` — 2 steps
- `deploy-migration-utilities.yml` — 2 steps

Closes #349