### PR TITLE
M15 #124: enforce v0 freshness declarations

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+## Summary
+
+Refs #
+
+## v0 freshness
+
+Choose one:
+
+- [ ] Linked v0 PR/commit:
+- [ ] No v0 impact:
+
+Reason when selecting "No v0 impact":
+
+## Validation
+
+- [ ] `pnpm sync:v0`
+- [ ] `pnpm check:v0-contracts`
+- [ ] Other:
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,27 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  v0-freshness:
+    name: v0 Freshness Gate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout runtime repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect changed files
+        run: |
+          git fetch origin "${{ github.base_ref }}" --depth=1
+          git diff --name-only "origin/${{ github.base_ref }}"...HEAD > "$RUNNER_TEMP/changed-files.txt"
+          cat "$RUNNER_TEMP/changed-files.txt"
+
+      - name: Verify v0 freshness declaration
+        env:
+          CHANGED_FILES_FILE: ${{ runner.temp }}/changed-files.txt
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: node scripts/ci/check-v0-freshness.mjs
+
   v0-contracts-sync:
     name: v0 Contracts Sync
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-budget-tracker.yml
+++ b/.github/workflows/deploy-budget-tracker.yml
@@ -104,6 +104,11 @@ jobs:
           V0_REPO_PATH: ${{ runner.temp }}/transformotion-apps-b8
         run: pnpm sync:v0
 
+      - name: Verify v0 contracts byte identity
+        env:
+          V0_REPO_PATH: ${{ runner.temp }}/transformotion-apps-b8
+        run: pnpm check:v0-contracts
+
       - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -221,6 +226,11 @@ jobs:
         env:
           V0_REPO_PATH: ${{ runner.temp }}/transformotion-apps-b8
         run: pnpm sync:v0
+
+      - name: Verify v0 contracts byte identity
+        env:
+          V0_REPO_PATH: ${{ runner.temp }}/transformotion-apps-b8
+        run: pnpm check:v0-contracts
 
       - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/deploy-launchpad.yml
+++ b/.github/workflows/deploy-launchpad.yml
@@ -93,6 +93,11 @@ jobs:
           V0_REPO_PATH: ${{ runner.temp }}/transformotion-apps-b8
         run: pnpm sync:v0
 
+      - name: Verify v0 contracts byte identity
+        env:
+          V0_REPO_PATH: ${{ runner.temp }}/transformotion-apps-b8
+        run: pnpm check:v0-contracts
+
       - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -212,6 +217,11 @@ jobs:
         env:
           V0_REPO_PATH: ${{ runner.temp }}/transformotion-apps-b8
         run: pnpm sync:v0
+
+      - name: Verify v0 contracts byte identity
+        env:
+          V0_REPO_PATH: ${{ runner.temp }}/transformotion-apps-b8
+        run: pnpm check:v0-contracts
 
       - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/deploy-stock-analyser.yml
+++ b/.github/workflows/deploy-stock-analyser.yml
@@ -102,6 +102,11 @@ jobs:
           V0_REPO_PATH: ${{ runner.temp }}/transformotion-apps-b8
         run: pnpm sync:v0
 
+      - name: Verify v0 contracts byte identity
+        env:
+          V0_REPO_PATH: ${{ runner.temp }}/transformotion-apps-b8
+        run: pnpm check:v0-contracts
+
       - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -230,6 +235,11 @@ jobs:
         env:
           V0_REPO_PATH: ${{ runner.temp }}/transformotion-apps-b8
         run: pnpm sync:v0
+
+      - name: Verify v0 contracts byte identity
+        env:
+          V0_REPO_PATH: ${{ runner.temp }}/transformotion-apps-b8
+        run: pnpm check:v0-contracts
 
       - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@v4

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,6 +148,17 @@ repo access is unavailable.
 Use TypeScript contract files for shapes and markdown for behaviour when
 creating new contracts in the v0 repo, following `CONTRIBUTING.md`.
 
