### PR TITLE
feat: add v0 contracts sync verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,37 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  v0-contracts-sync:
+    name: v0 Contracts Sync
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout runtime repo
+        uses: actions/checkout@v4
+        with:
+          path: transformotion-apps
+
+      - name: Require v0 repo read token
+        env:
+          V0_REPO_READ_TOKEN: ${{ secrets.V0_REPO_READ_TOKEN }}
+        run: |
+          if [ -z "$V0_REPO_READ_TOKEN" ]; then
+            echo "::error::Missing V0_REPO_READ_TOKEN secret. Configure a read-only PAT or GitHub App token with access to transformotion/transformotion-apps-b8."
+            exit 1
+          fi
+
+      - name: Checkout v0 repo
+        uses: actions/checkout@v4
+        with:
+          repository: transformotion/transformotion-apps-b8
+          token: ${{ secrets.V0_REPO_READ_TOKEN }}
+          path: transformotion-apps-b8
+
+      - name: Verify v0 contracts byte identity
+        working-directory: transformotion-apps
+        env:
+          V0_REPO_PATH: ${{ github.workspace }}/transformotion-apps-b8
+        run: bash scripts/ci/check-v0-contracts-synced.sh
+
   typecheck-and-lint:
     name: Typecheck & Lint
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "lint": "turbo lint",
     "typecheck": "turbo typecheck",
     "test": "turbo test",
+    "sync:v0": "bash scripts/sync-v0.sh",
+    "check:v0-contracts": "bash scripts/ci/check-v0-contracts-synced.sh",
     "clean": "turbo clean && rm -rf node_modules",
     "prepare": "husky"
   },

--- a/scripts/ci/check-v0-contracts-synced.sh
+++ b/scripts/ci/check-v0-contracts-synced.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Verifies the runtime repo's generated v0 contract sync target mirrors the
+# canonical v0 repo contracts directory exactly.
+#
+# Usage:
+#   V0_REPO_PATH=/path/to/transformotion-apps-b8 bash scripts/ci/check-v0-contracts-synced.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+TARGET="$REPO_ROOT/v0-reference/contracts"
+
+fail_if_generated_files_are_tracked() {
+  local tracked
+  tracked="$(git -C "$REPO_ROOT" ls-files 'v0-reference/**')"
+  if [[ -n "$tracked" ]]; then
+    cat >&2 <<EOF
+ERROR: generated v0-reference files are tracked by git.
+
+The v0 sync target must remain gitignored. Remove these files from git:
+
+$tracked
+EOF
+    exit 1
+  fi
+}
+
+resolve_v0_contracts() {
+  local v0_repo="${V0_REPO_PATH:-$REPO_ROOT/../transformotion-apps-b8}"
+  if [[ ! -d "$v0_repo/contracts" ]]; then
+    cat >&2 <<EOF
+ERROR: v0 contracts directory not found.
+
+Set V0_REPO_PATH to a checkout of transformotion-apps-b8.
+Expected contracts at:
+  $v0_repo/contracts
+EOF
+    exit 1
+  fi
+
+  (cd "$v0_repo/contracts" && pwd)
+}
+
+fail_if_generated_files_are_tracked
+
+V0_CONTRACTS="$(resolve_v0_contracts)"
+
+V0_SYNC_FORCE=1 bash "$REPO_ROOT/scripts/sync-v0.sh"
+
+fail_if_generated_files_are_tracked
+
+if ! diff -qr "$V0_CONTRACTS" "$TARGET"; then
+  cat >&2 <<EOF
+ERROR: synced v0 contracts differ from canonical v0 repo contracts.
+
+Canonical:
+  $V0_CONTRACTS
+
+Synced:
+  $TARGET
+EOF
+  exit 1
+fi
+
+echo "OK: v0-reference/contracts is byte-identical to $V0_CONTRACTS"

