### PR TITLE
M15 E2E A: mirror v0 Launchpad tile copy

### DIFF
--- a/apps/launchpad/components/launchpad/launchpad.tsx
+++ b/apps/launchpad/components/launchpad/launchpad.tsx
@@ -48,7 +48,7 @@ const APPS: App[] = [
   {
     id: 'budget-tracker',
     name: 'Budget Tracker',
-    description: 'Track income, expenses and savings across accounts',
+    description: 'Track spending, savings and cashflow across accounts',
     icon: Wallet,
     available: true,
     color: 'text-signal-green',


### PR DESCRIPTION
﻿## Summary

Refs #401

E2E A runtime half: mirrors the v0-authored Launchpad Budget Tracker tile copy change so we can prove the v0 -> runtime workflow.

## v0 freshness

Choose one:

- [x] Linked v0 PR/commit: https://github.com/transformotion/transformotion-apps-b8/pull/29 and https://github.com/transformotion/transformotion-apps-b8/commit/c3b3cc572b027db8d282933e7143d2ce1b4aa09f
- [ ] No v0 impact:

Reason when selecting "No v0 impact":

## Validation

- [x] `pnpm sync:v0`
- [x] `pnpm check:v0-contracts`
- [x] `pnpm --filter @transformotion/launchpad typecheck`
- [x] Local `pnpm check:v0-freshness` with the linked v0 PR/commit

## Notes

- Tiny visible copy change only.
- No contract files changed.
- No generated `v0-reference/contracts` files committed.
- Intended to trigger Launchpad dev deploy after merge for browser validation.
