### PR TITLE
docs: codify contract-first development governance

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,6 +2,21 @@
 
 Refs #
 
+## Change classification
+
+Choose one:
+
+- [ ] Contract-changing
+- [ ] Non-contract UI polish
+- [ ] Runtime-only / no v0 impact
+- [ ] Emergency hotfix
+
+Contract-changing work must be v0-first unless explicitly approved as an
+emergency hotfix. Non-contract UI polish means styling, layout, copy, icons,
+responsive behaviour, accessibility attributes, modal/scrollbar polish, or
+component arrangement only, with no data/API/WSS/cache/mock/settings/runtime
+semantic change.
+
 ## v0 freshness
 
 Choose one:
@@ -11,9 +26,20 @@ Choose one:
 
 Reason when selecting "No v0 impact":
 
+## Emergency v0 Reconciliation
+
+Complete only for approved runtime-first contract-changing hotfixes:
+
+- Why runtime-first was necessary:
+- Explicit owner approval reference:
+- Affected contract files/surfaces:
+- Affected UI/mock surfaces:
+- v0 reconciliation PR or issue link:
+- Expected reconciliation deadline:
+- Validation plan:
+
 ## Validation
 
 - [ ] `pnpm sync:v0`
 - [ ] `pnpm check:v0-contracts`
 - [ ] Other:
-

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,6 +159,59 @@ service/adaptor packages, and `packages/contracts/`. v0 sandboxes may be stale:
 refresh from `transformotion-apps-b8/main` before using them as freshness
 evidence.
 
+Before implementing runtime work, classify it as one of:
+
+1. `Contract-changing`
+2. `Non-contract UI polish`
+3. `Runtime-only / no v0 impact`
+4. `Emergency hotfix`
+
+Contract-changing runtime work is prohibited by default unless the canonical v0
+contract update exists first. A change is contract-changing if it adds, removes,
+renames, or changes frontend/backend data fields, API request/response payloads,
+WSS message shapes, cache/job/result shapes, auth/session/claim shapes, runtime
+configuration shapes, mock data assumptions, UI state that depends on a new or
+changed shape, persistence/storage shape that v0 mocks must represent, or app
+settings/configuration shape.
+
+The normal contract-changing workflow is:
+
+1. Update canonical contracts in `transformotion-apps-b8/contracts` first.
+2. Update typed mocks and v0 UI/adapters.
+3. Merge the v0 PR.
+4. In this runtime repo, run `pnpm sync:v0` and `pnpm check:v0-contracts`.
+5. Implement runtime backend/frontend against the synced contracts.
+6. Reference the v0 PR/commit in the runtime PR freshness section.
+
+Non-contract UI polish is allowed when it only affects styling,
+spacing/layout, copy text, icons, responsive behaviour, accessibility
+attributes, modal/scrollbar polish, or component arrangement that does not
+change data/API/WSS/cache/mock/settings/runtime semantics. If polish affects
+both v0 and runtime, prefer v0-first or paired v0/runtime PRs. Runtime PRs still
+need either a v0 PR/commit reference or a clear no-v0-impact reason.
+
+Runtime-first contract-changing work is allowed only as an emergency hotfix:
+the issue must be urgent, the owner must explicitly approve runtime-first work
+before implementation, and the PR must include an `Emergency v0 Reconciliation`
+section. Urgent means app unusable, auth broken, data loss/corruption risk,
+security issue, deployment blocked, provider/model execution broken, or a
+severe user-facing regression. The runtime fix must be the smallest safe change,
+affected contract and UI/mock surfaces must be listed, and a v0 reconciliation
+PR or issue must be created immediately. v0 contracts, mocks, and UI are then
+brought back into sync as soon as possible, followed by `pnpm sync:v0` and
+`pnpm check:v0-contracts`.
+
+The `Emergency v0 Reconciliation` section must include why runtime-first was
+necessary, the explicit owner approval reference, affected contract
+files/surfaces, affected UI/mock surfaces, the v0 reconciliation PR or issue
+link, the expected reconciliation deadline, and the validation plan.
+
+The freshness gate is a CI backstop, not permission to start runtime-first
+contract-changing work. If a runtime task is contract-changing and no v0
+contract update exists, stop and report that v0 must be updated first. If it is
+urgent and contract-changing, ask for explicit owner approval before
+runtime-first implementation.
+
 ### `docs/`
 
 Architecture, planning, audit, and archive material. `docs/architecture/` and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,6 +92,49 @@ explicitly declare `No v0 impact` with a reason. UI-affecting paths include app
 packages, and `packages/contracts/`. v0 sandboxes may be stale: refresh from
 `transformotion-apps-b8/main` before using them as freshness evidence.
 