--- a/scripts/sync-v0.sh
+++ b/scripts/sync-v0.sh
@@ -1,41 +1,172 @@
 #!/usr/bin/env bash
 # Sync canonical contracts from the v0 repo into v0-reference/contracts/.
-# Run from the repo root: ./scripts/sync-v0.sh
-# The v0 repo is expected at ../transformotion-apps-b8 relative to this repo.
-# Override the location: V0_REPO_PATH=/path/to/v0-repo ./scripts/sync-v0.sh
+#
+# Usage:
+#   bash scripts/sync-v0.sh
+#   V0_REPO_PATH=/path/to/transformotion-apps-b8 bash scripts/sync-v0.sh
+#   V0_SYNC_FORCE=1 bash scripts/sync-v0.sh
+#
+# The script mirrors only transformotion-apps-b8/contracts/. It does not know
+# or enforce the final M15 contract structure.
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+TARGET_ROOT="$REPO_ROOT/v0-reference"
+TARGET="$TARGET_ROOT/contracts"
+MANIFEST="$TARGET_ROOT/.contracts-manifest.sha256"
+README="$TARGET_ROOT/README.md"
 
-# Resolve v0 repo path
-if [[ -n "${V0_REPO_PATH:-}" ]]; then
-  V0_REPO="$V0_REPO_PATH"
-else
-  V0_REPO="$(cd "$REPO_ROOT/../transformotion-apps-b8" 2>/dev/null && pwd || echo "")"
+FORCE="${V0_SYNC_FORCE:-${FORCE:-}}"
+if [[ "${1:-}" == "--force" ]]; then
+  FORCE=1
 fi
 
+resolve_v0_repo() {
+  if [[ -n "${V0_REPO_PATH:-}" ]]; then
+    cd "$V0_REPO_PATH" 2>/dev/null && pwd
+    return
+  fi
+
+  cd "$REPO_ROOT/../transformotion-apps-b8" 2>/dev/null && pwd
+}
+
+V0_REPO="$(resolve_v0_repo || true)"
 if [[ -z "$V0_REPO" || ! -d "$V0_REPO" ]]; then
-  echo "ERROR: v0 repo not found. Expected at ../transformotion-apps-b8 or set V0_REPO_PATH." >&2
+  cat >&2 <<EOF
+ERROR: v0 repo not found.
+
+Expected sibling repo:
+  $REPO_ROOT/../transformotion-apps-b8
+
+Or set:
+  V0_REPO_PATH=/path/to/transformotion-apps-b8
+EOF
   exit 1
 fi
 
 V0_CONTRACTS="$V0_REPO/contracts"
 if [[ ! -d "$V0_CONTRACTS" ]]; then
-  echo "ERROR: contracts/ directory not found in v0 repo at $V0_REPO." >&2
+  cat >&2 <<EOF
+ERROR: v0 contracts directory not found:
+  $V0_CONTRACTS
+EOF
   exit 1
 fi
 
-TARGET="$REPO_ROOT/v0-reference/contracts"
-mkdir -p "$TARGET"
+hash_contracts_tree() {
+  local dir="$1"
+  if [[ ! -d "$dir" ]]; then
+    return 0
+  fi
 
-if command -v rsync &>/dev/null; then
-  rsync -a --delete "$V0_CONTRACTS/" "$TARGET/"
-else
-  # Fallback for environments without rsync (e.g. Windows Git Bash)
-  rm -rf "$TARGET"
-  cp -r "$V0_CONTRACTS" "$TARGET"
-fi
+  (
+    cd "$dir"
+    find . -type f -print0 \
+      | sort -z \
+      | xargs -0 -r sha256sum
+  )
+}
 
