### PR TITLE
fix: show app-owned AI overrides in Launchpad

### DIFF
--- a/apps/launchpad/functions/ai-runtime-config/src/index.test.ts
+++ b/apps/launchpad/functions/ai-runtime-config/src/index.test.ts
@@ -9,11 +9,18 @@ function makeClient(seed: Record<string, StoredItem> = {}) {
   return {
     items,
     client: {
-      send: async (command: { constructor: { name: string }; input?: { Key?: { sk?: string }; Item?: StoredItem } }) => {
+      send: async (command: { constructor: { name: string }; input?: { TableName?: string; Key?: Record<string, string>; Item?: StoredItem } }) => {
         const name = command.constructor.name;
         if (name === 'GetCommand') {
-          const sk = command.input?.Key?.sk;
-          return { Item: sk ? items.get(sk) : undefined };
+          const tableName = command.input?.TableName;
+          const key = command.input?.Key;
+          if (!key) return { Item: undefined };
+          const compositeKey = Object.entries(key).map(([k, v]) => `${k}=${v}`).join('|');
+          return {
+            Item: (tableName ? items.get(`${tableName}|${compositeKey}`) : undefined)
+              ?? items.get(compositeKey)
+              ?? (key.sk ? items.get(key.sk) : undefined),
+          };
         }
         if (name === 'PutCommand') {
           const item = command.input?.Item;
@@ -38,6 +45,7 @@ function event(
   body?: unknown,
   siteAdmin = true,
   appSlug?: string,
+  accounts: Record<string, Array<{ accountId: string; role: string }>> = {},
 ) {
   return {
     resource,
@@ -51,7 +59,7 @@ function event(
           email: 'admin@example.com',
           'cognito:groups': '',
           apps: JSON.stringify([]),
-          accounts: JSON.stringify({}),
+          accounts: JSON.stringify(accounts),
           site_admin: String(siteAdmin),
         },
       },
@@ -117,6 +125,64 @@ describe('ai-runtime-config handler', () => {
       supportedModels: {
         claude: ['claude-sonnet-4-6', 'claude-opus-4-8', 'claude-haiku-4-5-20251001'],
         openai: ['gpt-5.4-mini', 'gpt-5.4', 'gpt-5.5', 'gpt-5.4-nano'],
+      },
+    });
+  });
+
+  it('reads app-owned override summaries for the first account membership per app', async () => {
+    const { client } = makeClient({
+      [PLATFORM_DEFAULT_SK]: record(PLATFORM_DEFAULT_SK, 'claude', 'claude-sonnet-4-6'),
+      [appOverrideSk('stock-analyser')]: record(appOverrideSk('stock-analyser'), 'claude', 'claude-haiku-4-5-20251001'),
+      'budget-tracker.settings-dev|accountId=bt-account|settingKey=AI_CONFIG#APP#budget-tracker': record(appOverrideSk('budget-tracker'), 'openai', 'gpt-5.4-mini'),
+      'stock-analyser.settings-dev|pk=ACCOUNT#sa-account|sk=APP#AI_RUNTIME': {
+        pk: 'ACCOUNT#sa-account',
+        sk: 'APP#AI_RUNTIME',
+        config: record(appOverrideSk('stock-analyser'), 'openai', 'gpt-5.5'),
+      },
+    });
+    const handler = createHandler({
+      client,
+      tableName: 'launchpad-ai-runtime-config-dev',
+      budgetTrackerSettingsTable: 'budget-tracker.settings-dev',
+      stockAnalyserSettingsTable: 'stock-analyser.settings-dev',
+      now: () => new Date('2026-06-04T01:00:00.000Z'),
+    });
+
+    const response = await handler(event(
+      '/api/admin/ai-runtime-config',
+      'GET',
+      undefined,
+      true,
+      undefined,
+      {
+        'budget-tracker': [{ accountId: 'bt-account', role: 'owner' }],
+        'stock-analyser': [{ accountId: 'sa-account', role: 'owner' }],
+      },
+    )) as { statusCode: number; body: string };
+
+    expect(response.statusCode).toBe(200);
+    expect(responseBody(response)).toMatchObject({
+      appOverrides: {
+        'budget-tracker': {
+          provider: 'openai',
+          model: 'gpt-5.4-mini',
+        },
+        'stock-analyser': {
+          provider: 'openai',
+          model: 'gpt-5.5',
+        },
+      },
+      effective: {
+        'budget-tracker': {
+          provider: 'openai',
+          model: 'gpt-5.4-mini',
+          source: 'app_override',
+        },
+        'stock-analyser': {
+          provider: 'openai',
+          model: 'gpt-5.5',
+          source: 'app_override',
+        },
       },
     });
   });

--- a/apps/launchpad/functions/ai-runtime-config/src/index.ts
+++ b/apps/launchpad/functions/ai-runtime-config/src/index.ts
@@ -14,6 +14,7 @@ import {
   requireSiteAdmin,
   withAuthOnly,
   type APIGatewayProxyEvent,
+  type AuthClaims,
 } from '@transformotion/lambda-middleware';
 import {
   AI_CONFIG_PK,
@@ -31,16 +32,24 @@ import {
 
 const ddb = DynamoDBDocumentClient.from(new DynamoDBClient({}));
 const CONFIG_TABLE = process.env.AI_CONFIG_TABLE!;
+const BUDGET_TRACKER_SETTINGS_TABLE = process.env.BUDGET_TRACKER_SETTINGS_TABLE;
+const STOCK_ANALYSER_SETTINGS_TABLE = process.env.STOCK_ANALYSER_SETTINGS_TABLE;
+const BUDGET_TRACKER_SETTING_KEY = 'AI_CONFIG#APP#budget-tracker';
+const STOCK_ANALYSER_AI_RUNTIME_SK = 'APP#AI_RUNTIME';
 
 interface Dependencies {
   client: DynamoDBDocumentClient;
   tableName: string;
+  budgetTrackerSettingsTable?: string;
+  stockAnalyserSettingsTable?: string;
   now: () => Date;
 }
 
 const defaultDependencies: Dependencies = {
   client: ddb,
   tableName: CONFIG_TABLE,
+  budgetTrackerSettingsTable: BUDGET_TRACKER_SETTINGS_TABLE,
+  stockAnalyserSettingsTable: STOCK_ANALYSER_SETTINGS_TABLE,
   now: () => new Date(),
 };
 
@@ -95,6 +104,72 @@ async function readRecord(deps: Dependencies, sk: string): Promise<AiRuntimeConf
   return toRecord(sk as AiRuntimeConfigRecord['sk'], provider, model, updatedAt);
 }
 
+function parseRecord(
+  item: Record<string, unknown> | undefined,
+  sk: AiRuntimeConfigRecord['sk'],
+): AiRuntimeConfigRecord | null {
+  if (!item) return null;
+  const source = typeof item['config'] === 'object' && item['config'] !== null
+    ? item['config'] as Record<string, unknown>
+    : item;
+  const provider = source['provider'];
+  const model = source['model'];
+  const updatedAt = source['updatedAt'];
+  if (!isSupportedAiProvider(provider) || !isSupportedAiModel(provider, model) || typeof updatedAt !== 'string') {
+    return null;
+  }
+  return toRecord(sk, provider, model, updatedAt);
+}
+
+function firstAccountId(auth: AuthClaims, appSlug: AiConfigAppSlug): string | null {
+  const memberships = auth.accounts[appSlug] ?? [];
+  return memberships[0]?.accountId ?? null;
+}
+
+async function readBudgetTrackerAppOverride(
+  deps: Dependencies,
+  auth: AuthClaims,
+): Promise<AiRuntimeConfigRecord | null> {
+  const accountId = firstAccountId(auth, 'budget-tracker');
+  if (!deps.budgetTrackerSettingsTable || !accountId) return null;
+  const res = await deps.client.send(new GetCommand({
+    TableName: deps.budgetTrackerSettingsTable,
+    Key: { accountId, settingKey: BUDGET_TRACKER_SETTING_KEY },
+  }));
+  return parseRecord(res.Item, appOverrideSk('budget-tracker'));
+}
+
+async function readStockAnalyserAppOverride(
+  deps: Dependencies,
+  auth: AuthClaims,
+): Promise<AiRuntimeConfigRecord | null> {
+  const accountId = firstAccountId(auth, 'stock-analyser');
+  if (!deps.stockAnalyserSettingsTable || !accountId) return null;
+  const res = await deps.client.send(new GetCommand({
+    TableName: deps.stockAnalyserSettingsTable,
+    Key: { pk: `ACCOUNT#${accountId}`, sk: STOCK_ANALYSER_AI_RUNTIME_SK },
+  }));
+  return parseRecord(res.Item, appOverrideSk('stock-analyser'));
+}
+
+async function readAppOwnedOverride(
+  deps: Dependencies,
+  auth: AuthClaims,
+  appSlug: AiConfigAppSlug,
+): Promise<AiRuntimeConfigRecord | null> {
+  try {
+    if (appSlug === 'budget-tracker') {
+      return await readBudgetTrackerAppOverride(deps, auth);
+    }
+    if (appSlug === 'stock-analyser') {
+      return await readStockAnalyserAppOverride(deps, auth);
+    }
+  } catch (err) {
+    console.warn(`[launchpad-ai-runtime-config] App-owned AI override read failed for ${appSlug}:`, err);
+  }
+  return null;
+}
+
 async function putRecord(
   deps: Dependencies,
   sk: AiRuntimeConfigRecord['sk'],
@@ -134,10 +209,13 @@ function effectiveConfig(
   };
 }
 
-async function readConfig(deps: Dependencies) {
+async function readConfig(deps: Dependencies, auth: AuthClaims) {
   const platformDefault = await readRecord(deps, PLATFORM_DEFAULT_SK);
   const overrides = await Promise.all(
-    SUPPORTED_APP_SLUGS.map(async appSlug => [appSlug, await readRecord(deps, appOverrideSk(appSlug))] as const),
+    SUPPORTED_APP_SLUGS.map(async appSlug => [
+      appSlug,
+      await readAppOwnedOverride(deps, auth, appSlug) ?? await readRecord(deps, appOverrideSk(appSlug)),
+    ] as const),
   );
 
   const appOverrides = Object.fromEntries(overrides) as Record<AiConfigAppSlug, AiRuntimeConfigRecord | null>;
@@ -189,7 +267,7 @@ export function createHandler(deps: Dependencies = defaultDependencies) {
     const resource = event.resource ?? '';
 
     if (resource === '/api/admin/ai-runtime-config' && event.httpMethod === 'GET') {
-      return readConfig(deps);
+      return readConfig(deps, auth);
     }
     if (resource === '/api/admin/ai-runtime-config/platform-default' && event.httpMethod === 'PUT') {
       return updatePlatformDefault(deps, event);

--- a/apps/launchpad/infrastructure/launchpad-control-plane-stack.ts
+++ b/apps/launchpad/infrastructure/launchpad-control-plane-stack.ts
@@ -103,6 +103,16 @@ export class LaunchpadControlPlaneStack extends cdk.Stack {
       billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
       removalPolicy: stage === 'prod' ? cdk.RemovalPolicy.RETAIN : cdk.RemovalPolicy.DESTROY,
     });
+    const budgetTrackerSettingsTable = dynamodb.Table.fromTableName(
+      this,
+      'BudgetTrackerSettingsTable',
+      `budget-tracker.settings-${stage}`,
+    );
+    const stockAnalyserSettingsTable = dynamodb.Table.fromTableName(
+      this,
+      'StockAnalyserSettingsTable',
+      `stock-analyser.settings-${stage}`,
+    );
 
     const forgotProviderFn = new lambdaNodejs.NodejsFunction(this, 'ForgotProviderFn', {
       functionName: `launchpad-forgot-provider-${stage}`,
@@ -295,6 +305,8 @@ export class LaunchpadControlPlaneStack extends cdk.Stack {
       memorySize: 256,
       environment: {
         AI_CONFIG_TABLE: aiRuntimeConfigTable.tableName,
+        BUDGET_TRACKER_SETTINGS_TABLE: budgetTrackerSettingsTable.tableName,
+        STOCK_ANALYSER_SETTINGS_TABLE: stockAnalyserSettingsTable.tableName,
       },
       bundling: {
         externalModules: ['@aws-sdk/*'],
@@ -304,6 +316,13 @@ export class LaunchpadControlPlaneStack extends cdk.Stack {
     });
 
     aiRuntimeConfigTable.grantReadWriteData(aiRuntimeConfigFn);
+    aiRuntimeConfigFn.addToRolePolicy(new iam.PolicyStatement({
+      actions: ['dynamodb:GetItem', 'dynamodb:DescribeTable'],
+      resources: [
+        budgetTrackerSettingsTable.tableArn,
+        stockAnalyserSettingsTable.tableArn,
+      ],
+    }));
 
     const adminResource = apiResource.addResource('admin');
     const aiRuntimeConfigResource = adminResource.addResource('ai-runtime-config');


### PR DESCRIPTION
## Summary

Fixes the M15.1 Launchpad AI Engine Settings read-only app summary mismatch reported after PR #408.

Root cause: Launchpad `GET /api/admin/ai-runtime-config` still read only the Launchpad-owned platform default and deprecated Launchpad-owned `APP#...` override rows. After M15.1, Budget Tracker and Stock Analyser write app overrides into app-owned settings tables, so Launchpad displayed stale platform-default summaries even when the owning apps correctly showed `APP OVERRIDE`.

This PR keeps ownership unchanged:

- Launchpad remains write owner for the platform default only.
- Budget Tracker and Stock Analyser remain write owners for app overrides.
- Launchpad gets read-only summary access to app-owned AI override records.
- Deprecated Launchpad app override write/reset routes remain transition-only and are not used by the UI.
- Provider secrets are not exposed.

## Behaviour

Launchpad `GET /api/admin/ai-runtime-config` now resolves app summaries as:

1. app-owned override for the first JWT account membership for that app
2. deprecated Launchpad app override row, for transition fallback only
3. Launchpad platform default
4. environment fallback

This preserves account-scoped app override storage while making the Launchpad read-only summary accurate for the signed-in site-admin user's app accounts.

## v0 freshness

No v0 contract change is required. The existing canonical response shape already supports:

- `appOverrides[appSlug]`
- `effective[appSlug]`
- source `app_override | platform_default | environment_fallback`

No generated `v0-reference/contracts` files are committed.

## Validation

Passed locally:

- `pnpm sync:v0`
- `pnpm check:v0-contracts`
- `pnpm --filter @transformotion/fn-launchpad-ai-runtime-config test`
- `pnpm --filter @transformotion/fn-launchpad-ai-runtime-config typecheck`
- `pnpm --filter @transformotion/launchpad typecheck`
- `pnpm --filter @transformotion/launchpad build`
- `pnpm --filter @transformotion/infra typecheck`
- `pnpm typecheck`
- `pnpm exec cdk synth --app "npx ts-node --prefer-ts-exts bin/launchpad.ts" "TransformotionDev-LaunchpadControlPlane"`
- `pnpm exec cdk diff --app "npx ts-node --prefer-ts-exts bin/launchpad.ts" "TransformotionDev-LaunchpadControlPlane" --context stage=dev`
- `git diff --check`
- staged lint/typecheck pre-commit hooks

CDK diff summary:

- Updates `launchpad-ai-runtime-config-dev` Lambda code.
- Adds `BUDGET_TRACKER_SETTINGS_TABLE` and `STOCK_ANALYSER_SETTINGS_TABLE` env vars.
- Adds read-only `dynamodb:GetItem` and `dynamodb:DescribeTable` permissions for:
  - `budget-tracker.settings-dev`
  - `stock-analyser.settings-dev`
- No table replacements or destructive changes.

## Dev validation plan after merge

- Deploy Launchpad dev only through the develop workflow.
- Open Launchpad AI Engine Settings as site-admin.
- Confirm Budget Tracker summary reflects current app-owned override, expected from user report: `openai / gpt-5.4-mini`, source `APP OVERRIDE`.
- Confirm Stock Analyser summary reflects current app-owned override, expected from user report: `openai / gpt-5.5`, source `APP OVERRIDE`.
- Confirm Launchpad still has no app override Save/Reset controls.
- Confirm resetting app overrides inside each app makes Launchpad summary fall back to platform default.
- Confirm no provider secrets are shown.
