### PR TITLE
feat: move Stock Analyser AI runtime to app ownership

### DIFF
--- a/.github/workflows/deploy-stock-analyser.yml
+++ b/.github/workflows/deploy-stock-analyser.yml
@@ -14,6 +14,7 @@ on:
       - 'packages/auth-client/**'
       - 'packages/runtime-config/**'
       - 'packages/lambda-middleware/**'
+      - 'packages/fn-claude-proxy-core/**'
   workflow_call:
     inputs:
       target:
@@ -49,8 +50,8 @@ jobs:
     environment: dev
     env:
       NEXT_PUBLIC_API_URL: ${{ vars.NEXT_PUBLIC_API_URL }}
-      NEXT_PUBLIC_CLAUDE_API_URL: ${{ vars.NEXT_PUBLIC_CLAUDE_API_URL }}
-      NEXT_PUBLIC_CLAUDE_CACHE_URL: ${{ vars.NEXT_PUBLIC_CLAUDE_CACHE_URL }}
+      NEXT_PUBLIC_AI_API_URL: ${{ vars.NEXT_PUBLIC_AI_API_URL }}
+      NEXT_PUBLIC_AI_CACHE_URL: ${{ vars.NEXT_PUBLIC_AI_CACHE_URL }}
       NEXT_PUBLIC_COGNITO_USER_POOL_ID: ${{ vars.NEXT_PUBLIC_COGNITO_USER_POOL_ID }}
       NEXT_PUBLIC_COGNITO_CLIENT_ID: ${{ vars.NEXT_PUBLIC_STOCK_ANALYSER_COGNITO_CLIENT_ID }}
       NEXT_PUBLIC_COGNITO_REGION: ${{ vars.NEXT_PUBLIC_COGNITO_REGION }}
@@ -62,6 +63,8 @@ jobs:
       NEXT_PUBLIC_SIGNIN_URL: ${{ vars.NEXT_PUBLIC_APP_URL }}/sign-in/
       NEXT_PUBLIC_SIGNOUT_URL: ${{ vars.NEXT_PUBLIC_APP_URL }}/signed-out/
       NEXT_PUBLIC_COMMIT_HASH: ${{ github.sha }}
+      NEXT_PUBLIC_PLATFORM_WSS_URL: ${{ vars.NEXT_PUBLIC_PLATFORM_WSS_URL }}
+      NEXT_PUBLIC_SA_WSS_URL: ${{ vars.NEXT_PUBLIC_SA_WSS_URL }}
     steps:
       - uses: actions/checkout@v4
 
@@ -87,42 +90,45 @@ jobs:
 
       - name: CDK Deploy — Stock Analyser stacks (dev)
         working-directory: infrastructure
-        run: pnpm exec cdk deploy --app 'npx ts-node --prefer-ts-exts bin/stock-analyser.ts' 'TransformotionDev-StockAnalyserApi' --require-approval never
+        run: pnpm exec cdk deploy --app 'npx ts-node --prefer-ts-exts bin/stock-analyser.ts' 'TransformotionDev-StockAnalyserTables' 'TransformotionDev-StockAnalyserWs' 'TransformotionDev-StockAnalyserApi' --require-approval never
 
-      - name: Wait for PlatformWs stack (handles first-deploy race; see #295)
+      - name: Extract Stock Analyser API URLs from CDK output
         run: |
-          STACK=TransformotionDev-PlatformWs
-          if aws cloudformation describe-stacks --stack-name "$STACK" >/dev/null 2>&1; then
-            echo "$STACK exists, proceeding"
-          else
-            echo "$STACK not found, waiting up to 20 min..."
-            ATTEMPTS=0
-            until aws cloudformation describe-stacks --stack-name "$STACK" >/dev/null 2>&1; do
-              ATTEMPTS=$((ATTEMPTS + 1))
-              if [ "$ATTEMPTS" -ge 40 ]; then
-                echo "ERROR: $STACK not found after $((ATTEMPTS * 30))s"
-                exit 1
-              fi
-              echo "Attempt $ATTEMPTS/40: waiting 30s..."
-              sleep 30
-            done
-            echo "$STACK found, waiting for CREATE_COMPLETE..."
-            aws cloudformation wait stack-create-complete --stack-name "$STACK"
-            echo "$STACK is ready"
-          fi
-
-      - name: Extract WebSocket URL from CDK output
-        run: |
-          WSS_URL=$(aws cloudformation describe-stacks \
-            --stack-name TransformotionDev-PlatformWs \
-            --query "Stacks[0].Outputs[?OutputKey=='WssUrl'].OutputValue" \
+          API_URL=$(aws cloudformation describe-stacks \
+            --stack-name TransformotionDev-StockAnalyserApi \
+            --query "Stacks[0].Outputs[?OutputKey=='ApiUrl'].OutputValue" \
             --output text)
-          if [ -z "$WSS_URL" ]; then
-            echo "ERROR: Could not extract WssUrl from TransformotionDev-PlatformWs stack"
+          AI_API_URL=$(aws cloudformation describe-stacks \
+            --stack-name TransformotionDev-StockAnalyserApi \
+            --query "Stacks[0].Outputs[?OutputKey=='AiApiUrl'].OutputValue" \
+            --output text)
+          AI_CACHE_URL=$(aws cloudformation describe-stacks \
+            --stack-name TransformotionDev-StockAnalyserApi \
+            --query "Stacks[0].Outputs[?OutputKey=='AnalysisCacheUrl'].OutputValue" \
+            --output text)
+          if [ -z "$API_URL" ] || [ -z "$AI_API_URL" ] || [ -z "$AI_CACHE_URL" ]; then
+            echo "ERROR: Could not extract API URLs from TransformotionDev-StockAnalyserApi stack"
             exit 1
           fi
-          echo "NEXT_PUBLIC_PLATFORM_WSS_URL=$WSS_URL" >> $GITHUB_ENV
-          echo "Extracted WSS URL: $WSS_URL"
+          echo "NEXT_PUBLIC_API_URL=$API_URL" >> $GITHUB_ENV
+          echo "NEXT_PUBLIC_AI_API_URL=$AI_API_URL" >> $GITHUB_ENV
+          echo "NEXT_PUBLIC_AI_CACHE_URL=$AI_CACHE_URL" >> $GITHUB_ENV
+          echo "NEXT_PUBLIC_CLAUDE_API_URL=$AI_API_URL" >> $GITHUB_ENV
+          echo "NEXT_PUBLIC_CLAUDE_CACHE_URL=$AI_CACHE_URL" >> $GITHUB_ENV
+          echo "Extracted SA API URL: $API_URL"
+
+      - name: Extract Stock Analyser WebSocket URL from CDK output
+        run: |
+          SA_WSS_URL=$(aws cloudformation describe-stacks \
+            --stack-name TransformotionDev-StockAnalyserWs \
+            --query "Stacks[0].Outputs[?OutputKey=='WssUrl'].OutputValue" \
+            --output text)
+          if [ -z "$SA_WSS_URL" ]; then
+            echo "ERROR: Could not extract WssUrl from TransformotionDev-StockAnalyserWs stack"
+            exit 1
+          fi
+          echo "NEXT_PUBLIC_SA_WSS_URL=$SA_WSS_URL" >> $GITHUB_ENV
+          echo "Extracted SA WSS URL: $SA_WSS_URL"
 
       - name: Build Next.js (static export)
         working-directory: apps/stock-analyser
@@ -148,14 +154,14 @@ jobs:
           CI_COGNITO_PASSWORD: ${{ secrets.CI_COGNITO_PASSWORD }}
           COGNITO_USER_POOL_ID: ${{ vars.NEXT_PUBLIC_COGNITO_USER_POOL_ID }}
           COGNITO_APP_CLIENT_ID: ${{ vars.NEXT_PUBLIC_STOCK_ANALYSER_COGNITO_CLIENT_ID }}
-          API_BASE_URL: ${{ vars.NEXT_PUBLIC_API_URL }}
         run: |
+          export API_BASE_URL="${NEXT_PUBLIC_API_URL}"
           bash scripts/ci/verify-deploy.sh \
             "${{ vars.NEXT_PUBLIC_APP_URL }}/stock-analyser" \
             apps/stock-analyser/.env.example \
             "${{ github.sha }}" \
             "stock-analyser" \
-            "/api/user/profile"
+            "/portfolio"
 
   deploy-prod:
     name: Stock Analyser → Prod
@@ -164,8 +170,8 @@ jobs:
     environment: prod
     env:
       NEXT_PUBLIC_API_URL: ${{ vars.NEXT_PUBLIC_API_URL }}
-      NEXT_PUBLIC_CLAUDE_API_URL: ${{ vars.NEXT_PUBLIC_CLAUDE_API_URL }}
-      NEXT_PUBLIC_CLAUDE_CACHE_URL: ${{ vars.NEXT_PUBLIC_CLAUDE_CACHE_URL }}
+      NEXT_PUBLIC_AI_API_URL: ${{ vars.NEXT_PUBLIC_AI_API_URL }}
+      NEXT_PUBLIC_AI_CACHE_URL: ${{ vars.NEXT_PUBLIC_AI_CACHE_URL }}
       NEXT_PUBLIC_COGNITO_USER_POOL_ID: ${{ vars.NEXT_PUBLIC_COGNITO_USER_POOL_ID }}
       NEXT_PUBLIC_COGNITO_CLIENT_ID: ${{ vars.NEXT_PUBLIC_STOCK_ANALYSER_COGNITO_CLIENT_ID }}
       NEXT_PUBLIC_COGNITO_REGION: ${{ vars.NEXT_PUBLIC_COGNITO_REGION }}
@@ -177,6 +183,8 @@ jobs:
       NEXT_PUBLIC_SIGNIN_URL: ${{ vars.NEXT_PUBLIC_APP_URL }}/sign-in/
       NEXT_PUBLIC_SIGNOUT_URL: ${{ vars.NEXT_PUBLIC_APP_URL }}/signed-out/
       NEXT_PUBLIC_COMMIT_HASH: ${{ github.sha }}
+      NEXT_PUBLIC_PLATFORM_WSS_URL: ${{ vars.NEXT_PUBLIC_PLATFORM_WSS_URL }}
+      NEXT_PUBLIC_SA_WSS_URL: ${{ vars.NEXT_PUBLIC_SA_WSS_URL }}
     steps:
       - uses: actions/checkout@v4
 
@@ -202,42 +210,45 @@ jobs:
 
       - name: CDK Deploy — Stock Analyser stacks (prod)
         working-directory: infrastructure
-        run: pnpm exec cdk deploy --app 'npx ts-node --prefer-ts-exts bin/stock-analyser.ts' 'TransformotionProd-StockAnalyserTables' 'TransformotionProd-StockAnalyserApi' --require-approval never
+        run: pnpm exec cdk deploy --app 'npx ts-node --prefer-ts-exts bin/stock-analyser.ts' 'TransformotionProd-StockAnalyserTables' 'TransformotionProd-StockAnalyserWs' 'TransformotionProd-StockAnalyserApi' --require-approval never
 
-      - name: Wait for PlatformWs stack (handles first-deploy race; see #295)
+      - name: Extract Stock Analyser API URLs from CDK output
         run: |
-          STACK=TransformotionProd-PlatformWs
-          if aws cloudformation describe-stacks --stack-name "$STACK" >/dev/null 2>&1; then
-            echo "$STACK exists, proceeding"
-          else
-            echo "$STACK not found, waiting up to 20 min..."
-            ATTEMPTS=0
-            until aws cloudformation describe-stacks --stack-name "$STACK" >/dev/null 2>&1; do
-              ATTEMPTS=$((ATTEMPTS + 1))
-              if [ "$ATTEMPTS" -ge 40 ]; then
-                echo "ERROR: $STACK not found after $((ATTEMPTS * 30))s"
-                exit 1
-              fi
-              echo "Attempt $ATTEMPTS/40: waiting 30s..."
-              sleep 30
-            done
-            echo "$STACK found, waiting for CREATE_COMPLETE..."
-            aws cloudformation wait stack-create-complete --stack-name "$STACK"
-            echo "$STACK is ready"
-          fi
-
-      - name: Extract WebSocket URL from CDK output
-        run: |
-          WSS_URL=$(aws cloudformation describe-stacks \
-            --stack-name TransformotionProd-PlatformWs \
-            --query "Stacks[0].Outputs[?OutputKey=='WssUrl'].OutputValue" \
+          API_URL=$(aws cloudformation describe-stacks \
+            --stack-name TransformotionProd-StockAnalyserApi \
+            --query "Stacks[0].Outputs[?OutputKey=='ApiUrl'].OutputValue" \
             --output text)
-          if [ -z "$WSS_URL" ]; then
-            echo "ERROR: Could not extract WssUrl from TransformotionProd-PlatformWs stack"
+          AI_API_URL=$(aws cloudformation describe-stacks \
+            --stack-name TransformotionProd-StockAnalyserApi \
+            --query "Stacks[0].Outputs[?OutputKey=='AiApiUrl'].OutputValue" \
+            --output text)
+          AI_CACHE_URL=$(aws cloudformation describe-stacks \
+            --stack-name TransformotionProd-StockAnalyserApi \
+            --query "Stacks[0].Outputs[?OutputKey=='AnalysisCacheUrl'].OutputValue" \
+            --output text)
+          if [ -z "$API_URL" ] || [ -z "$AI_API_URL" ] || [ -z "$AI_CACHE_URL" ]; then
+            echo "ERROR: Could not extract API URLs from TransformotionProd-StockAnalyserApi stack"
             exit 1
           fi
-          echo "NEXT_PUBLIC_PLATFORM_WSS_URL=$WSS_URL" >> $GITHUB_ENV
-          echo "Extracted WSS URL: $WSS_URL"
+          echo "NEXT_PUBLIC_API_URL=$API_URL" >> $GITHUB_ENV
+          echo "NEXT_PUBLIC_AI_API_URL=$AI_API_URL" >> $GITHUB_ENV
+          echo "NEXT_PUBLIC_AI_CACHE_URL=$AI_CACHE_URL" >> $GITHUB_ENV
+          echo "NEXT_PUBLIC_CLAUDE_API_URL=$AI_API_URL" >> $GITHUB_ENV
+          echo "NEXT_PUBLIC_CLAUDE_CACHE_URL=$AI_CACHE_URL" >> $GITHUB_ENV
+          echo "Extracted SA API URL: $API_URL"
+
+      - name: Extract Stock Analyser WebSocket URL from CDK output
+        run: |
+          SA_WSS_URL=$(aws cloudformation describe-stacks \
+            --stack-name TransformotionProd-StockAnalyserWs \
+            --query "Stacks[0].Outputs[?OutputKey=='WssUrl'].OutputValue" \
+            --output text)
+          if [ -z "$SA_WSS_URL" ]; then
+            echo "ERROR: Could not extract WssUrl from TransformotionProd-StockAnalyserWs stack"
+            exit 1
+          fi
+          echo "NEXT_PUBLIC_SA_WSS_URL=$SA_WSS_URL" >> $GITHUB_ENV
+          echo "Extracted SA WSS URL: $SA_WSS_URL"
 
       - name: Build Next.js (static export)
         working-directory: apps/stock-analyser
@@ -263,11 +274,11 @@ jobs:
           CI_COGNITO_PASSWORD: ${{ secrets.CI_COGNITO_PASSWORD }}
           COGNITO_USER_POOL_ID: ${{ vars.NEXT_PUBLIC_COGNITO_USER_POOL_ID }}
           COGNITO_APP_CLIENT_ID: ${{ vars.NEXT_PUBLIC_STOCK_ANALYSER_COGNITO_CLIENT_ID }}
-          API_BASE_URL: ${{ vars.NEXT_PUBLIC_API_URL }}
         run: |
+          export API_BASE_URL="${NEXT_PUBLIC_API_URL}"
           bash scripts/ci/verify-deploy.sh \
             "${{ vars.NEXT_PUBLIC_APP_URL }}/stock-analyser" \
             apps/stock-analyser/.env.example \
             "${{ github.sha }}" \
             "stock-analyser" \
-            "/api/user/profile"
+            "/portfolio"

--- a/MONOREPO.md
+++ b/MONOREPO.md
@@ -82,7 +82,7 @@ transformotion-apps/
 │       │   ├── invitations/               # Invitation flow
 │       │   └── forgot-provider/           # Federated identity recovery
 │       ├── accounts/                      # Account management
-│       ├── claude-proxy/                  # Anthropic API proxy (WSS push when connectionId provided)
+│       ├── claude-proxy/                  # Legacy platform Anthropic API proxy (rollback/decommission path)
 │       ├── user/                          # Platform user data
 │       ├── ws-authorizer/                 # WS $connect custom authoriser (Cognito JWT + accounts claim)
 │       ├── ws-connect/                    # WS $connect handler (writes connection record)
@@ -275,15 +275,22 @@ organisational, not itself a package.
   Nested workspaces (like `apps/stock-analyser/functions/*` and
   `platform/functions/auth/*`) need explicit globs in `pnpm-workspace.yaml`.
 
-- **Shared API Gateway (current/transitional).** `apps/stock-analyser`
-  and `apps/budget-tracker` currently mount REST routes on the shared
-  platform API Gateway from `PlatformApiStack`. This shared runtime
-  gateway is transitional debt for M9, not the desired pattern for new
-  app runtime work. M9 moves Budget Tracker and Stock Analyser to
-  app-owned API Gateway ownership.
+- **Shared API Gateway (current/transitional).** `apps/budget-tracker`
+  still mounts REST routes on the shared platform API Gateway from
+  `PlatformApiStack`. Stock Analyser owns its REST API Gateway after
+  #366. Shared runtime gateway use is transitional debt for M9, not the
+  desired pattern for new app runtime work.
+
+- **Stock Analyser WSS and AI runtime.** `apps/stock-analyser`
+  owns `sa-ws-stack.ts`, WS handler packages under
+  `apps/stock-analyser/functions/ws-*`, and
+  `apps/stock-analyser/functions/ai-proxy` after #366. Live Stock
+  Analyser AI uses Stock Analyser-owned REST, WSS, job-results, and
+  AI runtime; platform runtime remains only for rollback and later
+  decommissioning.
 
 - **Analysis cache table.** The `platform.analysis-cache` table is
-  used by stock-analyser via the claude-proxy Lambda. Despite the
+  used by stock-analyser via the legacy platform claude-proxy Lambda. Despite the
   `platform.` prefix it is functionally stock-analyser data; M2.1
   ratifies the reclassification as a Stage 0b decision.
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -889,18 +889,24 @@ This milestone can run in parallel with M9 and M10.
 
 ---
 
-## 13. M9 — Per-app architecture (REST, WSS, auth ownership, Claude proxy, IAM)
+## 13. M9 - Per-app architecture (REST, WSS, auth ownership, AI proxy, IAM)
 
 ### Purpose
 
 Substantial architectural restructure moving from shared-Platform to
 per-app architecture across REST API gateways, WebSocket API gateways,
 auth substrate ownership (LP becomes the owner of Cognito and auth
-Lambdas), per-app Claude proxies, per-app deploy IAM roles. Shared
+Lambdas), per-app AI proxies, per-app deploy IAM roles. Shared
 platform layer shrinks to CloudFront, DNS, ACM, and build-time-only
 shared CDK constructs and workspace packages. Deploy mechanism for the
 residual shared platform shifts away from workflow_call cascade toward
 backwards-compatibility defaults and explicit coordinated migrations.
+
+M9 also establishes runtime-switchable multi-provider AI as an extension of
+the per-app runtime ownership work. Each app owns exactly one `ai-proxy`;
+provider-specific behaviour is internal to that proxy through provider modules
+such as `ClaudeProvider` and `OpenAIProvider`. Provider/model selection is
+runtime configuration, not provider-specific Lambda topology.
 
 Scope includes recon, design proposal, sub-phase breakdown into child
 issues, and implementation across all affected apps (LP, SA, BT, MU).
@@ -926,17 +932,18 @@ Goal 1 primarily (deployment isolation made true). Goal 3
 
 ### Gate to next
 
-All apps deploy independently at REST, WSS, auth, and IAM layers.
+All apps deploy independently at REST, WSS, auth, AI proxy, and IAM layers.
 CloudFront, DNS, ACM, build-time packages remain shared. Deploy of one
 app's infrastructure does not affect any other app's deployment state.
 Launchpad tile rendering reads the `apps` JWT claim (subsumed from
-original M9 scope).
+original M9 scope). App AI runtime supports runtime provider/model selection
+with safe fallback to current Claude behaviour.
 
 ### Dependencies
 
 - M7 (closed) provides the per-app stack foundation.
 - M2.2 (already closed).
-- M8 and M10 sub-phases may need re-sequencing — to be determined
+- M8 and M10 sub-phases may need re-sequencing - to be determined
   during M9's recon phase.
 
 This milestone can run in parallel with M8 and M10 (sequencing TBD
@@ -944,50 +951,72 @@ during recon).
 
 ### Sub-phases (M9 child issues)
 
-Phase 1 — Foundations (parallel, start immediately):
-- #360 M9-1: Phase A doc corrections — cdk.md, SA CLAUDE.md, BT CLAUDE.md
-- #361 M9-2: Workspace packages — `@transformotion/fn-claude-proxy-core`
-  extraction and `@transformotion/rate-limit-middleware` creation
+Phase 1 - Foundations (parallel, start immediately):
+- #360 M9-1: Phase A doc corrections - cdk.md, SA CLAUDE.md, BT CLAUDE.md
+- #361 M9-2: Workspace packages - initial Claude proxy mechanics extraction
+  and `@transformotion/rate-limit-middleware` creation
 - #362 M9-8: Per-app Cognito app clients + IAM deploy roles (moved to Phase 1
   because LP needs its own IAM role before taking auth ownership in Phase 2)
 
-Phase 2 — Per-app infrastructure (parallel after Phase 1):
-- #363 M9-3: LP auth ownership transfer (Cognito + auth Lambdas → LP CDK)
+Phase 2 - Per-app infrastructure ownership (parallel after Phase 1):
+- #363 M9-3: LP auth ownership transfer (Cognito + auth Lambdas to LP CDK)
 - #364 M9-4: SA per-app WSS (split SA from platform-ws)
 - #365 M9-5: BT per-app WSS (split BT from platform-ws)
-- #366 M9-6a: SA per-app REST API + per-app claude-proxy Lambda + `sa.job-results` table
-- #367 M9-7a: BT per-app REST API + per-app claude-proxy Lambda
+- #366 M9-6a: SA per-app REST API + app-owned AI proxy Lambda + `sa.job-results` table
+- #367 M9-7a: BT per-app REST API + app-owned AI proxy Lambda
   (+ remove unhandled /api/budget/v1/ai/categorise route)
 
-Phase 3 — AI service canonicalization (parallel with late Phase 2):
+Phase 3 - AI proxy naming and provider foundation (after Phase 2 ownership):
+- #376 M9-12: Rename app-owned Claude proxy concept to app-owned AI proxy
+- #377 M9-13: Shared AI provider abstraction with `ClaudeProvider` and
+  `OpenAIProvider`
+- #382 M9-18: AI proxy observability fields for provider, model, latency,
+  usage, and errors
+
+Phase 4 - Runtime provider switching (after provider foundation):
+- #378 M9-14: Runtime AI provider/model config storage and API
+- #379 M9-15: Wire Stock Analyser `ai-proxy` to runtime provider resolution
+- #380 M9-16: Wire Budget Tracker `ai-proxy` to runtime provider resolution
+
+Phase 5 - AI service canonicalization (parallel with late Phase 4):
 - #368 M9-6b: SA AI service canonical refactor (Hybrid A: AIService class +
   thin hook; cache in service layer)
 - #369 M9-7b: BT AI service hook wrapper + mock fidelity fix + cache layer
   (`budget-tracker.ai-cache-{stage}`, accountId+transactionsHash, 7-day TTL)
 