+M15 #391 established the reconciled v0 UI/contract baseline at v0 repo `main`
+commit `9515fc521d2eaa7431612e17b57e3fff517d131d`. From #124 onward, any
+runtime PR that changes UI-affecting or contract-affecting paths must link the
+matching `transformotion-apps-b8` PR/commit in the PR body's `v0 freshness`
+section, or explicitly declare `No v0 impact` with a reason. UI-affecting paths
+include app `app/`, `components/`, UI-used `lib/`, `stores/`, `hooks/`,
+`services/`, `data/`, app frontend config, shared UI packages, frontend
+service/adaptor packages, and `packages/contracts/`. v0 sandboxes may be stale:
+refresh from `transformotion-apps-b8/main` before using them as freshness
+evidence.
+
 ### `docs/`
 
 Architecture, planning, audit, and archive material. `docs/architecture/` and
@@ -400,6 +411,9 @@ Other working practices:
 - Prefer incremental migrations over large rewrites.
 - Preserve backwards compatibility during migrations unless the task explicitly
   authorizes a breaking cutover.
+- Complete the PR body's `v0 freshness` section for any UI-affecting or
+  contract-affecting runtime change. Link the matching v0 PR/commit, or select
+  `No v0 impact` and explain why.
 - Before changing AWS resources, IAM, workflows, or architecture topology,
   inspect sibling state, not only the one named attribute.
 - Before implementation work completes recon, identify which normative

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,17 @@ commit and push that v0 repo change, run `pnpm sync:v0` in this runtime repo,
 then implement against the synced contract. Stop and ask if v0 repo access is
 unavailable.
 
+**M15 v0 freshness rule**: #391 established the reconciled v0 UI/contract
+baseline at v0 repo `main` commit
+`9515fc521d2eaa7431612e17b57e3fff517d131d`. From #124 onward, any runtime PR
+that changes UI-affecting or contract-affecting paths must link the matching
+`transformotion-apps-b8` PR/commit in the PR body's `v0 freshness` section, or
+explicitly declare `No v0 impact` with a reason. UI-affecting paths include app
+`app/`, `components/`, UI-used `lib/`, `stores/`, `hooks/`, `services/`,
+`data/`, app frontend config, shared UI packages, frontend service/adaptor
+packages, and `packages/contracts/`. v0 sandboxes may be stale: refresh from
+`transformotion-apps-b8/main` before using them as freshness evidence.
+
 ## Boundary Discipline
 
 When the user instructs "diagnose only," "recon only," "don't take action," "verify only," or any similar scope-limiting language, the constraint is binding. It applies for the entire session until the user explicitly authorises a different scope. It is not overridden by:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -329,6 +329,47 @@ The contracts policy document (location ratified in Stage 0b) governs what
 goes in each contract file, the normative-vs-descriptive classification,
 and the relationship between contracts and TypeScript domain packages.
 
+### 3.5.1 v0 freshness enforcement
+
+M15 #391 established the reconciled v0 baseline for Launchpad, Stock Analyser,
+and Budget Tracker. The baseline starts from v0 repo `main` commit
+`9515fc521d2eaa7431612e17b57e3fff517d131d`. From #124 onward, v0 must not fall
+behind runtime UI or contract behaviour.
+
+Any runtime PR that changes UI-affecting or contract-affecting paths must do
+one of two things before CI can pass:
+
+1. Link the matching `transformotion-apps-b8` v0 PR or commit in the PR body's
+   `v0 freshness` section.
+2. Declare `No v0 impact` in that section and give a clear reason.
+
+UI-affecting or contract-affecting paths include:
+
+- `apps/*/app/**`
+- `apps/*/components/**`
+- `apps/*/lib/**` when it is used by UI, services, adapters, hooks, or state
+- `apps/*/stores/**`, `apps/*/hooks/**`, `apps/*/services/**`, and
+  `apps/*/data/**`
+- app frontend config such as `next.config.*`, app `package.json`,
+  `.env.example`, and `tsconfig.json`
+- shared UI/design-system packages such as `packages/ui/**`
+- frontend service/adaptor packages such as `packages/api-client/**`,
+  `packages/auth-client/**`, and `packages/runtime-config/**`
+- the v0 contract wrapper package, `packages/contracts/**`
+- canonical contract paths, when present in the runtime repo, and v0 mock or
+  adapter changes
+
+Usually non-UI examples include backend-only Lambda internals with no UI or
+contract shape change, infrastructure-only deploy role changes,
+documentation-only changes, and CI-only changes. If in doubt, treat the change
+as v0-impacting and link the v0 work.
+
+v0 working sandboxes and branches may be stale. Before v0 work is used to
+satisfy this gate, refresh from `transformotion-apps-b8/main`, land the v0
+change there, then run `pnpm sync:v0` and `pnpm check:v0-contracts` in this
+runtime repo. CI uses `V0_REPO_READ_TOKEN` for read-only verification only; it
+must never write to or auto-fix the v0 repo from runtime state.
+
 ### 3.6 The decision rule — where new code lives
 
 When a new piece of code is written, the question is: does it go in