+**M15 contract-first classification rule**: Before implementing runtime work,
+classify it as `Contract-changing`, `Non-contract UI polish`,
+`Runtime-only / no v0 impact`, or `Emergency hotfix`.
+
+Contract-changing runtime work is prohibited by default unless the canonical v0
+contract update exists first. A change is contract-changing if it adds, removes,
+renames, or changes frontend/backend data fields, API request/response payloads,
+WSS message shapes, cache/job/result shapes, auth/session/claim shapes, runtime
+configuration shapes, mock data assumptions, UI state that depends on a new or
+changed shape, persistence/storage shape that v0 mocks must represent, or app
+settings/configuration shape.
+
+Normal contract-changing workflow: update
+`transformotion-apps-b8/contracts`, update typed mocks and v0 UI/adapters, merge
+the v0 PR, run `pnpm sync:v0` and `pnpm check:v0-contracts` here, implement
+runtime against the synced contracts, and reference the v0 PR/commit in the
+runtime PR freshness section.
+
+Non-contract UI polish is allowed when it only affects styling,
+spacing/layout, copy text, icons, responsive behaviour, accessibility
+attributes, modal/scrollbar polish, or component arrangement that does not
+change data/API/WSS/cache/mock/settings/runtime semantics. If polish affects
+both v0 and runtime, prefer v0-first or paired v0/runtime PRs. Runtime PRs still
+need either a v0 PR/commit reference or a clear no-v0-impact reason.
+
+Runtime-first contract-changing work is allowed only as an emergency hotfix:
+the issue must be urgent, the owner must explicitly approve runtime-first work
+before implementation, and the PR must include an `Emergency v0 Reconciliation`
+section. Urgent means app unusable, auth broken, data loss/corruption risk,
+security issue, deployment blocked, provider/model execution broken, or severe
+user-facing regression. The runtime fix must be the smallest safe change,
+affected contract and UI/mock surfaces must be listed, and a v0 reconciliation
+PR or issue must be created immediately. v0 contracts, mocks, and UI are then
+brought back into sync as soon as possible, followed by `pnpm sync:v0` and
+`pnpm check:v0-contracts`.
+
+The `Emergency v0 Reconciliation` section must include why runtime-first was
+necessary, the explicit owner approval reference, affected contract
+files/surfaces, affected UI/mock surfaces, the v0 reconciliation PR or issue
+link, the expected reconciliation deadline, and the validation plan. The
+freshness gate is a CI backstop, not permission to start runtime-first
+contract-changing work.
+
 ## Boundary Discipline
 
 When the user instructs "diagnose only," "recon only," "don't take action," "verify only," or any similar scope-limiting language, the constraint is binding. It applies for the entire session until the user explicitly authorises a different scope. It is not overridden by:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -370,6 +370,73 @@ change there, then run `pnpm sync:v0` and `pnpm check:v0-contracts` in this
 runtime repo. CI uses `V0_REPO_READ_TOKEN` for read-only verification only; it
 must never write to or auto-fix the v0 repo from runtime state.
 