-Phase 4 — LP frontend (after M9-3):
+Phase 6 - LP frontend and admin settings:
 - #370 M9-10: LP tile rendering migration (apps JWT claim)
+- #381 M9-17: Launchpad Settings UI for AI provider/model settings
+  (site-admin only; no secret management)
 
-Phase 5 — Isolation close and cleanup (after Phases 2 and 4):
-- #371 M9-9: Deploy cascade restructure (workflow_call → independent
+Phase 7 - Isolation close and cleanup (after ownership and runtime switching):
+- #371 M9-9: Deploy cascade restructure (workflow_call to independent
   path-filtered triggers)
-- #372 M9-11: Platform cleanup — decommission shared claude-proxy, platform-ws,
+- #372 M9-11: Platform cleanup - decommission shared claude-proxy, platform-ws,
   platform.job-results
 
 ### Architectural decisions incorporated
 
-Phase B: per-app REST, WSS, auth, claude-proxy, IAM, StorageStack-to-MU,
+Phase B: per-app REST, WSS, auth, AI proxy, IAM, StorageStack-to-MU,
   deploy cascade, LP tile rendering, app client ownership, AuthApiStack fate.
 Phase C L1: all multi-route Lambdas are Type A (no cross-app routing issues).
 Phase C L3: rate-limiting via per-Lambda env vars +
   `@transformotion/rate-limit-middleware` + per-app DynamoDB rate-limit tables.
-Phase C L4: per-app claude-proxy Lambdas wrapping shared
-  `@transformotion/fn-claude-proxy-core`; sync mode (BT, no JOB_RESULTS_TABLE)
-  and async mode (SA, JOB_RESULTS_TABLE required) both supported;
-  original shared proxy decommissioned on completion.
-Phase C (C1–C5): Hybrid A canonical AI pattern — service class layer + thin
-  React hook wrapper — adopted in both SA and BT; cache belongs in service
+Phase C L4: per-app `ai-proxy` Lambdas wrapping shared AI proxy/provider
+  mechanics; sync mode (BT, no JOB_RESULTS_TABLE) and async mode (SA,
+  JOB_RESULTS_TABLE required) both supported; original shared platform
+  Claude proxy decommissioned on completion.
+Phase C (C1-C5): Hybrid A canonical AI pattern - service class layer + thin
+  React hook wrapper - adopted in both SA and BT; cache belongs in service
   layer, not hook.
+Runtime multi-provider AI: each app owns one `ai-proxy`, not separate
+Claude/OpenAI proxy Lambdas. The `ai-proxy` routes internally to
+`ClaudeProvider` or `OpenAIProvider`. Provider/model config is separate from
+secrets; API keys remain env/CDK/Secrets Manager managed. Runtime resolution
+order is app override, then platform default, then env fallback. Missing or
+invalid config must fail safe to current Claude behaviour. Launchpad Settings
+is the site-admin-only UI for provider/model switching. Observability includes
+provider, model, latency, token usage where available, and normalized errors.
 
 ---
 

--- a/apps/stock-analyser/.env.example
+++ b/apps/stock-analyser/.env.example
@@ -49,39 +49,47 @@
 # the deploy workflow's env block if [REQUIRED] or [BUILD-INJECTED].
 # ─────────────────────────────────────────────────────────────────────────────
 
-# ── Platform API ─────────────────────────────────────────────────────────────
+# ── Stock Analyser API ───────────────────────────────────────────────────────
 
-# [REQUIRED]
-# Base URL of the shared platform API Gateway.
-# All platform routes (auth session, accounts, portfolio, watchlist,
-# Claude proxy, analysis-cache) are sent here.
-# Source: CloudFormation output ApiUrl on TransformotionDev-Api (dev) or
-#         TransformotionProd-Api (prod).
+# [BUILD-INJECTED]
+# Base URL of the Stock Analyser-owned API Gateway. Extracted from
+# TransformotionDev/Prod-StockAnalyserApi -> ApiUrl by the deploy workflow.
 NEXT_PUBLIC_API_URL=https://your-platform-api-id.execute-api.ap-southeast-2.amazonaws.com/dev
 
-# [REQUIRED]
-# Claude proxy endpoint. AI features in the Stock Analyser invoke this
-# to call Anthropic via the shared backend proxy Lambda.
-# Path is /api/claude on the platform API — update both API ID and stage
-# whenever TransformotionDev-Api is recreated.
+# [BUILD-INJECTED]
+# Stock Analyser-owned AI proxy endpoint.
+# Extracted from TransformotionDev/Prod-StockAnalyserApi by the deploy workflow.
 # Source: <NEXT_PUBLIC_API_URL>/api/claude
+NEXT_PUBLIC_AI_API_URL=https://your-platform-api-id.execute-api.ap-southeast-2.amazonaws.com/dev/api/claude
+
+# [BUILD-INJECTED]
+# Compatibility alias for the app-owned AI proxy endpoint while older frontend
+# config still accepts the Claude-specific variable name.
 NEXT_PUBLIC_CLAUDE_API_URL=https://your-platform-api-id.execute-api.ap-southeast-2.amazonaws.com/dev/api/claude
 
-# [REQUIRED]
-# Analysis-cache endpoint. Persistent cache of AI analysis results,
-# used for reading async job results after WSS notification.
+# [BUILD-INJECTED]
+# Stock Analyser-owned analysis-cache endpoint. Persistent cache of AI analysis
+# results, used for reading async job results after WSS notification.
 # Source: <NEXT_PUBLIC_API_URL>/analysis-cache
+NEXT_PUBLIC_AI_CACHE_URL=https://your-platform-api-id.execute-api.ap-southeast-2.amazonaws.com/dev/analysis-cache
+
+# [BUILD-INJECTED]
+# Compatibility alias for the app-owned AI cache endpoint while older frontend
+# config still accepts the Claude-specific variable name.
 NEXT_PUBLIC_CLAUDE_CACHE_URL=https://your-platform-api-id.execute-api.ap-southeast-2.amazonaws.com/dev/analysis-cache
 
 # [BUILD-INJECTED]
-# Platform WebSocket API URL. Extracted from the CDK stack output
-# (TransformotionDev/Prod-PlatformWs → WssUrl) by the deploy workflow
-# immediately after the wait step, then written to $GITHUB_ENV so the
-# Next.js build can embed it. Not set manually — the workflow always
-# reads the live stack output, so the URL remains correct even if the
-# WebSocket API is recreated.
-# For local development: leave empty (mock AI provider is used instead).
+# Platform WebSocket API URL retained only as a rollback fallback while
+# PlatformWsStack remains deployed for #372 decommissioning.
+# For local development: leave empty.
 NEXT_PUBLIC_PLATFORM_WSS_URL=
