### PR TITLE
Add price-over-time candlestick chart to Analyser tab (#331)

### DIFF
--- a/apps/stock-analyser/CLAUDE.md
+++ b/apps/stock-analyser/CLAUDE.md
@@ -49,6 +49,7 @@ All Stock Analyser Lambdas share the platform API Gateway and Cognito JWT author
 | `transformotion-analysis-cache-{stage}` | `apps/stock-analyser/functions/analysis-cache` | `GET /api/analysis-cache/*` |
 | `transformotion-cycle-check-{stage}` | `apps/stock-analyser/functions/cycle-check` | EventBridge scheduled (no HTTP route) |
 | `transformotion-cycle-data-{stage}` | `apps/stock-analyser/functions/cycle-data` | `GET /cycle/ohlcv?ticker=` |
+| `transformotion-market-data-{stage}` | `apps/stock-analyser/functions/market-data` | `GET /price/ohlcv?ticker=&range=&interval=` |
 
 ## DynamoDB tables
 
@@ -113,7 +114,8 @@ Stock Analyser AI goes through `useClaude<T>()` or `callClaudeAPI<T>()` in `lib/
 | Metals | `METALS#all` | 2h |
 | Stock Analysis | `ANALYSIS#{ticker}` | 8h |
 | Market Cycle | `CYCLE#{geography}` | 8h |
-| OHLCV Cycle Data | `OHLCV#{ticker}` | 1h |
+| Computed Cycle Position | `OHLCV#{ticker}` | 1h |
+| Raw OHLCV (shared) | `MARKET-DATA#{ticker}#{range}#{interval}` | 8h |
 
 ## Cycle computation
 

--- a/apps/stock-analyser/components/price-chart/price-chart.tsx
+++ b/apps/stock-analyser/components/price-chart/price-chart.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { createChart, CrosshairMode, type IChartApi, type ISeriesApi, type CandlestickSeriesOptions, type Time } from 'lightweight-charts';
+import type { OhlcvDataResponse } from '@transformotion/api-client';
+
+interface PriceChartProps {
+  data: OhlcvDataResponse;
+  height?: number;
+}
+
+export function PriceChart({ data, height = 280 }: PriceChartProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const chartRef     = useRef<IChartApi | null>(null);
+  const seriesRef    = useRef<ISeriesApi<'Candlestick'> | null>(null);
+
+  // Create chart once on mount
+  useEffect(() => {
+    if (!containerRef.current) return;
+
+    const chart = createChart(containerRef.current, {
+      width:  containerRef.current.clientWidth,
+      height,
+      layout: {
+        background: { color: 'transparent' },
+        textColor:  'hsl(var(--muted-foreground))',
+      },
+      grid: {
+        vertLines: { color: 'hsl(var(--border))' },
+        horzLines: { color: 'hsl(var(--border))' },
+      },
+      crosshair: { mode: CrosshairMode.Normal },
+      rightPriceScale: { borderColor: 'hsl(var(--border))' },
+      timeScale:       { borderColor: 'hsl(var(--border))', timeVisible: false },
+    });
+
+    const series = chart.addCandlestickSeries({
+      upColor:          'hsl(var(--signal-green, 142 76% 36%))',
+      downColor:        'hsl(var(--signal-red, 0 84% 60%))',
+      borderUpColor:    'hsl(var(--signal-green, 142 76% 36%))',
+      borderDownColor:  'hsl(var(--signal-red, 0 84% 60%))',
+      wickUpColor:      'hsl(var(--signal-green, 142 76% 36%))',
+      wickDownColor:    'hsl(var(--signal-red, 0 84% 60%))',
+    } as Partial<CandlestickSeriesOptions>);
+
+    chartRef.current  = chart;
+    seriesRef.current = series;
+
+    const observer = new ResizeObserver(() => {
+      if (containerRef.current) {
+        chart.applyOptions({ width: containerRef.current.clientWidth });
+      }
+    });
+    observer.observe(containerRef.current);
+
+    return () => {
+      observer.disconnect();
+      chart.remove();
+      chartRef.current  = null;
+      seriesRef.current = null;
+    };
+  // height is stable; run once
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Update data whenever it changes
+  useEffect(() => {
+    if (!seriesRef.current || !data.dates.length) return;
+
+    const bars = data.dates.map((date, i) => ({
+      time:  date as Time,
+      open:  data.opens[i],
+      high:  data.highs[i],
+      low:   data.lows[i],
+      close: data.closes[i],
+    })).sort((a, b) => (a.time < b.time ? -1 : 1));
+
+    seriesRef.current.setData(bars);
+    chartRef.current?.timeScale().fitContent();
+  }, [data]);
+
+  return (
+    <div
+      ref={containerRef}
+      style={{ height }}
+      className="w-full rounded-lg overflow-hidden"
+    />
+  );
+}

--- a/apps/stock-analyser/components/stock-analyser/tabs/analyser-tab.tsx
+++ b/apps/stock-analyser/components/stock-analyser/tabs/analyser-tab.tsx
@@ -29,6 +29,9 @@ import {
 import { cn } from "@/lib/utils"
 import { useClaude } from "@/lib/hooks"
 import { useCycleData } from "@/lib/hooks/use-cycle-data"
+import { useOhlcvData } from "@/lib/hooks/use-ohlcv-data"
+import type { OhlcvRange } from "@transformotion/api-client"
+import { PriceChart } from "@/components/price-chart/price-chart"
 
 interface SignalMetric {
   name: string
@@ -79,8 +82,11 @@ export function AnalyserTab({
   const [searchValue, setSearchValue] = useState("")
   const [result, setResult] = useState<AnalysisResult | null>(null)
 
+  const [chartRange, setChartRange] = useState<OhlcvRange>('1y')
+
   const { callClaude, isLoading: isAnalyzing, error } = useClaude<AnalysisResult>()
   const { data: liveData, isLoading: isLoadingLive, error: liveError, fetch: fetchLive } = useCycleData()
+  const { data: ohlcvData, isLoading: isLoadingChart, fetch: fetchOhlcv } = useOhlcvData()
 
   // Auto-analyse only if navigated from another tab (source is set)
   useEffect(() => {
@@ -98,6 +104,14 @@ export function AnalyserTab({
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isLive, result?.ticker])
+
+  // Fetch price chart data whenever ticker or selected range changes
+  useEffect(() => {
+    if (result?.ticker) {
+      fetchOhlcv(result.ticker, chartRange)
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [result?.ticker, chartRange])
 
   const runAnalysis = async (ticker: string, forceRefresh = false) => {
     if (!ticker || isAnalyzing) return
@@ -263,6 +277,46 @@ Return ONLY valid JSON.`,
               <VerdictBadge verdict={result.verdict} size="md" />
             </div>
           </div>
+
+          {/* Price Chart */}
+          <Card>
+            <div className="flex items-center justify-between mb-3">
+              <h3 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                Price History
+                {isLoadingChart && <span className="ml-2 text-[10px] font-normal normal-case">Loading…</span>}
+              </h3>
+              <div className="flex gap-1">
+                {(['1mo', '3mo', '6mo', '1y', '5y'] as OhlcvRange[]).map((r) => (
+                  <button
+                    key={r}
+                    onClick={() => setChartRange(r)}
+                    className={cn(
+                      'px-2 py-0.5 text-[10px] font-medium rounded transition-colors',
+                      chartRange === r
+                        ? 'bg-primary text-primary-foreground'
+                        : 'text-muted-foreground hover:text-foreground'
+                    )}
+                  >
+                    {r.toUpperCase()}
+                  </button>
+                ))}
+              </div>
+            </div>
+            {ohlcvData ? (
+              <PriceChart data={ohlcvData} height={260} />
+            ) : (
+              !isLoadingChart && (
+                <div className="flex items-center justify-center h-[260px] text-xs text-muted-foreground">
+                  No price data available
+                </div>
+              )
+            )}
+            {isLoadingChart && (
+              <div className="flex items-center justify-center h-[260px]">
+                <Spinner className="size-5" />
+              </div>
+            )}
+          </Card>
 
           {/* Cycle Position Gauge */}
           <Card>

--- a/apps/stock-analyser/functions/_shared/market-data-fetcher.ts
+++ b/apps/stock-analyser/functions/_shared/market-data-fetcher.ts
@@ -1,0 +1,44 @@
+import YahooFinance from 'yahoo-finance2';
+
+const yf = new YahooFinance();
+
+export interface FetchedOhlcv {
+  dates:   string[];
+  opens:   number[];
+  highs:   number[];
+  lows:    number[];
+  closes:  number[];
+  volumes: number[];
+}
+
+const RANGE_TO_PERIOD: Record<string, () => Date> = {
+  '1mo': () => { const d = new Date(); d.setMonth(d.getMonth() - 1); return d; },
+  '3mo': () => { const d = new Date(); d.setMonth(d.getMonth() - 3); return d; },
+  '6mo': () => { const d = new Date(); d.setMonth(d.getMonth() - 6); return d; },
+  '1y':  () => { const d = new Date(); d.setFullYear(d.getFullYear() - 1); return d; },
+  '5y':  () => { const d = new Date(); d.setFullYear(d.getFullYear() - 5); return d; },
+  'max': () => new Date('2000-01-01'),
+};
+
+export async function fetchOhlcv(ticker: string, range: string, interval: string): Promise<FetchedOhlcv> {
+  const period1 = (RANGE_TO_PERIOD[range] ?? RANGE_TO_PERIOD['1y'])();
+  const result = await yf.chart(ticker, { period1, interval: interval as '1d' | '1wk' | '1mo' });
+  const quotes = result.quotes ?? [];
+
+  const valid = quotes.filter(q =>
+    q.date != null &&
+    q.open != null && (q.open as number) > 0 &&
+    q.high != null && (q.high as number) > 0 &&
+    q.low  != null && (q.low  as number) > 0 &&
+    q.close != null && (q.close as number) > 0
+  );
+
+  return {
+    dates:   valid.map(q => (q.date instanceof Date ? q.date.toISOString().split('T')[0] : String(q.date))),
+    opens:   valid.map(q => q.open   as number),
+    highs:   valid.map(q => q.high   as number),
+    lows:    valid.map(q => q.low    as number),
+    closes:  valid.map(q => q.close  as number),
+    volumes: valid.map(q => (q.volume ?? 0) as number),
+  };
+}

--- a/apps/stock-analyser/functions/_shared/package.json
+++ b/apps/stock-analyser/functions/_shared/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@transformotion/fn-shared",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "yahoo-finance2": "^3"
+  },
+  "devDependencies": {
+    "@types/aws-lambda": "^8",
+    "typescript": "*"
+  }
+}

--- a/apps/stock-analyser/functions/_shared/tsconfig.json
+++ b/apps/stock-analyser/functions/_shared/tsconfig.json
@@ -5,6 +5,6 @@
     "module": "CommonJS",
     "moduleResolution": "node"
   },
-  "include": ["src/**/*.ts", "../../../lib/cycle/**/*.ts", "../_shared/**/*.ts"],
+  "include": ["**/*.ts"],
   "exclude": ["node_modules", "dist"]
 }

--- a/apps/stock-analyser/functions/cycle-data/package.json
+++ b/apps/stock-analyser/functions/cycle-data/package.json
@@ -7,8 +7,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@transformotion/lambda-middleware": "workspace:*",
-    "yahoo-finance2": "^3"
+    "@transformotion/fn-shared": "workspace:*",
+    "@transformotion/lambda-middleware": "workspace:*"
   },
   "devDependencies": {
     "@aws-sdk/client-dynamodb": "^3",

--- a/apps/stock-analyser/functions/cycle-data/src/index.ts
+++ b/apps/stock-analyser/functions/cycle-data/src/index.ts
@@ -8,14 +8,14 @@ import {
   requireAccountAccess,
   HttpError,
 } from '@transformotion/lambda-middleware';
-import YahooFinance from 'yahoo-finance2';
+import { fetchOhlcv } from '../../_shared/market-data-fetcher';
 import { computeCyclePosition } from '../../../lib/cycle';
 
 const ddb = DynamoDBDocumentClient.from(new DynamoDBClient({}));
-const yf    = new YahooFinance();
-const TABLE   = process.env.ANALYSIS_CACHE_TABLE!;
-const SHARED  = 'SHARED';
-const TTL_SECS = 3600; // 1 hour
+const TABLE          = process.env.ANALYSIS_CACHE_TABLE!;
+const SHARED         = 'SHARED';
+const CYCLE_TTL      = 3600;  // 1 hour — computed result
+const MARKET_TTL     = 28800; // 8 hours — shared raw OHLCV
 
 export const handler = withAuth(async ({ auth, account, event }) => {
   requireAppAccess(auth, 'stock-analyser');
@@ -24,39 +24,65 @@ export const handler = withAuth(async ({ auth, account, event }) => {
   const ticker = event.queryStringParameters?.ticker;
   if (!ticker) throw badRequest('ticker is required');
 
-  const cacheKey = `OHLCV#${ticker}`;
+  const cycleCacheKey  = `OHLCV#${ticker}`;
+  const marketCacheKey = `MARKET-DATA#${ticker}#1y#1d`;
 
-  // Cache read — OHLCV is SHARED data (same for all users)
-  const cached = await ddb.send(new GetCommand({
+  // 1. Check computed cycle cache first
+  const cachedCycle = await ddb.send(new GetCommand({
     TableName: TABLE,
-    Key: { accountId: SHARED, cacheKey },
+    Key: { accountId: SHARED, cacheKey: cycleCacheKey },
   }));
 
-  if (cached.Item) {
-    const data = typeof cached.Item.data === 'string'
-      ? JSON.parse(cached.Item.data)
-      : cached.Item.data;
+  if (cachedCycle.Item) {
+    const data = typeof cachedCycle.Item.data === 'string'
+      ? JSON.parse(cachedCycle.Item.data)
+      : cachedCycle.Item.data;
     return ok({ ...data, source: 'cache' as const });
   }
 
-  // Fetch OHLCV from Yahoo Finance
-  const period1 = new Date();
-  period1.setFullYear(period1.getFullYear() - 1);
+  // 2. Check shared raw OHLCV cache
+  let closes: number[], highs: number[], volumes: number[];
 
-  let quotes: Array<{ close: number | null; high: number | null; volume: number | null }>;
-  try {
-    const result = await yf.chart(ticker, { period1, interval: '1d' });
-    quotes = result.quotes ?? [];
-  } catch (err) {
-    console.error(`[cycle-data] Yahoo Finance error for ${ticker}:`, err);
-    throw new HttpError(503, 'Failed to fetch market data from Yahoo Finance');
+  const cachedMarket = await ddb.send(new GetCommand({
+    TableName: TABLE,
+    Key: { accountId: SHARED, cacheKey: marketCacheKey },
+  }));
+
+  if (cachedMarket.Item) {
+    const raw = typeof cachedMarket.Item.data === 'string'
+      ? JSON.parse(cachedMarket.Item.data)
+      : cachedMarket.Item.data;
+    closes  = raw.closes;
+    highs   = raw.highs;
+    volumes = raw.volumes;
+  } else {
+    // 3. Fetch from Yahoo Finance and populate shared cache
+    let ohlcv: Awaited<ReturnType<typeof fetchOhlcv>>;
+    try {
+      ohlcv = await fetchOhlcv(ticker, '1y', '1d');
+    } catch (err) {
+      console.error(`[cycle-data] Yahoo Finance error for ${ticker}:`, err);
+      throw new HttpError(503, 'Failed to fetch market data from Yahoo Finance');
+    }
+
+    closes  = ohlcv.closes;
+    highs   = ohlcv.highs;
+    volumes = ohlcv.volumes;
+
+    const nowSecs = Math.floor(Date.now() / 1000);
+    await ddb.send(new PutCommand({
+      TableName: TABLE,
+      Item: {
+        accountId: SHARED,
+        cacheKey:  marketCacheKey,
+        data:      JSON.stringify({ ticker, range: '1y', interval: '1d', fetchedAt: new Date().toISOString(), ...ohlcv }),
+        dataType:  'market-data-ohlcv',
+        mode:      'live',
+        cachedAt:  nowSecs,
+        expiresAt: nowSecs + MARKET_TTL,
+      },
+    }));
   }
-
-  // Filter out any bars with null close/high and align all arrays
-  const validQuotes = quotes.filter(q => q.close != null && q.close > 0 && q.high != null);
-  const closes  = validQuotes.map(q => q.close!);
-  const highs   = validQuotes.map(q => q.high!);
-  const volumes = validQuotes.map(q => q.volume ?? 0);
 
   const position = computeCyclePosition({ closes, highs, volumes });
 
@@ -76,22 +102,21 @@ export const handler = withAuth(async ({ auth, account, event }) => {
     computedAt:     new Date().toISOString(),
   };
 
-  // Write to cache
   const nowSecs = Math.floor(Date.now() / 1000);
   await ddb.send(new PutCommand({
     TableName: TABLE,
     Item: {
       accountId: SHARED,
-      cacheKey,
+      cacheKey:  cycleCacheKey,
       data:      JSON.stringify(payload),
       dataType:  'ohlcv-cycle',
       mode:      'live',
       cachedAt:  nowSecs,
-      expiresAt: nowSecs + TTL_SECS,
+      expiresAt: nowSecs + CYCLE_TTL,
     },
   }));
 
-  console.log(`[cycle-data] Computed and cached: ${cacheKey}`);
+  console.log(`[cycle-data] Computed and cached: ${cycleCacheKey}`);
 
   return ok({ ...payload, source: 'live' as const });
 });

--- a/apps/stock-analyser/functions/market-data/package.json
+++ b/apps/stock-analyser/functions/market-data/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@transformotion/fn-market-data",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "build": "tsc --noEmit",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@transformotion/lambda-middleware": "workspace:*",
+    "yahoo-finance2": "^3"
+  },
+  "devDependencies": {
+    "@aws-sdk/client-dynamodb": "^3",
+    "@aws-sdk/lib-dynamodb": "^3",
+    "@types/aws-lambda": "^8",
+    "typescript": "*"
+  }
+}

--- a/apps/stock-analyser/functions/market-data/package.json
+++ b/apps/stock-analyser/functions/market-data/package.json
@@ -7,8 +7,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@transformotion/lambda-middleware": "workspace:*",
-    "yahoo-finance2": "^3"
+    "@transformotion/fn-shared": "workspace:*",
+    "@transformotion/lambda-middleware": "workspace:*"
   },
   "devDependencies": {
     "@aws-sdk/client-dynamodb": "^3",

--- a/apps/stock-analyser/functions/market-data/src/index.ts
+++ b/apps/stock-analyser/functions/market-data/src/index.ts
@@ -1,0 +1,81 @@
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import { DynamoDBDocumentClient, GetCommand, PutCommand } from '@aws-sdk/lib-dynamodb';
+import {
+  withAuth,
+  ok,
+  badRequest,
+  requireAppAccess,
+  requireAccountAccess,
+  HttpError,
+} from '@transformotion/lambda-middleware';
+import { fetchOhlcv } from '../../_shared/market-data-fetcher';
+
+const ddb = DynamoDBDocumentClient.from(new DynamoDBClient({}));
+const TABLE    = process.env.ANALYSIS_CACHE_TABLE!;
+const SHARED   = 'SHARED';
+const TTL_SECS = 28800; // 8 hours
+
+const VALID_RANGES    = new Set(['1mo', '3mo', '6mo', '1y', '5y', 'max']);
+const VALID_INTERVALS = new Set(['1d', '1wk', '1mo']);
+
+export const handler = withAuth(async ({ auth, account, event }) => {
+  requireAppAccess(auth, 'stock-analyser');
+  requireAccountAccess(auth, 'stock-analyser', account.accountId);
+
+  const { ticker, range = '1y', interval = '1d' } = event.queryStringParameters ?? {};
+  if (!ticker) throw badRequest('ticker is required');
+  if (!VALID_RANGES.has(range)) throw badRequest(`range must be one of: ${[...VALID_RANGES].join(', ')}`);
+  if (!VALID_INTERVALS.has(interval)) throw badRequest(`interval must be one of: ${[...VALID_INTERVALS].join(', ')}`);
+
+  const cacheKey = `MARKET-DATA#${ticker}#${range}#${interval}`;
+
+  const cached = await ddb.send(new GetCommand({
+    TableName: TABLE,
+    Key: { accountId: SHARED, cacheKey },
+  }));
+
+  if (cached.Item) {
+    const data = typeof cached.Item.data === 'string'
+      ? JSON.parse(cached.Item.data)
+      : cached.Item.data;
+    return ok({ ...data, source: 'cache' as const });
+  }
+
+  let ohlcv: Awaited<ReturnType<typeof fetchOhlcv>>;
+  try {
+    ohlcv = await fetchOhlcv(ticker, range, interval);
+  } catch (err) {
+    console.error(`[market-data] Yahoo Finance error for ${ticker}:`, err);
+    throw new HttpError(503, 'Failed to fetch market data from Yahoo Finance');
+  }
+
+  if (ohlcv.closes.length < 2) {
+    throw new HttpError(503, `Insufficient data for ${ticker}`);
+  }
+
+  const payload = {
+    ticker,
+    range,
+    interval,
+    ...ohlcv,
+    fetchedAt: new Date().toISOString(),
+  };
+
+  const nowSecs = Math.floor(Date.now() / 1000);
+  await ddb.send(new PutCommand({
+    TableName: TABLE,
+    Item: {
+      accountId: SHARED,
+      cacheKey,
+      data:      JSON.stringify(payload),
+      dataType:  'market-data-ohlcv',
+      mode:      'live',
+      cachedAt:  nowSecs,
+      expiresAt: nowSecs + TTL_SECS,
+    },
+  }));
+
+  console.log(`[market-data] Fetched and cached: ${cacheKey}`);
+
+  return ok({ ...payload, source: 'live' as const });
+});

--- a/apps/stock-analyser/functions/market-data/tsconfig.json
+++ b/apps/stock-analyser/functions/market-data/tsconfig.json
@@ -5,6 +5,6 @@
     "module": "CommonJS",
     "moduleResolution": "node"
   },
-  "include": ["src/**/*.ts", "../../../lib/cycle/**/*.ts", "../_shared/**/*.ts"],
+  "include": ["src/**/*.ts", "../_shared/**/*.ts"],
   "exclude": ["node_modules", "dist"]
 }

--- a/apps/stock-analyser/infrastructure/stock-analyser-api-stack.ts
+++ b/apps/stock-analyser/infrastructure/stock-analyser-api-stack.ts
@@ -28,6 +28,7 @@ export interface StockAnalyserApiStackProps extends cdk.StackProps {
  *   PUT  /analysis-cache/{key}
  *   DELETE /analysis-cache/{key}
  *   GET  /cycle/ohlcv        — cycle-data Lambda
+ *   GET  /price/ohlcv        — market-data Lambda (raw OHLCV bars for price chart)
  *
  * Lambda source: apps/stock-analyser/functions/
  */
@@ -146,6 +147,24 @@ export class StockAnalyserApiStack extends cdk.Stack {
     const cycleDataIntegration = new apigateway.LambdaIntegration(cycleDataFn, { proxy: true });
     const cycle = api.root.addResource('cycle');
     cycle.addResource('ohlcv').addMethod('GET', cycleDataIntegration, auth);
+
+    // ── /price/ohlcv — Market Data Lambda ─────────────────────────────────
+    const marketDataFn = new lambdaNodejs.NodejsFunction(this, 'MarketDataFn', {
+      functionName: `transformotion-market-data-${stage}`,
+      entry:        path.join(__dirname, '../functions/market-data/src/index.ts'),
+      handler:      'handler',
+      runtime:      lambda.Runtime.NODEJS_20_X,
+      timeout:      cdk.Duration.seconds(30),
+      memorySize:   512,
+      environment:  { ANALYSIS_CACHE_TABLE: analysisCacheTable.tableName },
+      bundling:     { externalModules: ['@aws-sdk/*'], minify: true, sourceMap: false, forceDockerBundling: false },
+    });
+
+    analysisCacheTable.grantReadWriteData(marketDataFn);
+
+    const marketDataIntegration = new apigateway.LambdaIntegration(marketDataFn, { proxy: true });
+    const price = api.root.addResource('price');
+    price.addResource('ohlcv').addMethod('GET', marketDataIntegration, auth);
   }
 }
 

--- a/apps/stock-analyser/lib/hooks/use-cycle-data.ts
+++ b/apps/stock-analyser/lib/hooks/use-cycle-data.ts
@@ -1,6 +1,8 @@
 import { useState, useCallback } from 'react';
 import type { CycleDataResponse } from '@transformotion/api-client';
 import { getStockAnalyserClient } from '../api';
+import { getConfig } from '../config';
+import { getMockCycleData } from '../services/ai/fixtures/cycle-data';
 
 export interface UseCycleDataResult {
   data:      CycleDataResponse | null;
@@ -18,6 +20,11 @@ export function useCycleData(): UseCycleDataResult {
     setIsLoading(true);
     setError(null);
     try {
+      if (getConfig().ai.provider === 'mock') {
+        const result = getMockCycleData(ticker);
+        setData(result);
+        return result;
+      }
       const result = await getStockAnalyserClient().getCycleData(ticker);
       setData(result);
       return result;

--- a/apps/stock-analyser/lib/hooks/use-ohlcv-data.ts
+++ b/apps/stock-analyser/lib/hooks/use-ohlcv-data.ts
@@ -1,0 +1,45 @@
+import { useState, useCallback } from 'react';
+import type { OhlcvDataResponse, OhlcvRange, OhlcvInterval } from '@transformotion/api-client';
+import { getStockAnalyserClient } from '../api';
+import { getConfig } from '../config';
+import { getMockOhlcvData } from '../services/ai/fixtures/ohlcv-data';
+
+export interface UseOhlcvDataResult {
+  data:      OhlcvDataResponse | null;
+  isLoading: boolean;
+  error:     string | null;
+  fetch:     (ticker: string, range?: OhlcvRange, interval?: OhlcvInterval) => Promise<OhlcvDataResponse | null>;
+}
+
+export function useOhlcvData(): UseOhlcvDataResult {
+  const [data,      setData]      = useState<OhlcvDataResponse | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error,     setError]     = useState<string | null>(null);
+
+  const fetch = useCallback(async (
+    ticker: string,
+    range: OhlcvRange = '1y',
+    interval: OhlcvInterval = '1d',
+  ): Promise<OhlcvDataResponse | null> => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      if (getConfig().ai.provider === 'mock') {
+        const result = getMockOhlcvData(ticker, range, interval);
+        setData(result);
+        return result;
+      }
+      const result = await getStockAnalyserClient().getOhlcvData(ticker, range, interval);
+      setData(result);
+      return result;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Failed to fetch price data';
+      setError(msg);
+      return null;
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  return { data, isLoading, error, fetch };
+}

--- a/apps/stock-analyser/lib/services/ai/fixtures/cycle-data.ts
+++ b/apps/stock-analyser/lib/services/ai/fixtures/cycle-data.ts
@@ -1,0 +1,66 @@
+import type { CycleDataResponse } from '@transformotion/api-client';
+
+const CYCLE_FIXTURES: Record<string, Omit<CycleDataResponse, 'source'>> = {
+  'CBA.AX': {
+    cyclePosition: 35, cycleStage: 'early',
+    rsiDivergence: 'bullish', macdMomentum: 'strengthening', volumeTrend: 'confirming',
+    weekHigh52Pct: 72, signals: [{ type: 'ok', text: 'RSI recovering from oversold' }, { type: 'ok', text: 'MACD positive crossover' }],
+    cycleSummary: 'Early cycle momentum with strong institutional accumulation patterns.',
+    computedAt: new Date().toISOString(),
+  },
+  'BHP.AX': {
+    cyclePosition: 55, cycleStage: 'mid',
+    rsiDivergence: 'none', macdMomentum: 'flat', volumeTrend: 'neutral',
+    weekHigh52Pct: 61, signals: [{ type: 'ok', text: 'Mid-cycle consolidation' }, { type: 'warn', text: 'Volume declining on advances' }],
+    cycleSummary: 'Mid-cycle consolidation. Commodity cycle headwinds from China demand uncertainty.',
+    computedAt: new Date().toISOString(),
+  },
+  'FMG.AX': {
+    cyclePosition: 68, cycleStage: 'late',
+    rsiDivergence: 'bearish', macdMomentum: 'weakening', volumeTrend: 'diverging',
+    weekHigh52Pct: 84, signals: [{ type: 'warn', text: 'RSI bearish divergence forming' }, { type: 'warn', text: 'MACD weakening above signal' }],
+    cycleSummary: 'Late cycle warning signals. Iron ore price sensitivity creates near-term risk.',
+    computedAt: new Date().toISOString(),
+  },
+  'CSL.AX': {
+    cyclePosition: 42, cycleStage: 'early',
+    rsiDivergence: 'bullish', macdMomentum: 'strengthening', volumeTrend: 'confirming',
+    weekHigh52Pct: 58, signals: [{ type: 'ok', text: 'Strong accumulation phase' }, { type: 'ok', text: 'Volume supporting price advance' }],
+    cycleSummary: 'Early cycle recovery with improving plasma collection volumes driving earnings recovery.',
+    computedAt: new Date().toISOString(),
+  },
+  'AAPL': {
+    cyclePosition: 72, cycleStage: 'late',
+    rsiDivergence: 'none', macdMomentum: 'flat', volumeTrend: 'neutral',
+    weekHigh52Pct: 91, signals: [{ type: 'warn', text: 'Near 52-week high resistance' }, { type: 'ok', text: 'Services revenue diversification' }],
+    cycleSummary: 'Late cycle positioning near highs. AI hardware cycle exposure adds volatility.',
+    computedAt: new Date().toISOString(),
+  },
+  'NVDA': {
+    cyclePosition: 88, cycleStage: 'peak',
+    rsiDivergence: 'bearish', macdMomentum: 'weakening', volumeTrend: 'diverging',
+    weekHigh52Pct: 97, signals: [{ type: 'danger', text: 'Extreme overbought conditions' }, { type: 'warn', text: 'Insider selling patterns emerging' }],
+    cycleSummary: 'Peak cycle territory. AI chip demand remains strong but valuation stretched.',
+    computedAt: new Date().toISOString(),
+  },
+  'MSFT': {
+    cyclePosition: 61, cycleStage: 'mid',
+    rsiDivergence: 'none', macdMomentum: 'strengthening', volumeTrend: 'confirming',
+    weekHigh52Pct: 78, signals: [{ type: 'ok', text: 'Cloud growth re-accelerating' }, { type: 'ok', text: 'AI Copilot monetisation underway' }],
+    cycleSummary: 'Mid cycle with AI tailwinds. Azure growth rate recovery supports multiple expansion.',
+    computedAt: new Date().toISOString(),
+  },
+};
+
+const DEFAULT_CYCLE: Omit<CycleDataResponse, 'source'> = {
+  cyclePosition: 50, cycleStage: 'mid',
+  rsiDivergence: 'none', macdMomentum: 'flat', volumeTrend: 'neutral',
+  weekHigh52Pct: 60, signals: [{ type: 'ok', text: 'No strong directional signals' }],
+  cycleSummary: 'Mid-cycle positioning with neutral signals.',
+  computedAt: new Date().toISOString(),
+};
+
+export function getMockCycleData(ticker: string): CycleDataResponse {
+  const base = CYCLE_FIXTURES[ticker.toUpperCase()] ?? DEFAULT_CYCLE;
+  return { ...base, source: 'cache' };
+}

--- a/apps/stock-analyser/lib/services/ai/fixtures/ohlcv-data.ts
+++ b/apps/stock-analyser/lib/services/ai/fixtures/ohlcv-data.ts
@@ -1,0 +1,91 @@
+import type { OhlcvDataResponse, OhlcvRange, OhlcvInterval } from '@transformotion/api-client';
+
+const BASE_PRICES: Record<string, number> = {
+  'CBA.AX': 115.42,
+  'BHP.AX':  42.80,
+  'FMG.AX':  18.90,
+  'CSL.AX': 298.50,
+  'AAPL':   182.00,
+  'NVDA':   875.00,
+  'MSFT':   415.00,
+};
+
+const RANGE_DAYS: Record<OhlcvRange, number> = {
+  '1mo':  22,
+  '3mo':  66,
+  '6mo': 132,
+  '1y':  252,
+  '5y':  252 * 5,
+  'max': 252 * 10,
+};
+
+function seededRandom(seed: number): () => number {
+  let s = seed;
+  return () => {
+    s = (s * 1664525 + 1013904223) & 0xffffffff;
+    return (s >>> 0) / 0xffffffff;
+  };
+}
+
+function buildDateSeries(count: number, interval: OhlcvInterval): string[] {
+  const dates: string[] = [];
+  const now = new Date('2026-05-23');
+  for (let i = count - 1; i >= 0; i--) {
+    const d = new Date(now);
+    if (interval === '1d')  d.setDate(d.getDate() - i);
+    if (interval === '1wk') d.setDate(d.getDate() - i * 7);
+    if (interval === '1mo') d.setMonth(d.getMonth() - i);
+    // skip weekends for daily
+    if (interval === '1d' && (d.getDay() === 0 || d.getDay() === 6)) continue;
+    dates.push(d.toISOString().split('T')[0]);
+  }
+  return dates;
+}
+
+export function getMockOhlcvData(ticker: string, range: OhlcvRange, interval: OhlcvInterval): OhlcvDataResponse {
+  const basePrice = BASE_PRICES[ticker.toUpperCase()] ?? 50;
+  const barCount  = Math.min(RANGE_DAYS[range], 500);
+  const dates     = buildDateSeries(barCount, interval);
+  const rng       = seededRandom(ticker.split('').reduce((a, c) => a + c.charCodeAt(0), 0));
+
+  const opens: number[]   = [];
+  const highs: number[]   = [];
+  const lows: number[]    = [];
+  const closes: number[]  = [];
+  const volumes: number[] = [];
+
+  let price = basePrice * (0.7 + rng() * 0.6);
+
+  for (let i = 0; i < dates.length; i++) {
+    const drift    = (rng() - 0.495) * 0.025;
+    const open     = price;
+    const close    = parseFloat((open * (1 + drift)).toFixed(3));
+    const highMult = 1 + rng() * 0.015;
+    const lowMult  = 1 - rng() * 0.015;
+    const high     = parseFloat((Math.max(open, close) * highMult).toFixed(3));
+    const low      = parseFloat((Math.min(open, close) * lowMult).toFixed(3));
+    const volume   = Math.floor(500000 + rng() * 4500000);
+
+    opens.push(open);
+    highs.push(high);
+    lows.push(low);
+    closes.push(close);
+    volumes.push(volume);
+
+    price = close;
+  }
+
+  return {
+    ticker,
+    range,
+    interval,
+    dates,
+    opens,
+    highs,
+    lows,
+    closes,
+    volumes,
+    fetchedAt: new Date().toISOString(),
+    source:    'cache',
+  };
+}

--- a/apps/stock-analyser/package.json
+++ b/apps/stock-analyser/package.json
@@ -64,7 +64,7 @@
     "react-dom": "^19",
     "react-hook-form": "^7.54.1",
     "react-resizable-panels": "^2.1.7",
-    "recharts": "2.15.0",
+    "lightweight-charts": "^4",
     "sonner": "^1.7.1",
     "tailwind-merge": "^3.3.1",
     "vaul": "^1.1.2",

--- a/apps/stock-analyser/tsconfig.json
+++ b/apps/stock-analyser/tsconfig.json
@@ -38,6 +38,7 @@
   "exclude": [
     "node_modules",
     "components/budget-tracker",
-    "infrastructure"
+    "infrastructure",
+    "functions"
   ]
 }

--- a/docs/architecture/cdk.md
+++ b/docs/architecture/cdk.md
@@ -99,6 +99,8 @@ Deployed by `deploy-budget-tracker.yml`. Source in `apps/budget-tracker/infrastr
 | `transformotion-watchlist-{stage}` | `apps/stock-analyser/functions/watchlist` | `GET/POST/PATCH/DELETE /api/watchlist` |
 | `transformotion-analysis-cache-{stage}` | `apps/stock-analyser/functions/analysis-cache` | `GET /api/analysis-cache/*` |
 | `transformotion-cycle-check-{stage}` | `apps/stock-analyser/functions/cycle-check` | EventBridge scheduled (no API Gateway route) |
+| `transformotion-cycle-data-{stage}` | `apps/stock-analyser/functions/cycle-data` | `GET /cycle/ohlcv?ticker=` |
+| `transformotion-market-data-{stage}` | `apps/stock-analyser/functions/market-data` | `GET /price/ohlcv?ticker=&range=&interval=` |
 
 ### Budget Tracker Lambda functions (`Transformotion{Stage}-BudgetTrackerApi`)
 

--- a/packages/api-client/src/client.ts
+++ b/packages/api-client/src/client.ts
@@ -23,6 +23,9 @@ import type {
   PutUserPreferencesRequest,
   PutUserPreferencesResponse,
   CycleDataResponse,
+  OhlcvDataResponse,
+  OhlcvRange,
+  OhlcvInterval,
 } from './types';
 
 /**
@@ -155,5 +158,12 @@ export class ApiClient {
   /** GET /cycle/ohlcv?ticker={ticker} — fetch OHLCV-computed cycle position for a ticker. */
   async getCycleData(ticker: string): Promise<CycleDataResponse> {
     return this.http.get<CycleDataResponse>(`cycle/ohlcv?ticker=${encodeURIComponent(ticker)}`);
+  }
+
+  /** GET /price/ohlcv?ticker={ticker}&range={range}&interval={interval} — fetch raw OHLCV bars. */
+  async getOhlcvData(ticker: string, range: OhlcvRange = '1y', interval: OhlcvInterval = '1d'): Promise<OhlcvDataResponse> {
+    return this.http.get<OhlcvDataResponse>(
+      `price/ohlcv?ticker=${encodeURIComponent(ticker)}&range=${range}&interval=${interval}`
+    );
   }
 }

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -67,4 +67,9 @@ export type {
   RsiDivergence,
   MacdMomentum,
   VolumeTrend,
+
+  // Market data OHLCV
+  OhlcvDataResponse,
+  OhlcvRange,
+  OhlcvInterval,
 } from './types';

--- a/packages/api-client/src/types.ts
+++ b/packages/api-client/src/types.ts
@@ -129,6 +129,25 @@ export interface CycleDataResponse {
   source:         'live' | 'cache';
 }
 
+// ── Market data OHLCV ─────────────────────────────────────────────────────────
+
+export type OhlcvRange    = '1mo' | '3mo' | '6mo' | '1y' | '5y' | 'max';
+export type OhlcvInterval = '1d' | '1wk' | '1mo';
+
+export interface OhlcvDataResponse {
+  ticker:    string;
+  range:     OhlcvRange;
+  interval:  OhlcvInterval;
+  dates:     string[];
+  opens:     number[];
+  highs:     number[];
+  lows:      number[];
+  closes:    number[];
+  volumes:   number[];
+  fetchedAt: string;
+  source:    'live' | 'cache';
+}
+
 // ── Claude proxy ──────────────────────────────────────────────────────────────
 
 export interface ClaudeProxyRequest {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -640,6 +640,9 @@ importers:
       input-otp:
         specifier: 1.4.2
         version: 1.4.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      lightweight-charts:
+        specifier: ^4
+        version: 4.2.3
       lucide-react:
         specifier: ^0.564.0
         version: 0.564.0(react@19.2.5)
@@ -664,9 +667,6 @@ importers:
       react-resizable-panels:
         specifier: ^2.1.7
         version: 2.1.9(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      recharts:
-        specifier: 2.15.0
-        version: 2.15.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       sonner:
         specifier: ^1.7.1
         version: 1.7.4(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -711,6 +711,19 @@ importers:
         specifier: ^3
         version: 3.2.4(@types/node@22.19.17)(jsdom@29.1.1)(lightningcss@1.32.0)
 
+  apps/stock-analyser/functions/_shared:
+    dependencies:
+      yahoo-finance2:
+        specifier: ^3
+        version: 3.14.1
+    devDependencies:
+      '@types/aws-lambda':
+        specifier: ^8
+        version: 8.10.161
+      typescript:
+        specifier: '*'
+        version: 5.7.3
+
   apps/stock-analyser/functions/analysis-cache:
     dependencies:
       '@transformotion/lambda-middleware':
@@ -737,6 +750,28 @@ importers:
         version: 5.7.3
 
   apps/stock-analyser/functions/cycle-data:
+    dependencies:
+      '@transformotion/lambda-middleware':
+        specifier: workspace:*
+        version: link:../../../../packages/lambda-middleware
+      yahoo-finance2:
+        specifier: ^3
+        version: 3.14.1
+    devDependencies:
+      '@aws-sdk/client-dynamodb':
+        specifier: ^3
+        version: 3.1032.0
+      '@aws-sdk/lib-dynamodb':
+        specifier: ^3
+        version: 3.1032.0(@aws-sdk/client-dynamodb@3.1032.0)
+      '@types/aws-lambda':
+        specifier: ^8
+        version: 8.10.161
+      typescript:
+        specifier: '*'
+        version: 5.7.3
+
+  apps/stock-analyser/functions/market-data:
     dependencies:
       '@transformotion/lambda-middleware':
         specifier: workspace:*
@@ -4641,6 +4676,9 @@ packages:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
 
+  fancy-canvas@2.1.0:
+    resolution: {integrity: sha512-nifxXJ95JNLFR2NgRV4/MxVP45G9909wJTEKz5fg/TZS20JJZA6hfgRVh/bC9bwl2zBtBNcYPjiBE4njQHVBwQ==}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -4995,6 +5033,9 @@ packages:
   lightningcss@1.32.0:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
+
+  lightweight-charts@4.2.3:
+    resolution: {integrity: sha512-5kS/2hY3wNYNzhnS8Gb+GAS07DX8GPF2YVDnd2NMC85gJVQ6RLU6YrXNgNJ6eg0AnWPwCnvaGtYmGky3HiLQEw==}
 
   lint-staged@16.4.0:
     resolution: {integrity: sha512-lBWt8hujh/Cjysw5GYVmZpFHXDCgZzhrOm8vbcUdobADZNOK/bRshr2kM3DfgrrtR1DQhfupW9gnIXOfiFi+bw==}
@@ -9623,6 +9664,8 @@ snapshots:
 
   expect-type@1.3.0: {}
 
+  fancy-canvas@2.1.0: {}
+
   fast-deep-equal@3.1.3: {}
 
   fast-equals@5.4.0: {}
@@ -9916,6 +9959,10 @@ snapshots:
       lightningcss-linux-x64-musl: 1.32.0
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
+
+  lightweight-charts@4.2.3:
+    dependencies:
+      fancy-canvas: 2.1.0
 
   lint-staged@16.4.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -751,12 +751,12 @@ importers:
 
   apps/stock-analyser/functions/cycle-data:
     dependencies:
+      '@transformotion/fn-shared':
+        specifier: workspace:*
+        version: link:../_shared
       '@transformotion/lambda-middleware':
         specifier: workspace:*
         version: link:../../../../packages/lambda-middleware
-      yahoo-finance2:
-        specifier: ^3
-        version: 3.14.1
     devDependencies:
       '@aws-sdk/client-dynamodb':
         specifier: ^3
@@ -773,12 +773,12 @@ importers:
 
   apps/stock-analyser/functions/market-data:
     dependencies:
+      '@transformotion/fn-shared':
+        specifier: workspace:*
+        version: link:../_shared
       '@transformotion/lambda-middleware':
         specifier: workspace:*
         version: link:../../../../packages/lambda-middleware
-      yahoo-finance2:
-        specifier: ^3
-        version: 3.14.1
     devDependencies:
       '@aws-sdk/client-dynamodb':
         specifier: ^3


### PR DESCRIPTION
## Summary

- New `market-data` Lambda (`GET /price/ohlcv?ticker=&range=&interval=`) fetches full OHLC arrays from Yahoo Finance; caches as `MARKET-DATA#<ticker>#<range>#<interval>` (8h TTL)
- `cycle-data` Lambda refactored to read from shared `MARKET-DATA` cache on miss — no duplicate Yahoo Finance fetches when user toggles Live mode after viewing chart
- Both `useCycleData` and new `useOhlcvData` hooks add mock branches keyed on `config.ai.provider === 'mock'` (closes v0 compliance gap on cycle)
- `PriceChart` component renders candlestick data via `lightweight-charts` v4 with range selector (1mo/3mo/6mo/1y/5y)
- Chart wires into Analyser tab between stock header and cycle gauge; auto-fetches when analysis result loads
- `recharts` removed (was unused); `lightweight-charts` added

## Files

| Path | Change |
|---|---|
| `functions/_shared/` | New shared Yahoo Finance fetcher (`@transformotion/fn-shared` workspace package) |
| `functions/market-data/` | New Lambda + CDK route `/price/ohlcv` |
| `functions/cycle-data/src/index.ts` | Reads shared cache before fetching; removes duplicate Yahoo Finance calls |
| `lib/hooks/use-cycle-data.ts` | Mock branch added |
| `lib/hooks/use-ohlcv-data.ts` | New hook (live + mock) |
| `components/price-chart/price-chart.tsx` | Candlestick chart component |
| `analyser-tab.tsx` | Chart + range selector wired in |
| `lib/services/ai/fixtures/{cycle-data,ohlcv-data}.ts` | Deterministic mock data |
| `packages/api-client` | `OhlcvDataResponse` type + `getOhlcvData` method |

## Test plan

- [ ] Local dev (`NEXT_PUBLIC_RUNTIME_PROFILE=mock`): open Analyser tab, search CBA.AX — chart renders with seeded OHLCV bars; range buttons (1MO/3MO/6MO/1Y/5Y) switch data; Live mode toggle shows mock cycle data
- [ ] Typecheck passes: `pnpm --filter @transformotion/stock-analyser typecheck`
- [ ] CDK synth bundles `MarketDataFn` successfully
- [ ] Cache key `MARKET-DATA#<ticker>#<range>#<interval>` distinct from existing keys

Closes #331

🤖 Generated with [Claude Code](https://claude.com/claude-code)