@@ -416,6 +457,11 @@ branch names.
 Every PR references at least one issue. The PR body includes "Closes
 #N" or "Fixes #N" for the issue it closes, or "Refs #N" for issues it
 relates to but does not close.
+
+Every PR must also complete the `v0 freshness` section when it changes
+UI-affecting or contract-affecting paths. Link the matching v0 PR/commit, or
+select `No v0 impact` and explain why no v0 change is required. CI enforces
+this declaration for the path classes in Section 3.5.1.
 
 PRs without a corresponding issue are acceptable only for trivial work
 (typo fixes, comment-only changes, single-line style adjustments). When in

--- a/apps/budget-tracker/AGENTS.md
+++ b/apps/budget-tracker/AGENTS.md
@@ -28,10 +28,7 @@ React + TypeScript + Tailwind CSS + shadcn/ui.
 | DynamoDB table schemas | [/docs/architecture/data.md](/docs/architecture/data.md) |
 | CDK stacks, Lambda names | [/docs/architecture/cdk.md](/docs/architecture/cdk.md) |
 | URL routing, CloudFront, deploy triggers | [/docs/architecture/urls-and-deploy.md](/docs/architecture/urls-and-deploy.md) |
-| Data models and types | [/v0-reference/contracts/budget-tracker/data-models.md](/v0-reference/contracts/budget-tracker/data-models.md) |
-| API contracts | [/v0-reference/contracts/budget-tracker/api-endpoints.md](/v0-reference/contracts/budget-tracker/api-endpoints.md) |
-| State management and adaptor pattern | [/v0-reference/contracts/budget-tracker/state-management.md](/v0-reference/contracts/budget-tracker/state-management.md) |
-| AWS infrastructure reference | [/v0-reference/contracts/budget-tracker/aws-infrastructure.md](/v0-reference/contracts/budget-tracker/aws-infrastructure.md) |
+| Canonical Budget Tracker contracts | [/v0-reference/contracts/budget-tracker/](/v0-reference/contracts/budget-tracker/) |
 
 ## CDK stacks owned
 
@@ -97,7 +94,7 @@ Budget Tracker UI uses the adaptor pattern. **Components never call APIs, Dynamo
 ```
 Component
   → Zustand store action
-  → Repository interface method   ← defined in contracts/state-management.md
+  → Repository interface method   ← defined in v0 contracts
   → stub adaptor (dev/v0) OR aws-adaptor (production)
 ```
 
@@ -106,13 +103,13 @@ The three Zustand stores:
 - `useAiStore` — AI review queue and CSV analysis
 - `useAuthStore` — current user and sign-in/out
 
-Repository interfaces are defined in the generated read-only `v0-reference/contracts/budget-tracker/state-management.md`. **Do not add methods to a repository without updating the contract file in the v0 repo first, committing and pushing that v0 change, then running `pnpm sync:v0`.**
+Repository interfaces are defined in the generated read-only `v0-reference/contracts/budget-tracker/` scope. **Do not add methods to a repository without updating the canonical contract in the v0 repo first, committing and pushing that v0 change, then running `pnpm sync:v0`.**
 
 ### Forbidden patterns
 
 - `fetch()` in components or store actions
 - `localStorage` reads/writes outside `lib/repositories/`
-- Types not in `v0-reference/contracts/budget-tracker/data-models.md`
+- UI/backend boundary types not sourced from `v0-reference/contracts/budget-tracker/`
 - `window.confirm` — use inline confirmation UI instead
 - IIFEs inside JSX — compute values above the return statement
 - `URL.createObjectURL` for CSV export — use data URI instead