+
+# [BUILD-INJECTED]
+# Stock Analyser-owned WebSocket API URL. Extracted from the CDK stack output
+# (TransformotionDev/Prod-StockAnalyserWs -> WssUrl) by the deploy workflow.
+# This is the live WebSocket endpoint for Stock Analyser AI after #366.
+# For local development: leave empty.
+NEXT_PUBLIC_SA_WSS_URL=
 
 # ── Cognito authentication ────────────────────────────────────────────────────
 

--- a/apps/stock-analyser/AGENTS.md
+++ b/apps/stock-analyser/AGENTS.md
@@ -35,20 +35,22 @@ React + TypeScript + Tailwind CSS.
 
 | Stack | Contents |
 |---|---|
-| `Transformotion{Stage}-StockAnalyserTables` | `stock-analyser.portfolio-{stage}`, `stock-analyser.watchlist-{stage}`, `stock-analyser.analysis-cache-{stage}` |
-| `Transformotion{Stage}-StockAnalyserApi` | All Stock Analyser Lambda functions + routes on the platform API Gateway |
+| `Transformotion{Stage}-StockAnalyserTables` | `stock-analyser.portfolio-{stage}`, `stock-analyser.watchlist-{stage}`, `stock-analyser.analysis-cache-{stage}`, `stock-analyser.job-results-{stage}` |
+| `Transformotion{Stage}-StockAnalyserWs` | Stock Analyser-owned WebSocket API, WS Lambdas, and `stock-analyser.ws-connections-{stage}` |
+| `Transformotion{Stage}-StockAnalyserApi` | Stock Analyser-owned REST API Gateway, app Lambdas, and `stock-analyser-ai-proxy-{stage}` |
 
 Source: `apps/stock-analyser/infrastructure/`
 
 ## Lambda functions
 
-Current/transitional state: Stock Analyser Lambdas are mounted on the shared platform API Gateway at the shared API root and use the platform Cognito JWT authoriser. This is not the M9 target; M9 moves Stock Analyser REST runtime ownership to a Stock Analyser-owned API Gateway.
+Current state after #366: Stock Analyser owns its REST API Gateway, AI proxy runtime, WSS completion path, and job-results table. Cognito remains platform-owned until #363. Platform REST/WSS/Claude runtime remains deployed only for rollback and #372 decommissioning.
 
 | Lambda | Source | Routes |
 |---|---|---|
 | `transformotion-portfolio-{stage}` | `apps/stock-analyser/functions/portfolio` | `GET/PUT /portfolio` |
 | `transformotion-watchlist-{stage}` | `apps/stock-analyser/functions/watchlist` | `GET/PUT /watchlist` |
 | `transformotion-analysis-cache-{stage}` | `apps/stock-analyser/functions/analysis-cache` | `GET/PUT/DELETE /analysis-cache/{key}` |
+| `stock-analyser-ai-proxy-{stage}` | `apps/stock-analyser/functions/ai-proxy` | `POST /api/claude` |
 | `transformotion-cycle-check-{stage}` | `apps/stock-analyser/functions/cycle-check` | EventBridge scheduled (no HTTP route) |
 | `transformotion-cycle-data-{stage}` | `apps/stock-analyser/functions/cycle-data` | `GET /cycle/ohlcv?ticker=` |
 | `transformotion-market-data-{stage}` | `apps/stock-analyser/functions/market-data` | `GET /price/ohlcv?ticker=&range=&interval=` |
@@ -59,9 +61,10 @@ Current/transitional state: Stock Analyser Lambdas are mounted on the shared pla
 |---|---|---|---|
 | `stock-analyser.portfolio-{stage}` | `accountId` | `ticker` | Portfolio holdings per account |
 | `stock-analyser.watchlist-{stage}` | `accountId` | `ticker` | Watchlist items per account |
-| `stock-analyser.analysis-cache-{stage}` | `accountId` | `cacheKey` | Claude analysis cache (TTL: expiresAt) |
+| `stock-analyser.analysis-cache-{stage}` | `accountId` | `cacheKey` | AI analysis cache (TTL: expiresAt) |
+| `stock-analyser.job-results-{stage}` | `accountId` | `cacheKey` | Async AI job state (TTL: expiresAt) |
 
-Analysis cache is accessed by `transformotion-analysis-cache-{stage}` (read/delete). As of M7 / PR #334 (Bucket A'), async job records (`job-*` keys) are written by `claude-proxy` to `platform.job-results-{stage}` (not this table). The `analysis-cache` Lambda routes GET requests for `job-*` keys to that platform table; all other keys stay on this table.
+Analysis cache is accessed by `transformotion-analysis-cache-{stage}` (read/delete). Async job records (`job-*` keys) are written by `stock-analyser-ai-proxy-{stage}` to `stock-analyser.job-results-{stage}`. The `analysis-cache` Lambda routes GET requests for `job-*` keys to that app-owned table; all other keys stay on `stock-analyser.analysis-cache-{stage}`.
 
 ## Authorization requirement
 
