### PR TITLE
docs: codify v0-first contract authoring

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,8 @@ Use these documents in this order:
 - `MONOREPO.md` - current repository topology, imports, deploy triggers.
 - `CONTRIBUTING.md` - workflow, discipline rule, contracts policy, branch/PR
   expectations.
-- `contracts/<scope>/` - explicit contract source of truth.
+- `v0-reference/contracts/<scope>/` - generated read-only sync of the v0
+  contract source of truth.
 - `apps/<app>/AGENTS.md` - app-specific operating notes when present.
 - `apps/<app>/CLAUDE.md` - Claude Code compatibility mirror for app-specific
   operating notes.
@@ -131,20 +132,21 @@ stacks themselves live with their owner:
 
 Do not reintroduce root `infrastructure/lib/<scope>` stack ownership.
 
-### `contracts/`
+### Contracts
 
-Normative contracts by scope. Contract mirrors under `apps/<app>/contracts/`
-are forbidden. Contract changes must be paired with code changes that depend on
-them, or code must be held until the contract is ratified.
+M15 makes the v0 repo (`transformotion-apps-b8`) canonical for contracts.
+Contracts are authored only under `transformotion-apps-b8/contracts/`. This
+runtime repo consumes them through the generated, gitignored
+`v0-reference/contracts/` sync target.
 
-Target shape:
-
-- `contracts/platform/`
-- `contracts/stock-analyser/`
-- `contracts/budget-tracker/`
+Do not edit `v0-reference/contracts/` directly. If runtime implementation
+requires a contract change, edit `transformotion-apps-b8/contracts/` first,
+commit and push that v0 repo change, run `pnpm sync:v0` in this runtime repo,
+then implement runtime changes against the synced contract. Stop and ask if v0
+repo access is unavailable.
 
 Use TypeScript contract files for shapes and markdown for behaviour when
-creating new contracts, following `CONTRIBUTING.md`.
+creating new contracts in the v0 repo, following `CONTRIBUTING.md`.
 
 ### `docs/`
 
@@ -241,6 +243,9 @@ AI agents must follow these rules:
 - Never reintroduce deprecated shared-platform patterns retired by M9 child
   issues.
 - Prefer explicit contracts over inferred behaviour.
+- Never edit `v0-reference/contracts/` directly. Contract changes are authored
+  in `transformotion-apps-b8/contracts/`, committed and pushed there, then
+  synced into this runtime repo with `pnpm sync:v0`.
 - Preserve migration compatibility unless explicitly instructed to perform a
   breaking migration.
 - Respect explicit scope boundaries such as "diagnose only", "recon only",
@@ -441,12 +446,15 @@ Runtime configuration pattern:
 - Do not recreate root stack libraries.
 - Each entrypoint should synthesize only the stacks it owns.
 
-### `contracts/`
+### Contracts
 
-- Use one canonical contract location per scope.
+- Use one canonical contract location per scope:
+  `transformotion-apps-b8/contracts/<scope>/`.
+- Treat `v0-reference/contracts/` as generated and read-only.
 - Keep shape authority in `.ts` files and behavioural authority in `.md` files
-  for new hybrid contracts.
-- Update contracts before or with implementation changes that depend on them.
+  for new hybrid contracts authored in the v0 repo.
+- Update and push v0 contracts before implementation changes that depend on
+  them, then run `pnpm sync:v0` in this runtime repo.
 
 ### `docs/`
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,12 +66,20 @@ This rule emerged from M7 recons where the named attribute checked out cleanly b
 Categories to consider in the impact check:
 - IAM policies, infrastructure resources → `cdk.md`, `inventory.md`
 - Auth flows, identity providers, claims → `auth.md`
