### PR TITLE
ci: exclude documentation-only files from deploy triggers

### DIFF
--- a/.github/workflows/deploy-budget-tracker.yml
+++ b/.github/workflows/deploy-budget-tracker.yml
@@ -4,7 +4,12 @@ on:
   push:
     branches: [develop, main]
     paths:
+      - '.github/workflows/deploy-budget-tracker.yml'
       - 'apps/budget-tracker/**'
+      - '!apps/budget-tracker/AGENTS.md'
+      - '!apps/budget-tracker/CLAUDE.md'
+      - '!apps/budget-tracker/README.md'
+      - '!apps/budget-tracker/docs/**'
       - 'infrastructure/bin/budget-tracker.ts'
       - 'infrastructure/lib/auth-domain-exports.ts'
       - 'packages/api-client/**'
@@ -17,6 +22,10 @@ on:
       - 'packages/lambda-middleware/**'
       - 'packages/fn-claude-proxy-core/**'
       - 'packages/budget-domain/**'
+      - '!packages/**/AGENTS.md'
+      - '!packages/**/CLAUDE.md'
+      - '!packages/**/README.md'
+      - '!packages/**/docs/**'
   workflow_call:
     inputs:
       target:

--- a/.github/workflows/deploy-launchpad.yml
+++ b/.github/workflows/deploy-launchpad.yml
@@ -6,12 +6,20 @@ on:
     paths:
       - '.github/workflows/deploy-launchpad.yml'
       - 'apps/launchpad/**'
+      - '!apps/launchpad/AGENTS.md'
+      - '!apps/launchpad/CLAUDE.md'
+      - '!apps/launchpad/README.md'
+      - '!apps/launchpad/docs/**'
       - 'infrastructure/lib/**'
       - 'infrastructure/bin/launchpad.ts'
       - 'platform/config/app-registry.json'
       - 'packages/auth-client/**'
       - 'packages/lambda-middleware/**'
       - 'packages/runtime-config/**'
+      - '!packages/**/AGENTS.md'
+      - '!packages/**/CLAUDE.md'
+      - '!packages/**/README.md'
+      - '!packages/**/docs/**'
   workflow_call:
     inputs:
       target:

--- a/.github/workflows/deploy-migration-utilities.yml
+++ b/.github/workflows/deploy-migration-utilities.yml
@@ -4,9 +4,18 @@ on:
   push:
     branches: [develop, main]
     paths:
+      - '.github/workflows/deploy-migration-utilities.yml'
       - 'migration-utilities/**'
+      - '!migration-utilities/**/AGENTS.md'
+      - '!migration-utilities/**/CLAUDE.md'
+      - '!migration-utilities/**/README.md'
+      - '!migration-utilities/**/docs/**'
       - 'infrastructure/bin/migration-utilities.ts'
       - 'packages/**'
+      - '!packages/**/AGENTS.md'
+      - '!packages/**/CLAUDE.md'
+      - '!packages/**/README.md'
+      - '!packages/**/docs/**'
   workflow_call:
     inputs:
       target:

--- a/.github/workflows/deploy-stock-analyser.yml
+++ b/.github/workflows/deploy-stock-analyser.yml
@@ -4,7 +4,12 @@ on:
   push:
     branches: [develop, main]
     paths:
+      - '.github/workflows/deploy-stock-analyser.yml'
       - 'apps/stock-analyser/**'
+      - '!apps/stock-analyser/AGENTS.md'
+      - '!apps/stock-analyser/CLAUDE.md'
+      - '!apps/stock-analyser/README.md'
+      - '!apps/stock-analyser/docs/**'
       - 'infrastructure/bin/stock-analyser.ts'
       - 'infrastructure/lib/auth-domain-exports.ts'
       - 'packages/api-client/**'
@@ -16,6 +21,10 @@ on:
       - 'packages/runtime-config/**'
       - 'packages/lambda-middleware/**'
       - 'packages/fn-claude-proxy-core/**'
+      - '!packages/**/AGENTS.md'
+      - '!packages/**/CLAUDE.md'
+      - '!packages/**/README.md'
+      - '!packages/**/docs/**'
   workflow_call:
     inputs:
       target:

