### PR TITLE
fix(m16-p4): Stock Analyser account selector shows names, not UUIDs

### DIFF
--- a/apps/stock-analyser/components/stock-analyser/app-shell.tsx
+++ b/apps/stock-analyser/components/stock-analyser/app-shell.tsx
@@ -306,7 +306,7 @@ export function NavigationProvider({
   // (Display name/email enrichment is a follow-up; the selector shows account ids.)
   const user: User = {
     ...state.user,
-    accounts: storeAccounts.map(a => ({ id: a.accountId, name: a.accountId, type: 'Personal' as const })),
+    accounts: storeAccounts.map(a => ({ id: a.accountId, name: a.name ?? a.accountId, type: 'Personal' as const })),
     activeAccountId: storeActiveId ?? '',
   }
 

--- a/apps/stock-analyser/stores/active-account/account-status.ts
+++ b/apps/stock-analyser/stores/active-account/account-status.ts
@@ -16,6 +16,8 @@ export type AccountAccessStatus = 'idle' | 'loading' | 'ready' | 'no-access' | '
 export interface AccountOption {
   accountId: string
   role: string
+  /** Display name from the control plane; absent until enriched (falls back to id). */
+  name?: string
 }
 
 /** Outcome of the control-plane active-accounts read. `ok: false` = fetch failed. */

--- a/apps/stock-analyser/stores/active-account/use-active-account-store.ts
+++ b/apps/stock-analyser/stores/active-account/use-active-account-store.ts
@@ -74,6 +74,21 @@ export const useActiveAccountStore = create<ActiveAccountState>((set, get) => ({
       accounts: next.status === 'no-access' ? [] : accounts,
       error: next.status === 'error' ? (errMsg ?? next.error) : null,
     })
+
+    // Best-effort: enrich account labels with real names (GET /accounts/{id}).
+    // Cosmetic only — never affects access status; falls back to the id on failure.
+    if (next.status !== 'no-access' && accounts.length > 0) {
+      void Promise.all(
+        accounts.map(async (a) => {
+          try {
+            const res = await cp.getAccount(a.accountId)
+            return { ...a, name: res.account?.name || a.accountId }
+          } catch {
+            return { ...a, name: a.accountId }
+          }
+        }),
+      ).then((named) => set({ accounts: named }))
+    }
   },
 
   switchTo: async (accountId: string) => {

--- a/packages/api-client/src/control-plane.test.ts
+++ b/packages/api-client/src/control-plane.test.ts
@@ -55,4 +55,18 @@ describe('ControlPlaneClient — preserves the API Gateway stage (#423-safe)', (
     const [url] = (f as unknown as { mock: { calls: [string][] } }).mock.calls[0];
     expect(url).toBe(`${BASE}api/user/active-accounts`);
   });
+
+  it('getAccount targets /accounts/{id}, keeps stage, sends X-Account-Id', async () => {
+    const f = mockFetch({ account: { accountId: 'acc-1', name: "Steve's Portfolio" } });
+    globalThis.fetch = f;
+    const client = new ControlPlaneClient({ baseUrl: BASE, getToken: async () => 'tok' });
+
+    const res = await client.getAccount('acc-1');
+
+    const [url, init] = (f as unknown as { mock: { calls: [string, RequestInit][] } }).mock.calls[0];
+    expect(url).toBe(`${BASE}accounts/acc-1`);
+    expect(init.method).toBe('GET');
+    expect((init.headers as Record<string, string>)['X-Account-Id']).toBe('acc-1');
+    expect(res.account.name).toBe("Steve's Portfolio");
+  });
 });

--- a/packages/api-client/src/control-plane.ts
+++ b/packages/api-client/src/control-plane.ts
@@ -49,4 +49,23 @@ export class ControlPlaneClient {
       signal,
     );
   }
+
+  /**
+   * GET /accounts/{accountId} — account metadata (incl. display name) for an
+   * account the caller is a member of. Used to label account selectors. The
+   * X-Account-Id header is required by the account-context middleware; the
+   * handler authorizes membership on the path id.
+   */
+  getAccount(accountId: string, signal?: AbortSignal): Promise<ControlPlaneAccount> {
+    return this.http.get(
+      `accounts/${encodeURIComponent(accountId)}`,
+      signal,
+      { 'X-Account-Id': accountId },
+    );
+  }
+}
+
+/** Minimal shape of GET /accounts/{accountId} needed for selector labels. */
+export interface ControlPlaneAccount {
+  account: { accountId: string; name?: string };
 }