-- Lambda handlers, API endpoints → `MONOREPO.md`, `CONTRIBUTING.md` §3, `contracts/<scope>/`, `inventory.md`
+- Lambda handlers, API endpoints → `MONOREPO.md`, `CONTRIBUTING.md` §3, v0-authored contracts synced through `v0-reference/contracts/<scope>/`, `inventory.md`
 - Build patterns, env vars, runtime config → `CONTRIBUTING.md` §5, `inventory.md`, deploy workflow env blocks, GH Actions variables/secrets
 - Repository structure → `CONTRIBUTING.md` §3, `MONOREPO.md`
 - Operating mode, agent behaviour → `AGENTS.md` and this compatibility mirror
 
 This rule emerged from cumulative M7 evidence. PRs #259, #261 (multiple rounds), the M6 launchpad-at-root work, the budget-tracker gateway consolidation, and the platform-functions migration all shipped code without their accompanying §2.1 obligations, requiring downstream cleanup PRs (#262, #266, #267, #269, #279, #283 among others) to make up the gap.
+
+**M15 contract authoring rule**: Contracts are authored only in the v0 repo
+(`transformotion-apps-b8/contracts/`). Do not edit
+`v0-reference/contracts/` directly; it is generated and read-only. If runtime
+implementation requires a contract change, edit the v0 repo contract first,
+commit and push that v0 repo change, run `pnpm sync:v0` in this runtime repo,
+then implement against the synced contract. Stop and ask if v0 repo access is
+unavailable.
 
 ## Boundary Discipline
 
