### PR TITLE
feat(launchpad/m16): Phase 3 — UI entitlement/read integration

### DIFF
--- a/apps/launchpad/components/launchpad/launchpad.tsx
+++ b/apps/launchpad/components/launchpad/launchpad.tsx
@@ -4,66 +4,30 @@ import { useState, useEffect } from 'react'
 import { cn } from '@/lib/utils'
 import { Wordmark } from '@/components/brand/wordmark'
 import { AiEngineSettings } from '@/components/launchpad/ai-engine-settings'
-import { TrendingUp, Wallet, Layers, LogOut, Settings, User as UserIcon, Check } from 'lucide-react'
+import { TrendingUp, Wallet, Layers, LogOut, Settings, User as UserIcon, Inbox } from 'lucide-react'
 import type { User } from '@transformotion/auth-client'
+import {
+  LAUNCHPAD_APPS,
+  deriveAppTiles,
+  hasVisibleApps,
+  resolveDisplayName,
+  firstNameOf,
+  type AppTile as AppTileModel,
+} from '@/lib/entitlement'
+import { useLaunchpadData } from '@/hooks/use-launchpad-data'
 
-interface App {
-  id: string
-  name: string
-  description: string
-  icon: React.ComponentType<{ className?: string }>
-  available: boolean
-  color: string
-  bgGradient: string
+const APP_ICONS: Record<string, React.ComponentType<{ className?: string }>> = {
+  'stock-analyser': TrendingUp,
+  'budget-tracker': Wallet,
+  'transformation-framework': Layers,
 }
 
-interface Account {
-  id: string
-  name: string
-  type: 'Personal' | 'Household' | 'Business'
+/** One account row in the profile menu (read-only in Phase 3; switching is Phase 4). */
+interface AccountRow {
+  appSlug: string
+  accountId: string
+  label: string
 }
-
-interface UserProfile {
-  name: string
-  email: string
-  avatar?: string
-  accounts: Account[]
-  activeAccount: string
-}
-
-const PLACEHOLDER_ACCOUNTS: Account[] = [
-  { id: '1', name: 'Personal', type: 'Personal' },
-]
-
-const APPS: App[] = [
-  {
-    id: 'stock-analyser',
-    name: 'Stock Signal Analyser',
-    description: 'Cycle signals across ASX, NASDAQ, Dow Jones and FTSE',
-    icon: TrendingUp,
-    available: true,
-    color: 'text-primary',
-    bgGradient: 'from-primary/20 via-primary/5 to-transparent',
-  },
-  {
-    id: 'budget-tracker',
-    name: 'Budget Tracker',
-    description: 'Track spending, savings and cashflow across accounts',
-    icon: Wallet,
-    available: true,
-    color: 'text-signal-green',
-    bgGradient: 'from-signal-green/20 via-signal-green/5 to-transparent',
-  },
-  {
-    id: 'transformation-framework',
-    name: 'Transformotion Framework',
-    description: 'Business transformation tools and methodologies',
-    icon: Layers,
-    available: false,
-    color: 'text-signal-gold',
-    bgGradient: 'from-signal-gold/20 via-signal-gold/5 to-transparent',
-  },
-]
 
 const getGreeting = () => {
   const hour = new Date().getHours()
@@ -72,11 +36,21 @@ const getGreeting = () => {
   return 'Good evening'
 }
 
+function initials(name: string): string {
+  return (
+    name
+      .split(' ')
+      .map((n) => n[0])
+      .join('')
+      .slice(0, 2) || '?'
+  )
+}
+
 function Header({
-  user,
+  displayName,
   onOpenProfile,
 }: {
-  user: UserProfile
+  displayName: string
   onOpenProfile: () => void
 }) {
   return (
@@ -95,10 +69,7 @@ function Header({
             onClick={onOpenProfile}
             className="size-10 rounded-full bg-primary/15 flex items-center justify-center text-primary font-semibold text-sm hover:bg-primary/25 transition-colors"
           >
-            {user?.name
-              ?.split(' ')
-              .map((n) => n[0])
-              .join('') || '?'}
+            {initials(displayName)}
           </button>
         </div>
       </div>
@@ -109,7 +80,6 @@ function Header({
 function Greeting({ name }: { name: string }) {
   const [mounted, setMounted] = useState(false)
   const greeting = mounted ? getGreeting() : 'Welcome'
-  const firstName = name.split(' ')[0]
 
   useEffect(() => {
     setMounted(true)
@@ -118,7 +88,7 @@ function Greeting({ name }: { name: string }) {
   return (
     <div className="mb-8">
       <h1 className="text-2xl md:text-3xl font-bold text-foreground mb-1">
-        {greeting}, {firstName}
+        {greeting}, {name}
       </h1>
       <p className="text-muted-foreground">Welcome to your Transformotion workspace</p>
     </div>
@@ -130,20 +100,20 @@ function AppTile({
   index,
   onLaunch,
 }: {
-  app: App
+  app: AppTileModel
   index: number
   onLaunch?: () => void
 }) {
-  const Icon = app.icon
+  const Icon = APP_ICONS[app.slug] ?? Layers
 
   return (
     <button
-      disabled={!app.available}
+      disabled={!app.launchable}
       onClick={onLaunch}
       className={cn(
         'relative overflow-hidden p-6 rounded-2xl border transition-all text-left',
         'animate-in fade-in slide-in-from-bottom-4',
-        app.available
+        app.launchable
           ? 'bg-card border-border hover:border-primary/30 hover:shadow-lg hover:shadow-primary/5 active:scale-[0.98]'
           : 'bg-card/50 border-border/50 cursor-not-allowed opacity-60',
       )}
@@ -154,15 +124,15 @@ function AppTile({
         <div
           className={cn(
             'size-14 rounded-xl flex items-center justify-center mb-4',
-            app.available ? 'bg-surface2' : 'bg-surface2/50',
+            app.launchable ? 'bg-surface2' : 'bg-surface2/50',
           )}
         >
-          <Icon className={cn('size-7', app.available ? app.color : 'text-muted-foreground')} />
+          <Icon className={cn('size-7', app.launchable ? app.color : 'text-muted-foreground')} />
         </div>
         <h3
           className={cn(
             'text-lg font-semibold mb-1',
-            app.available ? 'text-foreground' : 'text-muted-foreground',
+            app.launchable ? 'text-foreground' : 'text-muted-foreground',
           )}
         >
           {app.name}
@@ -170,12 +140,12 @@ function AppTile({
         <p
           className={cn(
             'text-sm leading-relaxed',
-            app.available ? 'text-muted-foreground' : 'text-muted-foreground/70',
+            app.launchable ? 'text-muted-foreground' : 'text-muted-foreground/70',
           )}
         >
           {app.description}
         </p>
-        {!app.available && (
+        {!app.launchable && (
           <div className="mt-4 inline-flex items-center px-3 py-1 bg-surface2 rounded-full text-xs font-medium text-muted-foreground">
             Coming Soon
           </div>
@@ -185,50 +155,66 @@ function AppTile({
   )
 }
 
-function AppGrid({
-  apps,
-  userCanAccessFramework,
-  onLaunchApp,
-  onLaunchBudgetTracker,
-}: {
-  apps: App[]
-  userCanAccessFramework: boolean
-  onLaunchApp?: () => void
-  onLaunchBudgetTracker?: () => void
-}) {
-  const visibleApps = apps.filter((app) => {
-    if (app.id === 'transformation-framework' && !userCanAccessFramework) return false
-    return true
-  })
+/** Shown when the user holds no app memberships — a real first-login state by design. */
+function EmptyApps() {
+  return (
+    <div className="rounded-2xl border border-border bg-card/50 p-10 text-center">
+      <div className="size-14 rounded-xl bg-surface2 flex items-center justify-center mx-auto mb-4">
+        <Inbox className="size-7 text-muted-foreground" />
+      </div>
+      <h3 className="text-lg font-semibold text-foreground mb-1">No apps yet</h3>
+      <p className="text-sm text-muted-foreground max-w-md mx-auto">
+        You don&apos;t have access to any apps yet. Access arrives by invitation — once
+        you&apos;re added to an account, the app will appear here.
+      </p>
+    </div>
+  )
+}
 
-  const getLaunchHandler = (appId: string) => {
-    if (appId === 'stock-analyser') return onLaunchApp
-    if (appId === 'budget-tracker') return onLaunchBudgetTracker
-    return undefined
-  }
+function AppGridSkeleton() {
+  return (
+    <div className="grid gap-4 md:gap-6 sm:grid-cols-2 lg:grid-cols-3">
+      {[0, 1].map((i) => (
+        <div key={i} className="h-44 rounded-2xl border border-border bg-card/50 animate-pulse" />
+      ))}
+    </div>
+  )
+}
+
+function AppGrid({
+  tiles,
+  getLaunchHandler,
+}: {
+  tiles: AppTileModel[]
+  getLaunchHandler: (slug: string) => (() => void) | undefined
+}) {
+  const visible = tiles.filter((t) => t.visible)
+  if (visible.length === 0) return <EmptyApps />
 
   return (
     <div className="grid gap-4 md:gap-6 sm:grid-cols-2 lg:grid-cols-3">
-      {visibleApps.map((app, index) => (
-        <AppTile key={app.id} app={app} index={index} onLaunch={getLaunchHandler(app.id)} />
+      {visible.map((app, index) => (
+        <AppTile key={app.slug} app={app} index={index} onLaunch={getLaunchHandler(app.slug)} />
       ))}
     </div>
   )
 }
 
 function ProfileMenu({
-  user,
+  displayName,
+  email,
+  accounts,
   isOpen,
   onClose,
   onLogout,
-  onAccountChange,
   onOpenSettings,
 }: {
-  user: UserProfile
+  displayName: string
+  email: string
+  accounts: AccountRow[]
   isOpen: boolean
   onClose: () => void
   onLogout: () => void
-  onAccountChange: (accountId: string) => void
   onOpenSettings?: () => void
 }) {
   if (!isOpen) return null
@@ -240,40 +226,31 @@ function ProfileMenu({
         <div className="p-4 border-b border-border">
           <div className="flex items-center gap-3">
             <div className="size-12 rounded-full bg-primary/15 flex items-center justify-center text-primary font-semibold">
-              {user.name
-                .split(' ')
-                .map((n) => n[0])
-                .join('')}
+              {initials(displayName)}
             </div>
-            <div>
-              <p className="font-semibold text-foreground">{user.name}</p>
-              <p className="text-sm text-muted-foreground">{user.email}</p>
+            <div className="min-w-0">
+              <p className="font-semibold text-foreground truncate">{displayName}</p>
+              <p className="text-sm text-muted-foreground truncate">{email}</p>
             </div>
           </div>
         </div>
 
-        <div className="border-b border-border py-2">
-          <p className="px-4 py-1 text-xs text-muted-foreground">Account</p>
-          {user.accounts.map((account) => (
-            <button
-              key={account.id}
-              onClick={() => {
-                onAccountChange(account.id)
-                onClose()
-              }}
-              className={cn(
-                'w-full flex items-center justify-between px-4 py-2.5 text-sm transition-colors hover:bg-surface2',
-                account.id === user.activeAccount && 'bg-primary/5',
-              )}
-            >
-              <div className="text-left">
-                <p className="font-medium text-foreground">{account.name}</p>
-                <p className="text-xs text-muted-foreground">{account.type}</p>
+        {accounts.length > 0 && (
+          <div className="border-b border-border py-2">
+            <p className="px-4 py-1 text-xs text-muted-foreground">Your accounts</p>
+            {accounts.map((account) => (
+              <div
+                key={`${account.appSlug}:${account.accountId}`}
+                className="w-full flex items-center justify-between px-4 py-2.5 text-sm"
+              >
+                <div className="text-left min-w-0">
+                  <p className="font-medium text-foreground truncate">{account.label}</p>
+                  <p className="text-xs text-muted-foreground truncate">{account.accountId}</p>
+                </div>
               </div>
-              {account.id === user.activeAccount && <Check className="size-4 text-primary" />}
-            </button>
-          ))}
-        </div>
+            ))}
+          </div>
+        )}
 
         <div className="py-2">
           <button className="w-full flex items-center gap-3 px-4 py-2.5 text-sm text-foreground hover:bg-surface2 transition-colors">
@@ -320,6 +297,10 @@ function Footer() {
   )
 }
 
+function appLabel(slug: string): string {
+  return LAUNCHPAD_APPS.find((a) => a.slug === slug)?.name ?? slug
+}
+
 export function Launchpad({
   user: authUser,
   onLaunchApp,
@@ -333,49 +314,61 @@ export function Launchpad({
 }) {
   const [profileMenuOpen, setProfileMenuOpen] = useState(false)
   const [settingsOpen, setSettingsOpen] = useState(false)
-  const [activeAccount, setActiveAccount] = useState(PLACEHOLDER_ACCOUNTS[0].id)
+
+  // Admin/control-plane surfaces gate on the site_admin claim, NOT app membership (D11).
   const isSiteAdmin = authUser?.metadata?.siteAdmin === true
 
-  const user: UserProfile = {
-    name:          authUser?.name  ?? 'User',
-    email:         authUser?.email ?? '',
-    accounts:      PLACEHOLDER_ACCOUNTS,
-    activeAccount,
-  }
+  const data = useLaunchpadData(authUser)
 
-  const handleAccountChange = (accountId: string) => {
-    setActiveAccount(accountId)
+  const email = authUser?.email ?? ''
+  const displayName = resolveDisplayName({
+    displayName: data.profile?.displayName ?? authUser?.name,
+    email,
+  })
+
+  // Tiles derive from entitlement (memberships per app), not a hard-coded list.
+  const tiles = deriveAppTiles(LAUNCHPAD_APPS, data.entitledSlugs)
+
+  const accounts: AccountRow[] = data.selections.map((s) => ({
+    appSlug: s.appSlug,
+    accountId: s.accountId,
+    label: appLabel(s.appSlug),
+  }))
+
+  const getLaunchHandler = (slug: string): (() => void) | undefined => {
+    if (slug === 'stock-analyser') return onLaunchApp
+    if (slug === 'budget-tracker') return onLaunchBudgetTracker
+    return undefined
   }
 
   return (
     <div className="min-h-screen bg-background flex flex-col">
-      <Header user={user} onOpenProfile={() => setProfileMenuOpen(true)} />
+      <Header displayName={displayName} onOpenProfile={() => setProfileMenuOpen(true)} />
 
       <main className="flex-1 py-8 md:py-12">
         <div className="max-w-5xl mx-auto px-4 md:px-6">
-          <Greeting name={user.name} />
-          <AppGrid
-            apps={APPS}
-            userCanAccessFramework={false}
-            onLaunchApp={onLaunchApp}
-            onLaunchBudgetTracker={onLaunchBudgetTracker}
-          />
+          <Greeting name={firstNameOf(displayName)} />
+          {data.loading ? (
+            <AppGridSkeleton />
+          ) : hasVisibleApps(tiles) ? (
+            <AppGrid tiles={tiles} getLaunchHandler={getLaunchHandler} />
+          ) : (
+            <EmptyApps />
+          )}
         </div>
       </main>
 
       <ProfileMenu
-        user={user}
+        displayName={displayName}
+        email={email}
+        accounts={accounts}
         isOpen={profileMenuOpen}
         onClose={() => setProfileMenuOpen(false)}
         onLogout={onSignOut || (() => {})}
-        onAccountChange={handleAccountChange}
         onOpenSettings={isSiteAdmin ? () => setSettingsOpen(true) : undefined}
       />
 
-      <AiEngineSettings
-        isOpen={settingsOpen && isSiteAdmin}
-        onClose={() => setSettingsOpen(false)}
-      />
+      <AiEngineSettings isOpen={settingsOpen && isSiteAdmin} onClose={() => setSettingsOpen(false)} />
 
       <Footer />
     </div>

--- a/apps/launchpad/hooks/use-launchpad-data.ts
+++ b/apps/launchpad/hooks/use-launchpad-data.ts
@@ -1,0 +1,121 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import type { User } from '@transformotion/auth-client'
+import { authService } from '@/lib/services/auth'
+import { getConfig } from '@/lib/config'
+import { getUserProfile, type UserProfile } from '@/lib/services/user-profile'
+import { getActiveAccounts, type ActiveAccountSelection } from '@/lib/services/active-accounts'
+import { LAUNCHPAD_APPS, entitledSlugsFromSelections } from '@/lib/entitlement'
+
+export interface LaunchpadData {
+  loading: boolean
+  profile: UserProfile | null
+  /** App slugs the user is entitled to (holds ≥1 membership in). */
+  entitledSlugs: Set<string>
+  /** Active account per app (M16 D7); empty when unavailable. */
+  selections: ActiveAccountSelection[]
+  /** True when the live read failed and entitlement came from a claims fallback. */
+  degraded: boolean
+}
+
+const EMPTY: LaunchpadData = {
+  loading: false,
+  profile: null,
+  entitledSlugs: new Set(),
+  selections: [],
+  degraded: false,
+}
+
+/**
+ * Loads the current user's entitlement + profile for the Launchpad home view
+ * (M16 Phase 3, read-only).
+ *
+ * Live path: GET /api/user/active-accounts (entitlement + active account per
+ * app) and GET /api/user/profile (displayName/profileComplete). When the
+ * control-plane API is unavailable (mock dev) or a read fails, it degrades to a
+ * claims-based entitlement probe — never crashes, never blank-crashes a tile.
+ */
+export function useLaunchpadData(user: User | null): LaunchpadData {
+  const [state, setState] = useState<LaunchpadData>({ ...EMPTY, loading: true })
+
+  useEffect(() => {
+    let cancelled = false
+
+    async function load() {
+      if (!user) {
+        if (!cancelled) setState({ ...EMPTY, loading: false })
+        return
+      }
+
+      const apiUrl = getConfig().controlPlane.apiUrl
+      const idToken = await authService.getIdToken().catch(() => null)
+
+      if (idToken && apiUrl) {
+        const [profileRes, activeRes] = await Promise.allSettled([
+          getUserProfile(idToken),
+          getActiveAccounts(idToken),
+        ])
+        const profile = profileRes.status === 'fulfilled' ? profileRes.value : null
+
+        if (activeRes.status === 'fulfilled') {
+          const selections = activeRes.value.selections ?? []
+          if (!cancelled) {
+            setState({
+              loading: false,
+              profile,
+              entitledSlugs: entitledSlugsFromSelections(selections),
+              selections,
+              degraded: false,
+            })
+          }
+          return
+        }
+
+        // active-accounts unavailable → fall back to claims for entitlement.
+        const entitledSlugs = await deriveEntitlementFromClaims()
+        if (!cancelled) {
+          setState({ loading: false, profile, entitledSlugs, selections: [], degraded: true })
+        }
+        return
+      }
+
+      // Mock / unconfigured control plane → claims-based entitlement.
+      const entitledSlugs = await deriveEntitlementFromClaims()
+      if (!cancelled) {
+        setState({ loading: false, profile: null, entitledSlugs, selections: [], degraded: true })
+      }
+    }
+
+    load().catch(() => {
+      if (!cancelled) setState({ ...EMPTY, loading: false, degraded: true })
+    })
+
+    return () => {
+      cancelled = true
+    }
+    // Re-run only when the authenticated identity changes, not on every store
+    // update (the persisted user object changes identity on each set()).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [user?.id])
+
+  return state
+}
+
+/**
+ * Resilience/mock fallback: probe per-app membership via the auth-client's
+ * accounts-claim accessor (implemented by both mock and cognito providers).
+ */
+async function deriveEntitlementFromClaims(): Promise<Set<string>> {
+  const gated = LAUNCHPAD_APPS.filter((a) => a.entitlementGated).map((a) => a.slug)
+  const results = await Promise.all(
+    gated.map(async (slug) => {
+      try {
+        return (await authService.getAccountIdForApp(slug)) ? slug : null
+      } catch {
+        return null
+      }
+    }),
+  )
+  return new Set(results.filter((s): s is string => s !== null))
+}

--- a/apps/launchpad/lib/entitlement.test.ts
+++ b/apps/launchpad/lib/entitlement.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest';
+import {
+  LAUNCHPAD_APPS,
+  entitledSlugsFromSelections,
+  deriveAppTiles,
+  hasVisibleApps,
+  resolveDisplayName,
+  firstNameOf,
+} from './entitlement';
+
+const visibleSlugs = (entitled: string[]) =>
+  deriveAppTiles(LAUNCHPAD_APPS, new Set(entitled))
+    .filter((t) => t.visible)
+    .map((t) => t.slug);
+
+describe('entitledSlugsFromSelections', () => {
+  it('maps active-account selections to the entitled slug set', () => {
+    const set = entitledSlugsFromSelections([
+      { appSlug: 'stock-analyser', accountId: 'a1' },
+      { appSlug: 'budget-tracker', accountId: 'a2' },
+    ]);
+    expect([...set].sort()).toEqual(['budget-tracker', 'stock-analyser']);
+  });
+
+  it('returns an empty set for no selections (zero-membership user)', () => {
+    expect(entitledSlugsFromSelections([]).size).toBe(0);
+  });
+});
+
+describe('deriveAppTiles — three-state model (D11)', () => {
+  it('shows a deployed app ONLY when the user is entitled', () => {
+    expect(visibleSlugs(['stock-analyser'])).toEqual(['stock-analyser']);
+  });
+
+  it('hides a deployed app when the user has no membership', () => {
+    // entitled to BT only → SA hidden, BT shown
+    expect(visibleSlugs(['budget-tracker'])).toEqual(['budget-tracker']);
+  });
+
+  it('shows multiple entitled apps in registry order', () => {
+    expect(visibleSlugs(['budget-tracker', 'stock-analyser'])).toEqual([
+      'stock-analyser',
+      'budget-tracker',
+    ]);
+  });
+
+  it('never shows the not-deployed marketing app (coming-soon stays hidden)', () => {
+    // even if a stray entitlement slug matched it, it is not entitlement-gated
+    expect(visibleSlugs(['transformation-framework'])).toEqual([]);
+  });
+
+  it('shows nothing for a zero-membership user (empty state)', () => {
+    const tiles = deriveAppTiles(LAUNCHPAD_APPS, new Set());
+    expect(hasVisibleApps(tiles)).toBe(false);
+    expect(visibleSlugs([])).toEqual([]);
+  });
+
+  it('marks visible gated tiles launchable and tolerates unknown slugs', () => {
+    const tiles = deriveAppTiles(LAUNCHPAD_APPS, new Set(['stock-analyser', 'made-up-app']));
+    const sa = tiles.find((t) => t.slug === 'stock-analyser')!;
+    expect(sa.visible).toBe(true);
+    expect(sa.launchable).toBe(true);
+    expect(hasVisibleApps(tiles)).toBe(true);
+  });
+});
+
+describe('resolveDisplayName — canonical fallback chain (D6)', () => {
+  it('uses displayName when present', () => {
+    expect(resolveDisplayName({ displayName: 'Ada Lovelace', email: 'ada@example.com' })).toBe(
+      'Ada Lovelace',
+    );
+  });
+
+  it('trims whitespace-only displayName and falls back to email local part', () => {
+    expect(resolveDisplayName({ displayName: '   ', email: 'carol@example.com' })).toBe('carol');
+  });
+
+  it('falls back to email local part when displayName is missing (legacy user)', () => {
+    expect(resolveDisplayName({ email: 'dave@example.com' })).toBe('dave');
+  });
+
+  it('handles null displayName', () => {
+    expect(resolveDisplayName({ displayName: null, email: 'eve@example.com' })).toBe('eve');
+  });
+
+  it('falls back to full email when there is no local part', () => {
+    expect(resolveDisplayName({ email: '@example.com' })).toBe('@example.com');
+  });
+});
+
+describe('firstNameOf', () => {
+  it('returns the first token', () => {
+    expect(firstNameOf('Ada Lovelace')).toBe('Ada');
+  });
+
+  it('returns the whole string when single-token', () => {
+    expect(firstNameOf('carol')).toBe('carol');
+  });
+});

--- a/apps/launchpad/lib/entitlement.ts
+++ b/apps/launchpad/lib/entitlement.ts
@@ -1,0 +1,131 @@
+/**
+ * Pure entitlement + display helpers for the Launchpad home view (M16 Phase 3).
+ *
+ * Tiles derive from the user's per-app membership (the access projection), NOT
+ * from a hard-coded list (ADR D11). Admin/control-plane surfaces gate on the
+ * site_admin / app_admin claims elsewhere — never on app membership.
+ *
+ * Everything here is pure and framework-free so it can be unit-tested without a
+ * DOM; the React component maps slugs to icons/launch handlers.
+ */
+
+/** Static catalogue of apps the Launchpad knows how to present. */
+export interface LaunchpadAppDef {
+  /** App slug; for real apps this matches an EntitledAppSlug in the contracts. */
+  slug: string;
+  name: string;
+  description: string;
+  /** A real, launchable app (false = future/marketing "coming soon"). */
+  deployed: boolean;
+  /**
+   * Whether visibility is gated by account membership. Real apps (SA/BT) are
+   * gated; marketing/coming-soon entries are not (and stay hidden by default,
+   * preserving the pre-M16 three-state handling).
+   */
+  entitlementGated: boolean;
+  color: string;
+  bgGradient: string;
+}
+
+/** One resolved tile for the current user. */
+export interface AppTile extends LaunchpadAppDef {
+  /** User holds at least one membership in this app. */
+  entitled: boolean;
+  /** Should the tile render at all. */
+  visible: boolean;
+  /** Tile is clickable (deployed AND entitled). */
+  launchable: boolean;
+}
+
+/**
+ * The Launchpad app catalogue. Order here is the render order.
+ * `transformation-framework` is a not-deployed marketing entry retained to
+ * preserve the three-state (deployed / coming-soon / hidden) handling; it stays
+ * hidden until a future phase turns coming-soon tiles on.
+ */
+export const LAUNCHPAD_APPS: readonly LaunchpadAppDef[] = [
+  {
+    slug: 'stock-analyser',
+    name: 'Stock Signal Analyser',
+    description: 'Cycle signals across ASX, NASDAQ, Dow Jones and FTSE',
+    deployed: true,
+    entitlementGated: true,
+    color: 'text-primary',
+    bgGradient: 'from-primary/20 via-primary/5 to-transparent',
+  },
+  {
+    slug: 'budget-tracker',
+    name: 'Budget Tracker',
+    description: 'Track spending, savings and cashflow across accounts',
+    deployed: true,
+    entitlementGated: true,
+    color: 'text-signal-green',
+    bgGradient: 'from-signal-green/20 via-signal-green/5 to-transparent',
+  },
+  {
+    slug: 'transformation-framework',
+    name: 'Transformotion Framework',
+    description: 'Business transformation tools and methodologies',
+    deployed: false,
+    entitlementGated: false,
+    color: 'text-signal-gold',
+    bgGradient: 'from-signal-gold/20 via-signal-gold/5 to-transparent',
+  },
+] as const;
+
+/**
+ * Derive the set of entitled app slugs from active-account selections
+ * (GET /api/user/active-accounts). A selection exists for every app the user
+ * holds at least one account in, so the slug set IS the entitlement set.
+ */
+export function entitledSlugsFromSelections<T extends { appSlug: string }>(
+  selections: readonly T[],
+): Set<string> {
+  return new Set(selections.map((s) => s.appSlug));
+}
+
+/**
+ * Resolve which tiles render for a user, given their entitled app slugs.
+ *
+ * Three-state model (D11):
+ *  - entitlement-gated + deployed + entitled  → visible, launchable
+ *  - entitlement-gated + deployed + NOT entitled → hidden (no membership, no tile)
+ *  - not entitlement-gated (coming-soon/future) → hidden by default
+ *
+ * Backfill tolerant: an unknown/empty entitlement set simply yields no visible
+ * gated tiles (the empty state), never an error.
+ */
+export function deriveAppTiles(
+  apps: readonly LaunchpadAppDef[],
+  entitledSlugs: ReadonlySet<string>,
+): AppTile[] {
+  return apps.map((app) => {
+    const entitled = entitledSlugs.has(app.slug);
+    const visible = app.entitlementGated ? app.deployed && entitled : false;
+    const launchable = visible && app.deployed && entitled;
+    return { ...app, entitled, visible, launchable };
+  });
+}
+
+/** True when at least one tile is visible (otherwise render the empty state). */
+export function hasVisibleApps(tiles: readonly AppTile[]): boolean {
+  return tiles.some((t) => t.visible);
+}
+
+/**
+ * Canonical display-name fallback chain (M16 D6): displayName → email local
+ * part → full email. The backend already resolves displayName this way; this
+ * mirror keeps greetings correct when the profile fetch is unavailable and for
+ * legacy users with no displayName.
+ */
+export function resolveDisplayName(input: { displayName?: string | null; email: string }): string {
+  const dn = input.displayName?.trim();
+  if (dn) return dn;
+  const localPart = input.email.split('@')[0];
+  return localPart || input.email;
+}
+
+/** First name for greetings, from a resolved display name. */
+export function firstNameOf(displayName: string): string {
+  return displayName.split(' ')[0] || displayName;
+}

--- a/apps/launchpad/lib/services/active-accounts/index.ts
+++ b/apps/launchpad/lib/services/active-accounts/index.ts
@@ -1,0 +1,36 @@
+import { getConfig } from '@/lib/config';
+import type {
+  GetActiveAccountsResponse,
+  ActiveAccountSelection,
+} from '@transformotion/contracts/launchpad/invitations';
+
+export type { GetActiveAccountsResponse, ActiveAccountSelection };
+
+function resolveControlPlaneBaseUrl(): string {
+  return getConfig().controlPlane.apiUrl;
+}
+
+/**
+ * Read the caller's active account per app (M16 D7, Phase 2 read API).
+ * Read-only — active-account SET is a mutation deferred to a later phase.
+ * The set of appSlugs present is the user's app entitlement (a selection exists
+ * for every app they hold a membership in).
+ */
+export async function getActiveAccounts(idToken: string): Promise<GetActiveAccountsResponse> {
+  const baseUrl = resolveControlPlaneBaseUrl();
+  if (!baseUrl) {
+    throw new Error('Launchpad control-plane API URL is not configured');
+  }
+
+  const response = await fetch(new URL('/api/user/active-accounts', baseUrl).toString(), {
+    headers: {
+      Authorization: `Bearer ${idToken}`,
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`GET /api/user/active-accounts failed: ${response.status}`);
+  }
+
+  return response.json() as Promise<GetActiveAccountsResponse>;
+}

--- a/apps/launchpad/lib/services/user-profile/index.ts
+++ b/apps/launchpad/lib/services/user-profile/index.ts
@@ -1,14 +1,9 @@
 import { getConfig } from '@/lib/config';
+import type { UserProfile, UserPreferences } from '@transformotion/contracts/_shared/auth';
 
-export interface UserPreferences {
-  notificationsEnabled: boolean;
-}
-
-export interface UserProfile {
-  userId: string;
-  email: string;
-  preferences: UserPreferences;
-}
+// Canonical shapes (contract m16.1.0). UserProfile carries the M16 fields:
+// userId, email, displayName, status, preferences, profileComplete, updatedAt.
+export type { UserProfile, UserPreferences };
 
 function resolveControlPlaneBaseUrl(): string {
   return getConfig().controlPlane.apiUrl;

--- a/apps/launchpad/package.json
+++ b/apps/launchpad/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start --port 3001",
     "typecheck": "tsc --noEmit",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "test": "vitest run"
   },
   "dependencies": {
     "@transformotion/auth-client": "workspace:*",
@@ -35,6 +36,7 @@
     "postcss": "^8.5",
     "tailwindcss": "^4.2.0",
     "tw-animate-css": "1.3.3",
-    "typescript": "5.7.3"
+    "typescript": "5.7.3",
+    "vitest": "^3"
   }
 }

--- a/apps/launchpad/vitest.config.ts
+++ b/apps/launchpad/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['lib/**/*.test.ts'],
+  },
+});

--- a/docs/architecture/auth.md
+++ b/docs/architecture/auth.md
@@ -283,7 +283,7 @@ app_admin:  string[]                                           — app slugs whe
 
 Plus the standard Cognito claims (`sub`, `email`, `cognito:groups`, token lifetime fields). `custom:accounts` is inert (see Custom attributes above).
 
-**Launchpad renders tiles by inspecting the `apps` claim.**
+**Launchpad renders tiles from the user's per-app membership** (the access projection, read at runtime via `GET /api/user/active-accounts`), not by inspecting the `apps` claim directly — see [Three-state tile model](#three-state-tile-model) (M16 Phase 3, D11).
 **API handlers enforce per-account authorization by inspecting `accounts`.**
 
 ---
@@ -337,15 +337,19 @@ The Hosted UI session cookie is what enables SSO across the three app clients �
 
 ## Three-state tile model
 
-The launchpad renders app tiles based on two conditions:
+> **M16 Phase 3 (D11) — revised.** Tiles now derive from the user's **account membership** (the access projection), read at runtime via the active-account read API (`GET /api/user/active-accounts`): the set of apps in which the user holds at least one account is the entitlement set. The previous rule — *"tiles from the `apps` claim plus a hardcoded deployed list"* — is **Stale-by-decision**. The `apps` claim survives as a coarse projection, but Launchpad reads entitlement from membership, and **admin/control-plane surfaces gate on the `site_admin` / app-admin claims, never on app membership.**
 
-| User has app in `apps` claim | App is deployed | Tile state |
+The launchpad resolves each app tile from two conditions — entitlement (membership) and deployment:
+
+| User holds a membership in the app | App is deployed | Tile state |
 |---|---|---|
-| Yes | Yes | Active — clickable link to app |
+| Yes | Yes | Active — clickable, launches the app |
 | Yes | No | Visible, greyed out, "Coming Soon" label |
 | No | Any | Not rendered |
 
-App deployment state is statically known to the launchpad (hardcoded list of deployed app slugs). The `apps` claim controls visibility; deployment state controls interactivity.
+A user with **zero** memberships sees an explicit empty state ("No apps yet — access arrives by invitation") — by design a real first-login state, never a blank page or an error. Backfill tolerance: missing or legacy entitlement data resolves to "not entitled" (no tile), never a crash.
+
+App deployment state is statically known to the launchpad (a catalogue of app slugs each carrying a `deployed` flag). Membership controls **visibility**; deployment controls **interactivity**. Not-deployed catalogue entries (coming-soon/marketing) stay hidden by default, preserving the pre-M16 deployed/coming-soon handling. Admin surfaces (e.g. AI runtime settings, and a future Users & Access view) are shown from the `site_admin` / app-admin claims independently of any app tile.
 
 ---
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -591,6 +591,9 @@ importers:
       typescript:
         specifier: 5.7.3
         version: 5.7.3
+      vitest:
+        specifier: ^3
+        version: 3.2.4(@types/node@22.19.17)(jsdom@29.1.1)(lightningcss@1.32.0)
 
   apps/launchpad/functions/access-summary:
     dependencies:


### PR DESCRIPTION
## Summary

Phase 3 of the M11 account lifecycle milestone: Launchpad UI entitlement/read integration. The home view stops using hard-coded tiles/accounts and derives from the user's real per-app membership and M16 profile via the Phase 2 read APIs (live on dev). Frontend read-integration only.

- **Slice 1 — tiles from entitlement (D11):** App tiles derive from the user's memberships-per-app (`GET /api/user/active-accounts`), not a hard-coded list. Three-state handling preserved (entitled+deployed → launchable; entitled+not-deployed → coming-soon; not-entitled → hidden). Zero-membership users get an explicit empty state ("No apps yet — access arrives by invitation"). Admin/control-plane surfaces (AI runtime settings) gate on the `site_admin` claim, never on app membership.
- **Slice 2 — profile/display (D6 read side):** Greeting, header avatar, and profile menu use the M16 `displayName` with the canonical fallback chain (displayName → email local part → email), via `GET /api/user/profile` (client updated to the canonical m16.1.0 `UserProfile`).
- **Slice 3 — account views (read-only):** Profile-menu account section derives from active-account selections (read-only). No role changes / removals / invites.
- **Slice 4 — docs:** auth.md three-state tile model rewritten (membership-derived; admin from claims), superseded statement tagged **Stale-by-decision** (§8).

## Files changed per slice

**Slice 1:** `apps/launchpad/lib/entitlement.ts` (new, pure), `apps/launchpad/lib/services/active-accounts/index.ts` (new read client), `apps/launchpad/hooks/use-launchpad-data.ts` (new), `apps/launchpad/components/launchpad/launchpad.tsx`
**Slice 2:** `apps/launchpad/lib/services/user-profile/index.ts` (M16 shape), greeting/menu in `launchpad.tsx`
**Slice 3:** account section in `launchpad.tsx`
**Slice 4:** `docs/architecture/auth.md`
**Tests:** `apps/launchpad/lib/entitlement.test.ts` (new), `apps/launchpad/vitest.config.ts` (new), `apps/launchpad/package.json`, `pnpm-lock.yaml`

## Validation

- `pnpm --filter @transformotion/launchpad test` — 15/15 pass (vitest; mirrors the stock-analyser lib-test convention, no new framework)
- typecheck — clean
- lint (eslint) — clean
- `next build` (static export) — success, all routes
- `pnpm check:v0-contracts` — OK (byte-identical, m16.1.0)
- `git diff --check` — clean

## Backfill tolerance

Every read path degrades gracefully: no displayName → email local part → email; no accounts / no apiUrl / read failure → claims-based fallback then empty state; unknown appSlug → not entitled (no tile). Never crashes, never guesses permissively.

## Gaps found (for owner triage / later phases)

- **No profile-setup / onboarding flow exists.** Slice 2.2 asked to *integrate* an existing flow; none exists. `profileComplete` is now read and available in `useLaunchpadData`, but there is no flow to surface — **not built** (per brief). Owner triage: which phase builds first-time profile setup.
- **No profile-edit surface exists.** Slice 2.3 — not built (per brief); noted as a gap. `updateUserPreferences` client exists but is unused.
- **No Users & Access admin view exists** to convert (Slice 3.1). Building it is new-view work, not a read-conversion — deferred. The access-summary API (`GET /api/admin/users/access`) and `pendingInvites` therefore have no UI surface yet; nothing special-cased.
- **Out-of-Phase-3 group/claim gating to sweep in Phase 5:** `packages/auth-client` still surfaces only `metadata.siteAdmin` and parses `site_admin` via `cognito:groups` fallback (`packages/auth-client/src/cognito-auth.ts`); it does not surface the `app_admin` claim or entitled `apps`. Per the revision map, auth-client consolidation + role vocabulary is **Phase 4**, so it is intentionally untouched here. The Launchpad entitlement read therefore comes from the Phase 2 APIs (with a claims fallback), not from an extended `User`.
- **Account switching is read-only here;** persisting active-account selection (`PUT /api/user/active-accounts`) is Phase 4 (app consumption of active account).

## v0 freshness

- [x] No v0 impact

Reason: Built entirely against the already-merged v0 contract baseline **m16.1.0** (`transformotion-apps-b8` main @ `34f5b3b`). This phase is runtime read-integration — it consumes existing m16.1.0 contracts (`UserProfile`, `GetActiveAccountsResponse`, `ActiveAccountSelection`) with no field/shape changes, so no v0 contract, mock, or UI-contract change is required.

## ⚠️ Merge = deploy to dev

Merge to `develop` triggers `deploy-launchpad.yml` (frontend build + deploy). **Do not merge without owner sign-off.**

## Owner smoke checklist (post-merge, dev)

- [ ] (a) Existing multi-app user sees exactly their entitled tiles (apps they hold a membership in) — no more, no less.
- [ ] (b) Site-admin sees admin surfaces (Settings) but **no** app tiles for apps they hold no membership in (admin ≠ entitlement).
- [ ] (c) Zero-membership user sees the empty state ("No apps yet…"), not a blank page or error.
- [ ] (d) `displayName` is correct in the greeting and profile menu — including a legacy user with **no** displayName (shows email local part).
- [ ] (e) Existing app launches (Stock Analyser, Budget Tracker) still work end-to-end from a tile.

## Refs
Refs #414 (phase issue), Refs #411 (tracking)

🤖 Generated with [Claude Code](https://claude.com/claude-code)