@@ -121,7 +118,7 @@ Repository interfaces are defined in the generated read-only `v0-reference/contr
 
 ## Data types
 
-All types that cross the UI/backend boundary are defined in [v0-reference/contracts/budget-tracker/data-models.md](/v0-reference/contracts/budget-tracker/data-models.md). Key types:
+Types that cross the UI/backend boundary are defined in the generated read-only [v0-reference/contracts/budget-tracker/](/v0-reference/contracts/budget-tracker/) scope. Key types:
 - `Transaction` — atomic unit; `_manual` flag prevents rules from overwriting; `categoryId`/`subcategoryId` are UUID FKs; deprecated `category`/`subcategory` string fields remain for migration fallback display
 - `MatchingRule` — user-managed keyword/regex rule referencing `categoryId`/`subcategoryId` UUIDs; sorted by `priority` (lower = higher priority); replaces the old `CustomRule` + `BuiltinRule` split (there are no built-in rules)
 - `BudgetData` — `{ categories: Category[], budgetAmounts: Record<subcategoryId, number>, budgetFrequencies: Record<subcategoryId, BudgetFrequency> }`; stored as a single `budgetData` key in the settings table
@@ -181,7 +178,7 @@ Provider is selected via `config.ai.provider` (`'mock'` or `'claude'`), resolved
 
 **Adding a new AI feature:**
 1. Add the method to the `AIService` interface in `lib/services/ai/index.ts`
-2. Update the contract in the v0 repo (`transformotion-apps-b8/contracts/budget-tracker/state-management.md`), commit and push that v0 change, then run `pnpm sync:v0`
+2. Update the contract in the v0 repo (`transformotion-apps-b8/contracts/budget-tracker/`), commit and push that v0 change, then run `pnpm sync:v0`
 3. Add a matching Lambda route to `apps/budget-tracker/functions/budget-ai/src/index.ts` with `requireAppAccess` + `requireAccountAccess`
 4. Implement the method in `MockAIService` (mock-ai.ts) and `ClaudeAIService` (claude-ai.ts)
 5. Add prompt text in the Lambda (server-side only — never in client code)

--- a/apps/budget-tracker/CLAUDE.md
+++ b/apps/budget-tracker/CLAUDE.md
@@ -31,10 +31,7 @@ React + TypeScript + Tailwind CSS + shadcn/ui.
 | DynamoDB table schemas | [/docs/architecture/data.md](/docs/architecture/data.md) |
 | CDK stacks, Lambda names | [/docs/architecture/cdk.md](/docs/architecture/cdk.md) |
 | URL routing, CloudFront, deploy triggers | [/docs/architecture/urls-and-deploy.md](/docs/architecture/urls-and-deploy.md) |
-| Data models and types | [/v0-reference/contracts/budget-tracker/data-models.md](/v0-reference/contracts/budget-tracker/data-models.md) |
-| API contracts | [/v0-reference/contracts/budget-tracker/api-endpoints.md](/v0-reference/contracts/budget-tracker/api-endpoints.md) |
-| State management and adaptor pattern | [/v0-reference/contracts/budget-tracker/state-management.md](/v0-reference/contracts/budget-tracker/state-management.md) |
-| AWS infrastructure reference | [/v0-reference/contracts/budget-tracker/aws-infrastructure.md](/v0-reference/contracts/budget-tracker/aws-infrastructure.md) |
+| Canonical Budget Tracker contracts | [/v0-reference/contracts/budget-tracker/](/v0-reference/contracts/budget-tracker/) |
 
 ## CDK stacks owned
 
@@ -100,7 +97,7 @@ Budget Tracker UI uses the adaptor pattern. **Components never call APIs, Dynamo
 ```
 Component
   → Zustand store action
