### PR TITLE
feat(m7): replace workflow_run with workflow_call cascade (#351)

### DIFF
--- a/.github/workflows/deploy-budget-tracker.yml
+++ b/.github/workflows/deploy-budget-tracker.yml
@@ -1,10 +1,23 @@
 name: Deploy — Budget Tracker
 
 on:
-  workflow_run:
-    workflows: ['Deploy — Platform Infrastructure']
-    types: [completed]
+  push:
     branches: [develop, main]
+    paths:
+      - 'apps/budget-tracker/**'
+      - 'infrastructure/bin/budget-tracker.ts'
+      - 'packages/api-client/**'
+      - 'packages/ui/**'
+      - 'packages/auth-client/**'
+      - 'packages/runtime-config/**'
+      - 'packages/lambda-middleware/**'
+      - 'packages/budget-domain/**'
+  workflow_call:
+    inputs:
+      target:
+        required: true
+        type: string
+        description: 'Deploy target: dev or prod'
   workflow_dispatch:
     inputs:
       target:
@@ -15,7 +28,7 @@ on:
         options: [dev, prod]
 
 concurrency:
-  group: deploy-budget-tracker-${{ github.event.workflow_run.head_branch || github.ref_name }}
+  group: deploy-budget-tracker-${{ github.ref_name }}
   cancel-in-progress: false
 
 permissions:
@@ -30,7 +43,7 @@ jobs:
   deploy-dev:
     name: Budget Tracker → Dev
     runs-on: ubuntu-latest
-    if: (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'develop') || (github.event_name == 'workflow_dispatch' && inputs.target == 'dev')
+    if: (github.event_name == 'push' && github.ref_name == 'develop') || (github.event_name == 'workflow_call' && inputs.target == 'dev') || (github.event_name == 'workflow_dispatch' && inputs.target == 'dev')
     environment: dev
     env:
       NEXT_PUBLIC_RUNTIME_PROFILE: live
@@ -146,7 +159,7 @@ jobs:
   deploy-prod:
     name: Budget Tracker → Prod
     runs-on: ubuntu-latest
-    if: (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main') || (github.event_name == 'workflow_dispatch' && inputs.target == 'prod')
+    if: (github.event_name == 'push' && github.ref_name == 'main') || (github.event_name == 'workflow_call' && inputs.target == 'prod') || (github.event_name == 'workflow_dispatch' && inputs.target == 'prod')
     environment: prod
     env:
       NEXT_PUBLIC_RUNTIME_PROFILE: live

--- a/.github/workflows/deploy-launchpad.yml
+++ b/.github/workflows/deploy-launchpad.yml
@@ -1,10 +1,19 @@
 name: Deploy — Launchpad
 
 on:
-  workflow_run:
-    workflows: ['Deploy — Platform Infrastructure']
-    types: [completed]
+  push:
     branches: [develop, main]
+    paths:
+      - 'apps/launchpad/**'
+      - 'infrastructure/bin/launchpad.ts'
+      - 'packages/auth-client/**'
+      - 'packages/runtime-config/**'
+  workflow_call:
+    inputs:
+      target:
+        required: true
+        type: string
+        description: 'Deploy target: dev or prod'
   workflow_dispatch:
     inputs:
       target:
@@ -15,7 +24,7 @@ on:
         options: [dev, prod]
 
 concurrency:
-  group: deploy-launchpad-${{ github.event.workflow_run.head_branch || github.ref_name }}
+  group: deploy-launchpad-${{ github.ref_name }}
   cancel-in-progress: false
 
 permissions:
@@ -30,7 +39,7 @@ jobs:
   deploy-dev:
     name: Launchpad → Dev
     runs-on: ubuntu-latest
-    if: (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'develop') || (github.event_name == 'workflow_dispatch' && inputs.target == 'dev')
+    if: (github.event_name == 'push' && github.ref_name == 'develop') || (github.event_name == 'workflow_call' && inputs.target == 'dev') || (github.event_name == 'workflow_dispatch' && inputs.target == 'dev')
     environment: dev
     env:
       NEXT_PUBLIC_COGNITO_USER_POOL_ID: ${{ vars.NEXT_PUBLIC_COGNITO_USER_POOL_ID }}
@@ -96,7 +105,7 @@ jobs:
   deploy-prod:
     name: Launchpad → Prod
     runs-on: ubuntu-latest
-    if: (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main') || (github.event_name == 'workflow_dispatch' && inputs.target == 'prod')
+    if: (github.event_name == 'push' && github.ref_name == 'main') || (github.event_name == 'workflow_call' && inputs.target == 'prod') || (github.event_name == 'workflow_dispatch' && inputs.target == 'prod')
     environment: prod
     env:
       NEXT_PUBLIC_COGNITO_USER_POOL_ID: ${{ vars.NEXT_PUBLIC_COGNITO_USER_POOL_ID }}

--- a/.github/workflows/deploy-migration-utilities.yml
+++ b/.github/workflows/deploy-migration-utilities.yml
@@ -1,10 +1,18 @@
 name: Deploy — Migration Utilities
 
 on:
-  workflow_run:
-    workflows: ['Deploy — Platform Infrastructure']
-    types: [completed]
+  push:
     branches: [develop, main]
+    paths:
+      - 'migration-utilities/**'
+      - 'infrastructure/bin/migration-utilities.ts'
+      - 'packages/**'
+  workflow_call:
+    inputs:
+      target:
+        required: true
+        type: string
+        description: 'Deploy target: dev or prod'
   workflow_dispatch:
     inputs:
       target:
@@ -15,7 +23,7 @@ on:
         options: [dev, prod]
 
 concurrency:
-  group: deploy-migration-utilities-${{ github.event.workflow_run.head_branch || github.ref_name }}
+  group: deploy-migration-utilities-${{ github.ref_name }}
   cancel-in-progress: false
 
 permissions:
@@ -30,7 +38,7 @@ jobs:
   deploy-dev:
     name: Migration Utilities → Dev
     runs-on: ubuntu-latest
-    if: (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'develop') || (github.event_name == 'workflow_dispatch' && inputs.target == 'dev')
+    if: (github.event_name == 'push' && github.ref_name == 'develop') || (github.event_name == 'workflow_call' && inputs.target == 'dev') || (github.event_name == 'workflow_dispatch' && inputs.target == 'dev')
     environment: dev
     steps:
       - uses: actions/checkout@v4
@@ -59,7 +67,7 @@ jobs:
   deploy-prod:
     name: Migration Utilities → Prod
     runs-on: ubuntu-latest
-    if: (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main') || (github.event_name == 'workflow_dispatch' && inputs.target == 'prod')
+    if: (github.event_name == 'push' && github.ref_name == 'main') || (github.event_name == 'workflow_call' && inputs.target == 'prod') || (github.event_name == 'workflow_dispatch' && inputs.target == 'prod')
     environment: prod
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/deploy-platform.yml
+++ b/.github/workflows/deploy-platform.yml
@@ -110,3 +110,41 @@ jobs:
       - name: CDK Deploy — PlatformWs (prod)
         working-directory: infrastructure
         run: pnpm exec cdk deploy --app 'npx ts-node --prefer-ts-exts bin/platform.ts' 'TransformotionProd-PlatformWs' --require-approval never
+
+  # ── App cascades ─────────────────────────────────────────────────────────────
+  # Reusable-workflow calls fire after whichever platform job succeeded.
+  # Using always() + result check so a skipped sibling job does not
+  # prevent the cascade from running.
+  # target is 'prod' when the prod platform job succeeded, otherwise 'dev'.
+
+  cascade-stock-analyser:
+    needs: [deploy-dev, deploy-prod]
+    if: always() && (needs.deploy-dev.result == 'success' || needs.deploy-prod.result == 'success')
+    uses: ./.github/workflows/deploy-stock-analyser.yml
+    with:
+      target: ${{ needs.deploy-prod.result == 'success' && 'prod' || 'dev' }}
+    secrets: inherit
+
+  cascade-budget-tracker:
+    needs: [deploy-dev, deploy-prod]
+    if: always() && (needs.deploy-dev.result == 'success' || needs.deploy-prod.result == 'success')
+    uses: ./.github/workflows/deploy-budget-tracker.yml
+    with:
+      target: ${{ needs.deploy-prod.result == 'success' && 'prod' || 'dev' }}
+    secrets: inherit
+
+  cascade-migration-utilities:
+    needs: [deploy-dev, deploy-prod]
+    if: always() && (needs.deploy-dev.result == 'success' || needs.deploy-prod.result == 'success')
+    uses: ./.github/workflows/deploy-migration-utilities.yml
+    with:
+      target: ${{ needs.deploy-prod.result == 'success' && 'prod' || 'dev' }}
+    secrets: inherit
+
+  cascade-launchpad:
+    needs: [deploy-dev, deploy-prod]
+    if: always() && (needs.deploy-dev.result == 'success' || needs.deploy-prod.result == 'success')
+    uses: ./.github/workflows/deploy-launchpad.yml
+    with:
+      target: ${{ needs.deploy-prod.result == 'success' && 'prod' || 'dev' }}
+    secrets: inherit

--- a/.github/workflows/deploy-stock-analyser.yml
+++ b/.github/workflows/deploy-stock-analyser.yml
@@ -1,10 +1,22 @@
 name: Deploy — Stock Analyser
 
 on:
-  workflow_run:
-    workflows: ['Deploy — Platform Infrastructure']
-    types: [completed]
+  push:
     branches: [develop, main]
+    paths:
+      - 'apps/stock-analyser/**'
+      - 'infrastructure/bin/stock-analyser.ts'
+      - 'packages/api-client/**'
+      - 'packages/ui/**'
+      - 'packages/auth-client/**'
+      - 'packages/runtime-config/**'
+      - 'packages/lambda-middleware/**'
+  workflow_call:
+    inputs:
+      target:
+        required: true
+        type: string
+        description: 'Deploy target: dev or prod'
   workflow_dispatch:
     inputs:
       target:
@@ -15,7 +27,7 @@ on:
         options: [dev, prod]
 
 concurrency:
-  group: deploy-stock-analyser-${{ github.event.workflow_run.head_branch || github.ref_name }}
+  group: deploy-stock-analyser-${{ github.ref_name }}
   cancel-in-progress: false
 
 permissions:
@@ -30,7 +42,7 @@ jobs:
   deploy-dev:
     name: Stock Analyser → Dev
     runs-on: ubuntu-latest
-    if: (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'develop') || (github.event_name == 'workflow_dispatch' && inputs.target == 'dev')
+    if: (github.event_name == 'push' && github.ref_name == 'develop') || (github.event_name == 'workflow_call' && inputs.target == 'dev') || (github.event_name == 'workflow_dispatch' && inputs.target == 'dev')
     environment: dev
     env:
       NEXT_PUBLIC_API_URL: ${{ vars.NEXT_PUBLIC_API_URL }}
@@ -145,7 +157,7 @@ jobs:
   deploy-prod:
     name: Stock Analyser → Prod
     runs-on: ubuntu-latest
-    if: (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main') || (github.event_name == 'workflow_dispatch' && inputs.target == 'prod')
+    if: (github.event_name == 'push' && github.ref_name == 'main') || (github.event_name == 'workflow_call' && inputs.target == 'prod') || (github.event_name == 'workflow_dispatch' && inputs.target == 'prod')
     environment: prod
     env:
       NEXT_PUBLIC_API_URL: ${{ vars.NEXT_PUBLIC_API_URL }}

--- a/docs/architecture/urls-and-deploy.md
+++ b/docs/architecture/urls-and-deploy.md
@@ -117,27 +117,51 @@ Implemented behaviors with `SubAppIndexRewrite` — all active as of M7 #251 (ve
 
 ## Deploy triggers
 
-Deploy ordering is sequenced via `workflow_run` (Pattern A, established M7 / #348): the platform workflow fires on push; the four app workflows fire automatically after platform completes successfully.
+Deploy ordering uses a two-layer model: platform fires on push; app workflows cascade via `workflow_call` from within `deploy-platform.yml`.
+
+### Why workflow_call, not workflow_run
+
+PR #348 used `workflow_run` for the cascade. GitHub's `workflow_run` trigger only activates when the listener workflow file exists on the **repository's default branch** (`main`). With `develop` as the active integration branch and `main` as the (not-yet-active) production branch, `workflow_run` cascades from `develop` were permanently inert — every app deploy after a platform deploy required a manual `workflow_dispatch`. PR #351 replaced `workflow_run` with `workflow_call` (reusable workflows), which has no default-branch restriction and fires correctly from any branch.
 
 ### Platform (fires on push)
 
 `deploy-platform.yml` triggers on push to `develop` or `main` when any of these paths change:
 - `platform/infrastructure/**`, `infrastructure/bin/platform.ts`, `platform/functions/**`
 
-Deploys all platform CDK stacks (`--app bin/platform.ts`): GithubActionsRole, Storage, Network, Auth, AuthApi, PlatformTables, PlatformWs, Api (dev + prod).
+Also triggerable via `workflow_dispatch` with `target: dev | prod`.
 
-### App workflows (fire after platform completes)
+Deploys all platform CDK stacks (`--app bin/platform.ts`): GithubActionsRole, Storage, Network, Auth, AuthApi, PlatformTables, PlatformWs, Api (dev + prod). After the platform job succeeds, four cascade jobs call the app workflows as reusable workflows in parallel.
 
-After `deploy-platform.yml` completes successfully, these workflows fire automatically via `workflow_run` with `conclusion == 'success'`:
+### App workflows (cascade via workflow_call)
 
-| Workflow | What it deploys |
+`deploy-platform.yml` calls each app workflow as a reusable workflow after the platform deploy succeeds. The cascade jobs in `deploy-platform.yml` run in parallel after `deploy-dev` or `deploy-prod` completes:
+
+| Workflow | Cascade job in platform | What it deploys |
+|---|---|---|
+| `deploy-stock-analyser.yml` | `cascade-stock-analyser` | `StockAnalyserTables` + `StockAnalyserApi` CDK stacks + S3 sync to `stock-analyser/` |
+| `deploy-budget-tracker.yml` | `cascade-budget-tracker` | `BudgetTrackerTables` + `BudgetTrackerApi` CDK stacks + S3 sync to `budget-tracker/` |
+| `deploy-migration-utilities.yml` | `cascade-migration-utilities` | `MigrationsApi` CDK stack |
+| `deploy-launchpad.yml` | `cascade-launchpad` | Static build + S3 sync to root |
+
+The cascade target (`dev` or `prod`) is computed from whichever platform job succeeded — `deploy-dev` → `dev`, `deploy-prod` → `prod`. A skipped platform job does not block the cascade; `always()` + result check handles the skipped-sibling pattern.
+
+### App-only deploys (push to app paths)
+
+App workflows also retain path-filtered push triggers for changes that don't touch platform. A push to `apps/stock-analyser/**` or `infrastructure/bin/stock-analyser.ts` fires `deploy-stock-analyser.yml` directly, without going through the platform workflow.
+
+| Workflow | Push paths |
 |---|---|
-| `deploy-stock-analyser.yml` | `StockAnalyserTables` + `StockAnalyserApi` CDK stacks (`--app bin/stock-analyser.ts`) + S3 sync to `stock-analyser/` |
-| `deploy-budget-tracker.yml` | `BudgetTrackerTables` + `BudgetTrackerApi` CDK stacks (`--app bin/budget-tracker.ts`) + S3 sync to `budget-tracker/` |
-| `deploy-migration-utilities.yml` | `MigrationsApi` CDK stack (`--app bin/migration-utilities.ts`) |
-| `deploy-launchpad.yml` | Static build + S3 sync to root |
+| `deploy-stock-analyser.yml` | `apps/stock-analyser/**`, `infrastructure/bin/stock-analyser.ts`, `packages/api-client/**`, `packages/ui/**`, `packages/auth-client/**`, `packages/runtime-config/**`, `packages/lambda-middleware/**` |
+| `deploy-budget-tracker.yml` | `apps/budget-tracker/**`, `infrastructure/bin/budget-tracker.ts`, `packages/api-client/**`, `packages/ui/**`, `packages/auth-client/**`, `packages/runtime-config/**`, `packages/lambda-middleware/**`, `packages/budget-domain/**` |
+| `deploy-migration-utilities.yml` | `migration-utilities/**`, `infrastructure/bin/migration-utilities.ts`, `packages/**` |
+| `deploy-launchpad.yml` | `apps/launchpad/**`, `infrastructure/bin/launchpad.ts`, `packages/auth-client/**`, `packages/runtime-config/**` |
 
-SA/BT/MU/LP workflows have no path-filtered push triggers of their own. All four fire in parallel on every successful platform deploy. Use `workflow_dispatch` to trigger an individual app deploy in isolation (e.g. after a pure app-code push that doesn't touch platform paths).
+### Manual deploys (workflow_dispatch)
+
+All five workflows retain `workflow_dispatch` as the operator escape hatch. Use it to deploy a single app without triggering a platform deploy:
+```bash
+gh workflow run deploy-budget-tracker.yml --ref develop -f target=dev
+```
 
 Each CDK deploy step passes an explicit `--app` flag pointing to the per-app entrypoint, so each workflow synthesises only its own stacks:
 
@@ -146,7 +170,7 @@ Each CDK deploy step passes an explicit `--app` flag pointing to the per-app ent
 - `deploy-migration-utilities.yml` — `MigrationsApi` only
 - `deploy-platform.yml` — platform stacks only (Network, Auth, AuthApi, PlatformTables, Api, PlatformWs, Storage, GithubActionsRole)
 
-Changing `packages/runtime-config` does not trigger any deploy workflow (the APPS const was removed from that package in M7 / #346; app identity is now sourced from `platform/config/app-registry.json` at synth time).
+Changing `packages/runtime-config` does not trigger a platform deploy (the APPS const was removed from that package in M7 / #346; app identity is now sourced from `platform/config/app-registry.json` at synth time).
 
 ---
 


### PR DESCRIPTION
## Summary

- Replaces `workflow_run` cascade (PR #348) with `workflow_call` (reusable workflows) in `deploy-platform.yml`
- All four app workflows (`deploy-stock-analyser.yml`, `deploy-budget-tracker.yml`, `deploy-migration-utilities.yml`, `deploy-launchpad.yml`) converted to reusable workflows via `workflow_call` trigger
- App-only push triggers restored (app code changes deploy directly without going through platform)
- `workflow_dispatch` retained on all five workflows as the operator escape hatch
- `docs/architecture/urls-and-deploy.md` updated with new trigger model and a "Why workflow_call not workflow_run" subsection

## Why

`workflow_run` listener workflows must exist on the **default branch** (`main`) to fire. Since our active integration branch is `develop` and `main` is the not-yet-active production branch, the `workflow_run` cascade installed in PR #348 was permanently inert — every app deploy after a platform deploy required a manual `workflow_dispatch`. `workflow_call` has no default-branch restriction and fires correctly from any branch.

## Cascade logic

`deploy-platform.yml` now has four cascade jobs (`cascade-stock-analyser`, `cascade-budget-tracker`, `cascade-migration-utilities`, `cascade-launchpad`). Each:
- `needs: [deploy-dev, deploy-prod]` — depends on both platform jobs
- `if: always() && (needs.deploy-dev.result == 'success' || needs.deploy-prod.result == 'success')` — runs when either succeeds; `always()` prevents a skipped sibling from blocking the cascade
- `target: ${{ needs.deploy-prod.result == 'success' && 'prod' || 'dev' }}` — routes to the environment that actually deployed

App workflow job conditions updated to handle `push`, `workflow_call`, and `workflow_dispatch` events correctly (the `workflow_run`-specific conditions are replaced).

## Verification

- V1: `workflow_call` present in all 4 app workflows ✓
- V2: `workflow_run` absent from all 4 app workflows ✓
- V3: 4 cascade jobs in `deploy-platform.yml` with correct `uses:` references ✓
- V4: all job `if:` conditions handle `push | workflow_call | workflow_dispatch` ✓
- V5: push triggers restored in all 4 app workflows ✓
- V6: `urls-and-deploy.md` updated ✓

## Context

This PR is the workflow restructure step. After merge, the M7 CF export migration (transitional CfnOutput in `platform-ws-stack.ts`) resumes via the new cascade mechanism.

Refs #348.