--- a/MONOREPO.md
+++ b/MONOREPO.md
@@ -100,20 +100,24 @@ The manual `cd.yml` workflow remains the explicit full redeploy escape hatch.
 
 | Changed path | Workflow |
 |---|---|
-| `apps/launchpad/**` | `deploy-launchpad.yml` |
+| `apps/launchpad/**` except documentation-only app files | `deploy-launchpad.yml` |
 | `infrastructure/bin/launchpad.ts` | `deploy-launchpad.yml` |
 | `.github/workflows/deploy-launchpad.yml` | `deploy-launchpad.yml` |
-| `apps/stock-analyser/**` | `deploy-stock-analyser.yml` |
+| `apps/stock-analyser/**` except documentation-only app files | `deploy-stock-analyser.yml` |
 | `infrastructure/bin/stock-analyser.ts` | `deploy-stock-analyser.yml` |
-| `apps/budget-tracker/**` | `deploy-budget-tracker.yml` |
+| `.github/workflows/deploy-stock-analyser.yml` | `deploy-stock-analyser.yml` |
+| `apps/budget-tracker/**` except documentation-only app files | `deploy-budget-tracker.yml` |
 | `infrastructure/bin/budget-tracker.ts` | `deploy-budget-tracker.yml` |
+| `.github/workflows/deploy-budget-tracker.yml` | `deploy-budget-tracker.yml` |
 | `platform/infrastructure/**` | `deploy-platform.yml` |
 | `infrastructure/bin/platform.ts` | `deploy-platform.yml` |
-| `migration-utilities/**` | `deploy-migration-utilities.yml` |
+| `migration-utilities/**` except documentation-only utility files | `deploy-migration-utilities.yml` |
 | `infrastructure/bin/migration-utilities.ts` | `deploy-migration-utilities.yml` |
+| `.github/workflows/deploy-migration-utilities.yml` | `deploy-migration-utilities.yml` |
 
 Shared package changes trigger the app/migration workflows whose path filters
-include the touched package.
+include the touched package, except package documentation-only files such as
+`README.md`, `AGENTS.md`, `CLAUDE.md`, and `docs/**`.
 
 ## Adding Code
 

--- a/docs/architecture/inventory.md
+++ b/docs/architecture/inventory.md
@@ -133,10 +133,10 @@ exports.
 | Workflow | Owner | Trigger paths |
 |---|---|---|
 | `deploy-platform.yml` | Platform | `platform/infrastructure/**`, `infrastructure/bin/platform.ts` |
-| `deploy-launchpad.yml` | Launchpad | `apps/launchpad/**`, `infrastructure/bin/launchpad.ts`, Launchpad dependency paths |
-| `deploy-stock-analyser.yml` | Stock Analyser | `apps/stock-analyser/**`, `infrastructure/bin/stock-analyser.ts`, Stock Analyser dependency paths |
-| `deploy-budget-tracker.yml` | Budget Tracker | `apps/budget-tracker/**`, `infrastructure/bin/budget-tracker.ts`, Budget Tracker dependency paths |
-| `deploy-migration-utilities.yml` | Migration Utilities | `migration-utilities/**`, `infrastructure/bin/migration-utilities.ts` |
+| `deploy-launchpad.yml` | Launchpad | `apps/launchpad/**` except documentation-only app files, `infrastructure/bin/launchpad.ts`, Launchpad dependency paths |
+| `deploy-stock-analyser.yml` | Stock Analyser | `apps/stock-analyser/**` except documentation-only app files, `infrastructure/bin/stock-analyser.ts`, Stock Analyser dependency paths |
+| `deploy-budget-tracker.yml` | Budget Tracker | `apps/budget-tracker/**` except documentation-only app files, `infrastructure/bin/budget-tracker.ts`, Budget Tracker dependency paths |
+| `deploy-migration-utilities.yml` | Migration Utilities | `migration-utilities/**` except documentation-only utility files, `infrastructure/bin/migration-utilities.ts` |
 
 The manual `cd.yml` workflow remains the explicit full redeploy path.
 

--- a/docs/architecture/urls-and-deploy.md
+++ b/docs/architecture/urls-and-deploy.md
@@ -85,10 +85,14 @@ APIs, or AI runtime.
 
 | Workflow | Push paths |
 |---|---|