-  → Repository interface method   ← defined in contracts/state-management.md
+  → Repository interface method   ← defined in v0 contracts
   → stub adaptor (dev/v0) OR aws-adaptor (production)
 ```
 
@@ -109,13 +106,13 @@ The three Zustand stores:
 - `useAiStore` — AI review queue and CSV analysis
 - `useAuthStore` — current user and sign-in/out
 
-Repository interfaces are defined in the generated read-only `v0-reference/contracts/budget-tracker/state-management.md`. **Do not add methods to a repository without updating the contract file in the v0 repo first, committing and pushing that v0 change, then running `pnpm sync:v0`.**
+Repository interfaces are defined in the generated read-only `v0-reference/contracts/budget-tracker/` scope. **Do not add methods to a repository without updating the canonical contract in the v0 repo first, committing and pushing that v0 change, then running `pnpm sync:v0`.**
 
 ### Forbidden patterns
 
 - `fetch()` in components or store actions
 - `localStorage` reads/writes outside `lib/repositories/`
-- Types not in `v0-reference/contracts/budget-tracker/data-models.md`
+- UI/backend boundary types not sourced from `v0-reference/contracts/budget-tracker/`
 - `window.confirm` — use inline confirmation UI instead
 - IIFEs inside JSX — compute values above the return statement
 - `URL.createObjectURL` for CSV export — use data URI instead
@@ -124,7 +121,7 @@ Repository interfaces are defined in the generated read-only `v0-reference/contr
 
 ## Data types
 
-All types that cross the UI/backend boundary are defined in [v0-reference/contracts/budget-tracker/data-models.md](/v0-reference/contracts/budget-tracker/data-models.md). Key types:
+Types that cross the UI/backend boundary are defined in the generated read-only [v0-reference/contracts/budget-tracker/](/v0-reference/contracts/budget-tracker/) scope. Key types:
 - `Transaction` — atomic unit; `_manual` flag prevents rules from overwriting; `categoryId`/`subcategoryId` are UUID FKs; deprecated `category`/`subcategory` string fields remain for migration fallback display
 - `MatchingRule` — user-managed keyword/regex rule referencing `categoryId`/`subcategoryId` UUIDs; sorted by `priority` (lower = higher priority); replaces the old `CustomRule` + `BuiltinRule` split (there are no built-in rules)
 - `BudgetData` — `{ categories: Category[], budgetAmounts: Record<subcategoryId, number>, budgetFrequencies: Record<subcategoryId, BudgetFrequency> }`; stored as a single `budgetData` key in the settings table
@@ -184,7 +181,7 @@ Provider is selected via `config.ai.provider` (`'mock'` or `'claude'`), resolved
 
 **Adding a new AI feature:**
 1. Add the method to the `AIService` interface in `lib/services/ai/index.ts`
-2. Update the contract in the v0 repo (`transformotion-apps-b8/contracts/budget-tracker/state-management.md`), commit and push that v0 change, then run `pnpm sync:v0`
+2. Update the contract in the v0 repo (`transformotion-apps-b8/contracts/budget-tracker/`), commit and push that v0 change, then run `pnpm sync:v0`
 3. Add a matching Lambda route to `apps/budget-tracker/functions/budget-ai/src/index.ts` with `requireAppAccess` + `requireAccountAccess`
 4. Implement the method in `MockAIService` (mock-ai.ts) and `ClaudeAIService` (claude-ai.ts)
 5. Add prompt text in the Lambda (server-side only — never in client code)

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "test": "pnpm sync:v0 && turbo test",
     "sync:v0": "bash scripts/sync-v0.sh",
     "check:v0-contracts": "bash scripts/ci/check-v0-contracts-synced.sh",
+    "check:v0-freshness": "node scripts/ci/check-v0-freshness.mjs",
     "clean": "turbo clean && rm -rf node_modules",
     "prepare": "husky"
   },

