### PR TITLE
ci: allow site admin deploy smoke account context

### DIFF
--- a/scripts/ci/verify-deploy.sh
+++ b/scripts/ci/verify-deploy.sh
@@ -267,7 +267,9 @@ const payload = token.split('.')[1] ?? '';
 try {
   const claims = JSON.parse(Buffer.from(payload, 'base64url').toString('utf8'));
   const accounts = claims.accounts ? JSON.parse(claims.accounts) : {};
-  const accountId = accounts?.[app]?.[0]?.accountId ?? '';
+  const accountId = accounts?.[app]?.[0]?.accountId
+    ?? (claims.site_admin === 'true' ? claims.sub : '')
+    ?? '';
   process.stdout.write(accountId);
 } catch {
   process.stdout.write('');
@@ -280,7 +282,8 @@ NODE
 FAIL: could not derive X-Account-Id for app '$EXPECTED_APP' from the smoke-test token.
 
 The authenticated smoke check calls an account-scoped API route. The CI user
-must have an accounts claim containing an account for '$EXPECTED_APP'.
+must have either an accounts claim containing an account for '$EXPECTED_APP',
+or the site_admin claim.
 
 EOF
       exit 1


### PR DESCRIPTION
## Summary

- Allows deploy smoke checks to derive `X-Account-Id` from `sub` when the smoke-test token has `site_admin=true` and no app account claim.
- Keeps account-scoped smoke checks strict for non-site-admin users.

## Root Cause

The #366 Stock Analyser deploy reached infrastructure deploy, API/WSS output extraction, frontend build, S3 upload, CloudFront invalidation, and bundle verification, but failed the `/portfolio` smoke check because the CI token did not include an `accounts['stock-analyser']` entry. The Lambda authorization model permits site-admin users without account membership, but the verifier did not mirror that fallback when constructing `X-Account-Id`.

## Validation

- `git diff --check`
- `pnpm --filter @transformotion/stock-analyser typecheck`