### PR TITLE
M15 E2E A: mirror v0 AI settings modal scrolling

### DIFF
--- a/apps/launchpad/app/globals.css
+++ b/apps/launchpad/app/globals.css
@@ -100,3 +100,32 @@
     @apply bg-background text-foreground;
   }
 }
+
+@layer utilities {
+  /* Subtle custom scrollbar for in-modal/panel scroll areas. */
+  .scrollbar-subtle {
+    scrollbar-width: thin;
+    scrollbar-color: var(--surface2) transparent;
+  }
+
+  .scrollbar-subtle::-webkit-scrollbar {
+    width: 8px;
+    height: 8px;
+  }
+
+  .scrollbar-subtle::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  .scrollbar-subtle::-webkit-scrollbar-thumb {
+    background-color: var(--surface2);
+    border: 2px solid transparent;
+    border-radius: 9999px;
+    background-clip: padding-box;
+  }
+
+  .scrollbar-subtle::-webkit-scrollbar-thumb:hover {
+    background-color: color-mix(in srgb, var(--surface2) 70%, var(--foreground) 30%);
+    background-clip: padding-box;
+  }
+}

--- a/apps/launchpad/components/launchpad/ai-engine-settings.tsx
+++ b/apps/launchpad/components/launchpad/ai-engine-settings.tsx
@@ -217,9 +217,9 @@ export function AiEngineSettings({
         role="dialog"
         aria-modal="true"
         aria-label="AI Engine Settings"
-        className="fixed inset-x-4 top-6 z-50 mx-auto max-h-[calc(100vh-3rem)] max-w-3xl overflow-y-auto rounded-lg border border-border bg-card shadow-2xl"
+        className="fixed inset-x-4 top-6 z-50 mx-auto flex max-h-[calc(100dvh-3rem)] max-w-3xl flex-col overflow-hidden rounded-lg border border-border bg-card shadow-2xl"
       >
-        <div className="sticky top-0 flex items-center justify-between gap-3 border-b border-border bg-card px-4 py-3">
+        <div className="flex shrink-0 items-center justify-between gap-3 border-b border-border bg-card px-4 py-3">
           <div>
             <h2 className="text-lg font-semibold text-foreground">AI Engine Settings</h2>
             <p className="text-sm text-muted-foreground">Provider and model selection</p>
@@ -234,7 +234,7 @@ export function AiEngineSettings({
           </button>
         </div>
 
-        <div className="grid gap-5 p-4">
+        <div className="scrollbar-subtle grid min-h-0 flex-1 gap-5 overflow-y-auto overscroll-contain p-4">
           {error ? <ErrorBanner message={error} /> : null}
 
           <div className="flex items-center justify-between gap-3">


### PR DESCRIPTION
﻿## Summary

Refs #401

M15 E2E Test A: v0-authored Launchpad AI Engine Settings modal scroll/layout polish flowing into runtime/dev.

This mirrors v0 PR #32's UI-only modal improvement in the runtime Launchpad app:

- adds a subtle modal scrollbar utility
- switches the AI Engine Settings dialog to a flex-column shell
- keeps the modal header fixed while the modal body scrolls internally
- preserves current settings behaviour and controls

## v0 freshness

Choose one:

- [x] Linked v0 PR/commit: https://github.com/transformotion/transformotion-apps-b8/pull/32 and https://github.com/transformotion/transformotion-apps-b8/commit/ef8bd1fa2fcde3023b9b2b53e734db69c8e7816a
- [ ] No v0 impact:

Reason when selecting "No v0 impact":

## Validation

- [x] `pnpm sync:v0`
- [x] `pnpm check:v0-contracts`
- [x] `pnpm --filter @transformotion/launchpad typecheck`
- [x] Local `pnpm check:v0-freshness` with linked v0 PR/commit
- [x] `git diff --check`

## Confirmations

- Launchpad UI only.
- No runtime behaviour change intended.
- No contract changes.
- No API, mock, or data shape changes.
- No Stock Analyser or Budget Tracker changes.
- No generated `v0-reference/contracts` files committed.
