### PR TITLE
M9 #367: Move Budget Tracker AI runtime to app ownership

### DIFF
--- a/.github/workflows/deploy-budget-tracker.yml
+++ b/.github/workflows/deploy-budget-tracker.yml
@@ -14,6 +14,7 @@ on:
       - 'packages/auth-client/**'
       - 'packages/runtime-config/**'
       - 'packages/lambda-middleware/**'
+      - 'packages/fn-claude-proxy-core/**'
       - 'packages/budget-domain/**'
   workflow_call:
     inputs:
@@ -92,6 +93,19 @@ jobs:
         working-directory: infrastructure
         run: pnpm exec cdk deploy --app 'npx ts-node --prefer-ts-exts bin/budget-tracker.ts' 'TransformotionDev-BudgetTrackerTables' 'TransformotionDev-BudgetTrackerWs' 'TransformotionDev-BudgetTrackerApi' --require-approval never
 
+      - name: Extract Budget Tracker API URL from CDK output
+        run: |
+          API_URL=$(aws cloudformation describe-stacks \
+            --stack-name TransformotionDev-BudgetTrackerApi \
+            --query "Stacks[0].Outputs[?OutputKey=='ApiUrl'].OutputValue" \
+            --output text)
+          if [ -z "$API_URL" ]; then
+            echo "ERROR: Could not extract ApiUrl from TransformotionDev-BudgetTrackerApi stack"
+            exit 1
+          fi
+          echo "NEXT_PUBLIC_API_URL=$API_URL" >> $GITHUB_ENV
+          echo "Extracted BT API URL: $API_URL"
+
       - name: Extract WebSocket URL from CDK output
         run: |
           WSS_URL=$(aws cloudformation describe-stacks \
@@ -129,14 +143,14 @@ jobs:
           CI_COGNITO_PASSWORD: ${{ secrets.CI_COGNITO_PASSWORD }}
           COGNITO_USER_POOL_ID: ${{ vars.NEXT_PUBLIC_COGNITO_USER_POOL_ID }}
           COGNITO_APP_CLIENT_ID: ${{ vars.NEXT_PUBLIC_BUDGET_TRACKER_COGNITO_CLIENT_ID }}
-          API_BASE_URL: ${{ vars.NEXT_PUBLIC_API_URL }}
         run: |
+          export API_BASE_URL="${NEXT_PUBLIC_API_URL}"
           bash scripts/ci/verify-deploy.sh \
             "${{ vars.NEXT_PUBLIC_BUDGET_TRACKER_APP_URL }}" \
             apps/budget-tracker/.env.example \
             "${{ github.sha }}" \
             "budget-tracker" \
-            "/api/user/profile"
+            "/api/budget/v1/settings"
 
   deploy-prod:
     name: Budget Tracker → Prod
@@ -187,6 +201,19 @@ jobs:
         working-directory: infrastructure
         run: pnpm exec cdk deploy --app 'npx ts-node --prefer-ts-exts bin/budget-tracker.ts' 'TransformotionProd-BudgetTrackerTables' 'TransformotionProd-BudgetTrackerWs' 'TransformotionProd-BudgetTrackerApi' --require-approval never
 
+      - name: Extract Budget Tracker API URL from CDK output
+        run: |
+          API_URL=$(aws cloudformation describe-stacks \
+            --stack-name TransformotionProd-BudgetTrackerApi \
+            --query "Stacks[0].Outputs[?OutputKey=='ApiUrl'].OutputValue" \
+            --output text)
+          if [ -z "$API_URL" ]; then
+            echo "ERROR: Could not extract ApiUrl from TransformotionProd-BudgetTrackerApi stack"
+            exit 1
+          fi
+          echo "NEXT_PUBLIC_API_URL=$API_URL" >> $GITHUB_ENV
+          echo "Extracted BT API URL: $API_URL"
+
       - name: Extract WebSocket URL from CDK output
         run: |
           WSS_URL=$(aws cloudformation describe-stacks \
@@ -224,11 +251,11 @@ jobs:
           CI_COGNITO_PASSWORD: ${{ secrets.CI_COGNITO_PASSWORD }}
           COGNITO_USER_POOL_ID: ${{ vars.NEXT_PUBLIC_COGNITO_USER_POOL_ID }}
           COGNITO_APP_CLIENT_ID: ${{ vars.NEXT_PUBLIC_BUDGET_TRACKER_COGNITO_CLIENT_ID }}
-          API_BASE_URL: ${{ vars.NEXT_PUBLIC_API_URL }}
         run: |
+          export API_BASE_URL="${NEXT_PUBLIC_API_URL}"
           bash scripts/ci/verify-deploy.sh \
             "${{ vars.NEXT_PUBLIC_BUDGET_TRACKER_APP_URL }}" \
             apps/budget-tracker/.env.example \
             "${{ github.sha }}" \
             "budget-tracker" \
-            "/api/user/profile"
+            "/api/budget/v1/settings"

--- a/MONOREPO.md
+++ b/MONOREPO.md
@@ -275,11 +275,11 @@ organisational, not itself a package.
   Nested workspaces (like `apps/stock-analyser/functions/*` and
   `platform/functions/auth/*`) need explicit globs in `pnpm-workspace.yaml`.
 
-- **Shared API Gateway (current/transitional).** `apps/budget-tracker`
-  still mounts REST routes on the shared platform API Gateway from
-  `PlatformApiStack`. Stock Analyser owns its REST API Gateway after
-  #366. Shared runtime gateway use is transitional debt for M9, not the
-  desired pattern for new app runtime work.
+- **App-owned REST APIs.** Stock Analyser owns its REST API Gateway after
+  #366. Budget Tracker owns its REST API Gateway and AI proxy runtime after
+  #367. The shared platform API Gateway remains deployed for platform routes,
+  rollback, and later #372 decommissioning of legacy app runtime paths; it is
+  not the desired pattern for new app runtime work.
 
 - **Stock Analyser WSS and AI runtime.** `apps/stock-analyser`
   owns `sa-ws-stack.ts`, WS handler packages under
@@ -287,6 +287,14 @@ organisational, not itself a package.
   `apps/stock-analyser/functions/ai-proxy` after #366. Live Stock
   Analyser AI uses Stock Analyser-owned REST, WSS, job-results, and
   AI runtime; platform runtime remains only for rollback and later
+  decommissioning.
+
+- **Budget Tracker WSS and AI runtime.** `apps/budget-tracker`
+  owns `bt-ws-stack.ts`, WS handler packages under
+  `apps/budget-tracker/functions/ws-*`, and
+  `apps/budget-tracker/functions/ai-proxy` after #367. Live Budget Tracker
+  AI review uses Budget Tracker-owned REST, WSS, `budget-tracker.ai-jobs`,
+  and AI runtime; platform runtime remains only for rollback and later
   decommissioning.
 
 - **Analysis cache table.** The `platform.analysis-cache` table is

--- a/apps/budget-tracker/.env.example
+++ b/apps/budget-tracker/.env.example
@@ -54,25 +54,21 @@
 # the deploy workflow's env block if [REQUIRED] or [BUILD-INJECTED].
 # ─────────────────────────────────────────────────────────────────────────────
 
-# ── Platform API ─────────────────────────────────────────────────────────────
+# ── Budget Tracker API ───────────────────────────────────────────────────────
+# [REQUIRED]
+# Base URL of the Budget Tracker-owned API Gateway.
+# Source: CloudFormation output ApiUrl on TransformotionDev/Prod-BudgetTrackerApi.
+NEXT_PUBLIC_API_URL=https://your-budget-tracker-api-id.execute-api.ap-southeast-2.amazonaws.com/dev
 
 # [REQUIRED]
-# Base URL of the shared platform API Gateway.
-# Used for platform routes (auth session, accounts).
-# Source: CloudFormation output ApiUrl on TransformotionDev-Api (dev) or
-#         TransformotionProd-Api (prod).
-NEXT_PUBLIC_API_URL=https://your-platform-api-id.execute-api.ap-southeast-2.amazonaws.com/dev
+# Compatibility placeholder. Budget Tracker AI routes call budget-ai-handler
+# under NEXT_PUBLIC_API_URL; the handler invokes the app-owned AI proxy Lambda.
+NEXT_PUBLIC_CLAUDE_API_URL=https://your-budget-tracker-api-id.execute-api.ap-southeast-2.amazonaws.com/dev/api/claude
 
 # [REQUIRED]
-# Claude proxy endpoint. AI features in the Budget Tracker (AI
-# categorisation) invoke this via the shared backend proxy Lambda.
-# Source: <NEXT_PUBLIC_API_URL>/api/claude
-NEXT_PUBLIC_CLAUDE_API_URL=https://your-platform-api-id.execute-api.ap-southeast-2.amazonaws.com/dev/api/claude
-
-# [REQUIRED]
-# Analysis-cache endpoint. Used for long-poll job status.
-# Source: <NEXT_PUBLIC_API_URL>/analysis-cache
-NEXT_PUBLIC_CLAUDE_CACHE_URL=https://your-platform-api-id.execute-api.ap-southeast-2.amazonaws.com/dev/analysis-cache
+# Compatibility placeholder retained for config shape. Budget Tracker does not
+# use Stock Analyser-style analysis-cache/job-results polling.
+NEXT_PUBLIC_CLAUDE_CACHE_URL=https://your-budget-tracker-api-id.execute-api.ap-southeast-2.amazonaws.com/dev/analysis-cache
 
 # ── Cognito authentication ────────────────────────────────────────────────────
 
@@ -215,7 +211,7 @@ NEXT_PUBLIC_PLATFORM_WSS_URL=
 # SETTINGS_TABLE            — DynamoDB table name for budget settings
 # TRANSACTIONS_TABLE        — DynamoDB table name for transactions
 # RULES_TABLE               — DynamoDB table name for categorisation rules
-# CLAUDE_PROXY_FUNCTION_NAME — Lambda function name for direct Claude invocation
+# CLAUDE_PROXY_FUNCTION_NAME — app-owned AI proxy Lambda name for direct invocation
 # AI_JOBS_TABLE             — DynamoDB table for async AI review jobs
 # WS_CONNECTIONS_TABLE      — DynamoDB table for WebSocket connection state
 # WS_API_ID                 — WebSocket API Gateway ID (for management API endpoint)

--- a/apps/budget-tracker/AGENTS.md
+++ b/apps/budget-tracker/AGENTS.md
@@ -38,14 +38,14 @@ React + TypeScript + Tailwind CSS + shadcn/ui.
 | Stack | Contents |
 |---|---|
 | `Transformotion{Stage}-BudgetTrackerTables` | `budget-tracker.accounts`, `budget-tracker.transactions`, `budget-tracker.rules`, `budget-tracker.settings` |
-| `Transformotion{Stage}-BudgetTrackerApi` | All Budget Tracker Lambda functions, mounted on the shared platform API Gateway |
+| `Transformotion{Stage}-BudgetTrackerApi` | Budget Tracker-owned REST API Gateway, Lambda functions, and AI proxy runtime |
 | `Transformotion{Stage}-BudgetTrackerWs` | Budget Tracker WebSocket API, WS Lambdas, and `budget-tracker.ws-connections-{stage}` |
 
 Source: `apps/budget-tracker/infrastructure/`
 
 The WebSocket stack is Budget Tracker-owned: `Transformotion{Stage}-BudgetTrackerWs` in `apps/budget-tracker/infrastructure/bt-ws-stack.ts`. BT may still send `?app=budget-tracker` during transition, but the app-owned authoriser only permits Budget Tracker scope.
 
-> Current/transitional state: Budget Tracker shares the platform API Gateway (`transformotion-api-{stage}`). Routes are mounted under `/api/budget/v1` on the shared gateway's `/api` resource, using the same Cognito authoriser as all other platform routes. This is not the M9 target; M9 moves Budget Tracker REST runtime ownership to a Budget Tracker-owned API Gateway.
+> Current state after #367: Budget Tracker owns its REST API Gateway and AI runtime. Cognito remains platform-owned until the M9 auth ownership migration. The shared platform API Gateway and legacy platform Claude proxy remain deployed only for rollback/decommission.
 
 ## Lambda functions
 
@@ -54,7 +54,8 @@ The WebSocket stack is Budget Tracker-owned: `Transformotion{Stage}-BudgetTracke
 | `budget-transactions-handler-{stage}` | `GET/POST/PATCH/DELETE /api/budget/v1/transactions` |
 | `budget-rules-handler-{stage}` | `GET/POST/PATCH/DELETE /api/budget/v1/rules` |
 | `budget-settings-handler-{stage}` | `GET/PATCH /api/budget/v1/settings` |
-| `budget-ai-handler-{stage}` | `POST /api/budget/v1/ai/categorise`, `POST /api/budget/v1/ai/review`, `POST /api/budget/v1/ai/csv-analysis` |
+| `budget-ai-handler-{stage}` | `POST /api/budget/v1/ai/review`, `POST /api/budget/v1/ai/csv-analysis` |
+| `budget-tracker-ai-proxy-{stage}` | Invoked synchronously by `budget-ai-handler-{stage}` for Anthropic calls |
 | `budget-data-handler-{stage}` | `GET/PATCH /api/budget/v1/budget-data` |
 | `budget-export-handler-{stage}` | `GET /api/budget/v1/business-export` |
 
@@ -212,7 +213,7 @@ Environment: copy `apps/budget-tracker/.env.example` to `.env.local` and fill in
 | `NEXT_PUBLIC_COGNITO_USER_POOL_ID` | Shared Cognito user pool ID |
 | `NEXT_PUBLIC_COGNITO_DOMAIN` | Hosted UI domain |
 | `NEXT_PUBLIC_RUNTIME_PROFILE` | `mock` (default; local development) or `live` (deployed environments). Determines defaults for auth, data, AI, and future concerns. See root `AGENTS.md` for the design map. |
-| `NEXT_PUBLIC_API_BASE_URL` | Budget Tracker API base URL |
+| `NEXT_PUBLIC_API_URL` | Budget Tracker-owned API Gateway base URL; deploy workflow extracts it from `Transformotion{Stage}-BudgetTrackerApi` |
 | `NEXT_PUBLIC_BT_WSS_URL` | Budget Tracker-owned WebSocket URL for AI review streaming; deploy workflow extracts it from `Transformotion{Stage}-BudgetTrackerWs` |
 | `NEXT_PUBLIC_PLATFORM_WSS_URL` | Transitional rollback fallback only; do not use for new Budget Tracker deploys |
 

--- a/apps/budget-tracker/CLAUDE.md
+++ b/apps/budget-tracker/CLAUDE.md
@@ -38,14 +38,14 @@ React + TypeScript + Tailwind CSS + shadcn/ui.
 | Stack | Contents |
 |---|---|
 | `Transformotion{Stage}-BudgetTrackerTables` | `budget-tracker.accounts`, `budget-tracker.transactions`, `budget-tracker.rules`, `budget-tracker.settings` |
-| `Transformotion{Stage}-BudgetTrackerApi` | All Budget Tracker Lambda functions, mounted on the shared platform API Gateway |
+| `Transformotion{Stage}-BudgetTrackerApi` | Budget Tracker-owned REST API Gateway, Lambda functions, and AI proxy runtime |
 | `Transformotion{Stage}-BudgetTrackerWs` | Budget Tracker WebSocket API, WS Lambdas, and `budget-tracker.ws-connections-{stage}` |
 
 Source: `apps/budget-tracker/infrastructure/`
 
 The WebSocket stack is Budget Tracker-owned: `Transformotion{Stage}-BudgetTrackerWs` in `apps/budget-tracker/infrastructure/bt-ws-stack.ts`. BT may still send `?app=budget-tracker` during transition, but the app-owned authoriser only permits Budget Tracker scope.
 
-> Current/transitional state: Budget Tracker shares the platform API Gateway (`transformotion-api-{stage}`). Routes are mounted under `/api/budget/v1` on the shared gateway's `/api` resource, using the same Cognito authoriser as all other platform routes. This is not the M9 target; M9 moves Budget Tracker REST runtime ownership to a Budget Tracker-owned API Gateway.
+> Current state after #367: Budget Tracker owns its REST API Gateway and AI runtime. Cognito remains platform-owned until the M9 auth ownership migration. The shared platform API Gateway and legacy platform Claude proxy remain deployed only for rollback/decommission.
 
 ## Lambda functions
 
@@ -54,7 +54,8 @@ The WebSocket stack is Budget Tracker-owned: `Transformotion{Stage}-BudgetTracke
 | `budget-transactions-handler-{stage}` | `GET/POST/PATCH/DELETE /api/budget/v1/transactions` |
 | `budget-rules-handler-{stage}` | `GET/POST/PATCH/DELETE /api/budget/v1/rules` |
 | `budget-settings-handler-{stage}` | `GET/PATCH /api/budget/v1/settings` |
-| `budget-ai-handler-{stage}` | `POST /api/budget/v1/ai/categorise`, `POST /api/budget/v1/ai/review`, `POST /api/budget/v1/ai/csv-analysis` |
+| `budget-ai-handler-{stage}` | `POST /api/budget/v1/ai/review`, `POST /api/budget/v1/ai/csv-analysis` |
+| `budget-tracker-ai-proxy-{stage}` | Invoked synchronously by `budget-ai-handler-{stage}` for Anthropic calls |
 | `budget-data-handler-{stage}` | `GET/PATCH /api/budget/v1/budget-data` |
 | `budget-export-handler-{stage}` | `GET /api/budget/v1/business-export` |
 
@@ -212,7 +213,7 @@ Environment: copy `apps/budget-tracker/.env.example` to `.env.local` and fill in
 | `NEXT_PUBLIC_COGNITO_USER_POOL_ID` | Shared Cognito user pool ID |
 | `NEXT_PUBLIC_COGNITO_DOMAIN` | Hosted UI domain |
 | `NEXT_PUBLIC_RUNTIME_PROFILE` | `mock` (default; local development) or `live` (deployed environments). Determines defaults for auth, data, AI, and future concerns. See root `AGENTS.md` for the design map. |
-| `NEXT_PUBLIC_API_BASE_URL` | Budget Tracker API base URL |
+| `NEXT_PUBLIC_API_URL` | Budget Tracker-owned API Gateway base URL; deploy workflow extracts it from `Transformotion{Stage}-BudgetTrackerApi` |
 | `NEXT_PUBLIC_BT_WSS_URL` | Budget Tracker-owned WebSocket URL for AI review streaming; deploy workflow extracts it from `Transformotion{Stage}-BudgetTrackerWs` |
 | `NEXT_PUBLIC_PLATFORM_WSS_URL` | Transitional rollback fallback only; do not use for new Budget Tracker deploys |
 

--- a/apps/budget-tracker/functions/ai-proxy/package.json
+++ b/apps/budget-tracker/functions/ai-proxy/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@transformotion/fn-budget-tracker-ai-proxy",
+  "version": "0.0.0",
+  "private": true,
+  "main": "./src/index.ts",
+  "scripts": {
+    "build": "tsc --noEmit",
+    "typecheck": "tsc --noEmit",
+    "lint": "echo \"lint: budget-tracker-ai-proxy\""
+  },
+  "dependencies": {
+    "@transformotion/fn-claude-proxy-core": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/aws-lambda": "^8",
+    "@types/node": "^22",
+    "typescript": "*"
+  }
+}

--- a/apps/budget-tracker/functions/ai-proxy/src/index.ts
+++ b/apps/budget-tracker/functions/ai-proxy/src/index.ts
@@ -1,0 +1,6 @@
+import { createClaudeProxyHandler } from '@transformotion/fn-claude-proxy-core';
+
+export const handler = createClaudeProxyHandler({
+  anthropicSecretName: process.env.ANTHROPIC_SECRET_NAME!,
+  permittedApps: ['budget-tracker'],
+});

--- a/apps/budget-tracker/functions/ai-proxy/tsconfig.json
+++ b/apps/budget-tracker/functions/ai-proxy/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "types": ["node", "aws-lambda"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/apps/budget-tracker/infrastructure/budget-tracker-api-stack.ts
+++ b/apps/budget-tracker/infrastructure/budget-tracker-api-stack.ts
@@ -1,14 +1,17 @@
 import * as path from 'path';
 import * as cdk from 'aws-cdk-lib';
 import * as apigateway from 'aws-cdk-lib/aws-apigateway';
+import * as cognito from 'aws-cdk-lib/aws-cognito';
 import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
 import * as iam from 'aws-cdk-lib/aws-iam';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as lambdaNodejs from 'aws-cdk-lib/aws-lambda-nodejs';
+import * as secretsmanager from 'aws-cdk-lib/aws-secretsmanager';
 import { Construct } from 'constructs';
 
 export interface BudgetTrackerApiStackProps extends cdk.StackProps {
   stage: 'dev' | 'prod';
+  userPoolId: string;
   /** budget-data table name — passed in to avoid cross-stack dependency issues. */
   budgetDataTableName: string;
   /** AI jobs table name from BudgetTrackerTablesStack. */
@@ -20,13 +23,13 @@ export interface BudgetTrackerApiStackProps extends cdk.StackProps {
 }
 
 /**
- * BudgetTrackerApiStack — Lambda functions and API routes for the Budget Tracker.
+ * BudgetTrackerApiStack — Budget Tracker-owned REST API routes and Lambdas.
  *
- * Imports the shared platform API Gateway and JWT authoriser from CloudFormation
- * exports produced by PlatformApiStack. This allows bin/budget-tracker.ts to
- * synthesise only BT stacks without instantiating platform stacks.
+ * After #367 this stack owns the Budget Tracker API Gateway and AI proxy
+ * runtime. Platform REST/Claude runtime remains deployed only for rollback and
+ * later #372 decommissioning.
  *
- * Routes (owned by this stack's CF template) under /api/budget/v1/:
+ * Routes under /api/budget/v1/:
  *   GET    /transactions
  *   POST   /transactions/bulk
  *   PATCH  /transactions/:id
@@ -37,36 +40,37 @@ export interface BudgetTrackerApiStackProps extends cdk.StackProps {
  *   DELETE /rules/:id
  *   GET    /settings
  *   PATCH  /settings
- *   POST   /ai/categorise
  *   POST   /ai/review
  *   POST   /ai/csv-analysis
  *   GET    /business-export
  */
 export class BudgetTrackerApiStack extends cdk.Stack {
+  public readonly api: apigateway.RestApi;
+
   constructor(scope: Construct, id: string, props: BudgetTrackerApiStackProps) {
     super(scope, id, props);
 
-    const { stage, budgetDataTableName, aiJobsTableName, wsConnectionsTableName, wsApiId } = props;
+    const { stage, userPoolId, budgetDataTableName, aiJobsTableName, wsConnectionsTableName, wsApiId } = props;
 
-    // Import shared platform API Gateway, /api resource, and JWT authoriser from CF exports.
-    const api = apigateway.RestApi.fromRestApiAttributes(this, 'PlatformApi', {
-      restApiId:      cdk.Fn.importValue(`Transformotion-${stage}-RestApiId`),
-      rootResourceId: cdk.Fn.importValue(`Transformotion-${stage}-RestApiRootResourceId`),
+    const userPool = cognito.UserPool.fromUserPoolId(this, 'UserPool', userPoolId);
+
+    this.api = new apigateway.RestApi(this, 'BudgetTrackerApi', {
+      restApiName: `budget-tracker-api-${stage}`,
+      description: `Budget Tracker ${stage} API`,
+      deployOptions: { stageName: stage },
+      defaultCorsPreflightOptions: corsPreflightOptions,
     });
 
-    const platformApiResource = apigateway.Resource.fromResourceAttributes(this, 'PlatformApiResource', {
-      restApi:    api,
-      resourceId: cdk.Fn.importValue(`Transformotion-${stage}-ApiResourceId`),
-      path:       '/api',
+    const authoriser = new apigateway.CognitoUserPoolsAuthorizer(this, 'JwtAuthoriser', {
+      cognitoUserPools: [userPool],
+      authorizerName: `budget-tracker-jwt-${stage}`,
+      resultsCacheTtl: cdk.Duration.minutes(5),
     });
+    const auth = authMethodOptions(authoriser);
 
-    const auth = authMethodOptions({
-      authorizerId:      cdk.Fn.importValue(`Transformotion-${stage}-AuthorizerId`),
-      authorizationType: apigateway.AuthorizationType.COGNITO,
-    });
-
-    // /api/budget/v1 — mounted on the shared platform gateway's /api resource
-    const apiResource = platformApiResource
+    // /api/budget/v1 — mounted on the Budget Tracker-owned API Gateway.
+    const apiResource = this.api.root
+      .addResource('api')
       .addResource('budget')
       .addResource('v1');
 
@@ -82,8 +86,6 @@ export class BudgetTrackerApiStack extends cdk.Stack {
     const aiJobsTable       = dynamodb.Table.fromTableName(this, 'AiJobsTable',       aiJobsTableName);
     const wsConnectionsTable = dynamodb.Table.fromTableName(this, 'WsConnectionsTable', wsConnectionsTableName);
 
-    const claudeProxyFnName = `transformotion-claude-proxy-${stage}`;
-
     const bundling: lambdaNodejs.BundlingOptions = {
       externalModules: ['@aws-sdk/*'],
       minify: true,
@@ -92,6 +94,25 @@ export class BudgetTrackerApiStack extends cdk.Stack {
     };
 
     const fnDir = path.join(__dirname, '../functions');
+
+    const anthropicSecret = secretsmanager.Secret.fromSecretNameV2(
+      this, 'AnthropicApiKey', `${stage}/anthropic/api-key`,
+    );
+
+    const aiProxyFnName = `budget-tracker-ai-proxy-${stage}`;
+    const aiProxyFn = new lambdaNodejs.NodejsFunction(this, 'AiProxyFn', {
+      functionName: aiProxyFnName,
+      entry:        path.join(fnDir, 'ai-proxy/src/index.ts'),
+      handler:      'handler',
+      runtime:      lambda.Runtime.NODEJS_20_X,
+      timeout:      cdk.Duration.seconds(600),
+      memorySize:   512,
+      environment:  {
+        ANTHROPIC_SECRET_NAME: anthropicSecret.secretName,
+      },
+      bundling,
+    });
+    anthropicSecret.grantRead(aiProxyFn);
 
     // ── budget-transactions-handler ──────────────────────────────────────────
     const txFn = new lambdaNodejs.NodejsFunction(this, 'TransactionsFn', {
@@ -132,7 +153,7 @@ export class BudgetTrackerApiStack extends cdk.Stack {
     });
     settingsTable.grantReadWriteData(settingsFn);
 
-    // ── budget-ai-handler (categorise + review-start + review-worker + csv-analysis) ──
+    // ── budget-ai-handler (review-start + review-worker + csv-analysis) ───────────────
     const aiFnName = `budget-ai-handler-${stage}`;
     const aiFn = new lambdaNodejs.NodejsFunction(this, 'AiFn', {
       functionName: aiFnName,
@@ -142,7 +163,7 @@ export class BudgetTrackerApiStack extends cdk.Stack {
       timeout:      cdk.Duration.seconds(300),
       memorySize:   512,
       environment:  {
-        CLAUDE_PROXY_FUNCTION_NAME: claudeProxyFnName,
+        CLAUDE_PROXY_FUNCTION_NAME: aiProxyFnName,
         AI_JOBS_TABLE:              aiJobsTableName,
         WS_CONNECTIONS_TABLE:       wsConnectionsTableName,
         WS_API_ID:                  wsApiId,
@@ -154,7 +175,7 @@ export class BudgetTrackerApiStack extends cdk.Stack {
     aiFn.addToRolePolicy(new iam.PolicyStatement({
       actions:   ['lambda:InvokeFunction'],
       resources: [
-        `arn:aws:lambda:${this.region}:${this.account}:function:${claudeProxyFnName}`,
+        `arn:aws:lambda:${this.region}:${this.account}:function:${aiProxyFnName}`,
         `arn:aws:lambda:${this.region}:${this.account}:function:${aiFnName}`,
       ],
     }));
@@ -227,7 +248,6 @@ export class BudgetTrackerApiStack extends cdk.Stack {
     // /ai
     const aiRes = apiResource.addResource('ai');
     const aiInt = new apigateway.LambdaIntegration(aiFn, { proxy: true });
-    aiRes.addResource('categorise').addMethod('POST',    aiInt, auth);
     aiRes.addResource('review').addMethod('POST',        aiInt, auth);
     aiRes.addResource('csv-analysis').addMethod('POST',  aiInt, auth);
 
@@ -241,8 +261,21 @@ export class BudgetTrackerApiStack extends cdk.Stack {
     apiResource.addResource('business-export').addMethod(
       'GET', new apigateway.LambdaIntegration(exportFn, { proxy: true }), auth
     );
+
+    new cdk.CfnOutput(this, 'ApiUrl', {
+      value: this.api.url,
+      description: 'Budget Tracker REST API URL',
+      exportName: `BudgetTrackerApi-${stage}-Url`,
+    });
   }
 }
+
+const corsPreflightOptions: apigateway.CorsOptions = {
+  allowOrigins: apigateway.Cors.ALL_ORIGINS,
+  allowMethods: apigateway.Cors.ALL_METHODS,
+  allowHeaders: ['Content-Type', 'Authorization', 'X-Account-Id'],
+  maxAge: cdk.Duration.hours(1),
+};
 
 function authMethodOptions(authoriser: apigateway.IAuthorizer): apigateway.MethodOptions {
   return {

--- a/docs/architecture/cdk.md
+++ b/docs/architecture/cdk.md
@@ -64,7 +64,7 @@ Deployed by `deploy-budget-tracker.yml`. Source in `apps/budget-tracker/infrastr
 | Stack name | Class | Contents |
 |---|---|---|
 | `Transformotion{Stage}-BudgetTrackerTables` | `BudgetTrackerTablesStack` | `budget-tracker.accounts`, `budget-tracker.transactions`, `budget-tracker.rules`, `budget-tracker.settings` |
-| `Transformotion{Stage}-BudgetTrackerApi` | `BudgetTrackerApiStack` | Budget Tracker Lambda functions + routes on the shared platform API Gateway |
+| `Transformotion{Stage}-BudgetTrackerApi` | `BudgetTrackerApiStack` | Budget Tracker-owned REST API Gateway, Lambda functions, and AI proxy runtime |
 | `Transformotion{Stage}-BudgetTrackerWs` | `BudgetTrackerWsStack` | Budget Tracker-owned WebSocket API, WS Lambdas, and `budget-tracker.ws-connections-{stage}` |
 
 ---
@@ -111,11 +111,12 @@ Deployed by `deploy-budget-tracker.yml`. Source in `apps/budget-tracker/infrastr
 | `budget-transactions-handler-{stage}` | Budget Tracker transactions Lambda | `GET/POST/PATCH/DELETE /api/budget/v1/transactions` |
 | `budget-rules-handler-{stage}` | Budget Tracker rules Lambda | `GET/POST/PATCH/DELETE /api/budget/v1/rules` |
 | `budget-settings-handler-{stage}` | Budget Tracker settings Lambda | `GET/PATCH /api/budget/v1/settings` |
-| `budget-ai-handler-{stage}` | Budget Tracker unified AI Lambda | `POST /api/budget/v1/ai/categorise`, `POST /api/budget/v1/ai/review`, `POST /api/budget/v1/ai/csv-analysis` |
+| `budget-ai-handler-{stage}` | Budget Tracker unified AI Lambda | `POST /api/budget/v1/ai/review`, `POST /api/budget/v1/ai/csv-analysis` |
+| `budget-tracker-ai-proxy-{stage}` | `apps/budget-tracker/functions/ai-proxy` | Invoked synchronously by `budget-ai-handler-{stage}` |
 | `budget-data-handler-{stage}` | Budget Tracker budget data Lambda | `GET/PATCH /api/budget/v1/budget-data` |
 | `budget-export-handler-{stage}` | Budget Tracker export Lambda | `GET /api/budget/v1/business-export` |
 
-> **Current/transitional state:** Budget Tracker's unified `budget-ai-handler-{stage}` consumes the shared platform `claude-proxy` Lambda through `CLAUDE_PROXY_FUNCTION_NAME` and an invoke permission. This is transitional runtime coupling. M9 removes it by moving Budget Tracker Claude proxy/runtime ownership into the Budget Tracker app boundary.
+> **Current state after #367:** Budget Tracker owns its REST API Gateway and AI runtime. `budget-ai-handler-{stage}` invokes `budget-tracker-ai-proxy-{stage}` synchronously for Anthropic calls and continues to own review orchestration, `budget-tracker.ai-jobs-{stage}`, and BT WSS streaming. The legacy platform `claude-proxy` remains deployed only for rollback/decommission.
 
 ### Migration Utilities Lambda functions (`MigrationsApi`)
 
@@ -150,21 +151,23 @@ Stacks in the same entrypoint share constructs via props as usual. CDK resolves 
 | `PlatformApiStack` | `PlatformWsStack` | `wsApiEndpoint`, `wsApiId` (strings — for claude-proxy WSS push permission) |
 | `PlatformWsStack` | `AuthStack` | `userPool` (construct — for custom authoriser JWKS validation) |
 
-### CF export pattern — app stacks to platform stacks (cross-entrypoint)
+### CF export pattern — cross-entrypoint platform substrate
 
-App stacks (`StockAnalyserApiStack`, `BudgetTrackerApiStack`, `MigrationsApiStack`) resolve shared platform resources via CloudFormation exports at deploy time. No construct references cross entrypoint boundaries.
+App stacks may resolve shared platform substrate via CloudFormation exports at deploy time. After #366 and #367, `StockAnalyserApiStack` and `BudgetTrackerApiStack` no longer import `PlatformApiStack` REST resources; they import Cognito user pool identity from `AuthStack` until #363 moves Cognito app-client ownership. `MigrationsApiStack` still imports shared Platform API REST resources for migration utility routes. No construct references cross entrypoint boundaries.
 
-`PlatformApiStack` and `PlatformWsStack` emit these exports:
+`AuthStack`, `PlatformApiStack`, `PlatformWsStack`, and app stacks emit these exports:
 
 | Export name | Produced by | Consumed by |
 |---|---|---|
-| `Transformotion-{stage}-RestApiId` | `PlatformApiStack` | BT, MU — `RestApi.fromRestApiAttributes`; SA no longer imports after #366 |
-| `Transformotion-{stage}-RestApiRootResourceId` | `PlatformApiStack` | BT, MU — `RestApi.fromRestApiAttributes`; SA no longer imports after #366 |
-| `Transformotion-{stage}-AuthorizerId` | `PlatformApiStack` | BT, MU — JWT authoriser on each route; SA owns its API authoriser after #366 |
-| `Transformotion-{stage}-ApiResourceId` | `PlatformApiStack` | BT, MU — `Resource.fromResourceAttributes` to mount under `/api/` |
+| `Transformotion-{stage}-UserPoolId` | `AuthStack` | SA and BT app API/WSS stacks until #363; migration utilities where Cognito auth is required |
+| `Transformotion-{stage}-RestApiId` | `PlatformApiStack` | MU only — `RestApi.fromRestApiAttributes`; SA/BT no longer import after #366/#367 |
+| `Transformotion-{stage}-RestApiRootResourceId` | `PlatformApiStack` | MU only — `RestApi.fromRestApiAttributes`; SA/BT no longer import after #366/#367 |
+| `Transformotion-{stage}-AuthorizerId` | `PlatformApiStack` | MU only — JWT authoriser on migration utility routes; SA/BT own API authorisers after #366/#367 |
+| `Transformotion-{stage}-ApiResourceId` | `PlatformApiStack` | MU only — `Resource.fromResourceAttributes` to mount under `/api/` |
 | `PlatformWs-{stage}-WsApiId` | `PlatformWsStack` | Transitional platform WSS consumers; SA and BT no longer consume after #366/#365 |
 | `StockAnalyserWs-{stage}-Url` | `StockAnalyserWsStack` | Deploy workflow injects `NEXT_PUBLIC_SA_WSS_URL` |
 | `StockAnalyserApi-{stage}-Url` | `StockAnalyserApiStack` | Deploy workflow injects `NEXT_PUBLIC_API_URL` |
+| `BudgetTrackerApi-{stage}-Url` | `BudgetTrackerApiStack` | Deploy workflow injects `NEXT_PUBLIC_API_URL` |
 
 The rule: cross-entrypoint references always go through CF exports (`Fn.importValue`), never through L2 construct passing. This allows each entrypoint to synthesise independently — no platform stacks are instantiated in app entrypoints.
 
@@ -176,10 +179,10 @@ The rule: cross-entrypoint references always go through CF exports (`Fn.importVa
 
 1. **Step 1 — GithubActionsRole** — account-level stack; deployed first as a one-off.
 2. **Step 2 — PlatformTables** — deployed in isolation before Auth, to release any stale export dependencies.
-3. **Step 3 — Main platform stacks** — deploys `Storage`, `Network`, `Auth`, `AuthApi`, `Api` together. CDK runs independent stacks in parallel within this step. `PlatformApiStack` emits the CF exports that SA/BT/MU consume.
+3. **Step 3 — Main platform stacks** — deploys `Storage`, `Network`, `Auth`, `AuthApi`, `Api` together. CDK runs independent stacks in parallel within this step. `AuthStack` emits the Cognito user pool export that app stacks consume until #363, and `PlatformApiStack` emits legacy/shared REST exports still used by migration utilities and rollback/decommission paths.
 4. **Step 4 — PlatformWs** — deployed after `Api`; retained during M9 dual-run until app-owned WSS cutovers and decommissioning.
 
-App stacks (`deploy-stock-analyser.yml`, `deploy-budget-tracker.yml`, `deploy-migration-utilities.yml`) consume the CF exports produced in Step 3/4 above where they still have transitional dependencies. Budget Tracker owns `Transformotion{Stage}-BudgetTrackerWs` after #365 and no longer consumes `PlatformWs-{stage}-WsApiId` for AI review streaming. Stock Analyser owns `Transformotion{Stage}-StockAnalyserWs`, `Transformotion{Stage}-StockAnalyserApi`, and `stock-analyser-ai-proxy-{stage}` after #366, and no longer uses platform REST/WSS/Claude runtime for live AI flow. On first-ever deploy, the platform auth stack must exist before app stacks because Cognito remains platform-owned until #363. On subsequent deploys, each workflow is independently triggered and independently deploys only its own stacks.
+App stacks (`deploy-stock-analyser.yml`, `deploy-budget-tracker.yml`, `deploy-migration-utilities.yml`) consume the CF exports produced in Step 3/4 above where they still have transitional dependencies. Budget Tracker owns `Transformotion{Stage}-BudgetTrackerWs`, `Transformotion{Stage}-BudgetTrackerApi`, and `budget-tracker-ai-proxy-{stage}` after #367 and no longer uses platform REST/WSS/Claude runtime for live Budget Tracker flow. Stock Analyser owns `Transformotion{Stage}-StockAnalyserWs`, `Transformotion{Stage}-StockAnalyserApi`, and `stock-analyser-ai-proxy-{stage}` after #366, and no longer uses platform REST/WSS/Claude runtime for live AI flow. On first-ever deploy, the platform auth stack must exist before app stacks because Cognito remains platform-owned until #363. On subsequent deploys, each workflow is independently triggered and independently deploys only its own stacks.
 
 ---
 
@@ -254,6 +257,13 @@ Budget Tracker API Lambda WSS environment variables:
 | `WS_CONNECTIONS_TABLE` | `budget-ai-handler-{stage}` | `budget-tracker.ws-connections-{stage}` |
 | `WS_API_ID` | `budget-ai-handler-{stage}` | Budget Tracker-owned WebSocket API ID from `BudgetTrackerWsStack` |
 | `WS_STAGE` | `budget-ai-handler-{stage}` | `dev` or `prod` |
+
+Budget Tracker AI proxy environment variables:
+
+| Variable | Lambda | Value |
+|---|---|---|
+| `ANTHROPIC_SECRET_NAME` | `budget-tracker-ai-proxy-{stage}` | `{stage}/anthropic/api-key` |
+| `CLAUDE_PROXY_FUNCTION_NAME` | `budget-ai-handler-{stage}` | `budget-tracker-ai-proxy-{stage}` compatibility env name; points at the app-owned AI proxy after #367 |
 
 ---
 

--- a/docs/architecture/inventory.md
+++ b/docs/architecture/inventory.md
@@ -513,25 +513,24 @@ is backfilled via the renamed endpoint.
 
 ### 2.9 Shared platform API Gateway runtime coupling
 
-**Status: Confirmed (current/transitional state; M9 targets removal)**
+**Status: Confirmed (current state after #367; legacy platform gateway retained for rollback/decommission)**
 
-The platform currently uses the shared platform REST API Gateway for
-remaining transitional app runtime routes:
+The platform previously used the shared platform REST API Gateway for
+app runtime routes. After #366/#367, Stock Analyser and Budget Tracker
+own their app runtime REST APIs:
 
 - **Platform gateway** — defined in `platform/infrastructure/platform-api-stack.ts`,
-  still serves platform routes and Budget Tracker routes.
+  still serves platform routes and remains deployed for rollback and later
+  #372 decommissioning of legacy app runtime paths.
 - **BudgetTrackerApiStack** — defined in
   `apps/budget-tracker/infrastructure/budget-tracker-api-stack.ts`,
-  imports the shared platform `RestApi` and mounts Budget Tracker routes
-  under `/api/budget/v1`.
+  owns the Budget Tracker REST API Gateway after #367.
 - **StockAnalyserApiStack** — defined in
   `apps/stock-analyser/infrastructure/stock-analyser-api-stack.ts`,
   owns the Stock Analyser REST API Gateway after #366.
 
-This shared gateway app-runtime ownership is transitional debt. Stock Analyser
-no longer uses it after #366. M9 moves Budget Tracker to app-owned API Gateway
-ownership as well; the shared platform gateway must not be treated as the
-target pattern for new app runtime routes.
+Shared platform gateway app-runtime ownership is legacy transitional debt.
+It must not be treated as the target pattern for new app runtime routes.
 
 ### 2.10 DynamoDB schema
 
@@ -1127,18 +1126,21 @@ CDK stacks — M7 #250 infrastructure split complete:
   disconnect Lambdas, and `stock-analyser.ws-connections-{stage}`
 
 **Budget-tracker stacks** (`apps/budget-tracker/infrastructure/`):
-- `budget-tracker-api-stack.ts` — mounts BT Lambdas on the shared
-  platform API Gateway; receives Budget Tracker-owned `wsConnectionsTableName`
-  + `wsApiId` from `BudgetTrackerWsStack`
+- `budget-tracker-api-stack.ts` — Budget Tracker-owned REST API Gateway,
+  app Lambdas, and `budget-tracker-ai-proxy-{stage}` after #367; receives
+  Budget Tracker-owned `wsConnectionsTableName` + `wsApiId` from
+  `BudgetTrackerWsStack`
 - `budget-tracker-tables-stack.ts`
 - `bt-ws-stack.ts` — Budget Tracker-owned WebSocket API
   (`budget-tracker-ws-{stage}`), custom Lambda authorizer, connect/default/
   disconnect Lambdas, and `budget-tracker.ws-connections-{stage}`
 
 Budget Tracker no longer uses `PlatformWsStack` for AI review streaming after
-#365. Stock Analyser no longer uses `PlatformWsStack` for live AI completion
-notifications after #366. Platform WSS remains deployed for rollback, any
-remaining transitional consumers, and later decommissioning.
+#365 and no longer uses the platform REST API Gateway or platform Claude proxy
+for live Budget Tracker runtime after #367. Stock Analyser no longer uses
+`PlatformWsStack` for live AI completion notifications after #366. Platform WSS
+and platform REST/Claude runtime remain deployed for rollback, any remaining
+transitional consumers, and later decommissioning.
 
 There is no `MonitoringStack`. M13 creates it.
 

--- a/infrastructure/bin/budget-tracker.ts
+++ b/infrastructure/bin/budget-tracker.ts
@@ -14,8 +14,8 @@ const env = {
 };
 
 // ── Dev stacks ─────────────────────────────────────────────────────────────────
-// Platform REST resources (RestApi, Authoriser, /api resource) are imported via
-// CloudFormation exports from TransformotionDev-Api. Budget Tracker owns WSS.
+// Budget Tracker owns its REST API and WSS runtime. Cognito remains platform-owned
+// until the M9 auth ownership migration completes.
 //
 // Deploy commands:
 //   cdk deploy --app bin/budget-tracker.ts TransformotionDev-BudgetTrackerTables TransformotionDev-BudgetTrackerWs TransformotionDev-BudgetTrackerApi
@@ -36,6 +36,7 @@ const devBudgetTrackerWs = new BudgetTrackerWsStack(app, 'TransformotionDev-Budg
 new BudgetTrackerApiStack(app, 'TransformotionDev-BudgetTrackerApi', {
   env,
   stage:                  'dev',
+  userPoolId:             cdk.Fn.importValue('Transformotion-dev-UserPoolId'),
   description:            'Transformotion Apps — Dev Budget Tracker API routes',
   budgetDataTableName:    devBudgetTrackerTables.budgetDataTable.tableName,
   aiJobsTableName:        devBudgetTrackerTables.aiJobsTable.tableName,
@@ -61,6 +62,7 @@ const prodBudgetTrackerWs = new BudgetTrackerWsStack(app, 'TransformotionProd-Bu
 new BudgetTrackerApiStack(app, 'TransformotionProd-BudgetTrackerApi', {
   env,
   stage:                  'prod',
+  userPoolId:             cdk.Fn.importValue('Transformotion-prod-UserPoolId'),
   description:            'Transformotion Apps — Prod Budget Tracker API routes',
   budgetDataTableName:    prodBudgetTrackerTables.budgetDataTable.tableName,
   aiJobsTableName:        prodBudgetTrackerTables.aiJobsTable.tableName,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -262,6 +262,22 @@ importers:
         specifier: 5.7.3
         version: 5.7.3
 
+  apps/budget-tracker/functions/ai-proxy:
+    dependencies:
+      '@transformotion/fn-claude-proxy-core':
+        specifier: workspace:*
+        version: link:../../../../packages/fn-claude-proxy-core
+    devDependencies:
+      '@types/aws-lambda':
+        specifier: ^8
+        version: 8.10.161
+      '@types/node':
+        specifier: ^22
+        version: 22.19.17
+      typescript:
+        specifier: '*'
+        version: 5.7.3
+
   apps/budget-tracker/functions/budget-ai:
     dependencies:
       '@transformotion/budget-domain':
@@ -791,6 +807,22 @@ importers:
         specifier: '*'
         version: 5.7.3
 
+  apps/stock-analyser/functions/ai-proxy:
+    dependencies:
+      '@transformotion/fn-claude-proxy-core':
+        specifier: workspace:*
+        version: link:../../../../packages/fn-claude-proxy-core
+    devDependencies:
+      '@types/aws-lambda':
+        specifier: ^8
+        version: 8.10.161
+      '@types/node':
+        specifier: ^22
+        version: 22.19.17
+      typescript:
+        specifier: '*'
+        version: 5.7.3
+
   apps/stock-analyser/functions/analysis-cache:
     dependencies:
       '@transformotion/lambda-middleware':
@@ -806,22 +838,6 @@ importers:
       '@types/aws-lambda':
         specifier: ^8
         version: 8.10.161
-      typescript:
-        specifier: '*'
-        version: 5.7.3
-
-  apps/stock-analyser/functions/ai-proxy:
-    dependencies:
-      '@transformotion/fn-claude-proxy-core':
-        specifier: workspace:*
-        version: link:../../../../packages/fn-claude-proxy-core
-    devDependencies:
-      '@types/aws-lambda':
-        specifier: ^8
-        version: 8.10.161
-      '@types/node':
-        specifier: ^22
-        version: 22.19.17
       typescript:
         specifier: '*'
         version: 5.7.3


### PR DESCRIPTION
## Summary

Implements M9 issue #367 for Budget Tracker runtime ownership.

- Adds a Budget Tracker-owned REST API Gateway in `BudgetTrackerApiStack`
- Adds `budget-tracker-ai-proxy-{stage}` as the app-owned AI proxy runtime
- Switches `budget-ai-handler` from `transformotion-claude-proxy-{stage}` to `budget-tracker-ai-proxy-{stage}`
- Keeps the existing Budget Tracker WSS runtime from #365
- Updates the Budget Tracker deploy workflow to extract and inject the BT-owned API URL
- Removes the dead `/api/budget/v1/ai/categorise` route registration
- Updates architecture and app docs to reflect post-#367 ownership

## Runtime Flow

Before:

`Browser -> Platform API Gateway -> budget-ai-handler -> transformotion-claude-proxy -> BT WSS`

After:

`Browser -> BT API Gateway -> budget-ai-handler -> budget-tracker-ai-proxy -> BT WSS`

## Validation

- `pnpm --filter @transformotion/fn-budget-tracker-ai-proxy typecheck`
- `pnpm --filter @transformotion/fn-budget-ai typecheck`
- `pnpm --filter @transformotion/infra typecheck`
- `pnpm --filter @transformotion/budget typecheck`
- `pnpm --dir infrastructure exec cdk synth --app 'npx ts-node --prefer-ts-exts bin/budget-tracker.ts' TransformotionDev-BudgetTrackerTables TransformotionDev-BudgetTrackerWs TransformotionDev-BudgetTrackerApi`
- `pnpm --dir infrastructure exec cdk diff --app 'npx ts-node --prefer-ts-exts bin/budget-tracker.ts' TransformotionDev-BudgetTrackerTables TransformotionDev-BudgetTrackerWs TransformotionDev-BudgetTrackerApi --no-color`
- `git diff --check`

## Rollback

Revert this PR and redeploy Budget Tracker. That restores the old shared Platform API route ownership and points `budget-ai-handler` back to `transformotion-claude-proxy-{stage}`. Platform API, platform WSS, platform proxy, Cognito, and BT WSS are not deleted by this change.

Closes #367.