### PR TITLE
fix(launchpad/m16): display fallback + loud read fallback (Phase 3 follow-up)

### DIFF
--- a/apps/launchpad/components/launchpad/launchpad.tsx
+++ b/apps/launchpad/components/launchpad/launchpad.tsx
@@ -321,8 +321,12 @@ export function Launchpad({
   const data = useLaunchpadData(authUser)
 
   const email = authUser?.email ?? ''
+  // Canonical chain (#423): profile displayName → Cognito name → email local part.
+  // authUser.name can be the raw email (no given/family name) — passed as cognitoName
+  // so resolveDisplayName skips it rather than rendering the full address.
   const displayName = resolveDisplayName({
-    displayName: data.profile?.displayName ?? authUser?.name,
+    displayName: data.profile?.displayName,
+    cognitoName: authUser?.name,
     email,
   })
 

--- a/apps/launchpad/hooks/use-launchpad-data.ts
+++ b/apps/launchpad/hooks/use-launchpad-data.ts
@@ -6,7 +6,7 @@ import { authService } from '@/lib/services/auth'
 import { getConfig } from '@/lib/config'
 import { getUserProfile, type UserProfile } from '@/lib/services/user-profile'
 import { getActiveAccounts, type ActiveAccountSelection } from '@/lib/services/active-accounts'
-import { LAUNCHPAD_APPS, entitledSlugsFromSelections } from '@/lib/entitlement'
+import { LAUNCHPAD_APPS, entitledSlugsFromSelections, fallbackWarnings } from '@/lib/entitlement'
 
 export interface LaunchpadData {
   loading: boolean
@@ -57,30 +57,42 @@ export function useLaunchpadData(user: User | null): LaunchpadData {
           getActiveAccounts(idToken),
         ])
         const profile = profileRes.status === 'fulfilled' ? profileRes.value : null
+        const tilesFromApi = activeRes.status === 'fulfilled'
+        const profileFromApi = profileRes.status === 'fulfilled'
 
-        if (activeRes.status === 'fulfilled') {
-          const selections = activeRes.value.selections ?? []
-          if (!cancelled) {
-            setState({
-              loading: false,
-              profile,
-              entitledSlugs: entitledSlugsFromSelections(selections),
-              selections,
-              degraded: false,
-            })
-          }
-          return
+        // Surface the discarded fetch errors so a failed read is not invisible (#423).
+        if (profileRes.status === 'rejected') {
+          console.warn('[launchpad] profile read error:', profileRes.reason)
+        }
+        if (activeRes.status === 'rejected') {
+          console.warn('[launchpad] active-accounts read error:', activeRes.reason)
+        }
+        for (const msg of fallbackWarnings({ apiConfigured: true, tilesFromApi, profileFromApi })) {
+          console.warn(msg)
         }
 
-        // active-accounts unavailable → fall back to claims for entitlement.
-        const entitledSlugs = await deriveEntitlementFromClaims()
+        // Entitlement from the API when available, else the claims fallback.
+        const selections = tilesFromApi ? activeRes.value.selections ?? [] : []
+        const entitledSlugs = tilesFromApi
+          ? entitledSlugsFromSelections(selections)
+          : await deriveEntitlementFromClaims()
+
         if (!cancelled) {
-          setState({ loading: false, profile, entitledSlugs, selections: [], degraded: true })
+          setState({
+            loading: false,
+            profile,
+            entitledSlugs,
+            selections,
+            degraded: !tilesFromApi || !profileFromApi,
+          })
         }
         return
       }
 
       // Mock / unconfigured control plane → claims-based entitlement.
+      for (const msg of fallbackWarnings({ apiConfigured: false, tilesFromApi: false, profileFromApi: false })) {
+        console.warn(msg)
+      }
       const entitledSlugs = await deriveEntitlementFromClaims()
       if (!cancelled) {
         setState({ loading: false, profile: null, entitledSlugs, selections: [], degraded: true })

--- a/apps/launchpad/lib/entitlement.test.ts
+++ b/apps/launchpad/lib/entitlement.test.ts
@@ -6,6 +6,7 @@ import {
   hasVisibleApps,
   resolveDisplayName,
   firstNameOf,
+  fallbackWarnings,
 } from './entitlement';
 
 const visibleSlugs = (entitled: string[]) =>
@@ -64,27 +65,71 @@ describe('deriveAppTiles — three-state model (D11)', () => {
   });
 });
 
-describe('resolveDisplayName — canonical fallback chain (D6)', () => {
-  it('uses displayName when present', () => {
-    expect(resolveDisplayName({ displayName: 'Ada Lovelace', email: 'ada@example.com' })).toBe(
-      'Ada Lovelace',
+describe('resolveDisplayName — canonical chain: displayName → Cognito name → email local part (#423)', () => {
+  it('uses profile displayName when present', () => {
+    expect(
+      resolveDisplayName({ displayName: 'Ada Lovelace', cognitoName: 'Ignored', email: 'ada@example.com' }),
+    ).toBe('Ada Lovelace');
+  });
+
+  it('uses a real Cognito name when there is no profile displayName', () => {
+    expect(resolveDisplayName({ cognitoName: 'Steve Moodie', email: 'steve.moodie@example.com' })).toBe(
+      'Steve Moodie',
     );
   });
 
-  it('trims whitespace-only displayName and falls back to email local part', () => {
-    expect(resolveDisplayName({ displayName: '   ', email: 'carol@example.com' })).toBe('carol');
+  it('SKIPS the Cognito name when it equals the email, falling back to the local part (the bug)', () => {
+    // auth client sets User.name = email when there is no given/family name
+    expect(
+      resolveDisplayName({ cognitoName: 'steve.moodie@example.com', email: 'steve.moodie@example.com' }),
+    ).toBe('steve.moodie');
   });
 
-  it('falls back to email local part when displayName is missing (legacy user)', () => {
+  it('falls back to email local part when nothing else is set (legacy user)', () => {
     expect(resolveDisplayName({ email: 'dave@example.com' })).toBe('dave');
   });
 
-  it('handles null displayName', () => {
-    expect(resolveDisplayName({ displayName: null, email: 'eve@example.com' })).toBe('eve');
+  it('trims whitespace-only displayName and null cognitoName', () => {
+    expect(resolveDisplayName({ displayName: '   ', cognitoName: null, email: 'carol@example.com' })).toBe(
+      'carol',
+    );
   });
 
-  it('falls back to full email when there is no local part', () => {
+  it('never returns the full email when a local part exists', () => {
+    const out = resolveDisplayName({ cognitoName: 'eve@example.com', email: 'eve@example.com' });
+    expect(out).toBe('eve');
+    expect(out).not.toContain('@');
+  });
+
+  it('falls back to full email only when there is no local part', () => {
     expect(resolveDisplayName({ email: '@example.com' })).toBe('@example.com');
+  });
+});
+
+describe('fallbackWarnings — loud degradation (#423)', () => {
+  it('is silent when both tiles and profile come from the API', () => {
+    expect(
+      fallbackWarnings({ apiConfigured: true, tilesFromApi: true, profileFromApi: true }),
+    ).toEqual([]);
+  });
+
+  it('warns once (expected) when the control-plane API URL is not configured', () => {
+    const msgs = fallbackWarnings({ apiConfigured: false, tilesFromApi: false, profileFromApi: false });
+    expect(msgs).toHaveLength(1);
+    expect(msgs[0]).toMatch(/not configured/i);
+  });
+
+  it('warns per failed read when the API is configured but reads fail', () => {
+    const msgs = fallbackWarnings({ apiConfigured: true, tilesFromApi: false, profileFromApi: false });
+    expect(msgs).toHaveLength(2);
+    expect(msgs.join(' ')).toMatch(/active-accounts read failed/);
+    expect(msgs.join(' ')).toMatch(/profile read failed/);
+  });
+
+  it('warns only about profile when tiles came from the API', () => {
+    const msgs = fallbackWarnings({ apiConfigured: true, tilesFromApi: true, profileFromApi: false });
+    expect(msgs).toHaveLength(1);
+    expect(msgs[0]).toMatch(/profile read failed/);
   });
 });
 

--- a/apps/launchpad/lib/entitlement.ts
+++ b/apps/launchpad/lib/entitlement.ts
@@ -113,14 +113,24 @@ export function hasVisibleApps(tiles: readonly AppTile[]): boolean {
 }
 
 /**
- * Canonical display-name fallback chain (M16 D6): displayName → email local
- * part → full email. The backend already resolves displayName this way; this
- * mirror keeps greetings correct when the profile fetch is unavailable and for
- * legacy users with no displayName.
+ * Canonical display-name fallback chain (M16 D6):
+ *   profile displayName → Cognito name → email local part → full email.
+ *
+ * The Cognito-provided name is only honoured when it is a real name: the auth
+ * client falls back to the raw email when the user has no given/family name, so
+ * a `cognitoName` equal to the email is skipped (otherwise the greeting shows
+ * the full address instead of the local part — issue #423). The full email is a
+ * last resort only when there is no usable local part.
  */
-export function resolveDisplayName(input: { displayName?: string | null; email: string }): string {
+export function resolveDisplayName(input: {
+  displayName?: string | null;
+  cognitoName?: string | null;
+  email: string;
+}): string {
   const dn = input.displayName?.trim();
   if (dn) return dn;
+  const cognito = input.cognitoName?.trim();
+  if (cognito && cognito !== input.email) return cognito;
   const localPart = input.email.split('@')[0];
   return localPart || input.email;
 }
@@ -128,4 +138,35 @@ export function resolveDisplayName(input: { displayName?: string | null; email: 
 /** First name for greetings, from a resolved display name. */
 export function firstNameOf(displayName: string): string {
   return displayName.split(' ')[0] || displayName;
+}
+
+/**
+ * Build console warnings when the home view renders from the claims/token
+ * fallback rather than the live read APIs, so silent degradation becomes
+ * visible (issue #423). Pure — the hook emits these via console.warn.
+ */
+export function fallbackWarnings(opts: {
+  apiConfigured: boolean;
+  tilesFromApi: boolean;
+  profileFromApi: boolean;
+}): string[] {
+  const out: string[] = [];
+  if (opts.tilesFromApi && opts.profileFromApi) return out;
+  if (!opts.apiConfigured) {
+    out.push(
+      '[launchpad] control-plane API URL not configured — tiles/profile rendered from token-claims fallback (expected in mock/dev).',
+    );
+    return out;
+  }
+  if (!opts.tilesFromApi) {
+    out.push(
+      '[launchpad] active-accounts read failed — app tiles derived from token claims, not the API.',
+    );
+  }
+  if (!opts.profileFromApi) {
+    out.push(
+      '[launchpad] profile read failed — display name from token fallback, not the API.',
+    );
+  }
+  return out;
 }


### PR DESCRIPTION
## Summary
Micro-fix follow-up to Phase 3 (#414), resolving #423.

1. **Display fallback bug:** the greeting showed a user's **full email** instead of a name. `resolveDisplayName` now follows the canonical chain **displayName → Cognito name → email local part**, and skips a Cognito name that equals the email (the auth client sets `User.name = email` when there's no `given_name`/`family_name`). A nameless user now sees `steve.moodie`, never the full address.
2. **Loud fallback:** `use-launchpad-data` now `console.warn`s when tiles or profile render from the claims/token fallback instead of the live read APIs, and surfaces the previously-discarded `Promise.allSettled` rejection reasons. A failing `GET /api/user/profile` / `GET /api/user/active-accounts` is no longer silent — the exact browser error will now show in the console.

## Why (read-only investigation, see #423)
During Phase 3 smoke the deployed (correct) bundle fired the reads, but the actual GETs never reached the user Lambda (0 invocations; API Gateway saw only CORS preflights, 0 4XX). The view degraded to the claims fallback **silently**, and the display bug then rendered the full email. This PR makes the next dev load self-diagnosing and fixes the display chain.

## Files changed
- `apps/launchpad/lib/entitlement.ts` — `resolveDisplayName` chain + `cognitoName` guard; new pure `fallbackWarnings`
- `apps/launchpad/hooks/use-launchpad-data.ts` — emit warnings + surface fetch errors
- `apps/launchpad/components/launchpad/launchpad.tsx` — pass `cognitoName` separately (not into the displayName slot)
- `apps/launchpad/lib/entitlement.test.ts` — tests for both

## Validation
- launchpad vitest: 21/21 pass
- typecheck · eslint · `next build` (static export) — clean
- `pnpm check:v0-contracts` — OK (no contract change) · `git diff --check` — clean

## Scope / out of scope
- **No `/auth/setup` displayName reconciliation** — that is the separately-specced, identity-sourced reconcile-at-login slice (capture-only prompt, no rename surface). Deliberately not here.
- The underlying "why did the browser GET fail after a clean preflight" cause is to be read off the console once this loud-fallback change is deployed; not chased blind in this PR.

## v0 freshness
- [x] No v0 impact

Reason: Pure runtime/UI bug-fix against the existing m16.1.0 baseline (`transformotion-apps-b8` main @ `34f5b3b`). No contract, mock, or UI-contract shape change.

## ⚠️ Merge = deploy to dev
Merge to `develop` triggers `deploy-launchpad.yml` (frontend build + deploy). Do not merge without owner sign-off.

## Refs
Refs #423, #414, #411

🤖 Generated with [Claude Code](https://claude.com/claude-code)