@@ -114,7 +122,7 @@ Note: some paths are migrating per `CONTRIBUTING.md` Section 3 — see `MONOREPO
 
 | What | Where (current) |
 |---|---|
-| Cross-app contracts | `/contracts/<scope>/` |
+| Cross-app contracts | Authored in `transformotion-apps-b8/contracts/<scope>/`; consumed here from generated read-only `/v0-reference/contracts/<scope>/` |
 | Shared packages | `/packages/` |
 | Platform infrastructure | `/platform/infrastructure/` |
 | Per-app infrastructure | `/apps/<app>/infrastructure/` |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,7 +148,7 @@ ways of working change. Changes are themselves PRs.
 | URLs and deploy | `/docs/architecture/urls-and-deploy.md` | Normative | URL routing, CloudFront, S3 layout, deploy triggers, Next.js basePath per app. | Steve |
 | CDK | `/docs/architecture/cdk.md` | Normative | CDK stack topology, cross-stack references, deploy ordering. | Steve |
 | Contracts policy | `/docs/architecture/contracts.md` (TBD by Stage 0b) | Normative | The policy for how contracts are organised: where they live, what is normative vs descriptive, single-source-of-truth rules. Location may shift to an extension of an existing document per Stage 0b ratification. | Steve |
-| Per-app contracts | `/contracts/<scope>/*.md` where `<scope>` is `platform` or an app slug | Normative | The actual contracts: data models, API endpoints, state management. Per-app mirrors at `apps/<app>/contracts/` are not allowed. | Per-app team |
+| Per-app contracts | `transformotion-apps-b8/contracts/<scope>/` in the v0 repo, synced read-only into `/v0-reference/contracts/<scope>/` in this runtime repo | Normative | The actual contracts: TypeScript shapes, API endpoints, data models, state management, and behavioural notes. Runtime-side contract mirrors and direct edits to `/v0-reference/contracts/` are not allowed. | Per-app team |
 | Agent guide | `/AGENTS.md` and `/apps/<app>/AGENTS.md` | Operational | Canonical AI-agent operating guidance. Required at root and for every app. Minimum per-app content: app's purpose, key entry points, app-specific conventions, app-specific gotchas, sync flow if v0-driven. | Root / per-app team |
 | Claude Code mirror | `/CLAUDE.md` and `/apps/<app>/CLAUDE.md` | Operational | Claude Code compatibility mirror for the corresponding AGENTS.md file. Must remain semantically equivalent; changes to one without the other are governance drift. | Root / per-app team |
 | Architectural inventory | `/docs/architecture/inventory.md` | Normative (living document) | The current-state inventory of the platform — what is true about code, infrastructure, and operating state right now. Updated as state changes per the discipline rule (Section 2.1). Findings carry status tags including **Resolved by M*N* / PR #*N*** and **Superseded by [reference]** for living-document use. | Steve |
@@ -171,9 +171,11 @@ compatibility mirrors. They cover only app-specific concerns and must remain
 semantically equivalent to the corresponding AGENTS file.
 
 The contracts policy document (location ratified in Stage 0b) governs the
-per-app contract files at `contracts/<scope>/`. Drift between contracts
-policy and per-app contract content is a documentation reconciliation
-concern.
+per-app contract files in the v0 repo at
+`transformotion-apps-b8/contracts/<scope>/`. This runtime repo consumes those
+contracts through the generated, gitignored `v0-reference/contracts/<scope>/`
+sync target. Drift between contracts policy and per-app contract content is a
+documentation reconciliation concern.
 
 ---
 
@@ -298,23 +300,30 @@ packages/ui/
 
 The decision rule for "should this go in a package?" is in Section 3.6.
 
-### 3.5 The `contracts/` directory
+### 3.5 Contracts and `v0-reference/`
 
-Contracts live at `contracts/<scope>/*.md` where `<scope>` is `platform` or
-an app slug.
+Contracts are authored in the v0 repo at
+`transformotion-apps-b8/contracts/<scope>/`, where `<scope>` is `platform`,
+`launchpad`, an app slug, or a future ratified scope. This runtime repo
+consumes a generated read-only copy at `v0-reference/contracts/<scope>/`.
 
 ```
-contracts/
-├── platform/              # Platform-wide contracts (Account, User, AccountMember shapes; auth claims)
+transformotion-apps-b8/contracts/
+├── _shared/               # Shared contract shapes and version metadata
+├── launchpad/             # Launchpad auth/control-plane contracts
+├── platform/              # Neutral substrate contracts
 ├── stock-analyser/        # Stock Analyser contracts
 ├── budget-tracker/        # Budget Tracker contracts
-└── <future-app>/
+└── <future-scope>/
 ```
 
-Per-app mirrors of contracts at `apps/<app>/contracts/` are forbidden. A
-contract has exactly one canonical location at `contracts/<scope>/`. If a
-contract drifts between locations, the canonical version wins; the mirror
-is removed.
+Per-app mirrors of contracts at `apps/<app>/contracts/` are forbidden.
+Direct edits to `v0-reference/contracts/` are also forbidden because that tree
+is generated from v0. A contract has exactly one canonical location: the v0
+repo. If runtime implementation requires a contract change, make the contract
+change in `transformotion-apps-b8/contracts/`, commit and push it there, run
+`pnpm sync:v0` in this runtime repo, and then implement runtime changes against
+the synced copy.
 
 The contracts policy document (location ratified in Stage 0b) governs what
 goes in each contract file, the normative-vs-descriptive classification,
@@ -775,7 +784,7 @@ The layered architecture applies broadly. All data access goes through domain in
 
 ### 5.2 Domain interfaces and implementations
 
-**Domain interfaces** declare data-access shapes in store-agnostic terms. They live in `contracts/<scope>/`. A domain interface specifies what operations exist (`findAll`, `getById`, `save`, `delete`) and what types they take and return. It does not specify how those operations are implemented.
+**Domain interfaces** declare data-access shapes in store-agnostic terms. They live canonically in `transformotion-apps-b8/contracts/<scope>/` and are consumed in this runtime repo through `v0-reference/contracts/<scope>/`. A domain interface specifies what operations exist (`findAll`, `getById`, `save`, `delete`) and what types they take and return. It does not specify how those operations are implemented.
 
 **Implementations** of a domain interface live in the data-access layer. Each implementation is named for its physical store. Examples:
 
@@ -902,7 +911,10 @@ A **contract** documents the binding interface between a provider and one or mor
 
 Contracts live canonically in the **v0 repo** (`transformotion-apps-b8`), not the Claude repo. The v0 repo is the only location both AIs (v0 and Claude Code) can read natively — v0 cannot access the Claude repo; Claude Code can access the v0 repo.
 
-The Claude repo accesses contracts via a one-way sync from v0 repo into a gitignored location. Runtime code imports contracts from the gitignored synced location. The sync is implemented in `scripts/sync-v0.sh` and runs as part of CI before tests.
+The Claude/runtime repo accesses contracts via a one-way sync from v0 repo into
+the gitignored `v0-reference/contracts/` location. Runtime code imports
+contracts from the synced location. The sync is implemented in
+`scripts/sync-v0.sh` and exposed as `pnpm sync:v0`.
 
 #### Single source of truth
 
@@ -912,14 +924,22 @@ This is a strict rule. Independent type declarations in runtime code that match 
 
 #### Authoring discipline
 
-Contracts are edited in the v0 repo first. Claude-side work that needs a contract change goes through this workflow:
+Contracts are edited in the v0 repo first. Runtime-side work that needs a
+contract change goes through this workflow:
 
 1. Edit the contract in the v0 repo (`transformotion-apps-b8/contracts/...`)
 2. Commit and push the v0 repo change
-3. Run sync into Claude repo (or wait for CI to do it)
-4. Then proceed with Claude-side implementation work that depends on the change
+3. Run `pnpm sync:v0` in this runtime repo
+4. Then proceed with runtime implementation work that depends on the change
 
-The discipline is enforced by CI verification (Level 3): Claude repo's CI verifies the gitignored sync target is byte-identical to v0 repo's contracts at HEAD. Mechanical guardrails (gitignore, sync target README warning against direct edits, sync script refusing to run if it detects local modifications) reduce the chance of mistakes reaching CI.
+The discipline is enforced by CI verification (Level 3): this runtime repo's CI
+uses `V0_REPO_READ_TOKEN` only for read-only verification that the gitignored
+sync target is byte-identical to v0 repo's contracts at HEAD. CI must never
+auto-write to the v0 repo, auto-fix v0 contracts, or treat runtime repo state
+as authoritative over `transformotion-apps-b8/contracts/`. Mechanical
+guardrails (gitignore, sync target README warning against direct edits, sync
+script refusing to run if it detects local modifications) reduce the chance of
+mistakes reaching CI.
 
 #### Bucket structure
 
@@ -1312,8 +1332,10 @@ When removing a field from `BudgetSettings`, the required steps are:
 
 1. Remove from `SETTING_KEYS` and `DEFAULT_SETTINGS` in the settings
    Lambda.
-2. Remove from the `BudgetSettings` type in `packages/budget-domain/src/contracts.ts`
-   and `v0-reference/contracts/budget-tracker/data-models.md`.
+2. Update the canonical contract in
+   `transformotion-apps-b8/contracts/budget-tracker/`, commit and push the v0
+   repo change, run `pnpm sync:v0`, then remove any runtime mirrors such as the
+   `BudgetSettings` type in `packages/budget-domain/src/contracts.ts`.
 3. Create a one-shot migration script in
    `scripts/migrations/budget-tracker/` to delete the orphaned rows.
    Use `DRY_RUN=true` by default.

--- a/apps/budget-tracker/AGENTS.md
+++ b/apps/budget-tracker/AGENTS.md
@@ -106,7 +106,7 @@ The three Zustand stores:
 - `useAiStore` — AI review queue and CSV analysis
 - `useAuthStore` — current user and sign-in/out
 
-Repository interfaces are defined in `v0-reference/contracts/budget-tracker/state-management.md`. **Do not add methods to a repository without updating the contract file in the v0 repo first, then re-running `scripts/sync-v0.sh`.**
+Repository interfaces are defined in the generated read-only `v0-reference/contracts/budget-tracker/state-management.md`. **Do not add methods to a repository without updating the contract file in the v0 repo first, committing and pushing that v0 change, then running `pnpm sync:v0`.**
 
 ### Forbidden patterns
 
@@ -181,7 +181,7 @@ Provider is selected via `config.ai.provider` (`'mock'` or `'claude'`), resolved
 
 **Adding a new AI feature:**
 1. Add the method to the `AIService` interface in `lib/services/ai/index.ts`
-2. Update the contract in the v0 repo (`transformotion-apps-b8/contracts/budget-tracker/state-management.md`) and re-run `scripts/sync-v0.sh`
+2. Update the contract in the v0 repo (`transformotion-apps-b8/contracts/budget-tracker/state-management.md`), commit and push that v0 change, then run `pnpm sync:v0`
 3. Add a matching Lambda route to `apps/budget-tracker/functions/budget-ai/src/index.ts` with `requireAppAccess` + `requireAccountAccess`
 4. Implement the method in `MockAIService` (mock-ai.ts) and `ClaudeAIService` (claude-ai.ts)
 5. Add prompt text in the Lambda (server-side only — never in client code)

--- a/apps/budget-tracker/CLAUDE.md
+++ b/apps/budget-tracker/CLAUDE.md
@@ -109,7 +109,7 @@ The three Zustand stores:
 - `useAiStore` — AI review queue and CSV analysis
 - `useAuthStore` — current user and sign-in/out
 
-Repository interfaces are defined in `v0-reference/contracts/budget-tracker/state-management.md`. **Do not add methods to a repository without updating the contract file in the v0 repo first, then re-running `scripts/sync-v0.sh`.**
+Repository interfaces are defined in the generated read-only `v0-reference/contracts/budget-tracker/state-management.md`. **Do not add methods to a repository without updating the contract file in the v0 repo first, committing and pushing that v0 change, then running `pnpm sync:v0`.**
 
 ### Forbidden patterns
 
@@ -184,7 +184,7 @@ Provider is selected via `config.ai.provider` (`'mock'` or `'claude'`), resolved
 
 **Adding a new AI feature:**
 1. Add the method to the `AIService` interface in `lib/services/ai/index.ts`
-2. Update the contract in the v0 repo (`transformotion-apps-b8/contracts/budget-tracker/state-management.md`) and re-run `scripts/sync-v0.sh`
+2. Update the contract in the v0 repo (`transformotion-apps-b8/contracts/budget-tracker/state-management.md`), commit and push that v0 change, then run `pnpm sync:v0`
 3. Add a matching Lambda route to `apps/budget-tracker/functions/budget-ai/src/index.ts` with `requireAppAccess` + `requireAccountAccess`
 4. Implement the method in `MockAIService` (mock-ai.ts) and `ClaudeAIService` (claude-ai.ts)
 5. Add prompt text in the Lambda (server-side only — never in client code)

--- a/apps/stock-analyser/AGENTS.md
+++ b/apps/stock-analyser/AGENTS.md
@@ -28,7 +28,7 @@ React + TypeScript + Tailwind CSS.
 | DynamoDB table schemas | [/docs/architecture/data.md](/docs/architecture/data.md) |
 | CDK stacks, Lambda names | [/docs/architecture/cdk.md](/docs/architecture/cdk.md) |
 | URL routing, CloudFront, deploy triggers | [/docs/architecture/urls-and-deploy.md](/docs/architecture/urls-and-deploy.md) |
-| Stock Analyser API contracts and types | [contracts/stock-analyser/DATA_CONTRACTS.md](/contracts/stock-analyser/DATA_CONTRACTS.md) |
+| Stock Analyser API contracts and types | Authored in `transformotion-apps-b8/contracts/stock-analyser/`; consumed here from generated read-only [/v0-reference/contracts/stock-analyser/](/v0-reference/contracts/stock-analyser/) |
 | Migration invariants from HTML version | [apps/stock-analyser/MIGRATION_INVARIANTS.md](./MIGRATION_INVARIANTS.md) |
 
 ## CDK stacks owned
@@ -84,7 +84,11 @@ Call `requireAppAccess` at the top of every handler, then `requireAccountAccess`
 
 The app uses a service-adaptor pattern: components call service methods → service handles mock vs real internally. Components never check provider flags directly.
 
-Key service methods defined in [contracts/DATA_CONTRACTS.md](./contracts/DATA_CONTRACTS.md):
+Contracted service/API shapes are authored in the v0 repo first and consumed
+here from `v0-reference/contracts/stock-analyser/`. Do not edit the synced
+runtime copy directly; follow the root M15 contract authoring rule.
+
+Key service methods currently covered by the Stock Analyser contract set:
 - `portfolioService.getHoldings()` / `saveHoldings()` / `enrichHoldings()`
 - `watchlistService.getItems()` / `saveItems()`
 - `useClaude()` hook — POST to `/api/claude` + async polling pattern

--- a/apps/stock-analyser/CLAUDE.md
+++ b/apps/stock-analyser/CLAUDE.md
@@ -31,7 +31,7 @@ React + TypeScript + Tailwind CSS.
 | DynamoDB table schemas | [/docs/architecture/data.md](/docs/architecture/data.md) |
 | CDK stacks, Lambda names | [/docs/architecture/cdk.md](/docs/architecture/cdk.md) |
 | URL routing, CloudFront, deploy triggers | [/docs/architecture/urls-and-deploy.md](/docs/architecture/urls-and-deploy.md) |
-| Stock Analyser API contracts and types | [contracts/stock-analyser/DATA_CONTRACTS.md](/contracts/stock-analyser/DATA_CONTRACTS.md) |
+| Stock Analyser API contracts and types | Authored in `transformotion-apps-b8/contracts/stock-analyser/`; consumed here from generated read-only [/v0-reference/contracts/stock-analyser/](/v0-reference/contracts/stock-analyser/) |
 | Migration invariants from HTML version | [apps/stock-analyser/MIGRATION_INVARIANTS.md](./MIGRATION_INVARIANTS.md) |
 
 ## CDK stacks owned
@@ -87,7 +87,11 @@ Call `requireAppAccess` at the top of every handler, then `requireAccountAccess`
 
 The app uses a service-adaptor pattern: components call service methods → service handles mock vs real internally. Components never check provider flags directly.
 
-Key service methods defined in [contracts/DATA_CONTRACTS.md](./contracts/DATA_CONTRACTS.md):
+Contracted service/API shapes are authored in the v0 repo first and consumed
+here from `v0-reference/contracts/stock-analyser/`. Do not edit the synced
+runtime copy directly; follow the root M15 contract authoring rule.
+
+Key service methods currently covered by the Stock Analyser contract set:
 - `portfolioService.getHoldings()` / `saveHoldings()` / `enrichHoldings()`
 - `watchlistService.getItems()` / `saveItems()`
 - `useClaude()` hook — POST to `/api/claude` + async polling pattern


### PR DESCRIPTION
## Summary
- Codifies the M15 v0-first contract-authoring rule in CONTRIBUTING.md.
- Mirrors the agent instructions in root AGENTS.md / CLAUDE.md.
- Updates conflicting Stock Analyser and Budget Tracker app agent guidance to defer to the v0-authored, read-only synced contract rule.

## Scope guardrails
- Documentation/agent guidance only.
- No contract content changes.
- No v0-reference edits.
- No sync script, CI workflow, or package.json changes.
- Does not implement #135/#136/#137/#138/#139/#391/#124.

## Validation
- git diff --check
- git diff --cached --check
- Confirmed changed files are only the approved documentation/agent guidance files.