-| `deploy-launchpad.yml` | `.github/workflows/deploy-launchpad.yml`, `apps/launchpad/**`, `infrastructure/bin/launchpad.ts`, `infrastructure/lib/**`, `platform/config/app-registry.json`, `packages/auth-client/**`, `packages/lambda-middleware/**`, `packages/runtime-config/**` |
-| `deploy-stock-analyser.yml` | `apps/stock-analyser/**`, `infrastructure/bin/stock-analyser.ts`, `packages/api-client/**`, `packages/cache/**`, `packages/data-access/**`, `packages/logger/**`, `packages/ui/**`, `packages/auth-client/**`, `packages/runtime-config/**`, `packages/lambda-middleware/**` |
-| `deploy-budget-tracker.yml` | `apps/budget-tracker/**`, `infrastructure/bin/budget-tracker.ts`, `packages/api-client/**`, `packages/cache/**`, `packages/data-access/**`, `packages/logger/**`, `packages/ui/**`, `packages/auth-client/**`, `packages/runtime-config/**`, `packages/lambda-middleware/**`, `packages/budget-domain/**` |
-| `deploy-migration-utilities.yml` | `migration-utilities/**`, `infrastructure/bin/migration-utilities.ts`, `packages/**` |
+| `deploy-launchpad.yml` | `.github/workflows/deploy-launchpad.yml`, `apps/launchpad/**` except documentation-only app files, `infrastructure/bin/launchpad.ts`, `infrastructure/lib/**`, `platform/config/app-registry.json`, `packages/auth-client/**`, `packages/lambda-middleware/**`, `packages/runtime-config/**` except package documentation-only files |
+| `deploy-stock-analyser.yml` | `.github/workflows/deploy-stock-analyser.yml`, `apps/stock-analyser/**` except documentation-only app files, `infrastructure/bin/stock-analyser.ts`, `packages/api-client/**`, `packages/cache/**`, `packages/data-access/**`, `packages/logger/**`, `packages/ui/**`, `packages/auth-client/**`, `packages/runtime-config/**`, `packages/lambda-middleware/**`, `packages/fn-claude-proxy-core/**` except package documentation-only files |
+| `deploy-budget-tracker.yml` | `.github/workflows/deploy-budget-tracker.yml`, `apps/budget-tracker/**` except documentation-only app files, `infrastructure/bin/budget-tracker.ts`, `packages/api-client/**`, `packages/cache/**`, `packages/data-access/**`, `packages/logger/**`, `packages/ui/**`, `packages/auth-client/**`, `packages/runtime-config/**`, `packages/lambda-middleware/**`, `packages/fn-claude-proxy-core/**`, `packages/budget-domain/**` except package documentation-only files |
+| `deploy-migration-utilities.yml` | `.github/workflows/deploy-migration-utilities.yml`, `migration-utilities/**` except documentation-only utility files, `infrastructure/bin/migration-utilities.ts`, `packages/**` except package documentation-only files |
+
+Documentation-only exclusions cover `AGENTS.md`, `CLAUDE.md`, `README.md`,
+and `docs/**`. Contract/source files remain deploy-eligible when they are
+under an included app, utility, or package path.
 
 Each CDK deploy step passes an explicit `--app` flag pointing to the owner
 entrypoint:


### PR DESCRIPTION
## Summary
- Closes #395.
- Adds ordered negative path filters so documentation-only app/utility/package files do not trigger deploy workflows.
- Adds deploy workflow files themselves as deployment-affecting trigger paths where they were missing.
- Updates deploy trigger documentation in MONOREPO and architecture docs.

## Validation
- `git diff --check`
- Local path-filter reasoning confirmed:
  - `apps/budget-tracker/AGENTS.md` alone does not trigger Budget Tracker deploy
  - `apps/stock-analyser/CLAUDE.md` alone does not trigger Stock Analyser deploy
  - app source changes still trigger deploy
  - app infrastructure changes still trigger deploy
  - relevant shared package source changes still trigger deploy
  - package README/docs changes do not trigger deploy

## Scope guardrails
- No app runtime source changes.
- No contract content changes.
- No `v0-reference/` changes.
- No M15 contract migration work.
- No prod deploy.