+### 3.5.2 Contract-first development classification
+
+Before implementing runtime work, classify it as one of:
+
+1. `Contract-changing`
+2. `Non-contract UI polish`
+3. `Runtime-only / no v0 impact`
+4. `Emergency hotfix`
+
+The v0 freshness gate is a CI backstop, not permission to start
+runtime-first contract-changing work.
+
+**Contract-changing work is prohibited by default unless the canonical v0
+contract update exists first.** A change is contract-changing if it adds,
+removes, renames, or changes:
+
+- frontend/backend data fields
+- API request/response payloads
+- WSS message shapes
+- cache/job/result shapes
+- auth/session/claim shapes
+- runtime configuration shapes
+- mock data assumptions
+- UI state that depends on a new or changed shape
+- persistence/storage shape that v0 mocks must represent
+- app settings/configuration shape
+
+Normal contract-changing workflow:
+
+1. Update canonical contracts in `transformotion-apps-b8/contracts` first.
+2. Update typed mocks and v0 UI/adapters.
+3. Merge the v0 PR.
+4. In this runtime repo, run `pnpm sync:v0` and `pnpm check:v0-contracts`.
+5. Implement runtime backend/frontend against the synced contracts.
+6. Reference the v0 PR/commit in the runtime PR freshness section.
+
+**Non-contract UI polish is allowed.** UI polish is non-contract-changing when
+it only affects styling, spacing/layout, copy text, icons, responsive
+behaviour, accessibility attributes, modal/scrollbar polish, or component
+arrangement that does not change data/API/WSS/cache/mock/settings/runtime
+semantics. If polish affects both v0 and runtime, prefer v0-first or paired
+v0/runtime PRs. Runtime PRs still need either a v0 PR/commit reference or a
+clear no-v0-impact reason.
+
+**Runtime-first contract-changing work is allowed only as an emergency
+hotfix.** The issue must be urgent, the owner must explicitly approve
+runtime-first work before implementation, and the PR must include an
+`Emergency v0 Reconciliation` section. Urgent means app unusable, auth broken,
+data loss/corruption risk, security issue, deployment blocked, provider/model
+execution broken, or severe user-facing regression.
+
+The emergency runtime fix must be the smallest safe change. The PR must list
+affected contract surfaces and affected UI/mock surfaces, and a v0
+reconciliation PR or issue must be created immediately. v0 contracts, mocks,
+and UI must be brought back into sync as soon as possible. After
+reconciliation, run `pnpm sync:v0` and `pnpm check:v0-contracts`.
+
+The `Emergency v0 Reconciliation` section must include:
+
+- why runtime-first was necessary
+- explicit owner approval reference
+- affected contract files/surfaces
+- affected UI/mock surfaces
+- v0 reconciliation PR or issue link
+- expected reconciliation deadline
+- validation plan
+
 ### 3.6 The decision rule — where new code lives
 
 When a new piece of code is written, the question is: does it go in


### PR DESCRIPTION
## Summary

Codifies the M15 contract-first development rule in runtime repo guidance and the PR template.

This documents:
- contract-changing runtime work must be v0-contract-first by default
- non-contract UI polish is allowed when it does not change data/API/WSS/cache/mock/settings/runtime semantics
- runtime-first contract-changing work is allowed only as an explicitly approved emergency hotfix
- emergency PRs must include an `Emergency v0 Reconciliation` section

## Scope

Changed files:
- `AGENTS.md`
- `CLAUDE.md`
- `CONTRIBUTING.md`
- `.github/PULL_REQUEST_TEMPLATE.md`

No app code, contracts, generated `v0-reference/`, sync scripts, or CI workflows were changed.

## Change classification

- [ ] Contract-changing
- [ ] Non-contract UI polish
- [x] Runtime-only / no v0 impact
- [ ] Emergency hotfix

## v0 freshness

- [ ] Linked v0 PR/commit:
- [x] No v0 impact:

Reason when selecting "No v0 impact": runtime documentation/template governance only; no runtime UI, contract, mock, data, API, WSS, cache, settings, or runtime semantics changed. A sibling v0 guidance PR is being opened for the v0 repo copy of the same rule.

## Emergency v0 Reconciliation

Not applicable.

## Validation

- [x] `git diff --check`
- [x] `pnpm sync:v0`
- [x] `pnpm check:v0-contracts`
- [x] Scope check confirmed no app code, contract files, or generated sync files changed
