### PR TITLE
docs(arch): Phase A recon corrections and additions for M9

### DIFF
--- a/MONOREPO.md
+++ b/MONOREPO.md
@@ -208,7 +208,7 @@ the other app's deployment.
 | `apps/stock-analyser/infrastructure/**` | `deploy-stock-analyser.yml` |
 | `apps/budget-tracker/**` | `deploy-budget-tracker.yml` |
 | `apps/budget-tracker/infrastructure/**` | `deploy-budget-tracker.yml` |
-| `apps/launchpad/**` | `deploy-platform.yml` |
+| `apps/launchpad/**` | `deploy-launchpad.yml` |
 | `platform/infrastructure/**` | `deploy-platform.yml` |
 | `infrastructure/bin/**` | `deploy-platform.yml` |
 | `platform/functions/**` | `deploy-platform.yml` |
@@ -232,7 +232,7 @@ mechanical steps within this monorepo are:
    *not* at `apps/<app-name>/contracts/`. Per-app contract mirrors are
    forbidden per `CONTRIBUTING.md` Section 3.5.
 4. Add CDK stacks in `apps/<app-name>/infrastructure/`.
-5. Register stacks in `infrastructure/bin/app.ts`.
+5. Create `infrastructure/bin/{app-name}.ts` containing only the new app's stacks, resolving shared platform resources via `cdk.Fn.importValue`.
 6. Add Lambda source at `apps/<app-name>/functions/`. Register the
    nested workspace glob in `pnpm-workspace.yaml` if Lambdas are
    workspaces themselves.

--- a/docs/architecture/auth.md
+++ b/docs/architecture/auth.md
@@ -84,7 +84,19 @@ Social sign-in is enabled on the launchpad client only. Per-app clients are Cogn
 | `NEXT_PUBLIC_BUDGET_TRACKER_COGNITO_CLIENT_ID` | BudgetTrackerAppClient |
 
 **Callback URL convention:** `{host}/{app-slug}/callback`
-**Logout URL convention:** `{host}/sign-in`
+**Logout URL convention:** `{host}/signed-out/`
+
+**Launchpad dual callback:** The launchpad app client registers two callback URLs: `{host}/launchpad/callback` (flows initiated from launchpad pages) and `{host}/sign-in/callback` (flows initiated via the sign-in route). Both are registered; SSO flows may originate from either path.
+
+### Registered callback URLs (operational state)
+
+The following callback and logout URLs are registered on the dev Cognito app clients:
+
+| Client | Callback URLs | Logout URL |
+|---|---|---|
+| `LaunchpadAppClient` | `{host}/launchpad/callback`, `{host}/sign-in/callback` | `{host}/signed-out/` |
+| `StockAnalyserAppClient` | `{host}/stock-analyser/callback` | `{host}/signed-out/` |
+| `BudgetTrackerAppClient` | `{host}/budget-tracker/callback` | `{host}/signed-out/` |
 
 For current client IDs, read from CloudFormation outputs:
 