--- a/scripts/ci/check-v0-freshness.mjs
+++ b/scripts/ci/check-v0-freshness.mjs
@@ -1,0 +1,144 @@
+#!/usr/bin/env node
+
+import { execSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+
+const uiImpactPatterns = [
+  /^apps\/[^/]+\/app\//,
+  /^apps\/[^/]+\/components\//,
+  /^apps\/[^/]+\/lib\//,
+  /^apps\/[^/]+\/stores\//,
+  /^apps\/[^/]+\/hooks\//,
+  /^apps\/[^/]+\/services\//,
+  /^apps\/[^/]+\/data\//,
+  /^apps\/[^/]+\/next\.config\.[cm]?js$/,
+  /^apps\/[^/]+\/package\.json$/,
+  /^apps\/[^/]+\/\.env\.example$/,
+  /^apps\/[^/]+\/tsconfig\.json$/,
+  /^packages\/ui\//,
+  /^packages\/contracts\//,
+  /^packages\/api-client\//,
+  /^packages\/auth-client\//,
+  /^packages\/runtime-config\//,
+  /^packages\/budget-domain\//,
+  /^contracts\//,
+];
+
+const nonUiExamples = [
+  "backend-only Lambda internals with no UI or contract shape change",
+  "infrastructure-only deploy role changes",
+  "documentation-only changes",
+  "CI-only changes",
+];
+
+function readChangedFiles() {
+  if (process.env.CHANGED_FILES_FILE) {
+    return readFileSync(process.env.CHANGED_FILES_FILE, "utf8");
+  }
+
+  if (process.env.CHANGED_FILES) {
+    return process.env.CHANGED_FILES;
+  }
+
+  const baseRef = process.env.GITHUB_BASE_REF;
+  if (baseRef) {
+    execSync(`git fetch origin ${shellQuote(baseRef)} --depth=1`, {
+      stdio: "inherit",
+    });
+    return execSync(`git diff --name-only origin/${shellQuote(baseRef)}...HEAD`, {
+      encoding: "utf8",
+    });
+  }
+
+  return execSync("git diff --name-only HEAD~1...HEAD", { encoding: "utf8" });
+}
+
+function readPrBody() {
+  if (process.env.PR_BODY_FILE && existsSync(process.env.PR_BODY_FILE)) {
+    return readFileSync(process.env.PR_BODY_FILE, "utf8");
+  }
+
+  return process.env.PR_BODY ?? "";
+}
+
+function shellQuote(value) {
+  if (!/^[A-Za-z0-9._/-]+$/.test(value)) {
+    throw new Error(`Unsafe ref value: ${value}`);
+  }
+  return value;
+}
+
+function isUiImpactingPath(path) {
+  const normalized = path.replaceAll("\\", "/");
+  return uiImpactPatterns.some((pattern) => pattern.test(normalized));
+}
+
+function hasLinkedV0Reference(section) {
+  return /transformotion-apps-b8\/(?:pull|commit)\/[A-Za-z0-9._/-]+/i.test(
+    section,
+  );
+}
+
+function hasNoImpactReason(section) {
+  const selectedNoImpact =
+    /-\s*\[[xX]\]\s*No v0 impact/i.test(section) ||
+    /No v0 impact\s*:\s*(?!\s*$).+/i.test(section);
+
+  if (!selectedNoImpact) {
+    return false;
+  }
+
+  const reasonMatch = section.match(/Reason[^:\n]*:\s*([\s\S]+)/i);
+  return Boolean(reasonMatch && reasonMatch[1].trim().length >= 10);
+}
+
+function getV0Section(body) {
+  const match = body.match(/(^|\n)##\s+v0 freshness\s*\n([\s\S]*?)(?=\n##\s+|\s*$)/i);
+  return match?.[2] ?? "";
+}
+
+const changedFiles = readChangedFiles()
+  .split(/\r?\n/)
+  .map((line) => line.trim())
+  .filter(Boolean);
+
+const impactingFiles = changedFiles.filter(isUiImpactingPath);
+
+if (impactingFiles.length === 0) {
+  console.log("OK: no UI-affecting or contract-affecting paths changed.");
+  process.exit(0);
+}
+
+const prBody = readPrBody();
+const v0Section = getV0Section(prBody);
+
+if (
+  v0Section &&
+  (hasLinkedV0Reference(v0Section) || hasNoImpactReason(v0Section))
+) {
+  console.log("OK: v0 freshness declaration found for impacted paths.");
+  console.log("Impacted paths:");
+  for (const file of impactingFiles) {
+    console.log(`- ${file}`);
+  }
+  process.exit(0);
+}
+
+console.error("ERROR: v0 freshness declaration is required.");
+console.error("");
+console.error("These paths are UI-affecting or contract-affecting:");
+for (const file of impactingFiles) {
+  console.error(`- ${file}`);
+}
+console.error("");
+console.error("Add a PR body section named '## v0 freshness' with either:");
+console.error("- a link to the matching transformotion-apps-b8 PR/commit, or");
+console.error("- 'No v0 impact' selected plus a clear reason.");
+console.error("");
+console.error("Non-UI examples that usually do not require v0 work:");
+for (const example of nonUiExamples) {
+  console.error(`- ${example}`);
+}
+
+process.exit(1);
+


### PR DESCRIPTION
﻿Refs #124

## Summary

Adds the M15 #124 v0 freshness enforcement layer so runtime PRs cannot change UI-affecting or contract-affecting paths without either linking the matching v0 work or declaring why no v0 change is required.

## Enforcement model

- Adds a PR template with a required `v0 freshness` section.
- Adds `scripts/ci/check-v0-freshness.mjs` and `pnpm check:v0-freshness`.
- Adds a `v0 Freshness Gate` job to PR CI. The job diffs the PR against the base branch, classifies UI/contract-impacting paths, then requires the PR body to include either a `transformotion-apps-b8` PR/commit link or a selected `No v0 impact` declaration with a reason.
- Keeps the existing `v0 Contracts Sync` byte-identity job for canonical contract freshness.
- Adds `pnpm check:v0-contracts` after `pnpm sync:v0` in Launchpad, Stock Analyser, and Budget Tracker deploy workflows before AWS deploy work starts.

## UI-affecting path classification

The gate treats these as UI-affecting or contract-affecting:

- `apps/*/app/**`
- `apps/*/components/**`
- `apps/*/lib/**`
- `apps/*/stores/**`, `apps/*/hooks/**`, `apps/*/services/**`, `apps/*/data/**`
- app frontend config such as `next.config.*`, app `package.json`, `.env.example`, and `tsconfig.json`
- `packages/ui/**`
- `packages/contracts/**`
- `packages/api-client/**`, `packages/auth-client/**`, `packages/runtime-config/**`
- `packages/budget-domain/**`
- `contracts/**` if present in the runtime repo

Usually non-UI examples are backend-only Lambda internals with no UI/contract shape change, infrastructure-only deploy role changes, documentation-only changes, and CI-only changes.

## Passing and failing declarations

Passing linked-v0 example:

```md
## v0 freshness

- [x] Linked v0 PR/commit: https://github.com/transformotion/transformotion-apps-b8/pull/19
- [ ] No v0 impact:

Reason when selecting "No v0 impact":
```

Passing no-impact example:

```md
## v0 freshness

- [ ] Linked v0 PR/commit:
- [x] No v0 impact:

Reason when selecting "No v0 impact":
Only backend Lambda internals changed; no UI, mock, adapter, or contract shape changed.
```

Failing example: an impacted path changed with no `## v0 freshness` section, no v0 PR/commit link, and no explicit no-impact reason.

## v0 freshness

- [ ] Linked v0 PR/commit:
- [x] No v0 impact:

Reason when selecting "No v0 impact":
This PR changes CI/deploy enforcement, PR template text, and agent/contributor documentation only. It does not change runtime UI behaviour, canonical v0 contracts, v0 mocks/adapters, or app contract shapes.

## Validation

- `pnpm check:v0-freshness` with non-UI path: passed
- `pnpm check:v0-freshness` with impacted path and missing declaration: failed as expected
- `pnpm check:v0-freshness` with impacted path and linked v0 PR: passed
- `pnpm check:v0-freshness` with impacted path and no-impact reason: passed
- `pnpm sync:v0`: passed
- `pnpm check:v0-contracts`: passed
- `git diff --check`: passed
- `pnpm typecheck`: passed
- `pnpm build`: passed
- Confirmed no generated `v0-reference/contracts/` files are tracked or committed

## Known limitations

- The freshness gate is a PR-body declaration check; it does not semantically compare runtime UI against v0 UI.
- Direct pushes to `develop` would bypass the PR-body gate, so branch protection should require PR CI for normal integration. App deploy workflows still run the v0 contract byte-identity check before deploy.
- Path classification is intentionally conservative; teams can declare `No v0 impact` with a reason for false positives.