-echo "Synced $V0_CONTRACTS → $TARGET"
+target_has_files() {
+  [[ -d "$TARGET" ]] && find "$TARGET" -type f -print -quit | grep -q .
+}
+
+refuse_if_target_was_edited() {
+  if ! target_has_files; then
+    return
+  fi
+
+  if [[ ! -f "$MANIFEST" ]]; then
+    if [[ "$FORCE" == "1" || "$FORCE" == "true" ]]; then
+      return
+    fi
+
+    cat >&2 <<EOF
+ERROR: $TARGET already contains files but no sync manifest exists.
+
+This script refuses to overwrite an unverified generated contracts target.
+If this is the first #134 sync over an older v0-reference checkout, rerun with:
+
+  V0_SYNC_FORCE=1 bash scripts/sync-v0.sh
+
+or:
+
+  bash scripts/sync-v0.sh --force
+EOF
+    exit 1
+  fi
+
+  local current_manifest
+  current_manifest="$(mktemp)"
+  hash_contracts_tree "$TARGET" > "$current_manifest"
+
+  if ! cmp -s "$current_manifest" "$MANIFEST"; then
+    rm -f "$current_manifest"
+    if [[ "$FORCE" == "1" || "$FORCE" == "true" ]]; then
+      return
+    fi
+
+    cat >&2 <<EOF
+ERROR: local modifications detected in generated contracts target:
+  $TARGET
+
+Edit canonical contracts in:
+  $V0_CONTRACTS
+
+Then rerun the sync. To discard local generated-target edits explicitly:
+
+  V0_SYNC_FORCE=1 bash scripts/sync-v0.sh
+EOF
+    exit 1
+  fi
+
+  rm -f "$current_manifest"
+}
+
+write_readme() {
+  mkdir -p "$TARGET_ROOT"
+  cat > "$README" <<EOF
+# v0 Reference
+
+Generated content. Do not edit this directory directly.
+
+Canonical contracts live in:
+
+  transformotion-apps-b8/contracts/
+
+This runtime repository consumes a synced copy at:
+
+  v0-reference/contracts/
+
+To update the synced copy, edit the canonical contracts in the v0 repo and run:
+
+  bash scripts/sync-v0.sh
+
+If the generated target contains local edits, the sync script refuses to
+overwrite them unless explicitly forced.
+EOF
+}
+
+sync_contracts() {
+  mkdir -p "$TARGET_ROOT"
+
+  if command -v rsync >/dev/null 2>&1; then
+    mkdir -p "$TARGET"
+    rsync -a --delete "$V0_CONTRACTS/" "$TARGET/"
+  else
+    rm -rf "$TARGET"
+    mkdir -p "$TARGET"
+    cp -R "$V0_CONTRACTS/." "$TARGET/"
+  fi
+}
+
+refuse_if_target_was_edited
+sync_contracts
+hash_contracts_tree "$TARGET" > "$MANIFEST"
+write_readme
+
+echo "Synced v0 contracts:"
+echo "  from: $V0_CONTRACTS"
+echo "  to:   $TARGET"


### PR DESCRIPTION
﻿## Summary

Implements M15 #134 infrastructure for v0 contract sync verification.

- hardens `scripts/sync-v0.sh` to mirror `transformotion-apps-b8/contracts/` into ignored `v0-reference/contracts/`
- adds generated-target overwrite protection using a sync manifest
- adds a CI check that fails if generated `v0-reference/**` files are tracked
- adds CI checkout of the v0 repo and byte-identity verification against canonical v0 contracts
- adds local package scripts for sync and verification

## Scope guard

This PR contains only #134 files:

- `.github/workflows/ci.yml`
- `package.json`
- `scripts/sync-v0.sh`
- `scripts/ci/check-v0-contracts-synced.sh`

It does not migrate, restructure, or edit contract contents. It does not implement #135/#136/#137/#138/#139/#391/#124 and does not deploy.

## Validation

- `v0 Contracts Sync` passed on the prior scoped commit after `V0_REPO_READ_TOKEN` was configured
- local validation already performed on the same patch: sync, byte-identity check, unsafe overwrite refusal, missing v0 path error, shell syntax, and diff hygiene

## CI requirement

Requires repository secret `V0_REPO_READ_TOKEN` with read access to `transformotion/transformotion-apps-b8`.

Closes #134.