--- a/docs/architecture/cdk.md
+++ b/docs/architecture/cdk.md
@@ -95,10 +95,9 @@ Deployed by `deploy-budget-tracker.yml`. Source in `apps/budget-tracker/infrastr
 
 | Function name | Handler | Routes |
 |---|---|---|
-| `transformotion-portfolio-{stage}` | `apps/stock-analyser/functions/portfolio` | `GET/POST/PATCH/DELETE /api/portfolio` |
-| `transformotion-watchlist-{stage}` | `apps/stock-analyser/functions/watchlist` | `GET/POST/PATCH/DELETE /api/watchlist` |
-| `transformotion-analysis-cache-{stage}` | `apps/stock-analyser/functions/analysis-cache` | `GET /api/analysis-cache/*` |
-| `transformotion-cycle-check-{stage}` | `apps/stock-analyser/functions/cycle-check` | EventBridge scheduled (no API Gateway route) |
+| `transformotion-portfolio-{stage}` | `apps/stock-analyser/functions/portfolio` | `GET/PUT /portfolio` |
+| `transformotion-watchlist-{stage}` | `apps/stock-analyser/functions/watchlist` | `GET/PUT /watchlist` |
+| `transformotion-analysis-cache-{stage}` | `apps/stock-analyser/functions/analysis-cache` | `GET/PUT/DELETE /analysis-cache/{key}` |
 | `transformotion-cycle-data-{stage}` | `apps/stock-analyser/functions/cycle-data` | `GET /cycle/ohlcv?ticker=` |
 | `transformotion-market-data-{stage}` | `apps/stock-analyser/functions/market-data` | `GET /price/ohlcv?ticker=&range=&interval=` |
 
@@ -113,7 +112,15 @@ Deployed by `deploy-budget-tracker.yml`. Source in `apps/budget-tracker/infrastr
 | `budget-ai-review-handler-{stage}` | Budget Tracker AI Lambda | `POST /api/budget/v1/ai/review` |
 | `budget-ai-csv-analysis-handler-{stage}` | Budget Tracker AI Lambda | `POST /api/budget/v1/ai/csv-analysis` |
 | `budget-export-handler-{stage}` | Budget Tracker export Lambda | `GET /api/budget/v1/business-export` |
-| `budget-migrate-handler-{stage}` | Budget Tracker migrate Lambda | `POST /api/budget/v1/migrate-from-localstorage` |
+
+> **Note:** BT does NOT consume the shared `claude-proxy` Lambda. BT's AI routes (`/api/budget/v1/ai/*`) are independent Lambdas with their own Anthropic API key access. SA consumes `claude-proxy` directly. M9 design must account for this asymmetry.
+
+### Migration Utilities Lambda functions (`MigrationsApi`)
+
+| Function name | Handler | Routes |
+|---|---|---|
+| `migration-budget-tracker-transactions-{stage}` | `migration-utilities/budget-tracker/transactions` | `POST /api/migrations/budget-tracker/transactions/import` |
+| `migration-budget-tracker-budget-data-{stage}` | `migration-utilities/budget-tracker/budget-data` | `POST /api/migrations/budget-tracker/budget-data/run` |
 
 ### Platform WS Lambda functions (`Transformotion{Stage}-PlatformWs`)
 
@@ -222,6 +229,26 @@ Platform WS Lambda environment variables:
 | `prod` | `RETAIN` (data is permanent) | `RETAIN` on user pool, Secrets Manager entries |
 
 Secrets Manager entries for social IDP credentials are always `RETAIN` in both environments (credentials should not be destroyed if the stack is torn down).
+
+---
+
+## GitHub Actions deploy IAM
+
+A single shared IAM role `GitHubActionsDeployRole` handles all GitHub Actions deploy workflows. Source: `platform/infrastructure/github-actions-role-stack.ts`.
+
+**OIDC trust:** Federated trust from `token.actions.githubusercontent.com`, scoped to `repo:transformotion/transformotion-apps:*`.
+
+**Inline policies:**
+
+| Policy name | Permissions | Resource scope |
+|---|---|---|
+| `CDKAssumeBootstrapRoles` | `sts:AssumeRole` | CDK bootstrap role ARNs (`cdk-*`) in account `959516291617` / `ap-southeast-2` |
+| `TransformotionDevDeploy` | S3 bucket actions | `Resource: *` |
+| `TransformotionDevDeploy` | CloudFront distribution actions | `Resource: *` |
+| `TransformotionDevDeploy` | CloudFormation stack actions | `arn:aws:cloudformation:ap-southeast-2:959516291617:stack/Transformotion*` |
+| `TransformotionDevDeploy` | Cognito user pool and client actions | Both pools: `ap-southeast-2_7QhxUvefw` (dev, active) and `ap-southeast-2_8hHCARUWq` (prod — empty pool created 2026-04-22, no users, no clients) |
+
+M9 will evaluate per-app IAM scoping as part of the per-app deploy isolation outcome.
 
 ---
 

--- a/docs/architecture/data.md
+++ b/docs/architecture/data.md
@@ -46,6 +46,8 @@ User preferences, stored per Cognito `sub`.
 
 Served by `transformotion-user-{stage}` Lambda (`GET /api/user/profile`, `PUT /api/user/preferences`).
 
+> **Partial implementation:** Only `notificationsEnabled` is currently read and written by the Lambda handler. The fields `defaultMode`, `cycleAlertThreshold`, and `lastAnalysedTicker` appear in `@transformotion/api-client` types but are not implemented in the Lambda — writes are silently ignored and reads return `undefined` for these fields.
+
 ### `platform.accounts-{stage}`
 
 Account container records, shared across all apps.
@@ -94,6 +96,19 @@ Pending, redeemed, and expired invitations.
 
 Served by `transformotion-invitations-{stage}` Lambda.
 
+### `platform.job-results-{stage}`
+
+Async Claude AI job results, written by `transformotion-claude-proxy-{stage}` after self-invoked async jobs complete. Read by `transformotion-analysis-cache-{stage}` when the requested cache key matches the `job-*` prefix.
+
+| Attribute | Type | Notes |
+|---|---|---|
+| `accountId` (PK) | String | |
+| `jobId` (SK) | String | UUID — also used as analysis-cache key suffix (`job-{jobId}`) |
+| `result` | Map | Claude AI response payload |
+| `expiresAt` | Number | Epoch-seconds (TTL attribute) |
+
+Managed by `PlatformTablesStack`.
+
 ---
 
 ## Per-app tables
@@ -119,17 +134,25 @@ Managed by `TransformotionDev-StockAnalyserTables` / `TransformotionProd-StockAn
 |---|---|---|
 | `accountId` (PK) | String | |
 | `ticker` (SK) | String | |
+| `name` | String | Company or instrument name |
+| `addedAt` | Number | Epoch ms |
+| `addedPrice` | Number | Price at time of addition (optional) |
 
 #### `stock-analyser.analysis-cache-{stage}`
 
-Cache of Claude AI analysis results, keyed per account.
+Cache of Claude AI analysis results and shared market data.
 
 | Attribute | Type | Notes |
 |---|---|---|
-| `accountId` (PK) | String | |
-| `cacheKey` (SK) | String | Namespaced cache key (e.g. `MARKET#ASX`, `ANALYSIS#CBA.AX`) |
-| `result` | Map | Cached response |
+| `accountId` (PK) | String | `SHARED` for entries not scoped to one account (market data, ETFs, raw OHLCV) |
+| `cacheKey` (SK) | String | Namespaced cache key (e.g. `MARKET#ASX`, `ANALYSIS#CBA.AX`, `MARKET-DATA#CBA.AX#1y#1d`) |
+| `data` | String | JSON-serialised cached response |
+| `cachedAt` | String | ISO 8601 |
+| `dataType` | String | Identifies the type of cached data |
+| `mode` | String | Cache mode flag |
 | `expiresAt` | Number | Epoch-seconds (TTL attribute) |
+
+`accountId = 'SHARED'` is used for data shared across accounts (raw OHLCV, market-wide analysis). Account-specific entries use the account UUID.
 
 Served by `transformotion-analysis-cache-{stage}` Lambda (`GET/PUT/DELETE /analysis-cache/{key}`).
 
@@ -163,9 +186,13 @@ Managed by `TransformotionDev-BudgetTrackerTables` / `TransformotionProd-BudgetT
 |---|---|---|
 | `accountId` (PK) | String | |
 | `ruleId` (SK) | String | UUID |
+| `name` | String | Human-readable rule name |
 | `match` | String | Keyword or regex pattern, case-insensitive |
-| `category` | String | |
-| `subcategory` | String | |
+| `matchType` | String | `keyword` or `regex` |
+| `categoryId` | String | UUID FK — category reference |
+| `subcategoryId` | String | UUID FK — subcategory reference |
+| `enabled` | Boolean | |
+| `priority` | Number | Lower value = higher priority |
 | `learned` | Boolean | `true` = created via "Learn" button; `false` = manually authored |
 | `createdAt` | String | ISO 8601 |
 
@@ -176,10 +203,35 @@ Key-value store — each settings field is its own DynamoDB item.
 | Attribute | Type | Notes |
 |---|---|---|
 | `accountId` (PK) | String | |
-| `settingKey` (SK) | String | `budgetOverrides`, `budgetFreqs`, `customCategories`, `projectBudgets`, `deletedSubs`, `csvFormatMappings`, and others |
+| `settingKey` (SK) | String | `csvFormatMappings`, `aiReviewBatchSize`, `aiReviewParallelLimit`, `aiReviewConfidenceThreshold` |
 | `value` | Map or List | Shape depends on `settingKey` — see [v0-reference/contracts/budget-tracker/data-models.md](/v0-reference/contracts/budget-tracker/data-models.md) |
 
 For full type definitions see [v0-reference/contracts/budget-tracker/data-models.md](/v0-reference/contracts/budget-tracker/data-models.md).
+
+#### `budget-tracker.budget-data-{stage}`
+
+Key-value store for structured budget configuration (categories, budget amounts, frequencies). Kept on a dedicated table rather than in `budget-tracker.settings-{stage}` to avoid packing unrelated concepts into one key-value store.
+
+| Attribute | Type | Notes |
+|---|---|---|
+| `accountId` (PK) | String | |
+| `concept` (SK) | String | `categories`, `budgetAmounts`, `budgetFrequencies` |
+| `value` | Map or List | Shape depends on `concept` |
+
+#### `budget-tracker.ai-jobs-{stage}`
+
+Tracks in-progress and completed AI review jobs per account.
+
+| Attribute | Type | Notes |
+|---|---|---|
+| `accountId` (PK) | String | |
+| `jobId` (SK) | String | UUID |
+| `userId` | String | Cognito sub of the requesting user |
+| `status` | String | Job status |
+| `createdAt` | String | ISO 8601 |
+| `expiresAt` | Number | Epoch-seconds (TTL attribute — 24h) |
+
+**GSI:** `userId-index` (PK: `userId`) — look up jobs by user.
 
 ---
 
@@ -244,3 +296,5 @@ These CDK and CloudFormation constraints are not obvious and have cost real depl
 **4. S3 buckets containing important data should NEVER have `autoDeleteObjects: true`.** This is a CDK convenience for ephemeral dev buckets. For backups buckets, use `removalPolicy: RETAIN` alone and allow manual deletion only.
 
 **5. `cdk import` requires CDK config to match deployed reality exactly.** If the deployed table has a sort key but the CDK construct doesn't declare it (or vice versa), the import changeset will fail. Run `aws dynamodb describe-table` before writing the CDK construct for any table being imported.
+
+**6. App stacks that mount routes onto the shared API Gateway do not own a `Deployment` resource.** `StockAnalyserApiStack` and `BudgetTrackerApiStack` add routes to the shared `RestApi` via `Fn.importValue`, but they never create an `AWS::ApiGateway::Deployment`. The platform deploy workflow creates the deployment resource; until the next platform deploy, the active stage continues serving the snapshot from the last platform deploy — newly added routes return 403 "Missing Authentication Token" even though they exist in the API configuration. Workaround for the current architecture: trigger a platform deploy after adding new routes in an app stack. Per-app architecture (M9) removes this constraint by giving each app ownership of its own RestApi and deployment lifecycle.

--- a/docs/architecture/inventory.md
+++ b/docs/architecture/inventory.md
@@ -45,8 +45,8 @@ relevant finding in this document in the same PR.
 
 The repository contains the following top-level directories:
 
-- `apps/` — four subdirectories: `budget-tracker/`, `launchpad/`,
-  `stock-analyser/`, `web/` (0-LOC shell, M3 cleanup)
+- `apps/` — three subdirectories: `budget-tracker/`, `launchpad/`,
+  `stock-analyser/`. `apps/web/` was deleted in M7 / PR #250.
 - `packages/` — nine subdirectories: `api-client/`, `auth-client/`,
   `budget-domain/`, `cache/`, `data-access/`, `lambda-middleware/`, `logger/`, `runtime-config/`, `ui/`
   (organisational directory; two sub-packages: `ui-error-boundaries`,


### PR DESCRIPTION
## Summary

Applies the 14 documentation corrections identified in the M9 Phase A recon (documentation gap-finding pass). No code changes — architecture docs only.

**Milestone:** M9 — Per-app architecture (REST, WSS, auth ownership, Claude proxy, IAM)

## Changes by file

### `docs/architecture/cdk.md`
- **D1**: Fix SA Lambda route table — remove erroneous `/api/` prefix; correct HTTP methods to `GET/PUT` for portfolio/watchlist and `GET/PUT/DELETE` for analysis-cache
- **D2**: Remove stale `transformotion-cycle-check-{stage}` row (EventBridge-only Lambda not wired to API Gateway)
- **D3**: Remove stale `budget-migrate-handler-{stage}` row from BT section; add new Migration Utilities Lambda section with two migration Lambdas
- **D12**: Add "GitHub Actions deploy IAM" section documenting `GitHubActionsDeployRole`, OIDC trust, inline policies (`CDKAssumeBootstrapRoles`, `TransformotionDevDeploy`), and the empty prod Cognito pool finding
- **D14**: Add BT/SA claude-proxy asymmetry note (BT uses independent AI Lambdas, SA uses claude-proxy; M9 must account for this)

### `docs/architecture/data.md`
- **D4**: Fix analysis-cache schema (`data` field not `result`; add `cachedAt`, `dataType`, `mode`; document SHARED partition); fix watchlist schema (add `name`, `addedAt`, `addedPrice`); fix rules schema (UUID FKs, `name`, `matchType`, `enabled`, `priority`); fix settings keys (4 actual keys, not the stale list); add `budget-tracker.budget-data-{stage}` table; add `budget-tracker.ai-jobs-{stage}` table; add platform.users partial-implementation note
- **D5**: Add `platform.job-results-{stage}` to Platform tables section
- **D13**: Add 6th CDK constraint: deployment-snapshot lifecycle (app stacks don't own a Deployment resource; new routes return 403 until next platform deploy; M9 removes this constraint)

### `docs/architecture/auth.md`
- **D9**: Fix logout URL convention (`/sign-in` → `/signed-out/`)
- **D10**: Add launchpad dual-callback note (both `/launchpad/callback` and `/sign-in/callback` registered)
- **D11**: Add "Registered callback URLs (operational state)" subsection with the three-client table

### `docs/architecture/inventory.md`
- **D6**: Fix Section 1.1 `apps/` subdirectory count (four → three; `apps/web/` was deleted in M7 / PR #250)

### `MONOREPO.md`
- **D7**: Fix "How deploys work" table: `apps/launchpad/**` triggers `deploy-launchpad.yml`, not `deploy-platform.yml`
- **D8**: Fix "Adding a new app" step 5 to reference `infrastructure/bin/{app-name}.ts` (not the monolithic `infrastructure/bin/app.ts`)

## Deferred to Phase B

Full documentation for WSS ownership design, Claude proxy per-app split, and ACM/DNS multi-domain design are deferred — these require Phase B architectural decisions before they can be documented.

## Related

- Settings architecture Backlog issue: #356
- M9 milestone: #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)