### PR TITLE
feat(m16-p4a): role vocabulary + write-path row-check helper (Phase 4 foundation)

### DIFF
--- a/docs/architecture/auth.md
+++ b/docs/architecture/auth.md
@@ -210,6 +210,8 @@ Account membership is stored in `launchpad-account-members-{stage}` (PK: `accoun
 **Role hierarchy** (for `requireAccountAccess` minRole checks):
 `owner > manager > member > viewer`. A check for `minRole: 'manager'` succeeds for `owner` and `manager`; fails for `member` and `viewer`.
 
+**Write-path row check (D8, M16).** App-data **writes** (Stock Analyser / Budget Tracker mutations) go through `requireAccountWrite` (`packages/lambda-middleware`): the claims membership check **plus** a live read of the caller's `launchpad-account-members` row. The live row is the authority because claims can be stale — a user demoted to `viewer`, disabled, or removed after token issuance still carries the old claim for up to the access-token lifetime. The write is rejected (403) when the row is missing (**fail closed**), the row's `status` is not `active`, or the role is `viewer` (read-only). There is **no site-admin bypass** on this path: membership is the only grant of data authority (D9). Reads stay claims-only — no table read on the hot path. (Layered on the existing claims helpers; folds into the Phase 5 `requireAccountData`/`requireAccountAdmin` split.)
+
 ### Conflict resolution between dimensions
 
 Dimensions A and B describe different axes and can express potentially conflicting states (e.g., user has app-access but is `viewer` on all accounts; user lacks app-access but somehow has a `member` row).
@@ -731,6 +733,10 @@ Frontend code follows the same layered architecture pattern as data access (see 
 A domain interface (`AuthService`) lives in contracts. Implementations are named for what they wrap: `CognitoAuthService` (production; reads JWT claims from a Cognito session) and `MockAuthService` (v0; returns mocked auth state without any real auth backend). Selection is build-time per the layered architecture pattern.
 
 Components, services, and hooks access claim-derived data only via the `AuthService` interface — never by reading JWT claims directly. The interface is the canonical access path for any claim-derived value (active account ID, app access flags, user identity, etc.).
+
+**Account role vocabulary (D10, M16).** The client `Account` type in `packages/auth-client` uses `owner | manager | member | viewer`, matching the contract `AccountRole`; the legacy `owner | admin | member` is removed. No membership rows used `admin` (verified on dev: 0 rows), so this is a type-level correction with no data backfill.
+
+**Stable identity vs reactive account state (#210).** `AuthService.getCurrentUser()` is the read-once stable-identity accessor (name, email, userId from cached token claims). The reactive, mutable **per-app active account** is control-plane-owned (D7) and lives in each app's account store — never in the stable-identity path. `getAccountIdForApp` (first membership from the token's `accounts` claim) is a legacy convenience superseded by the control-plane active-account read in the app layer (Phase 4 SA/BT wiring).
 
 The current state has the interface duplicated across `packages/auth-client/`, `apps/stock-analyser/`, and `apps/budget-tracker/`, with the production implementation only existing for stock-analyser. Migration to the canonical pattern (interface in contracts, both implementations in `packages/auth-client/`, build-time selection) happens alongside the production bug fix for the missing `accounts` JWT claim.
 

--- a/packages/auth-client/src/index.ts
+++ b/packages/auth-client/src/index.ts
@@ -13,7 +13,13 @@ export interface Account {
   id: string
   name: string
   type: 'personal' | 'business' | 'family'
-  role: 'owner' | 'admin' | 'member'
+  /**
+   * M16 account role vocabulary (D10): owner | manager | member | viewer.
+   * Replaces the legacy `owner | admin | member`. Matches AccountRole in
+   * @transformotion/contracts/_shared/auth (kept inline to avoid a contracts
+   * dependency in this low-level package).
+   */
+  role: 'owner' | 'manager' | 'member' | 'viewer'
 }
 
 export interface AuthTokens {
@@ -41,6 +47,14 @@ export interface SignUpCredentials {
 }
 
 export interface AuthService {
+  /**
+   * Stable session identity from the cached ID-token claims — the read-once
+   * side of the #210 split (stable identity vs reactive account state). The
+   * reactive, mutable per-app ACTIVE account is control-plane-owned (D7) and
+   * lives in each app's account store, never here. `getAccountIdForApp` reads
+   * the token's `accounts` claim (first membership) and is a legacy convenience
+   * superseded by the control-plane active-account read in the app layer.
+   */
   getCurrentUser():  Promise<User | null>
   getSession():      Promise<AuthSession | null>
   signIn(credentials: SignInCredentials):  Promise<AuthSession>

--- a/packages/lambda-middleware/src/auth.test.ts
+++ b/packages/lambda-middleware/src/auth.test.ts
@@ -5,10 +5,12 @@ import {
   requireAnyAppAccess,
   requireAccountAccess,
   requireAccountOwner,
+  requireAccountWrite,
   requireGroup,
   extractAuthClaims,
   resolveAccountContext,
 } from './auth';
+import type { AccountMembershipRow } from './auth';
 import type { AuthClaims } from './types';
 import { HttpError } from './errors';
 import type { APIGatewayProxyEvent } from 'aws-lambda';
@@ -307,5 +309,79 @@ describe('requireGroup', () => {
 
   it('throws 403 when user is in none of the required groups', () => {
     expect(() => requireGroup(makeClaims({ groups: ['other'] }), 'admin', 'site-admin')).toThrow(HttpError);
+  });
+});
+
+// ── requireAccountWrite (D8 write-path: claims + live row) ────────────────────
+
+describe('requireAccountWrite', () => {
+  const memberClaims = (role = 'member') =>
+    makeClaims({ accounts: { 'budget-tracker': [{ accountId: 'acc-1', role: role as never }] } });
+
+  /** Loader that returns a fixed row (or undefined to simulate a removed member). */
+  const loader = (row: AccountMembershipRow | undefined) => {
+    const calls: Array<{ accountId: string; userId: string }> = [];
+    const fn = async (accountId: string, userId: string) => {
+      calls.push({ accountId, userId });
+      return row;
+    };
+    return Object.assign(fn, { calls });
+  };
+
+  it('passes for an active member', async () => {
+    await expect(
+      requireAccountWrite(memberClaims('member'), 'budget-tracker', 'acc-1', loader({ role: 'member' })),
+    ).resolves.toBeUndefined();
+  });
+
+  it('passes for manager and owner', async () => {
+    await expect(
+      requireAccountWrite(memberClaims('manager'), 'budget-tracker', 'acc-1', loader({ role: 'manager' })),
+    ).resolves.toBeUndefined();
+    await expect(
+      requireAccountWrite(memberClaims('owner'), 'budget-tracker', 'acc-1', loader({ role: 'owner' })),
+    ).resolves.toBeUndefined();
+  });
+
+  it('passes when row status is explicitly active', async () => {
+    await expect(
+      requireAccountWrite(memberClaims('member'), 'budget-tracker', 'acc-1', loader({ role: 'member', status: 'active' })),
+    ).resolves.toBeUndefined();
+  });
+
+  it('REJECTS a viewer (read-only) with 403', async () => {
+    await expect(
+      requireAccountWrite(memberClaims('viewer'), 'budget-tracker', 'acc-1', loader({ role: 'viewer' })),
+    ).rejects.toMatchObject({ statusCode: 403 });
+  });
+
+  it('REJECTS a disabled member (status not active) with 403', async () => {
+    await expect(
+      requireAccountWrite(memberClaims('member'), 'budget-tracker', 'acc-1', loader({ role: 'member', status: 'disabled' })),
+    ).rejects.toMatchObject({ statusCode: 403 });
+  });
+
+  it('FAILS CLOSED with 403 when the live row is missing (removed since token issuance)', async () => {
+    const l = loader(undefined);
+    await expect(
+      requireAccountWrite(memberClaims('member'), 'budget-tracker', 'acc-1', l),
+    ).rejects.toMatchObject({ statusCode: 403 });
+    expect(l.calls).toHaveLength(1); // claim passed, so the row WAS read
+  });
+
+  it('REJECTS a non-member (no claim) with 403 WITHOUT reading the row', async () => {
+    const l = loader({ role: 'owner' });
+    await expect(
+      requireAccountWrite(makeClaims(), 'budget-tracker', 'acc-1', l),
+    ).rejects.toMatchObject({ statusCode: 403 });
+    expect(l.calls).toHaveLength(0); // cheap claim reject, no table read
+  });
+
+  it('REJECTS a site-admin with no membership (no data-authority bypass, D9)', async () => {
+    const l = loader({ role: 'owner' });
+    await expect(
+      requireAccountWrite(makeClaims({ siteAdmin: true }), 'budget-tracker', 'acc-1', l),
+    ).rejects.toMatchObject({ statusCode: 403 });
+    expect(l.calls).toHaveLength(0);
   });
 });

--- a/packages/lambda-middleware/src/auth.ts
+++ b/packages/lambda-middleware/src/auth.ts
@@ -147,6 +147,67 @@ export function requireAccountAccess(
   throw forbidden(`Account access required (accountId: ${accountId}, minRole: ${minRole})`);
 }
 
+/** A live membership row, loaded from the account-members table by the caller. */
+export interface AccountMembershipRow {
+  role: AccountRole;
+  /** 'active' | 'disabled' | undefined. Absent means active (backwards compat). */
+  status?: string;
+}
+
+/**
+ * Loads the caller's live membership row for an account, or undefined when no
+ * row exists. Injected by the handler so this package stays AWS-SDK-free and
+ * unit-testable; each app provides a GetItem against its account-members table.
+ */
+export type MembershipLoader = (
+  accountId: string,
+  userId: string,
+) => Promise<AccountMembershipRow | undefined>;
+
+/**
+ * D8 WRITE-path authorization for app-data mutations (SA/BT). Claims gate PLUS
+ * a live membership-row read — the row is the authority, because claims can be
+ * stale (a user demoted to `viewer` or removed after token issuance still
+ * carries the old claim for up to the token lifetime).
+ *
+ * Rejects (403) when:
+ *  - the caller shows no membership claim for the account (cheap reject; the
+ *    same surface reads gate on — a caller who cannot read cannot write), or
+ *  - the live row is missing — removed since token issuance → **fail closed**, or
+ *  - the live row's status is not `active` (disabled), or
+ *  - the live row's role is `viewer` (read-only).
+ *
+ * No site-admin bypass: membership is the only grant of data authority (D9); a
+ * site-admin without a row is rejected like anyone else. Reads stay claims-only
+ * — do NOT call this on read paths (D8: no table reads on the hot path).
+ *
+ * Phase 4 layering: this composes on top of the existing claims helpers; it will
+ * be folded into the Phase 5 `requireAccountData`/`requireAccountAdmin` split.
+ */
+export async function requireAccountWrite(
+  auth: AuthClaims,
+  app: AppName,
+  accountId: string,
+  loadMembership: MembershipLoader,
+): Promise<void> {
+  const appAccounts = auth.accounts[app] ?? [];
+  const hasClaim = appAccounts.some(m => m.accountId === accountId);
+  if (!hasClaim) {
+    throw forbidden(`Account membership required (accountId: ${accountId})`);
+  }
+
+  const row = await loadMembership(accountId, auth.userId);
+  if (!row) {
+    throw forbidden(`Account membership required (accountId: ${accountId})`);
+  }
+  if (row.status && row.status !== 'active') {
+    throw forbidden('Account membership is not active');
+  }
+  if (row.role === 'viewer') {
+    throw forbidden('Viewer role is read-only');
+  }
+}
+
 /**
  * Throws HttpError(403) unless the user is the owner of `accountId` within `app`.
  *

--- a/packages/lambda-middleware/src/index.ts
+++ b/packages/lambda-middleware/src/index.ts
@@ -33,6 +33,7 @@
 //   requireAnyAppAccess(auth, apps)                     — throws 403 unless user has access to any of the apps
 //   requireAccountAccess(auth, app, accountId, minRole) — throws 403 unless user has account access
 //   requireAccountOwner(auth, app, accountId)           — throws 403 unless user owns account
+//   requireAccountWrite(auth, app, accountId, loader)   — D8 write-path: claims + live row (viewer/disabled/missing → 403)
 
 export { withAuth, withAuthOnly, withPublic }            from './middleware';
 export { ok, created, noContent, errorResponse }        from './response';
@@ -46,6 +47,7 @@ export {
   requireAnyAppAccess,
   requireAccountAccess,
   requireAccountOwner,
+  requireAccountWrite,
 }                                                       from './auth';
 export type {
   AuthClaims,
@@ -60,3 +62,4 @@ export type {
   AppName,
   AccountRole,
 } from './types';
+export type { AccountMembershipRow, MembershipLoader } from './auth';


### PR DESCRIPTION
## Summary
**PR-A of 3** for Phase 4 (we sequenced Phase 4 into PR-A foundation → PR-B Stock Analyser → PR-C Budget Tracker, smoke-tested per PR). PR-A is the low-risk, package-only foundation; it changes no deployed handler behaviour.

- **Slice 1 (D10) — role vocabulary:** `packages/auth-client` `Account.role` → `owner | manager | member | viewer` (was `owner | admin | member`), matching the contract `AccountRole`. **Data check (read-only, dev):** `launchpad-account-members-dev` has 5 rows, all `role='owner'`, **0** `admin` — so this is purely type-level, no backfill (Phase 10/#146 stays vacuous for roles). No consumer branches on `admin` (verified).
- **Slice 1 (#210):** documented `getCurrentUser()` as the read-once stable-identity accessor; the reactive **per-app active account** is control-plane-owned (D7) and lands in each app's store in PR-B/PR-C (where #210's "apps updated" acceptance items belong). No gold-plating in auth-client.
- **Slice 4 (D8) — `requireAccountWrite` helper:** new `packages/lambda-middleware` helper for app-data **writes**: claims membership gate **plus** a live membership-row read (injected loader → package stays AWS-SDK-free + unit-testable). Rejects (403): no claim (no table read), missing row (**fail closed**), `status != active`, role `viewer`. **No site-admin bypass** (D9). Applied to SA handlers in PR-B, BT handlers in PR-C.
- **Slice 5 (docs):** auth.md write-path row check + viewer rejection, role vocab (D10), #210 split. Staleness sentence already present (Phase 2).

## Files per slice
- Slice 1: `packages/auth-client/src/index.ts`
- Slice 4: `packages/lambda-middleware/src/{auth.ts,index.ts,auth.test.ts}`
- Slice 5: `docs/architecture/auth.md`

## Validation
- lambda-middleware: **50/50** tests pass (8 new `requireAccountWrite`: member/manager/owner pass; viewer/disabled/missing-row/non-member/site-admin-without-row reject; loader-not-called on cheap rejects).
- auth-client: 9/9 tests pass.
- typecheck: both packages + all three consumer apps (launchpad, stock-analyser, budget-tracker) clean.
- lint (both packages) clean · `pnpm check:v0-contracts` OK · `git diff --check` clean.
- No infra/CDK change → `cdk synth` unaffected (CI still runs it).

## v0 freshness
- [x] No v0 impact

Reason: Built against the existing m16.1.0 baseline (`transformotion-apps-b8` main @ `34f5b3b`). Role vocabulary aligns to the existing contract `AccountRole`; the write-path helper is runtime middleware. No contract/mock/UI-contract shape change.

## ⚠️ Merge = deploy to dev
`packages/auth-client/**` and `packages/lambda-middleware/**` are watched by the app deploy workflows, so merge triggers dev deploy(s). **PR-A is behaviour-neutral**: the role change is compile-time, and `requireAccountWrite` is added but **not yet called** by any handler. Smoke for PR-A is therefore minimal — clean deploy, apps still load and authenticate. The functional smoke checklist (account switching, no-access gates, viewer 403, per-app independence) lands with **PR-B (Stock Analyser)** and **PR-C (Budget Tracker + cross-app checks)**, per the agreed per-PR smoke plan.

## Refs
Refs #415, #411, #210

🤖 Generated with [Claude Code](https://claude.com/claude-code)