@@ -88,14 +91,16 @@ Key service methods defined in [contracts/DATA_CONTRACTS.md](./contracts/DATA_CO
 
 ### Claude AI pattern
 
-The `useClaude<T>()` hook handles the full async request cycle via the platform WebSocket:
-1. Open platform WSS (`NEXT_PUBLIC_PLATFORM_WSS_URL`) with Cognito ID token and `?app=stock-analyser`
+The `useClaude<T>()` hook handles the full async request cycle via Stock Analyser-owned runtime:
+1. Open SA WSS (`NEXT_PUBLIC_SA_WSS_URL`) with Cognito ID token and `?app=stock-analyser`
 2. Send `{ action: 'init' }` → receive `{ type: 'connected', connectionId }`
 3. POST to `/api/claude` with prompt + `connectionId` → returns `jobId`
 4. Receive `{ type: 'job_complete' }` push on the WebSocket when the job finishes
 5. Read result from `/analysis-cache/job-{jobId}` and return typed result
 
 See `apps/stock-analyser/docs/claude-ai-pattern.md` for usage examples and configuration.
+
+`NEXT_PUBLIC_PLATFORM_WSS_URL` is retained only as rollback fallback while platform WSS remains deployed for #372 decommissioning.
 
 ### Adding a new AI feature
 
@@ -171,8 +176,9 @@ Required env vars marked `[REQUIRED]` in `.env.example` must be set before the d
 | `NEXT_PUBLIC_COGNITO_USER_POOL_ID` | Shared Cognito user pool ID |
 | `NEXT_PUBLIC_COGNITO_DOMAIN` | Hosted UI domain |
 | `NEXT_PUBLIC_RUNTIME_PROFILE` | `mock` (default; local development) or `live` (deployed environments). Determines defaults for auth, data, AI, and future concerns. See root `AGENTS.md` for the design map. |
-| `NEXT_PUBLIC_API_BASE_URL` | Platform API base URL |
-| `NEXT_PUBLIC_PLATFORM_WSS_URL` | Platform WebSocket URL for async AI job notifications — extracted from `TransformotionDev-PlatformWs` CloudFormation output at deploy time |
+| `NEXT_PUBLIC_API_URL` | Stock Analyser-owned API Gateway URL from `Transformotion{Stage}-StockAnalyserApi` |
+| `NEXT_PUBLIC_PLATFORM_WSS_URL` | Rollback fallback while `PlatformWsStack` remains deployed for #372 decommissioning |
+| `NEXT_PUBLIC_SA_WSS_URL` | Stock Analyser-owned WebSocket URL from `Transformotion{Stage}-StockAnalyserWs`; live AI WSS endpoint after #366 |
 
 **Cognito client variable rebind:** The GitHub Actions variable `NEXT_PUBLIC_STOCK_ANALYSER_COGNITO_CLIENT_ID` is mapped to the generic runtime env var `NEXT_PUBLIC_COGNITO_CLIENT_ID` in the deploy workflow's env block. This allows each app to have its own Cognito App Client (established in sub-phase 7b.5-alpha) while the runtime code (`@transformotion/auth-client`) reads a single generic name. Local development reads `NEXT_PUBLIC_COGNITO_CLIENT_ID` directly from `.env.local`.
 

--- a/apps/stock-analyser/CLAUDE.md
+++ b/apps/stock-analyser/CLAUDE.md
@@ -35,20 +35,22 @@ React + TypeScript + Tailwind CSS.
 
 | Stack | Contents |
 |---|---|
-| `Transformotion{Stage}-StockAnalyserTables` | `stock-analyser.portfolio-{stage}`, `stock-analyser.watchlist-{stage}`, `stock-analyser.analysis-cache-{stage}` |
-| `Transformotion{Stage}-StockAnalyserApi` | All Stock Analyser Lambda functions + routes on the platform API Gateway |
+| `Transformotion{Stage}-StockAnalyserTables` | `stock-analyser.portfolio-{stage}`, `stock-analyser.watchlist-{stage}`, `stock-analyser.analysis-cache-{stage}`, `stock-analyser.job-results-{stage}` |
+| `Transformotion{Stage}-StockAnalyserWs` | Stock Analyser-owned WebSocket API, WS Lambdas, and `stock-analyser.ws-connections-{stage}` |
+| `Transformotion{Stage}-StockAnalyserApi` | Stock Analyser-owned REST API Gateway, app Lambdas, and `stock-analyser-ai-proxy-{stage}` |
 
 Source: `apps/stock-analyser/infrastructure/`
 
 ## Lambda functions
 
-Current/transitional state: Stock Analyser Lambdas are mounted on the shared platform API Gateway at the shared API root and use the platform Cognito JWT authoriser. This is not the M9 target; M9 moves Stock Analyser REST runtime ownership to a Stock Analyser-owned API Gateway.
+Current state after #366: Stock Analyser owns its REST API Gateway, AI proxy runtime, WSS completion path, and job-results table. Cognito remains platform-owned until #363. Platform REST/WSS/Claude runtime remains deployed only for rollback and #372 decommissioning.
 
 | Lambda | Source | Routes |
 |---|---|---|
 | `transformotion-portfolio-{stage}` | `apps/stock-analyser/functions/portfolio` | `GET/PUT /portfolio` |
 | `transformotion-watchlist-{stage}` | `apps/stock-analyser/functions/watchlist` | `GET/PUT /watchlist` |
 | `transformotion-analysis-cache-{stage}` | `apps/stock-analyser/functions/analysis-cache` | `GET/PUT/DELETE /analysis-cache/{key}` |
+| `stock-analyser-ai-proxy-{stage}` | `apps/stock-analyser/functions/ai-proxy` | `POST /api/claude` |
 | `transformotion-cycle-check-{stage}` | `apps/stock-analyser/functions/cycle-check` | EventBridge scheduled (no HTTP route) |
 | `transformotion-cycle-data-{stage}` | `apps/stock-analyser/functions/cycle-data` | `GET /cycle/ohlcv?ticker=` |
 | `transformotion-market-data-{stage}` | `apps/stock-analyser/functions/market-data` | `GET /price/ohlcv?ticker=&range=&interval=` |
@@ -59,9 +61,10 @@ Current/transitional state: Stock Analyser Lambdas are mounted on the shared pla
 |---|---|---|---|
 | `stock-analyser.portfolio-{stage}` | `accountId` | `ticker` | Portfolio holdings per account |
 | `stock-analyser.watchlist-{stage}` | `accountId` | `ticker` | Watchlist items per account |
-| `stock-analyser.analysis-cache-{stage}` | `accountId` | `cacheKey` | Claude analysis cache (TTL: expiresAt) |
+| `stock-analyser.analysis-cache-{stage}` | `accountId` | `cacheKey` | AI analysis cache (TTL: expiresAt) |
+| `stock-analyser.job-results-{stage}` | `accountId` | `cacheKey` | Async AI job state (TTL: expiresAt) |
 
-Analysis cache is accessed by `transformotion-analysis-cache-{stage}` (read/delete). As of M7 / PR #334 (Bucket A'), async job records (`job-*` keys) are written by `claude-proxy` to `platform.job-results-{stage}` (not this table). The `analysis-cache` Lambda routes GET requests for `job-*` keys to that platform table; all other keys stay on this table.
+Analysis cache is accessed by `transformotion-analysis-cache-{stage}` (read/delete). Async job records (`job-*` keys) are written by `stock-analyser-ai-proxy-{stage}` to `stock-analyser.job-results-{stage}`. The `analysis-cache` Lambda routes GET requests for `job-*` keys to that app-owned table; all other keys stay on `stock-analyser.analysis-cache-{stage}`.
 
 ## Authorization requirement
 
@@ -88,14 +91,16 @@ Key service methods defined in [contracts/DATA_CONTRACTS.md](./contracts/DATA_CO
 
 ### Claude AI pattern
 
-The `useClaude<T>()` hook handles the full async request cycle via the platform WebSocket:
-1. Open platform WSS (`NEXT_PUBLIC_PLATFORM_WSS_URL`) with Cognito ID token and `?app=stock-analyser`
+The `useClaude<T>()` hook handles the full async request cycle via Stock Analyser-owned runtime:
+1. Open SA WSS (`NEXT_PUBLIC_SA_WSS_URL`) with Cognito ID token and `?app=stock-analyser`
 2. Send `{ action: 'init' }` → receive `{ type: 'connected', connectionId }`
 3. POST to `/api/claude` with prompt + `connectionId` → returns `jobId`
 4. Receive `{ type: 'job_complete' }` push on the WebSocket when the job finishes
 5. Read result from `/analysis-cache/job-{jobId}` and return typed result
 
 See `apps/stock-analyser/docs/claude-ai-pattern.md` for usage examples and configuration.
+
+`NEXT_PUBLIC_PLATFORM_WSS_URL` is retained only as rollback fallback while platform WSS remains deployed for #372 decommissioning.
 
 ### Adding a new AI feature
 
@@ -171,8 +176,9 @@ Required env vars marked `[REQUIRED]` in `.env.example` must be set before the d
 | `NEXT_PUBLIC_COGNITO_USER_POOL_ID` | Shared Cognito user pool ID |
 | `NEXT_PUBLIC_COGNITO_DOMAIN` | Hosted UI domain |
 | `NEXT_PUBLIC_RUNTIME_PROFILE` | `mock` (default; local development) or `live` (deployed environments). Determines defaults for auth, data, AI, and future concerns. See root `AGENTS.md` for the design map. |
-| `NEXT_PUBLIC_API_BASE_URL` | Platform API base URL |
-| `NEXT_PUBLIC_PLATFORM_WSS_URL` | Platform WebSocket URL for async AI job notifications — extracted from `TransformotionDev-PlatformWs` CloudFormation output at deploy time |
+| `NEXT_PUBLIC_API_URL` | Stock Analyser-owned API Gateway URL from `Transformotion{Stage}-StockAnalyserApi` |
+| `NEXT_PUBLIC_PLATFORM_WSS_URL` | Rollback fallback while `PlatformWsStack` remains deployed for #372 decommissioning |
+| `NEXT_PUBLIC_SA_WSS_URL` | Stock Analyser-owned WebSocket URL from `Transformotion{Stage}-StockAnalyserWs`; live AI WSS endpoint after #366 |
 
 **Cognito client variable rebind:** The GitHub Actions variable `NEXT_PUBLIC_STOCK_ANALYSER_COGNITO_CLIENT_ID` is mapped to the generic runtime env var `NEXT_PUBLIC_COGNITO_CLIENT_ID` in the deploy workflow's env block. This allows each app to have its own Cognito App Client (established in sub-phase 7b.5-alpha) while the runtime code (`@transformotion/auth-client`) reads a single generic name. Local development reads `NEXT_PUBLIC_COGNITO_CLIENT_ID` directly from `.env.local`.
 

--- a/apps/stock-analyser/docs/claude-ai-pattern.md
+++ b/apps/stock-analyser/docs/claude-ai-pattern.md
@@ -73,8 +73,8 @@ Set environment variables to control behavior:
 NEXT_PUBLIC_RUNTIME_PROFILE=mock
 
 # API Endpoints
-NEXT_PUBLIC_CLAUDE_API_URL=/api/claude       # Where to POST prompt
-NEXT_PUBLIC_CLAUDE_CACHE_URL=/analysis-cache # Where to read job results
+NEXT_PUBLIC_AI_API_URL=/api/claude           # Where to POST prompt
+NEXT_PUBLIC_AI_CACHE_URL=/analysis-cache     # Where to read job results
 NEXT_PUBLIC_PLATFORM_WSS_URL=wss://...         # Platform WebSocket URL for job notifications
 ```
 
@@ -238,6 +238,6 @@ const result = await call({ prompt })
 
 When integrating with a deployed Claude backend:
 1. Create a Lambda function that calls Anthropic Claude API
-2. Expose it via API Gateway at `NEXT_PUBLIC_CLAUDE_API_URL`
+2. Expose it via API Gateway at `NEXT_PUBLIC_AI_API_URL`
 3. Deploy with `NEXT_PUBLIC_RUNTIME_PROFILE=live` (already set in deploy workflows)
 4. All component code stays the same ✨

--- a/apps/stock-analyser/functions/ai-proxy/package.json
+++ b/apps/stock-analyser/functions/ai-proxy/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@transformotion/fn-stock-analyser-ai-proxy",
+  "version": "0.0.0",
+  "private": true,
+  "main": "./src/index.ts",
+  "scripts": {
+    "build": "tsc --noEmit",
+    "typecheck": "tsc --noEmit",
+    "lint": "echo \"lint: stock-analyser-ai-proxy\""
+  },
+  "dependencies": {
+    "@transformotion/fn-claude-proxy-core": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/aws-lambda": "^8",
+    "@types/node": "^22",
+    "typescript": "*"
+  }
+}

--- a/apps/stock-analyser/functions/ai-proxy/src/index.ts
+++ b/apps/stock-analyser/functions/ai-proxy/src/index.ts
@@ -1,0 +1,9 @@
+import { createClaudeProxyHandler } from '@transformotion/fn-claude-proxy-core';
+
+export const handler = createClaudeProxyHandler({
+  anthropicSecretName: process.env.ANTHROPIC_SECRET_NAME!,
+  permittedApps: ['stock-analyser'],
+  jobResultsTable: process.env.JOB_RESULTS_TABLE,
+  wsApiEndpoint: process.env.WS_API_ENDPOINT,
+  lambdaFunctionName: process.env.AWS_LAMBDA_FUNCTION_NAME,
+});

--- a/apps/stock-analyser/functions/ai-proxy/tsconfig.json
+++ b/apps/stock-analyser/functions/ai-proxy/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "types": ["node", "aws-lambda"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/apps/stock-analyser/functions/analysis-cache/src/index.ts
+++ b/apps/stock-analyser/functions/analysis-cache/src/index.ts
@@ -87,8 +87,9 @@ export const handler = withAuth(async ({ auth, account, event }) => {
 
   // ── GET /analysis-cache/{key} ─────────────────────────────────────────────
   if (event.httpMethod === 'GET') {
-    // job-* keys are platform-owned async job records written by claude-proxy.
-    // They live in the platform.job-results table keyed by accountId + cacheKey.
+    // job-* keys are app-owned async job records written by the SA AI proxy.
+    // After #366 they live in stock-analyser.job-results-{stage}; platform
+    // job-results may exist only as legacy/rollback until #372.
     if (cacheKey.startsWith('job-')) {
       const res = await ddb.send(new GetCommand({
         TableName: JOB_RESULTS_TABLE,

--- a/apps/stock-analyser/functions/ws-authorizer/package.json
+++ b/apps/stock-analyser/functions/ws-authorizer/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@transformotion/fn-stock-analyser-ws-authorizer",
+  "version": "0.0.0",
+  "private": true,
+  "main": "./src/index.ts",
+  "scripts": {
+    "build": "tsc --noEmit",
+    "typecheck": "tsc --noEmit",
+    "lint": "echo \"lint: stock-analyser-ws-authorizer\""
+  },
+  "dependencies": {
+    "jose": "^5.9.6"
+  },
+  "devDependencies": {
+    "@types/aws-lambda": "^8",
+    "@types/node": "^22",
+    "typescript": "*"
+  }
+}

--- a/apps/stock-analyser/functions/ws-authorizer/src/index.ts
+++ b/apps/stock-analyser/functions/ws-authorizer/src/index.ts
@@ -1,0 +1,85 @@
+import * as jose from 'jose';
+
+const USER_POOL_ID = process.env.COGNITO_USER_POOL_ID!;
+const REGION       = process.env.AWS_REGION ?? 'ap-southeast-2';
+const APP_NAME     = process.env.APP_NAME ?? 'stock-analyser';
+
+const JWKS_URL = `https://cognito-idp.${REGION}.amazonaws.com/${USER_POOL_ID}/.well-known/jwks.json`;
+const ISSUER   = `https://cognito-idp.${REGION}.amazonaws.com/${USER_POOL_ID}`;
+
+const JWKS = jose.createRemoteJWKSet(new URL(JWKS_URL));
+
+interface WsAuthorizerEvent {
+  type: 'REQUEST';
+  methodArn: string;
+  requestContext: {
+    stage: string;
+    apiId: string;
+    routeKey: string;
+  };
+  queryStringParameters?: Record<string, string | undefined>;
+}
+
+interface AuthorizerResult {
+  principalId: string;
+  policyDocument: {
+    Version: '2012-10-17';
+    Statement: Array<{
+      Action: string;
+      Effect: 'Allow' | 'Deny';
+      Resource: string;
+    }>;
+  };
+  context?: Record<string, string>;
+}
+
+function makePolicy(effect: 'Allow' | 'Deny', resource: string, principalId: string, context?: Record<string, string>): AuthorizerResult {
+  return {
+    principalId,
+    policyDocument: {
+      Version: '2012-10-17',
+      Statement: [{ Action: 'execute-api:Invoke', Effect: effect, Resource: resource }],
+    },
+    ...(context ? { context } : {}),
+  };
+}
+
+export const handler = async (event: WsAuthorizerEvent): Promise<AuthorizerResult> => {
+  const token        = event.queryStringParameters?.token;
+  const accountId    = event.queryStringParameters?.accountId;
+  const requestedApp = event.queryStringParameters?.app ?? APP_NAME;
+
+  if (!token) {
+    console.log('[sa-ws-authorizer] rejected: no token in query string');
+    return makePolicy('Deny', event.methodArn, 'anonymous');
+  }
+
+  if (requestedApp !== APP_NAME) {
+    console.log(`[sa-ws-authorizer] rejected: app '${requestedApp}' is not '${APP_NAME}'`);
+    return makePolicy('Deny', event.methodArn, 'anonymous');
+  }
+
+  try {
+    const { payload } = await jose.jwtVerify(token, JWKS, { issuer: ISSUER });
+
+    const userId      = payload.sub as string;
+    const accountsRaw = JSON.parse((payload['accounts'] as string | undefined) ?? '{}') as
+      Record<string, Array<{ accountId: string; role: string }>>;
+    const appAccountIds = (accountsRaw[APP_NAME] ?? []).map(a => a.accountId);
+
+    if (accountId && !appAccountIds.includes(accountId)) {
+      console.log(`[sa-ws-authorizer] rejected: accountId ${accountId} not in user's ${APP_NAME} accounts`);
+      return makePolicy('Deny', event.methodArn, userId);
+    }
+
+    console.log(`[sa-ws-authorizer] allowed: userId=${userId} accountId=${accountId ?? 'none'}`);
+    return makePolicy('Allow', event.methodArn, userId, {
+      userId,
+      accountId: accountId ?? '',
+      app:       APP_NAME,
+    });
+  } catch (err) {
+    console.log('[sa-ws-authorizer] rejected: token verification failed:', (err as Error).message);
+    return makePolicy('Deny', event.methodArn, 'anonymous');
+  }
+};

--- a/apps/stock-analyser/functions/ws-authorizer/tsconfig.json
+++ b/apps/stock-analyser/functions/ws-authorizer/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "types": ["node", "aws-lambda"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/apps/stock-analyser/functions/ws-connect/package.json
+++ b/apps/stock-analyser/functions/ws-connect/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@transformotion/fn-stock-analyser-ws-connect",
+  "version": "0.0.0",
+  "private": true,
+  "main": "./src/index.ts",
+  "scripts": {
+    "build": "tsc --noEmit",
+    "typecheck": "tsc --noEmit",
+    "lint": "echo \"lint: stock-analyser-ws-connect\""
+  },
+  "devDependencies": {
+    "@aws-sdk/client-dynamodb": "^3",
+    "@aws-sdk/lib-dynamodb": "^3",
+    "@types/aws-lambda": "^8",
+    "@types/node": "^22",
+    "typescript": "*"
+  }
+}

--- a/apps/stock-analyser/functions/ws-connect/src/index.ts
+++ b/apps/stock-analyser/functions/ws-connect/src/index.ts
@@ -1,0 +1,40 @@
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import { DynamoDBDocumentClient, PutCommand } from '@aws-sdk/lib-dynamodb';
+
+const ddb   = DynamoDBDocumentClient.from(new DynamoDBClient({}));
+const TABLE = process.env.CONNECTIONS_TABLE!;
+
+interface ConnectEvent {
+  requestContext: {
+    connectionId: string;
+    authorizer?: {
+      userId?: string;
+      accountId?: string;
+      app?: string;
+    };
+  };
+}
+
+export const handler = async (event: ConnectEvent): Promise<{ statusCode: number }> => {
+  const { connectionId, authorizer } = event.requestContext;
+  const userId    = authorizer?.userId ?? 'unknown';
+  const accountId = authorizer?.accountId ?? '';
+  const app       = authorizer?.app ?? 'stock-analyser';
+  const now       = Math.floor(Date.now() / 1000);
+
+  console.log(`[sa-ws-connect] connectionId=${connectionId} userId=${userId} accountId=${accountId} app=${app}`);
+
+  await ddb.send(new PutCommand({
+    TableName: TABLE,
+    Item: {
+      connectionId,
+      userId,
+      accountId,
+      app,
+      createdAt: new Date().toISOString(),
+      expiresAt: now + 3600,
+    },
+  }));
+
+  return { statusCode: 200 };
+};

--- a/apps/stock-analyser/functions/ws-connect/tsconfig.json
+++ b/apps/stock-analyser/functions/ws-connect/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "types": ["node", "aws-lambda"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/apps/stock-analyser/functions/ws-default/package.json
+++ b/apps/stock-analyser/functions/ws-default/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@transformotion/fn-stock-analyser-ws-default",
+  "version": "0.0.0",
+  "private": true,
+  "main": "./src/index.ts",
+  "scripts": {
+    "build": "tsc --noEmit",
+    "typecheck": "tsc --noEmit",
+    "lint": "echo \"lint: stock-analyser-ws-default\""
+  },
+  "devDependencies": {
+    "@aws-sdk/client-apigatewaymanagementapi": "^3",
+    "@types/aws-lambda": "^8",
+    "@types/node": "^22",
+    "typescript": "*"
+  }
+}

--- a/apps/stock-analyser/functions/ws-default/src/index.ts
+++ b/apps/stock-analyser/functions/ws-default/src/index.ts
@@ -1,0 +1,39 @@
+import { ApiGatewayManagementApiClient, PostToConnectionCommand } from '@aws-sdk/client-apigatewaymanagementapi';
+
+interface DefaultEvent {
+  requestContext: {
+    connectionId: string;
+    routeKey: string;
+    stage: string;
+    domainName: string;
+  };
+  body?: string;
+}
+
+export const handler = async (event: DefaultEvent): Promise<{ statusCode: number }> => {
+  const { connectionId, routeKey, stage, domainName } = event.requestContext;
+
+  console.log(`[sa-ws-default] connectionId=${connectionId} routeKey=${routeKey}`);
+
+  let action: string | undefined;
+  try {
+    if (event.body) action = (JSON.parse(event.body) as { action?: string }).action;
+  } catch { /* ignore malformed body */ }
+
+  if (action === 'init') {
+    const mgmt = new ApiGatewayManagementApiClient({
+      endpoint: `https://${domainName}/${stage}`,
+    });
+    try {
+      await mgmt.send(new PostToConnectionCommand({
+        ConnectionId: connectionId,
+        Data:         Buffer.from(JSON.stringify({ type: 'connected', connectionId })),
+      }));
+      console.log(`[sa-ws-default] sent connected message to ${connectionId}`);
+    } catch (err) {
+      console.warn(`[sa-ws-default] failed to push connected message: ${(err as Error).message}`);
+    }
+  }
+
+  return { statusCode: 200 };
+};

--- a/apps/stock-analyser/functions/ws-default/tsconfig.json
+++ b/apps/stock-analyser/functions/ws-default/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "types": ["node", "aws-lambda"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/apps/stock-analyser/functions/ws-disconnect/package.json
+++ b/apps/stock-analyser/functions/ws-disconnect/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@transformotion/fn-stock-analyser-ws-disconnect",
+  "version": "0.0.0",
+  "private": true,
+  "main": "./src/index.ts",
+  "scripts": {
+    "build": "tsc --noEmit",
+    "typecheck": "tsc --noEmit",
+    "lint": "echo \"lint: stock-analyser-ws-disconnect\""
+  },
+  "devDependencies": {
+    "@aws-sdk/client-dynamodb": "^3",
+    "@aws-sdk/lib-dynamodb": "^3",
+    "@types/aws-lambda": "^8",
+    "@types/node": "^22",
+    "typescript": "*"
+  }
+}

--- a/apps/stock-analyser/functions/ws-disconnect/src/index.ts
+++ b/apps/stock-analyser/functions/ws-disconnect/src/index.ts
@@ -1,0 +1,28 @@
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import { DynamoDBDocumentClient, DeleteCommand } from '@aws-sdk/lib-dynamodb';
+
+const ddb   = DynamoDBDocumentClient.from(new DynamoDBClient({}));
+const TABLE = process.env.CONNECTIONS_TABLE!;
+
+interface DisconnectEvent {
+  requestContext: {
+    connectionId: string;
+  };
+}
+
+export const handler = async (event: DisconnectEvent): Promise<{ statusCode: number }> => {
+  const { connectionId } = event.requestContext;
+
+  console.log(`[sa-ws-disconnect] connectionId=${connectionId}`);
+
+  try {
+    await ddb.send(new DeleteCommand({
+      TableName: TABLE,
+      Key: { connectionId },
+    }));
+  } catch (err) {
+    console.warn(`[sa-ws-disconnect] delete failed (may be already gone): ${(err as Error).message}`);
+  }
+
+  return { statusCode: 200 };
+};

--- a/apps/stock-analyser/functions/ws-disconnect/tsconfig.json
+++ b/apps/stock-analyser/functions/ws-disconnect/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "types": ["node", "aws-lambda"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/apps/stock-analyser/infrastructure/sa-ws-stack.ts
+++ b/apps/stock-analyser/infrastructure/sa-ws-stack.ts
@@ -1,0 +1,164 @@
+import * as path from 'path';
+import * as cdk from 'aws-cdk-lib';
+import * as apigatewayv2 from 'aws-cdk-lib/aws-apigatewayv2';
+import * as authorizers from 'aws-cdk-lib/aws-apigatewayv2-authorizers';
+import * as integrations from 'aws-cdk-lib/aws-apigatewayv2-integrations';
+import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
+import * as iam from 'aws-cdk-lib/aws-iam';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import * as lambdaNodejs from 'aws-cdk-lib/aws-lambda-nodejs';
+import { Construct } from 'constructs';
+
+export interface StockAnalyserWsStackProps extends cdk.StackProps {
+  stage: 'dev' | 'prod';
+  userPoolId: string;
+}
+
+/**
+ * StockAnalyserWsStack - Stock Analyser-owned WebSocket runtime.
+ *
+ * After #366, the Stock Analyser AI runtime sends job_complete notifications
+ * through this app-owned WSS endpoint. PlatformWsStack remains deployed only
+ * for rollback and later #372 decommissioning.
+ */
+export class StockAnalyserWsStack extends cdk.Stack {
+  public readonly webSocketApi: apigatewayv2.WebSocketApi;
+  public readonly webSocketStage: apigatewayv2.WebSocketStage;
+  public readonly connectionsTable: dynamodb.Table;
+  public readonly wsApiEndpoint: string;
+
+  constructor(scope: Construct, id: string, props: StockAnalyserWsStackProps) {
+    super(scope, id, props);
+
+    const { stage, userPoolId } = props;
+
+    cdk.Tags.of(this).add('app', 'stock-analyser');
+    cdk.Tags.of(this).add('environment', stage);
+
+    this.connectionsTable = new dynamodb.Table(this, 'WsConnectionsTable', {
+      tableName:           `stock-analyser.ws-connections-${stage}`,
+      partitionKey:        { name: 'connectionId', type: dynamodb.AttributeType.STRING },
+      billingMode:         dynamodb.BillingMode.PAY_PER_REQUEST,
+      timeToLiveAttribute: 'expiresAt',
+      removalPolicy:       stage === 'prod' ? cdk.RemovalPolicy.RETAIN : cdk.RemovalPolicy.DESTROY,
+    });
+
+    this.connectionsTable.addGlobalSecondaryIndex({
+      indexName:      'userId-index',
+      partitionKey:   { name: 'userId', type: dynamodb.AttributeType.STRING },
+      projectionType: dynamodb.ProjectionType.ALL,
+    });
+
+    const bundling: lambdaNodejs.BundlingOptions = {
+      externalModules: ['@aws-sdk/*'],
+      minify: true,
+      sourceMap: false,
+      forceDockerBundling: false,
+    };
+
+    const fnDir = path.join(__dirname, '../functions');
+
+    const authorizerFn = new lambdaNodejs.NodejsFunction(this, 'AuthorizerFn', {
+      functionName: `stock-analyser-ws-authorizer-${stage}`,
+      entry:        path.join(fnDir, 'ws-authorizer/src/index.ts'),
+      handler:      'handler',
+      runtime:      lambda.Runtime.NODEJS_20_X,
+      timeout:      cdk.Duration.seconds(10),
+      memorySize:   256,
+      environment: {
+        COGNITO_USER_POOL_ID: userPoolId,
+        APP_NAME:             'stock-analyser',
+      },
+      bundling,
+    });
+
+    const wsAuthorizer = new authorizers.WebSocketLambdaAuthorizer('WsAuthorizer', authorizerFn, {
+      identitySource: ['route.request.querystring.token'],
+    });
+
+    const connectFn = new lambdaNodejs.NodejsFunction(this, 'ConnectFn', {
+      functionName: `stock-analyser-ws-connect-${stage}`,
+      entry:        path.join(fnDir, 'ws-connect/src/index.ts'),
+      handler:      'handler',
+      runtime:      lambda.Runtime.NODEJS_20_X,
+      timeout:      cdk.Duration.seconds(10),
+      memorySize:   256,
+      environment:  { CONNECTIONS_TABLE: this.connectionsTable.tableName },
+      bundling,
+    });
+    this.connectionsTable.grantReadWriteData(connectFn);
+
+    const disconnectFn = new lambdaNodejs.NodejsFunction(this, 'DisconnectFn', {
+      functionName: `stock-analyser-ws-disconnect-${stage}`,
+      entry:        path.join(fnDir, 'ws-disconnect/src/index.ts'),
+      handler:      'handler',
+      runtime:      lambda.Runtime.NODEJS_20_X,
+      timeout:      cdk.Duration.seconds(10),
+      memorySize:   256,
+      environment:  { CONNECTIONS_TABLE: this.connectionsTable.tableName },
+      bundling,
+    });
+    this.connectionsTable.grantReadWriteData(disconnectFn);
+
+    const defaultFn = new lambdaNodejs.NodejsFunction(this, 'DefaultFn', {
+      functionName: `stock-analyser-ws-default-${stage}`,
+      entry:        path.join(fnDir, 'ws-default/src/index.ts'),
+      handler:      'handler',
+      runtime:      lambda.Runtime.NODEJS_20_X,
+      timeout:      cdk.Duration.seconds(10),
+      memorySize:   256,
+      bundling,
+    });
+
+    this.webSocketApi = new apigatewayv2.WebSocketApi(this, 'StockAnalyserWsApi', {
+      apiName: `stock-analyser-ws-${stage}`,
+      connectRouteOptions: {
+        integration: new integrations.WebSocketLambdaIntegration('ConnectInt', connectFn),
+        authorizer:  wsAuthorizer,
+      },
+      disconnectRouteOptions: {
+        integration: new integrations.WebSocketLambdaIntegration('DisconnectInt', disconnectFn),
+      },
+      defaultRouteOptions: {
+        integration: new integrations.WebSocketLambdaIntegration('DefaultInt', defaultFn),
+      },
+    });
+
+    this.webSocketStage = new apigatewayv2.WebSocketStage(this, 'StockAnalyserWsStage', {
+      webSocketApi: this.webSocketApi,
+      stageName:    stage,
+      autoDeploy:   true,
+    });
+
+    defaultFn.addToRolePolicy(new iam.PolicyStatement({
+      actions:   ['execute-api:ManageConnections'],
+      resources: [`arn:aws:execute-api:${this.region}:${this.account}:${this.webSocketApi.apiId}/${stage}/*`],
+    }));
+
+    this.wsApiEndpoint = `https://${this.webSocketApi.apiId}.execute-api.${this.region}.amazonaws.com/${stage}`;
+
+    new cdk.CfnOutput(this, 'WssUrl', {
+      value:       this.webSocketStage.url,
+      description: 'WebSocket URL for Stock Analyser WSS service',
+      exportName:  `StockAnalyserWs-${stage}-Url`,
+    });
+
+    new cdk.CfnOutput(this, 'WsApiId', {
+      value:       this.webSocketApi.apiId,
+      description: 'Stock Analyser WebSocket API ID',
+      exportName:  `StockAnalyserWs-${stage}-WsApiId`,
+    });
+
+    new cdk.CfnOutput(this, 'WsApiEndpoint', {
+      value:       this.wsApiEndpoint,
+      description: 'HTTPS management endpoint for Stock Analyser WebSocket API',
+      exportName:  `StockAnalyserWs-${stage}-Endpoint`,
+    });
+
+    new cdk.CfnOutput(this, 'ConnectionsTableName', {
+      value:       this.connectionsTable.tableName,
+      description: 'Stock Analyser DynamoDB table for WebSocket connection state',
+      exportName:  `StockAnalyserWs-${stage}-ConnectionsTableName`,
+    });
+  }
+}

--- a/apps/stock-analyser/infrastructure/stock-analyser-api-stack.ts
+++ b/apps/stock-analyser/infrastructure/stock-analyser-api-stack.ts
@@ -1,176 +1,231 @@
 import * as path from 'path';
 import * as cdk from 'aws-cdk-lib';
 import * as apigateway from 'aws-cdk-lib/aws-apigateway';
+import * as cognito from 'aws-cdk-lib/aws-cognito';
 import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
+import * as iam from 'aws-cdk-lib/aws-iam';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as lambdaNodejs from 'aws-cdk-lib/aws-lambda-nodejs';
+import * as secretsmanager from 'aws-cdk-lib/aws-secretsmanager';
 import { Construct } from 'constructs';
 
 export interface StockAnalyserApiStackProps extends cdk.StackProps {
   stage: 'dev' | 'prod';
-  /** From PlatformTablesStack — analysis-cache Lambda reads job-* keys from here. */
-  jobResultsTableName: string;
+  userPoolId: string;
+  portfolioTable: dynamodb.ITable;
+  watchlistTable: dynamodb.ITable;
+  analysisCacheTable: dynamodb.ITable;
+  jobResultsTable: dynamodb.ITable;
+  wsApiEndpoint: string;
+  wsApiId: string;
 }
 
 /**
- * StockAnalyserApiStack — Stock Analyser API routes and Lambdas.
+ * StockAnalyserApiStack - Stock Analyser-owned REST API routes and Lambdas.
  *
- * Imports the shared platform API Gateway and JWT authoriser from CloudFormation
- * exports produced by PlatformApiStack. This allows bin/stock-analyser.ts to
- * synthesise only SA stacks without instantiating platform stacks.
+ * After #366 this stack owns the Stock Analyser API Gateway and AI proxy
+ * runtime. Platform REST/Claude runtime remains deployed only for rollback and
+ * later #372 decommissioning.
  *
- * Routes (owned by this stack's CF template):
- *   GET  /portfolio          — portfolio Lambda
- *   PUT  /portfolio
- *   GET  /watchlist          — watchlist Lambda
- *   PUT  /watchlist
- *   GET  /analysis-cache/{key}   — analysis-cache Lambda
- *   PUT  /analysis-cache/{key}
- *   DELETE /analysis-cache/{key}
- *   GET  /cycle/ohlcv        — cycle-data Lambda
- *   GET  /price/ohlcv        — market-data Lambda (raw OHLCV bars for price chart)
- *
- * Lambda source: apps/stock-analyser/functions/
+ * Routes:
+ *   GET/PUT           /portfolio
+ *   GET/PUT           /watchlist
+ *   GET/PUT/DELETE    /analysis-cache/{key}
+ *   GET               /cycle/ohlcv
+ *   GET               /price/ohlcv
+ *   POST              /api/claude
  */
 export class StockAnalyserApiStack extends cdk.Stack {
+  public readonly api: apigateway.RestApi;
+
   constructor(scope: Construct, id: string, props: StockAnalyserApiStackProps) {
     super(scope, id, props);
 
-    const { stage, jobResultsTableName } = props;
+    const {
+      stage,
+      userPoolId,
+      portfolioTable,
+      watchlistTable,
+      analysisCacheTable,
+      jobResultsTable,
+      wsApiEndpoint,
+      wsApiId,
+    } = props;
 
-    // Import shared platform API Gateway and JWT authoriser from CF exports.
-    const api = apigateway.RestApi.fromRestApiAttributes(this, 'PlatformApi', {
-      restApiId:      cdk.Fn.importValue(`Transformotion-${stage}-RestApiId`),
-      rootResourceId: cdk.Fn.importValue(`Transformotion-${stage}-RestApiRootResourceId`),
+    const userPool = cognito.UserPool.fromUserPoolId(this, 'UserPool', userPoolId);
+
+    this.api = new apigateway.RestApi(this, 'StockAnalyserApi', {
+      restApiName: `stock-analyser-api-${stage}`,
+      description: `Stock Analyser ${stage} API`,
+      deployOptions: { stageName: stage },
+      defaultCorsPreflightOptions: corsPreflightOptions,
     });
 
-    const auth = authMethodOptions({
-      authorizerId:      cdk.Fn.importValue(`Transformotion-${stage}-AuthorizerId`),
-      authorizationType: apigateway.AuthorizationType.COGNITO,
+    const authoriser = new apigateway.CognitoUserPoolsAuthorizer(this, 'JwtAuthoriser', {
+      cognitoUserPools: [userPool],
+      authorizerName: `stock-analyser-jwt-${stage}`,
+      resultsCacheTtl: cdk.Duration.minutes(5),
     });
+    const auth = authMethodOptions(authoriser);
 
-    // ── /portfolio — Portfolio Lambda ─────────────────────────────────────
-    const portfolioTable = dynamodb.Table.fromTableName(
-      this, 'PortfolioTable', `stock-analyser.portfolio-${stage}`,
-    );
+    const bundling: lambdaNodejs.BundlingOptions = {
+      externalModules: ['@aws-sdk/*'],
+      minify: true,
+      sourceMap: false,
+      forceDockerBundling: false,
+    };
 
     const portfolioFn = new lambdaNodejs.NodejsFunction(this, 'PortfolioFn', {
       functionName: `transformotion-portfolio-${stage}`,
-      entry:        path.join(__dirname, '../functions/portfolio/src/index.ts'),
-      handler:      'handler',
-      runtime:      lambda.Runtime.NODEJS_20_X,
-      timeout:      cdk.Duration.seconds(15),
-      memorySize:   256,
-      environment:  { PORTFOLIO_TABLE: portfolioTable.tableName },
-      bundling:     { externalModules: ['@aws-sdk/*'], minify: true, sourceMap: false, forceDockerBundling: false },
+      entry: path.join(__dirname, '../functions/portfolio/src/index.ts'),
+      handler: 'handler',
+      runtime: lambda.Runtime.NODEJS_20_X,
+      timeout: cdk.Duration.seconds(15),
+      memorySize: 256,
+      environment: { PORTFOLIO_TABLE: portfolioTable.tableName },
+      bundling,
     });
-
     portfolioTable.grantReadWriteData(portfolioFn);
 
     const portfolioIntegration = new apigateway.LambdaIntegration(portfolioFn, { proxy: true });
-    const portfolio = api.root.addResource('portfolio');
+    const portfolio = this.api.root.addResource('portfolio');
     portfolio.addMethod('GET', portfolioIntegration, auth);
     portfolio.addMethod('PUT', portfolioIntegration, auth);
 
-    // ── /watchlist — Watchlist Lambda ─────────────────────────────────────
-    const watchlistTable = dynamodb.Table.fromTableName(
-      this, 'WatchlistTable', `stock-analyser.watchlist-${stage}`,
-    );
-
     const watchlistFn = new lambdaNodejs.NodejsFunction(this, 'WatchlistFn', {
       functionName: `transformotion-watchlist-${stage}`,
-      entry:        path.join(__dirname, '../functions/watchlist/src/index.ts'),
-      handler:      'handler',
-      runtime:      lambda.Runtime.NODEJS_20_X,
-      timeout:      cdk.Duration.seconds(15),
-      memorySize:   256,
-      environment:  { WATCHLIST_TABLE: watchlistTable.tableName },
-      bundling:     { externalModules: ['@aws-sdk/*'], minify: true, sourceMap: false, forceDockerBundling: false },
+      entry: path.join(__dirname, '../functions/watchlist/src/index.ts'),
+      handler: 'handler',
+      runtime: lambda.Runtime.NODEJS_20_X,
+      timeout: cdk.Duration.seconds(15),
+      memorySize: 256,
+      environment: { WATCHLIST_TABLE: watchlistTable.tableName },
+      bundling,
     });
-
     watchlistTable.grantReadWriteData(watchlistFn);
 
     const watchlistIntegration = new apigateway.LambdaIntegration(watchlistFn, { proxy: true });
-    const watchlist = api.root.addResource('watchlist');
+    const watchlist = this.api.root.addResource('watchlist');
     watchlist.addMethod('GET', watchlistIntegration, auth);
     watchlist.addMethod('PUT', watchlistIntegration, auth);
 
-    // Shared table used by both analysis-cache and cycle-data Lambdas
-    const analysisCacheTable = dynamodb.Table.fromTableName(
-      this, 'AnalysisCacheTable', `stock-analyser.analysis-cache-${stage}`,
-    );
-
-    // ── /analysis-cache/{key} — Analysis Cache Lambda ─────────────────────
-    const jobResultsTable = dynamodb.Table.fromTableName(
-      this, 'JobResultsTable', jobResultsTableName,
-    );
-
     const cacheFn = new lambdaNodejs.NodejsFunction(this, 'CacheFn', {
       functionName: `transformotion-analysis-cache-${stage}`,
-      entry:        path.join(__dirname, '../functions/analysis-cache/src/index.ts'),
-      handler:      'handler',
-      runtime:      lambda.Runtime.NODEJS_20_X,
-      timeout:      cdk.Duration.seconds(15),
-      memorySize:   256,
+      entry: path.join(__dirname, '../functions/analysis-cache/src/index.ts'),
+      handler: 'handler',
+      runtime: lambda.Runtime.NODEJS_20_X,
+      timeout: cdk.Duration.seconds(15),
+      memorySize: 256,
       environment: {
-        CACHE_TABLE:       analysisCacheTable.tableName,
+        CACHE_TABLE: analysisCacheTable.tableName,
         JOB_RESULTS_TABLE: jobResultsTable.tableName,
       },
-      bundling:     { externalModules: ['@aws-sdk/*'], minify: true, sourceMap: false, forceDockerBundling: false },
+      bundling,
     });
-
     analysisCacheTable.grantReadWriteData(cacheFn);
     jobResultsTable.grantReadData(cacheFn);
 
     const cacheIntegration = new apigateway.LambdaIntegration(cacheFn, { proxy: true });
-    const cacheKey = api.root
+    const cacheKey = this.api.root
       .addResource('analysis-cache')
       .addResource('{key}');
-    cacheKey.addMethod('GET',    cacheIntegration, auth);
-    cacheKey.addMethod('PUT',    cacheIntegration, auth);
+    cacheKey.addMethod('GET', cacheIntegration, auth);
+    cacheKey.addMethod('PUT', cacheIntegration, auth);
     cacheKey.addMethod('DELETE', cacheIntegration, auth);
 
-    // ── /cycle/ohlcv — Cycle Data Lambda ──────────────────────────────────
     const cycleDataFn = new lambdaNodejs.NodejsFunction(this, 'CycleDataFn', {
       functionName: `transformotion-cycle-data-${stage}`,
-      entry:        path.join(__dirname, '../functions/cycle-data/src/index.ts'),
-      handler:      'handler',
-      runtime:      lambda.Runtime.NODEJS_20_X,
-      timeout:      cdk.Duration.seconds(15),
-      memorySize:   512,
-      environment:  { ANALYSIS_CACHE_TABLE: analysisCacheTable.tableName },
-      bundling:     { externalModules: ['@aws-sdk/*'], minify: true, sourceMap: false, forceDockerBundling: false },
+      entry: path.join(__dirname, '../functions/cycle-data/src/index.ts'),
+      handler: 'handler',
+      runtime: lambda.Runtime.NODEJS_20_X,
+      timeout: cdk.Duration.seconds(15),
+      memorySize: 512,
+      environment: { ANALYSIS_CACHE_TABLE: analysisCacheTable.tableName },
+      bundling,
     });
-
     analysisCacheTable.grantReadWriteData(cycleDataFn);
 
     const cycleDataIntegration = new apigateway.LambdaIntegration(cycleDataFn, { proxy: true });
-    const cycle = api.root.addResource('cycle');
-    cycle.addCorsPreflight(corsPreflightOptions);
+    const cycle = this.api.root.addResource('cycle');
     const cycleOhlcv = cycle.addResource('ohlcv');
-    cycleOhlcv.addCorsPreflight(corsPreflightOptions);
     cycleOhlcv.addMethod('GET', cycleDataIntegration, auth);
 
-    // ── /price/ohlcv — Market Data Lambda ─────────────────────────────────
     const marketDataFn = new lambdaNodejs.NodejsFunction(this, 'MarketDataFn', {
       functionName: `transformotion-market-data-${stage}`,
-      entry:        path.join(__dirname, '../functions/market-data/src/index.ts'),
-      handler:      'handler',
-      runtime:      lambda.Runtime.NODEJS_20_X,
-      timeout:      cdk.Duration.seconds(30),
-      memorySize:   512,
-      environment:  { ANALYSIS_CACHE_TABLE: analysisCacheTable.tableName },
-      bundling:     { externalModules: ['@aws-sdk/*'], minify: true, sourceMap: false, forceDockerBundling: false },
+      entry: path.join(__dirname, '../functions/market-data/src/index.ts'),
+      handler: 'handler',
+      runtime: lambda.Runtime.NODEJS_20_X,
+      timeout: cdk.Duration.seconds(30),
+      memorySize: 512,
+      environment: { ANALYSIS_CACHE_TABLE: analysisCacheTable.tableName },
+      bundling,
     });
-
     analysisCacheTable.grantReadWriteData(marketDataFn);
 
     const marketDataIntegration = new apigateway.LambdaIntegration(marketDataFn, { proxy: true });
-    const price = api.root.addResource('price');
-    price.addCorsPreflight(corsPreflightOptions);
+    const price = this.api.root.addResource('price');
     const priceOhlcv = price.addResource('ohlcv');
-    priceOhlcv.addCorsPreflight(corsPreflightOptions);
     priceOhlcv.addMethod('GET', marketDataIntegration, auth);
+
+    const anthropicSecret = secretsmanager.Secret.fromSecretNameV2(
+      this, 'AnthropicApiKey', `${stage}/anthropic/api-key`,
+    );
+
+    const aiProxyFn = new lambdaNodejs.NodejsFunction(this, 'AiProxyFn', {
+      functionName: `stock-analyser-ai-proxy-${stage}`,
+      entry: path.join(__dirname, '../functions/ai-proxy/src/index.ts'),
+      handler: 'handler',
+      runtime: lambda.Runtime.NODEJS_20_X,
+      timeout: cdk.Duration.seconds(600),
+      memorySize: 512,
+      environment: {
+        ANTHROPIC_SECRET_NAME: anthropicSecret.secretName,
+        JOB_RESULTS_TABLE: jobResultsTable.tableName,
+        WS_API_ENDPOINT: wsApiEndpoint,
+      },
+      bundling,
+    });
+    anthropicSecret.grantRead(aiProxyFn);
+    jobResultsTable.grantReadWriteData(aiProxyFn);
+    aiProxyFn.addToRolePolicy(new iam.PolicyStatement({
+      actions: ['lambda:InvokeFunction'],
+      resources: [
+        `arn:aws:lambda:${this.region}:${this.account}:function:stock-analyser-ai-proxy-${stage}`,
+      ],
+    }));
+    aiProxyFn.addToRolePolicy(new iam.PolicyStatement({
+      actions: ['execute-api:ManageConnections'],
+      resources: [`arn:aws:execute-api:${this.region}:${this.account}:${wsApiId}/${stage}/*`],
+    }));
+
+    const apiResource = this.api.root.addResource('api');
+    apiResource
+      .addResource('claude')
+      .addMethod('POST', new apigateway.LambdaIntegration(aiProxyFn, { proxy: true }), auth);
+
+    new cdk.CfnOutput(this, 'ApiUrl', {
+      value: this.api.url,
+      description: 'Stock Analyser REST API URL',
+      exportName: `StockAnalyserApi-${stage}-Url`,
+    });
+
+    new cdk.CfnOutput(this, 'AiApiUrl', {
+      value: `${this.api.url}api/claude`,
+      description: 'Stock Analyser AI proxy URL',
+      exportName: `StockAnalyserApi-${stage}-AiApiUrl`,
+    });
+
+    new cdk.CfnOutput(this, 'ClaudeApiUrl', {
+      value: `${this.api.url}api/claude`,
+      description: 'Compatibility output for the Stock Analyser AI proxy URL',
+      exportName: `StockAnalyserApi-${stage}-ClaudeApiUrl`,
+    });
+
+    new cdk.CfnOutput(this, 'AnalysisCacheUrl', {
+      value: `${this.api.url}analysis-cache`,
+      description: 'Stock Analyser analysis-cache URL',
+      exportName: `StockAnalyserApi-${stage}-AnalysisCacheUrl`,
+    });
   }
 }
 
@@ -183,13 +238,13 @@ const corsPreflightOptions: apigateway.CorsOptions = {
 
 function authMethodOptions(authoriser: apigateway.IAuthorizer): apigateway.MethodOptions {
   return {
-    authorizer:        authoriser,
+    authorizer: authoriser,
     authorizationType: apigateway.AuthorizationType.COGNITO,
     methodResponses: [
       {
         statusCode: '200',
         responseParameters: {
-          'method.response.header.Access-Control-Allow-Origin':  true,
+          'method.response.header.Access-Control-Allow-Origin': true,
           'method.response.header.Access-Control-Allow-Headers': true,
         },
       },

--- a/apps/stock-analyser/infrastructure/stock-analyser-tables-stack.ts
+++ b/apps/stock-analyser/infrastructure/stock-analyser-tables-stack.ts
@@ -13,11 +13,13 @@ export interface StockAnalyserTablesStackProps extends cdk.StackProps {
  *   stock-analyser.portfolio       PK: accountId  SK: ticker
  *   stock-analyser.watchlist       PK: accountId  SK: ticker
  *   stock-analyser.analysis-cache  PK: accountId  SK: cacheKey  TTL: expiresAt
+ *   stock-analyser.job-results     PK: accountId  SK: cacheKey  TTL: expiresAt
  */
 export class StockAnalyserTablesStack extends cdk.Stack {
   public readonly portfolioTableNew:  dynamodb.Table;
   public readonly watchlistTableNew:  dynamodb.Table;
   public readonly analysisCacheTable: dynamodb.Table;
+  public readonly jobResultsTable:    dynamodb.Table;
 
   constructor(scope: Construct, id: string, props: StockAnalyserTablesStackProps) {
     super(scope, id, props);
@@ -56,6 +58,18 @@ export class StockAnalyserTablesStack extends cdk.Stack {
       removalPolicy:       removal,
     });
 
+    // ── stock-analyser.job-results ─────────────────────────────────────────
+    // Short-lived async Claude job state owned by Stock Analyser after #366.
+    // PK: accountId  SK: cacheKey (`job-{jobId}`)  TTL: expiresAt
+    this.jobResultsTable = new dynamodb.Table(this, 'JobResultsTable', {
+      tableName:           `stock-analyser.job-results-${stage}`,
+      partitionKey:        { name: 'accountId', type: dynamodb.AttributeType.STRING },
+      sortKey:             { name: 'cacheKey',  type: dynamodb.AttributeType.STRING },
+      billingMode:         dynamodb.BillingMode.PAY_PER_REQUEST,
+      timeToLiveAttribute: 'expiresAt',
+      removalPolicy:       removal,
+    });
+
     // ── Outputs ───────────────────────────────────────────────────────────
     const out = (id: string, table: dynamodb.Table, hint: string) => {
       new cdk.CfnOutput(this, id, {
@@ -68,5 +82,6 @@ export class StockAnalyserTablesStack extends cdk.Stack {
     out('SAPortfolioNewTableArn',  this.portfolioTableNew,  'stock-analyser.portfolio table ARN');
     out('SAWatchlistNewTableArn',  this.watchlistTableNew,  'stock-analyser.watchlist table ARN');
     out('SAAnalysisCacheTableArn', this.analysisCacheTable, 'stock-analyser.analysis-cache table ARN');
+    out('SAJobResultsTableArn',    this.jobResultsTable,    'stock-analyser.job-results table ARN');
   }
 }

--- a/apps/stock-analyser/lib/config/index.ts
+++ b/apps/stock-analyser/lib/config/index.ts
@@ -23,6 +23,7 @@ export interface AIConfig {
   provider: 'mock' | 'claude'
   model: string
   wssUrl: string
+  saWssUrl: string
 }
 
 export interface AppConfig {
@@ -68,8 +69,9 @@ function loadConfig(): AppConfig {
         profileDefaults: { mock: 'mock', live: 'claude' },
         validValues: ['mock', 'claude'] as const,
       }),
-      model:   process.env.NEXT_PUBLIC_AI_MODEL || 'claude-3-sonnet',
-      wssUrl:  process.env.NEXT_PUBLIC_PLATFORM_WSS_URL || '',
+      model:    process.env.NEXT_PUBLIC_AI_MODEL || 'claude-3-sonnet',
+      wssUrl:   process.env.NEXT_PUBLIC_SA_WSS_URL || process.env.NEXT_PUBLIC_PLATFORM_WSS_URL || '',
+      saWssUrl: process.env.NEXT_PUBLIC_SA_WSS_URL || '',
     },
     storage: {
       provider: selectProvider({
@@ -86,7 +88,7 @@ function loadConfig(): AppConfig {
       cloudwatchLogGroup: process.env.CLOUDWATCH_LOG_GROUP,
     },
     claude: {
-      apiUrl: process.env.NEXT_PUBLIC_CLAUDE_API_URL || '/api/claude',
+      apiUrl: process.env.NEXT_PUBLIC_AI_API_URL || process.env.NEXT_PUBLIC_CLAUDE_API_URL || '/api/claude',
     },
     features: {
       debugMode: process.env.NEXT_PUBLIC_DEBUG_MODE === 'true',

--- a/apps/stock-analyser/lib/hooks/use-claude.ts
+++ b/apps/stock-analyser/lib/hooks/use-claude.ts
@@ -165,7 +165,7 @@ async function subscribeViaWss<T>(
   wssUrl: string,
   signal: AbortSignal,
 ): Promise<T> {
-  if (!wssUrl) throw new Error('WSS URL not configured (NEXT_PUBLIC_PLATFORM_WSS_URL)')
+  if (!wssUrl) throw new Error('WSS URL not configured (NEXT_PUBLIC_SA_WSS_URL)')
 
   const token     = await authService.getIdToken()
   const accountId = (await authService.getAccountIdForApp('stock-analyser')) ?? ''

--- a/docs/architecture/cdk.md
+++ b/docs/architecture/cdk.md
@@ -10,12 +10,12 @@ Region: `ap-southeast-2`
 | Entrypoint | Stacks synthesised | Deploy workflow |
 |---|---|---|
 | `infrastructure/bin/platform.ts` | All platform stacks (Network, Auth, AuthApi, PlatformTables, Api, PlatformWs, Storage, GithubActionsRole) | `deploy-platform.yml` |
-| `infrastructure/bin/stock-analyser.ts` | `StockAnalyserTables`, `StockAnalyserApi` | `deploy-stock-analyser.yml` |
+| `infrastructure/bin/stock-analyser.ts` | `StockAnalyserTables`, `StockAnalyserWs`, `StockAnalyserApi` | `deploy-stock-analyser.yml` |
 | `infrastructure/bin/budget-tracker.ts` | `BudgetTrackerTables`, `BudgetTrackerApi` | `deploy-budget-tracker.yml` |
 | `infrastructure/bin/migration-utilities.ts` | `MigrationsApi` | `deploy-migration-utilities.yml` |
 | `infrastructure/bin/launchpad.ts` | Launchpad stacks | `deploy-launchpad.yml` |
 
-Each entrypoint synthesises *only* the stacks it owns. App stacks (SA, BT, MU) resolve shared platform resources (REST API, authoriser, WebSocket API) via CloudFormation imports at deploy time — not via construct references passed through props. This enables independent deployment: changing SA code deploys only SA stacks; the platform stacks are untouched.
+Each entrypoint synthesises *only* the stacks it owns. App stacks resolve remaining shared substrate resources via CloudFormation imports at deploy time where needed — not via construct references passed through props. After #366, Stock Analyser owns its REST API, WSS, AI proxy, and job-results runtime.
 
 Stacks are deployed by GitHub Actions workflows — see [urls-and-deploy.md](./urls-and-deploy.md) for workflow triggers.
 
@@ -53,8 +53,9 @@ Deployed by `deploy-stock-analyser.yml`. Source in `apps/stock-analyser/infrastr
 
 | Stack name | Class | Contents |
 |---|---|---|
-| `Transformotion{Stage}-StockAnalyserTables` | `StockAnalyserTablesStack` | `stock-analyser.portfolio-{stage}`, `stock-analyser.watchlist-{stage}`, `stock-analyser.analysis-cache-{stage}` |
-| `Transformotion{Stage}-StockAnalyserApi` | `StockAnalyserApiStack` | Stock Analyser Lambda functions + routes on the shared platform API Gateway |
+| `Transformotion{Stage}-StockAnalyserTables` | `StockAnalyserTablesStack` | `stock-analyser.portfolio-{stage}`, `stock-analyser.watchlist-{stage}`, `stock-analyser.analysis-cache-{stage}`, `stock-analyser.job-results-{stage}` |
+| `Transformotion{Stage}-StockAnalyserWs` | `StockAnalyserWsStack` | Stock Analyser-owned WebSocket API, WS Lambdas, and `stock-analyser.ws-connections-{stage}` |
+| `Transformotion{Stage}-StockAnalyserApi` | `StockAnalyserApiStack` | Stock Analyser-owned REST API Gateway, app Lambda functions, Cognito authoriser, and `stock-analyser-ai-proxy-{stage}` |
 
 ### Budget Tracker stacks
 
@@ -101,6 +102,7 @@ Deployed by `deploy-budget-tracker.yml`. Source in `apps/budget-tracker/infrastr
 | `transformotion-analysis-cache-{stage}` | `apps/stock-analyser/functions/analysis-cache` | `GET/PUT/DELETE /analysis-cache/{key}` |
 | `transformotion-cycle-data-{stage}` | `apps/stock-analyser/functions/cycle-data` | `GET /cycle/ohlcv?ticker=` |
 | `transformotion-market-data-{stage}` | `apps/stock-analyser/functions/market-data` | `GET /price/ohlcv?ticker=&range=&interval=` |
+| `stock-analyser-ai-proxy-{stage}` | `apps/stock-analyser/functions/ai-proxy` | `POST /api/claude` |
 
 ### Budget Tracker Lambda functions (`Transformotion{Stage}-BudgetTrackerApi`)
 
@@ -156,11 +158,13 @@ App stacks (`StockAnalyserApiStack`, `BudgetTrackerApiStack`, `MigrationsApiStac
 
 | Export name | Produced by | Consumed by |
 |---|---|---|
-| `Transformotion-{stage}-RestApiId` | `PlatformApiStack` | SA, BT, MU — `RestApi.fromRestApiAttributes` |
-| `Transformotion-{stage}-RestApiRootResourceId` | `PlatformApiStack` | SA, BT, MU — `RestApi.fromRestApiAttributes` |
-| `Transformotion-{stage}-AuthorizerId` | `PlatformApiStack` | SA, BT, MU — JWT authoriser on each route |
+| `Transformotion-{stage}-RestApiId` | `PlatformApiStack` | BT, MU — `RestApi.fromRestApiAttributes`; SA no longer imports after #366 |
+| `Transformotion-{stage}-RestApiRootResourceId` | `PlatformApiStack` | BT, MU — `RestApi.fromRestApiAttributes`; SA no longer imports after #366 |
+| `Transformotion-{stage}-AuthorizerId` | `PlatformApiStack` | BT, MU — JWT authoriser on each route; SA owns its API authoriser after #366 |
 | `Transformotion-{stage}-ApiResourceId` | `PlatformApiStack` | BT, MU — `Resource.fromResourceAttributes` to mount under `/api/` |
-| `PlatformWs-{stage}-WsApiId` | `PlatformWsStack` | Transitional platform WSS consumers; Budget Tracker no longer imports this after #365 |
+| `PlatformWs-{stage}-WsApiId` | `PlatformWsStack` | Transitional platform WSS consumers; SA and BT no longer consume after #366/#365 |
+| `StockAnalyserWs-{stage}-Url` | `StockAnalyserWsStack` | Deploy workflow injects `NEXT_PUBLIC_SA_WSS_URL` |
+| `StockAnalyserApi-{stage}-Url` | `StockAnalyserApiStack` | Deploy workflow injects `NEXT_PUBLIC_API_URL` |
 
 The rule: cross-entrypoint references always go through CF exports (`Fn.importValue`), never through L2 construct passing. This allows each entrypoint to synthesise independently — no platform stacks are instantiated in app entrypoints.
 
@@ -175,7 +179,7 @@ The rule: cross-entrypoint references always go through CF exports (`Fn.importVa
 3. **Step 3 — Main platform stacks** — deploys `Storage`, `Network`, `Auth`, `AuthApi`, `Api` together. CDK runs independent stacks in parallel within this step. `PlatformApiStack` emits the CF exports that SA/BT/MU consume.
 4. **Step 4 — PlatformWs** — deployed after `Api`; retained during M9 dual-run until app-owned WSS cutovers and decommissioning.
 
-App stacks (`deploy-stock-analyser.yml`, `deploy-budget-tracker.yml`, `deploy-migration-utilities.yml`) consume the CF exports produced in Step 3/4 above where they still have transitional dependencies. Budget Tracker owns `Transformotion{Stage}-BudgetTrackerWs` after #365 and no longer consumes `PlatformWs-{stage}-WsApiId` for AI review streaming. On first-ever deploy, the platform stacks must be deployed before the app stacks. On subsequent deploys, each workflow is independently triggered and independently deploys only its own stacks.
+App stacks (`deploy-stock-analyser.yml`, `deploy-budget-tracker.yml`, `deploy-migration-utilities.yml`) consume the CF exports produced in Step 3/4 above where they still have transitional dependencies. Budget Tracker owns `Transformotion{Stage}-BudgetTrackerWs` after #365 and no longer consumes `PlatformWs-{stage}-WsApiId` for AI review streaming. Stock Analyser owns `Transformotion{Stage}-StockAnalyserWs`, `Transformotion{Stage}-StockAnalyserApi`, and `stock-analyser-ai-proxy-{stage}` after #366, and no longer uses platform REST/WSS/Claude runtime for live AI flow. On first-ever deploy, the platform auth stack must exist before app stacks because Cognito remains platform-owned until #363. On subsequent deploys, each workflow is independently triggered and independently deploys only its own stacks.
 
 ---
 
@@ -218,6 +222,22 @@ Platform WS Lambda environment variables:
 | `PERMITTED_APPS` | `platform-ws-authorizer-{stage}` | `budget-tracker,stock-analyser` (comma-separated allowlist) |
 | `APP_NAME` | `platform-ws-authorizer-{stage}` | Default app slug when `?app=` is absent (currently `budget-tracker`) |
 | `CONNECTIONS_TABLE` | `platform-ws-connect-{stage}`, `platform-ws-disconnect-{stage}` | `platform.ws-connections-{stage}` |
+
+Stock Analyser WS Lambda environment variables:
+
+| Variable | Lambda | Value |
+|---|---|---|
+| `COGNITO_USER_POOL_ID` | `stock-analyser-ws-authorizer-{stage}` | Cognito user pool ID (for JWKS verification) |
+| `APP_NAME` | `stock-analyser-ws-authorizer-{stage}` | `stock-analyser` |
+| `CONNECTIONS_TABLE` | `stock-analyser-ws-connect-{stage}`, `stock-analyser-ws-disconnect-{stage}` | `stock-analyser.ws-connections-{stage}` |
+
+Stock Analyser AI proxy environment variables:
+
+| Variable | Lambda | Value |
+|---|---|---|
+| `ANTHROPIC_SECRET_NAME` | `stock-analyser-ai-proxy-{stage}` | `{stage}/anthropic/api-key` |
+| `JOB_RESULTS_TABLE` | `stock-analyser-ai-proxy-{stage}` | `stock-analyser.job-results-{stage}` |
+| `WS_API_ENDPOINT` | `stock-analyser-ai-proxy-{stage}` | Stock Analyser-owned WSS management endpoint |
 
 Budget Tracker WS Lambda environment variables:
 
@@ -278,7 +298,7 @@ Cognito app clients still live in `AuthStack`; #362 has not transferred app-clie
 
 There are three categories of Lambda in this repo. Category determines authorization pattern and CI check applicability.
 
-**App handlers** — Lambdas serving authenticated user requests for a specific app. Located in `apps/*/functions/` (per-app) or `functions/claude-proxy/` (cross-app). Subject to the documented authorization pattern: `requireAppAccess` (or `requireAnyAppAccess`) at the top, then `requireAccountAccess` before account-scoped data operations. CI enforces this pattern.
+**App handlers** — Lambdas serving authenticated user requests for a specific app. Located in `apps/*/functions/` (per-app) or `platform/functions/claude-proxy/` (transitional platform multi-app runtime). Subject to the documented authorization pattern: `requireAppAccess` (or `requireAnyAppAccess`) at the top, then `requireAccountAccess` before account-scoped data operations. CI enforces this pattern.
 
 **Auth infrastructure** — Lambdas that produce, verify, or recover identity-related state. Located in `functions/auth/`. Examples: `pre-token-generation`, `forgot-provider`, `account-provisioning`, `invitations` (forthcoming). Each has a bespoke authorization pattern (some unauthenticated, some `withAuthOnly`, some `requireAccountOwner`, etc.). Not subject to the CI handler-authz check.
 
@@ -305,7 +325,7 @@ This is a coarse file-level check — it confirms authorization helpers are pres
 Both checks cover the same scope:
 
 - `apps/*/functions/` — app-specific handlers (Budget Tracker, Stock Analyser)
-- `functions/claude-proxy/` — platform multi-app handler
+- `platform/functions/claude-proxy/` — transitional platform multi-app handler
 
 ### Exempt paths
 
@@ -323,8 +343,8 @@ Both checks cover the same scope:
 When a new app is added to the platform:
 
 1. Create `apps/{app-name}/infrastructure/{app-name}-tables-stack.ts` — DynamoDB tables
-2. Create `apps/{app-name}/infrastructure/{app-name}-api-stack.ts` — Lambda functions + routes on the shared platform API Gateway. Import the API and authoriser via `Fn.importValue` using the CF export names above — do not accept `api`/`authoriser` as props.
-3. Create `infrastructure/bin/{app-name}.ts` containing only the new app's stacks. Use `cdk.Fn.importValue` only for documented transitional platform exports that the app still needs; new runtime ownership should be app-owned, including WebSocket resources.
+2. Create `apps/{app-name}/infrastructure/{app-name}-api-stack.ts` — app-owned API Gateway, Lambda functions, routes, and authorizer. Do not mount new app runtime routes on the shared platform API Gateway.
+3. Create `infrastructure/bin/{app-name}.ts` containing only the new app's stacks. Use `cdk.Fn.importValue` only for documented transitional platform exports that the app still needs; new runtime ownership should be app-owned, including REST and WebSocket resources.
 4. Create `.github/workflows/deploy-{app-name}.yml` with `--app 'bin/{app-name}.ts'` on all CDK deploy steps.
 5. Add a Cognito app client for the new app in `auth-stack.ts`.
 6. Update `docs/architecture/cdk.md` (this file), `docs/architecture/urls-and-deploy.md`, and `CONTRIBUTING.md §3.4` with the new stacks.

--- a/docs/architecture/inventory.md
+++ b/docs/architecture/inventory.md
@@ -516,19 +516,22 @@ is backfilled via the renamed endpoint.
 **Status: Confirmed (current/transitional state; M9 targets removal)**
 
 The platform currently uses the shared platform REST API Gateway for
-multiple app runtime routes:
+remaining transitional app runtime routes:
 
 - **Platform gateway** — defined in `platform/infrastructure/platform-api-stack.ts`,
-  serves Stock Analyser routes and Budget Tracker routes.
+  still serves platform routes and Budget Tracker routes.
 - **BudgetTrackerApiStack** — defined in
   `apps/budget-tracker/infrastructure/budget-tracker-api-stack.ts`,
   imports the shared platform `RestApi` and mounts Budget Tracker routes
   under `/api/budget/v1`.
+- **StockAnalyserApiStack** — defined in
+  `apps/stock-analyser/infrastructure/stock-analyser-api-stack.ts`,
+  owns the Stock Analyser REST API Gateway after #366.
 
-This shared gateway app-runtime ownership is transitional debt. M9 moves
-Budget Tracker and Stock Analyser to app-owned API Gateway ownership;
-the shared platform gateway must not be treated as the target pattern for
-new app runtime routes.
+This shared gateway app-runtime ownership is transitional debt. Stock Analyser
+no longer uses it after #366. M9 moves Budget Tracker to app-owned API Gateway
+ownership as well; the shared platform gateway must not be treated as the
+target pattern for new app runtime routes.
 
 ### 2.10 DynamoDB schema
 
@@ -555,6 +558,8 @@ new app runtime routes.
 | `stock-analyser.portfolio-{stage}` | accountId | ticker |
 | `stock-analyser.watchlist-{stage}` | accountId | ticker |
 | `stock-analyser.analysis-cache-{stage}` | accountId | cacheKey |
+| `stock-analyser.ws-connections-{stage}` | connectionId | — |
+| `stock-analyser.job-results-{stage}` | accountId | cacheKey |
 
 CDK source declares all three tables with composite keys
 (`apps/stock-analyser/infrastructure/stock-analyser-tables-stack.ts`
@@ -571,6 +576,11 @@ table names match (`stock-analyser.portfolio-dev`,
 in both source and deployment. The mismatch concern likely originated
 before a CDK fix landed and was carried forward without re-verification
 during v4 inventory production.
+
+WebSocket connection state for Stock Analyser is app-owned in
+`stock-analyser.ws-connections-{stage}`. Async AI job state is app-owned in
+`stock-analyser.job-results-{stage}`. After #366, live Stock Analyser AI uses
+Stock Analyser REST, AI proxy, job-results, and WSS runtime.
 
 #### 2.10.3 Budget-tracker tables
 
@@ -1107,9 +1117,14 @@ CDK stacks — M7 #250 infrastructure split complete:
 - `storage-stack.ts` — S3 backups bucket
 
 **Stock-analyser stacks** (`apps/stock-analyser/infrastructure/`):
-- `stock-analyser-api-stack.ts` — portfolio, watchlist, analysis-cache,
-  and cycle-data Lambdas + routes on shared platform API Gateway
-- `stock-analyser-tables-stack.ts`
+- `stock-analyser-api-stack.ts` — Stock Analyser-owned REST API Gateway,
+  portfolio, watchlist, analysis-cache, market-data, cycle-data, and
+  `stock-analyser-ai-proxy-{stage}` Lambdas
+- `stock-analyser-tables-stack.ts` — Stock Analyser data tables, including
+  `stock-analyser.job-results-{stage}` after #366
+- `sa-ws-stack.ts` — Stock Analyser-owned WebSocket API
+  (`stock-analyser-ws-{stage}`), custom Lambda authorizer, connect/default/
+  disconnect Lambdas, and `stock-analyser.ws-connections-{stage}`
 
 **Budget-tracker stacks** (`apps/budget-tracker/infrastructure/`):
 - `budget-tracker-api-stack.ts` — mounts BT Lambdas on the shared
@@ -1121,7 +1136,9 @@ CDK stacks — M7 #250 infrastructure split complete:
   disconnect Lambdas, and `budget-tracker.ws-connections-{stage}`
 
 Budget Tracker no longer uses `PlatformWsStack` for AI review streaming after
-#365. Platform WSS remains deployed for M9 dual-run and later decommissioning.
+#365. Stock Analyser no longer uses `PlatformWsStack` for live AI completion
+notifications after #366. Platform WSS remains deployed for rollback, any
+remaining transitional consumers, and later decommissioning.
 
 There is no `MonitoringStack`. M13 creates it.
 

--- a/infrastructure/bin/stock-analyser.ts
+++ b/infrastructure/bin/stock-analyser.ts
@@ -4,6 +4,7 @@ import * as cdk from 'aws-cdk-lib';
 
 import { StockAnalyserTablesStack } from '../../apps/stock-analyser/infrastructure/stock-analyser-tables-stack';
 import { StockAnalyserApiStack }    from '../../apps/stock-analyser/infrastructure/stock-analyser-api-stack';
+import { StockAnalyserWsStack }     from '../../apps/stock-analyser/infrastructure/sa-ws-stack';
 
 const app = new cdk.App();
 
@@ -12,37 +13,60 @@ const env = {
   region: 'ap-southeast-2',
 };
 
-// ── Dev stacks ─────────────────────────────────────────────────────────────────
-// Platform resources (RestApi, Authoriser, /api resource) are imported via
-// CloudFormation exports from TransformotionDev-Api at deploy time.
+// Stock Analyser owns REST, WSS, AI runtime, and app data after #366.
+// Cognito remains platform-owned until #363 and is imported by User Pool ID.
 //
 // Deploy commands:
-//   cdk deploy --app bin/stock-analyser.ts TransformotionDev-StockAnalyserTables TransformotionDev-StockAnalyserApi
+//   cdk deploy --app bin/stock-analyser.ts TransformotionDev-StockAnalyserTables TransformotionDev-StockAnalyserWs TransformotionDev-StockAnalyserApi
 
-new StockAnalyserTablesStack(app, 'TransformotionDev-StockAnalyserTables', {
+const devStockAnalyserTables = new StockAnalyserTablesStack(app, 'TransformotionDev-StockAnalyserTables', {
   env,
   stage:       'dev',
-  description: 'Transformotion Apps — Dev Stock Analyser DynamoDB tables',
+  description: 'Transformotion Apps - Dev Stock Analyser DynamoDB tables',
+});
+
+const devStockAnalyserWs = new StockAnalyserWsStack(app, 'TransformotionDev-StockAnalyserWs', {
+  env,
+  stage:       'dev',
+  userPoolId:  cdk.Fn.importValue('Transformotion-dev-UserPoolId'),
+  description: 'Transformotion Apps - Dev Stock Analyser WebSocket API',
 });
 
 new StockAnalyserApiStack(app, 'TransformotionDev-StockAnalyserApi', {
   env,
-  stage:               'dev',
-  description:         'Transformotion Apps — Dev Stock Analyser API routes',
-  jobResultsTableName: 'platform.job-results-dev',
+  stage:              'dev',
+  userPoolId:         cdk.Fn.importValue('Transformotion-dev-UserPoolId'),
+  portfolioTable:     devStockAnalyserTables.portfolioTableNew,
+  watchlistTable:     devStockAnalyserTables.watchlistTableNew,
+  analysisCacheTable: devStockAnalyserTables.analysisCacheTable,
+  jobResultsTable:    devStockAnalyserTables.jobResultsTable,
+  wsApiEndpoint:      devStockAnalyserWs.wsApiEndpoint,
+  wsApiId:            devStockAnalyserWs.webSocketApi.apiId,
+  description:        'Transformotion Apps - Dev Stock Analyser API routes',
 });
 
-// ── Prod stacks ────────────────────────────────────────────────────────────────
-
-new StockAnalyserTablesStack(app, 'TransformotionProd-StockAnalyserTables', {
+const prodStockAnalyserTables = new StockAnalyserTablesStack(app, 'TransformotionProd-StockAnalyserTables', {
   env,
   stage:       'prod',
-  description: 'Transformotion Apps — Prod Stock Analyser DynamoDB tables',
+  description: 'Transformotion Apps - Prod Stock Analyser DynamoDB tables',
+});
+
+const prodStockAnalyserWs = new StockAnalyserWsStack(app, 'TransformotionProd-StockAnalyserWs', {
+  env,
+  stage:       'prod',
+  userPoolId:  cdk.Fn.importValue('Transformotion-prod-UserPoolId'),
+  description: 'Transformotion Apps - Prod Stock Analyser WebSocket API',
 });
 
 new StockAnalyserApiStack(app, 'TransformotionProd-StockAnalyserApi', {
   env,
-  stage:               'prod',
-  description:         'Transformotion Apps — Prod Stock Analyser API routes',
-  jobResultsTableName: 'platform.job-results-prod',
+  stage:              'prod',
+  userPoolId:         cdk.Fn.importValue('Transformotion-prod-UserPoolId'),
+  portfolioTable:     prodStockAnalyserTables.portfolioTableNew,
+  watchlistTable:     prodStockAnalyserTables.watchlistTableNew,
+  analysisCacheTable: prodStockAnalyserTables.analysisCacheTable,
+  jobResultsTable:    prodStockAnalyserTables.jobResultsTable,
+  wsApiEndpoint:      prodStockAnalyserWs.wsApiEndpoint,
+  wsApiId:            prodStockAnalyserWs.webSocketApi.apiId,
+  description:        'Transformotion Apps - Prod Stock Analyser API routes',
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -810,6 +810,22 @@ importers:
         specifier: '*'
         version: 5.7.3
 
+  apps/stock-analyser/functions/ai-proxy:
+    dependencies:
+      '@transformotion/fn-claude-proxy-core':
+        specifier: workspace:*
+        version: link:../../../../packages/fn-claude-proxy-core
+    devDependencies:
+      '@types/aws-lambda':
+        specifier: ^8
+        version: 8.10.161
+      '@types/node':
+        specifier: ^22
+        version: 22.19.17
+      typescript:
+        specifier: '*'
+        version: 5.7.3
+
   apps/stock-analyser/functions/cycle-check:
     devDependencies:
       typescript:
@@ -894,6 +910,73 @@ importers:
       '@types/aws-lambda':
         specifier: ^8
         version: 8.10.161
+      typescript:
+        specifier: '*'
+        version: 5.7.3
+
+  apps/stock-analyser/functions/ws-authorizer:
+    dependencies:
+      jose:
+        specifier: ^5.9.6
+        version: 5.10.0
+    devDependencies:
+      '@types/aws-lambda':
+        specifier: ^8
+        version: 8.10.161
+      '@types/node':
+        specifier: ^22
+        version: 22.19.17
+      typescript:
+        specifier: '*'
+        version: 5.7.3
+
+  apps/stock-analyser/functions/ws-connect:
+    devDependencies:
+      '@aws-sdk/client-dynamodb':
+        specifier: ^3
+        version: 3.1032.0
+      '@aws-sdk/lib-dynamodb':
+        specifier: ^3
+        version: 3.1032.0(@aws-sdk/client-dynamodb@3.1032.0)
+      '@types/aws-lambda':
+        specifier: ^8
+        version: 8.10.161
+      '@types/node':
+        specifier: ^22
+        version: 22.19.17
+      typescript:
+        specifier: '*'
+        version: 5.7.3
+
+  apps/stock-analyser/functions/ws-default:
+    devDependencies:
+      '@aws-sdk/client-apigatewaymanagementapi':
+        specifier: ^3
+        version: 3.1049.0
+      '@types/aws-lambda':
+        specifier: ^8
+        version: 8.10.161
+      '@types/node':
+        specifier: ^22
+        version: 22.19.17
+      typescript:
+        specifier: '*'
+        version: 5.7.3
+
+  apps/stock-analyser/functions/ws-disconnect:
+    devDependencies:
+      '@aws-sdk/client-dynamodb':
+        specifier: ^3
+        version: 3.1032.0
+      '@aws-sdk/lib-dynamodb':
+        specifier: ^3
+        version: 3.1032.0(@aws-sdk/client-dynamodb@3.1032.0)
+      '@types/aws-lambda':
+        specifier: ^8
+        version: 8.10.161
+      '@types/node':
+        specifier: ^22
+        version: 22.19.17
       typescript:
         specifier: '*'
         version: 5.7.3

--- a/scripts/ci/verify-deploy.sh
+++ b/scripts/ci/verify-deploy.sh
@@ -26,6 +26,9 @@
 #   COGNITO_APP_CLIENT_ID — Cognito app client ID for this app
 #   API_BASE_URL          — Platform API Gateway base URL (no trailing slash)
 #
+# When the optional app identity is supplied, the smoke check derives the
+# X-Account-Id header from the token's accounts claim for that app.
+#
 # The [REQUIRED] var substitution check reads each var's value from the current
 # shell environment. In CI the job-level env block provides all NEXT_PUBLIC_* vars
 # automatically. Locally, export them before running this script.
@@ -255,9 +258,43 @@ EOF
   id_token=$(echo "$auth_response" | grep -o '"IdToken": *"[^"]*"' | sed 's/"IdToken": *"//' | tr -d '"')
   echo "      Token acquired."
 
+  smoke_account_id=""
+  if [[ -n "$EXPECTED_APP" ]]; then
+    smoke_account_id=$(ID_TOKEN="$id_token" EXPECTED_APP="$EXPECTED_APP" node - <<'NODE'
+const token = process.env.ID_TOKEN ?? '';
+const app = process.env.EXPECTED_APP ?? '';
+const payload = token.split('.')[1] ?? '';
+try {
+  const claims = JSON.parse(Buffer.from(payload, 'base64url').toString('utf8'));
+  const accounts = claims.accounts ? JSON.parse(claims.accounts) : {};
+  const accountId = accounts?.[app]?.[0]?.accountId ?? '';
+  process.stdout.write(accountId);
+} catch {
+  process.stdout.write('');
+}
+NODE
+)
+    if [[ -z "$smoke_account_id" ]]; then
+      cat >&2 <<EOF
+
+FAIL: could not derive X-Account-Id for app '$EXPECTED_APP' from the smoke-test token.
+
+The authenticated smoke check calls an account-scoped API route. The CI user
+must have an accounts claim containing an account for '$EXPECTED_APP'.
+
+EOF
+      exit 1
+    fi
+    echo "      Derived X-Account-Id for ${EXPECTED_APP}."
+  fi
+
   echo "      Calling ${API_BASE_URL}${SMOKE_ENDPOINT}..."
+  curl_headers=(-H "Authorization: Bearer ${id_token}")
+  if [[ -n "$smoke_account_id" ]]; then
+    curl_headers+=(-H "X-Account-Id: ${smoke_account_id}")
+  fi
   smoke_code=$(curl -s -o /dev/null -w "%{http_code}" \
-    -H "Authorization: Bearer ${id_token}" \
+    "${curl_headers[@]}" \
     "${API_BASE_URL}${SMOKE_ENDPOINT}")
 
   if [[ "${smoke_code:0:1}" != "2" ]]; then


### PR DESCRIPTION
## Summary

- Moves Stock Analyser runtime ownership onto app-owned REST, WSS, AI proxy, and job-results resources.
- Adds `stock-analyser-ai-proxy-{stage}` as the app-owned AI runtime while retaining the legacy platform `claude-proxy` for rollback/decommission.
- Switches Stock Analyser frontend deploy config to app-owned API/WSS outputs and updates smoke verification to send `X-Account-Id` from the token accounts claim.
- Updates M9 architecture docs and Stock Analyser agent docs for the post-#366 ownership boundary.

Refs #366.

## Validation

- `pnpm --filter @transformotion/fn-stock-analyser-ai-proxy typecheck`
- Stock Analyser WSS Lambda package typechecks
- `pnpm --filter @transformotion/infra typecheck`
- `pnpm --filter @transformotion/stock-analyser typecheck`
- `pnpm --dir infrastructure exec cdk synth --app 'npx ts-node --prefer-ts-exts bin/stock-analyser.ts' TransformotionDev-StockAnalyserTables TransformotionDev-StockAnalyserWs TransformotionDev-StockAnalyserApi`
- `pnpm --dir infrastructure exec cdk diff --app 'npx ts-node --prefer-ts-exts bin/stock-analyser.ts' TransformotionDev-StockAnalyserTables TransformotionDev-StockAnalyserWs TransformotionDev-StockAnalyserApi`
- `git diff --check` passed with only the existing `.env.example` CRLF warning

## Deploy Watch Points

- `TransformotionDev-StockAnalyserTables`
- `TransformotionDev-StockAnalyserWs`
- `TransformotionDev-StockAnalyserApi`
- Stock Analyser frontend build with `NEXT_PUBLIC_AI_API_URL` and `NEXT_PUBLIC_SA_WSS_URL`
- Live SA analysis completion over app-owned WSS