### PR TITLE
fix(launchpad): preserve API Gateway /dev stage in control-plane URLs

### DIFF
--- a/apps/launchpad/lib/services/account-admin/index.ts
+++ b/apps/launchpad/lib/services/account-admin/index.ts
@@ -1,4 +1,4 @@
-import { getConfig } from '@/lib/config';
+import { controlPlaneUrl } from '@/lib/services/control-plane';
 
 export interface AccountSummary {
   accountId: string;
@@ -15,10 +15,6 @@ export interface AccountMember {
   joinedAt: string;
 }
 
-function resolveControlPlaneBaseUrl(): string {
-  return getConfig().controlPlane.apiUrl;
-}
-
 function authHeaders(idToken: string, accountId: string): HeadersInit {
   return {
     Authorization: `Bearer ${idToken}`,
@@ -33,12 +29,7 @@ async function request<T>(
   path: string,
   init: RequestInit = {},
 ): Promise<T> {
-  const baseUrl = resolveControlPlaneBaseUrl();
-  if (!baseUrl) {
-    throw new Error('Launchpad control-plane API URL is not configured');
-  }
-
-  const response = await fetch(new URL(path, baseUrl).toString(), {
+  const response = await fetch(controlPlaneUrl(path), {
     ...init,
     headers: {
       ...authHeaders(idToken, activeAccountId),

--- a/apps/launchpad/lib/services/account-onboarding/index.ts
+++ b/apps/launchpad/lib/services/account-onboarding/index.ts
@@ -1,5 +1,5 @@
-import { getConfig } from '@/lib/config';
 import type { AccountSetupResponse } from '@transformotion/contracts/launchpad/types';
+import { controlPlaneUrl } from '@/lib/services/control-plane';
 
 // Canonical shape lives in the contracts package (m16.1.0). /auth/setup is
 // profile-bootstrap only (D11): `accountId` is omitted for a fresh user,
@@ -7,17 +7,8 @@ import type { AccountSetupResponse } from '@transformotion/contracts/launchpad/t
 // first-time setup. Re-exported so existing import sites keep resolving.
 export type { AccountSetupResponse };
 
-function resolveControlPlaneBaseUrl(): string {
-  return getConfig().controlPlane.apiUrl;
-}
-
 export async function setupAccount(idToken: string): Promise<AccountSetupResponse> {
-  const baseUrl = resolveControlPlaneBaseUrl();
-  if (!baseUrl) {
-    throw new Error('Launchpad control-plane API URL is not configured');
-  }
-
-  const response = await fetch(new URL('/auth/setup', baseUrl).toString(), {
+  const response = await fetch(controlPlaneUrl('/auth/setup'), {
     method: 'POST',
     headers: {
       Authorization: `Bearer ${idToken}`,

--- a/apps/launchpad/lib/services/active-accounts/index.ts
+++ b/apps/launchpad/lib/services/active-accounts/index.ts
@@ -1,14 +1,10 @@
-import { getConfig } from '@/lib/config';
 import type {
   GetActiveAccountsResponse,
   ActiveAccountSelection,
 } from '@transformotion/contracts/launchpad/invitations';
+import { controlPlaneUrl } from '@/lib/services/control-plane';
 
 export type { GetActiveAccountsResponse, ActiveAccountSelection };
-
-function resolveControlPlaneBaseUrl(): string {
-  return getConfig().controlPlane.apiUrl;
-}
 
 /**
  * Read the caller's active account per app (M16 D7, Phase 2 read API).
@@ -17,12 +13,7 @@ function resolveControlPlaneBaseUrl(): string {
  * for every app they hold a membership in).
  */
 export async function getActiveAccounts(idToken: string): Promise<GetActiveAccountsResponse> {
-  const baseUrl = resolveControlPlaneBaseUrl();
-  if (!baseUrl) {
-    throw new Error('Launchpad control-plane API URL is not configured');
-  }
-
-  const response = await fetch(new URL('/api/user/active-accounts', baseUrl).toString(), {
+  const response = await fetch(controlPlaneUrl('/api/user/active-accounts'), {
     headers: {
       Authorization: `Bearer ${idToken}`,
     },

--- a/apps/launchpad/lib/services/ai-runtime-config/index.ts
+++ b/apps/launchpad/lib/services/ai-runtime-config/index.ts
@@ -1,4 +1,4 @@
-import { getConfig } from '@/lib/config'
+import { controlPlaneUrl } from '@/lib/services/control-plane'
 import {
   AI_MODEL_ALLOWLIST,
   type AiConfigAppSlug,
@@ -23,21 +23,6 @@ export const FALLBACK_SUPPORTED_MODELS: Record<AiProviderId, readonly string[]> 
   openai: AI_MODEL_ALLOWLIST.openai,
 }
 
-function resolveControlPlaneBaseUrl(): string {
-  return getConfig().controlPlane.apiUrl
-}
-
-function buildControlPlaneUrl(path: string): string {
-  const baseUrl = resolveControlPlaneBaseUrl()
-  if (!baseUrl) {
-    throw new Error('Launchpad control-plane API URL is not configured')
-  }
-
-  const normalizedBase = baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`
-  const normalizedPath = path.replace(/^\/+/, '')
-  return new URL(normalizedPath, normalizedBase).toString()
-}
-
 async function readError(response: Response, fallback: string): Promise<string> {
   try {
     const body = await response.json() as { message?: string; error?: string }
@@ -52,7 +37,7 @@ async function request<T>(
   path: string,
   init: RequestInit = {},
 ): Promise<T> {
-  const response = await fetch(buildControlPlaneUrl(path), {
+  const response = await fetch(controlPlaneUrl(path), {
     ...init,
     headers: {
       Authorization: `Bearer ${idToken}`,

--- a/apps/launchpad/lib/services/control-plane.test.ts
+++ b/apps/launchpad/lib/services/control-plane.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { joinControlPlaneUrl } from './control-plane';
+
+const HOST = 'https://qrwal90470.execute-api.ap-southeast-2.amazonaws.com';
+
+describe('joinControlPlaneUrl — preserves the API Gateway stage (#423)', () => {
+  it('keeps the /dev stage when base has it and path is absolute (the bug)', () => {
+    // new URL('/api/user/profile', `${HOST}/dev/`) would have dropped /dev.
+    expect(joinControlPlaneUrl(`${HOST}/dev/`, '/api/user/profile')).toBe(
+      `${HOST}/dev/api/user/profile`,
+    );
+  });
+
+  it('works when the base has no trailing slash', () => {
+    expect(joinControlPlaneUrl(`${HOST}/dev`, '/api/user/profile')).toBe(
+      `${HOST}/dev/api/user/profile`,
+    );
+  });
+
+  it('works when the path has no leading slash', () => {
+    expect(joinControlPlaneUrl(`${HOST}/dev/`, 'api/user/active-accounts')).toBe(
+      `${HOST}/dev/api/user/active-accounts`,
+    );
+  });
+
+  it('tolerates redundant slashes on both sides', () => {
+    expect(joinControlPlaneUrl(`${HOST}/dev//`, '//auth/setup')).toBe(`${HOST}/dev/auth/setup`);
+  });
+
+  it('preserves nested/encoded path segments', () => {
+    expect(
+      joinControlPlaneUrl(`${HOST}/dev/`, '/accounts/acct-123/members/user-9'),
+    ).toBe(`${HOST}/dev/accounts/acct-123/members/user-9`);
+  });
+
+  it('works with a multi-segment stage', () => {
+    expect(joinControlPlaneUrl(`${HOST}/v1/dev/`, '/api/user/profile')).toBe(
+      `${HOST}/v1/dev/api/user/profile`,
+    );
+  });
+
+  it('works against a bare origin (no stage)', () => {
+    expect(joinControlPlaneUrl(HOST, '/api/user/profile')).toBe(`${HOST}/api/user/profile`);
+  });
+});

--- a/apps/launchpad/lib/services/control-plane.ts
+++ b/apps/launchpad/lib/services/control-plane.ts
@@ -1,0 +1,31 @@
+import { getConfig } from '@/lib/config';
+
+/**
+ * Join the control-plane base URL — which includes the API Gateway STAGE path
+ * (e.g. `https://<api>.execute-api.<region>.amazonaws.com/dev/`) — with a route
+ * path, preserving the stage.
+ *
+ * Deliberately a pure string join, NOT `new URL(path, base)`: a leading-slash
+ * path is absolute, so `new URL('/api/user/profile', '.../dev/')` discards the
+ * base path and resolves to `.../api/user/profile`, dropping the `/dev` stage
+ * and hitting a non-existent route (issue #423). Stripping a leading slash and
+ * appending keeps the stage intact regardless of slashes on either side.
+ */
+export function joinControlPlaneUrl(base: string, path: string): string {
+  const b = base.replace(/\/+$/, '');
+  const p = path.replace(/^\/+/, '');
+  return `${b}/${p}`;
+}
+
+/**
+ * Build a control-plane request URL for `path`, throwing if the API URL is not
+ * configured. All Launchpad control-plane service clients must route through
+ * this so the stage is never dropped.
+ */
+export function controlPlaneUrl(path: string): string {
+  const base = getConfig().controlPlane.apiUrl;
+  if (!base) {
+    throw new Error('Launchpad control-plane API URL is not configured');
+  }
+  return joinControlPlaneUrl(base, path);
+}

--- a/apps/launchpad/lib/services/user-profile/index.ts
+++ b/apps/launchpad/lib/services/user-profile/index.ts
@@ -1,21 +1,12 @@
-import { getConfig } from '@/lib/config';
 import type { UserProfile, UserPreferences } from '@transformotion/contracts/_shared/auth';
+import { controlPlaneUrl } from '@/lib/services/control-plane';
 
 // Canonical shapes (contract m16.1.0). UserProfile carries the M16 fields:
 // userId, email, displayName, status, preferences, profileComplete, updatedAt.
 export type { UserProfile, UserPreferences };
 
-function resolveControlPlaneBaseUrl(): string {
-  return getConfig().controlPlane.apiUrl;
-}
-
 export async function getUserProfile(idToken: string): Promise<UserProfile> {
-  const baseUrl = resolveControlPlaneBaseUrl();
-  if (!baseUrl) {
-    throw new Error('Launchpad control-plane API URL is not configured');
-  }
-
-  const response = await fetch(new URL('/api/user/profile', baseUrl).toString(), {
+  const response = await fetch(controlPlaneUrl('/api/user/profile'), {
     headers: {
       Authorization: `Bearer ${idToken}`,
     },
@@ -32,12 +23,7 @@ export async function updateUserPreferences(
   idToken: string,
   preferences: Partial<UserPreferences>,
 ): Promise<{ preferences: UserPreferences }> {
-  const baseUrl = resolveControlPlaneBaseUrl();
-  if (!baseUrl) {
-    throw new Error('Launchpad control-plane API URL is not configured');
-  }
-
-  const response = await fetch(new URL('/api/user/preferences', baseUrl).toString(), {
+  const response = await fetch(controlPlaneUrl('/api/user/preferences'), {
     method: 'PUT',
     headers: {
       Authorization: `Bearer ${idToken}`,

--- a/apps/launchpad/vitest.config.ts
+++ b/apps/launchpad/vitest.config.ts
@@ -1,8 +1,16 @@
 import { defineConfig } from 'vitest/config';
+import { fileURLToPath } from 'node:url';
 
 export default defineConfig({
   test: {
     environment: 'node',
     include: ['lib/**/*.test.ts'],
+  },
+  resolve: {
+    // Mirror the Next.js `@/*` path alias (tsconfig) so tests can import modules
+    // that reference `@/lib/...`.
+    alias: {
+      '@': fileURLToPath(new URL('.', import.meta.url)),
+    },
   },
 });


### PR DESCRIPTION
## Summary
Fixes the root cause of the Phase 3 control-plane read failures (#423): every Launchpad service client built request URLs with `new URL('/api/...', base)`. A leading-slash path is absolute, so `new URL` discards the base path — **dropping the `/dev` API Gateway stage** — and requests went to `https://<api>.execute-api.../api/user/profile` (no stage), hitting a non-existent route (403, no CORS). The home view then degraded silently to the claims fallback.

Confirmed in dev DevTools: the failed `profile`/`active-accounts` requests had URLs missing `/dev`.

## Changes
- New shared helper `apps/launchpad/lib/services/control-plane.ts`:
  - `joinControlPlaneUrl(base, path)` — pure string join (strip trailing slash from base, leading slash from path) that preserves the stage.
  - `controlPlaneUrl(path)` — reads the configured base, throws if unset.
- Routed **all five** service clients through it: `user-profile`, `active-accounts`, `account-admin`, `account-onboarding`, and `ai-runtime-config` (which already had its own correct copy — now deduped). The four buggy clients were latent until Phase 3 became the first code to call them.
- Unit tests for the join incl. the `/dev`-stage regression case and slash/stage variations.
- Added the `@` path alias to the launchpad vitest config so service tests resolve `@/lib/*`.

## Validation
- launchpad vitest: 28/28 pass (21 entitlement + 7 control-plane)
- typecheck · eslint · `next build` (static export) — clean
- `pnpm check:v0-contracts` — OK (no contract change) · `git diff --check` — clean

## v0 freshness
- [x] No v0 impact

Reason: Pure runtime/UI bug-fix against the existing m16.1.0 baseline (`transformotion-apps-b8` main @ `34f5b3b`). No contract, mock, or UI-contract shape change.

## ⚠️ Merge = deploy to dev
Merge to `develop` triggers `deploy-launchpad.yml` (frontend build + deploy). Do not merge without owner sign-off.

## Follow-up
**#414 (Phase 3) stays open** pending re-validation after this deploys: confirm the home view renders tiles + profile from the **API** (greeting from `displayName`, not the Cognito-name fallback) and the browser console is **clean of `[launchpad] … read failed` fallback warnings**. Only then is the Phase 3 read path actually exercised end-to-end.

## Refs
Refs #423, #414, #411

🤖 Generated with [Claude Code](https://claude.com/claude-code)