--- a/packages/api-client/src/http.ts
+++ b/packages/api-client/src/http.ts
@@ -34,8 +34,8 @@ export class HttpClient {
     this.getAccountId = opts.getAccountId;
   }
 
-  async get<T>(path: string, signal?: AbortSignal): Promise<T> {
-    return this.request<T>('GET', path, undefined, signal);
+  async get<T>(path: string, signal?: AbortSignal, extraHeaders?: Record<string, string>): Promise<T> {
+    return this.request<T>('GET', path, undefined, signal, extraHeaders);
   }
 
   async put<T>(path: string, body: unknown, signal?: AbortSignal): Promise<T> {
@@ -54,7 +54,13 @@ export class HttpClient {
     await this.request<void>('DELETE', path, undefined, signal);
   }
 
-  private async request<T>(method: string, path: string, body?: unknown, signal?: AbortSignal): Promise<T> {
+  private async request<T>(
+    method: string,
+    path: string,
+    body?: unknown,
+    signal?: AbortSignal,
+    extraHeaders?: Record<string, string>,
+  ): Promise<T> {
     const token     = await this.getToken();
     const accountId = this.getAccountId ? await this.getAccountId() : undefined;
 
@@ -65,6 +71,10 @@ export class HttpClient {
 
     if (accountId) {
       headers['X-Account-Id'] = accountId;
+    }
+    // Per-call headers (e.g. a one-off X-Account-Id) override the defaults.
+    if (extraHeaders) {
+      Object.assign(headers, extraHeaders);
     }
 
     // Strip leading slash so baseUrl + path doesn't produce double slashes

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -20,7 +20,7 @@ export { HttpClient }                     from './http';
 export { ControlPlaneClient }             from './control-plane';
 export { ApiError }                       from './errors';
 export type { ApiClientOptions }          from './http';
-export type { ControlPlaneClientOptions } from './control-plane';
+export type { ControlPlaneClientOptions, ControlPlaneAccount } from './control-plane';
 
 export type {
   // Portfolio


### PR DESCRIPTION
## Summary
Follow-up to PR-B (#428): the SA account selector rendered raw account UUIDs (e.g. `a03f9cd4-…`) because account names aren't carried in the token's `accounts` claim. This enriches the selector with the real name (e.g. "Steve's Portfolio").

- `ControlPlaneClient.getAccount(accountId)` → `GET /accounts/{accountId}` for account metadata (incl. name). Sends the `X-Account-Id` header the account-context middleware requires; the handler authorizes membership on the path id. `HttpClient.get` gains an **optional, backward-compatible** per-call `extraHeaders` arg.
- The active-account store fetches names **best-effort after access is resolved** — cosmetic only, never affects the access decision/status, and **falls back to the account id** if the fetch fails.
- The app-shell selector uses `name ?? accountId`.

## Validation
- api-client: 4 tests (added `getAccount` — URL/stage/X-Account-Id); typecheck clean.
- SA: 31 tests, typecheck, `next build` clean.
- api-client consumers (budget-tracker, launchpad) typecheck clean (the new HttpClient arg is optional).
- `check:v0-contracts` OK · `git diff --check` clean · lint (changed files) clean.

## v0 freshness
- [x] No v0 impact

Reason: m16.1.0 baseline. Uses the existing `GET /accounts/{accountId}` contract; HttpClient gains an optional param. No contract/mock/UI-contract shape change.

## ⚠️ Merge = deploy to dev
Touches `packages/api-client` → triggers the app deploys (SA changes behaviourally — selector labels).

## Smoke
- Open SA → the account switcher shows the account **name** ("Steve's Portfolio"), not the UUID; Network shows a `GET /accounts/{id}` 200 per account. If that call fails, the label gracefully falls back to the id (no crash, no effect on access).

Refs #415, #411

🤖 Generated with [Claude Code](https://claude.com/claude-code)