### PR TITLE
fix(launchpad): show account names, not raw GUIDs, in profile chip (#433)

### DIFF
--- a/apps/launchpad/components/launchpad/launchpad.tsx
+++ b/apps/launchpad/components/launchpad/launchpad.tsx
@@ -26,7 +26,10 @@ const APP_ICONS: Record<string, React.ComponentType<{ className?: string }>> = {
 interface AccountRow {
   appSlug: string
   accountId: string
-  label: string
+  /** The app's display name (e.g. "Budget Tracker"). */
+  appLabel: string
+  /** The account's real name when known (e.g. "Steve's Budget"); undefined while/if unresolved. */
+  accountName?: string
 }
 
 const getGreeting = () => {
@@ -244,8 +247,10 @@ function ProfileMenu({
                 className="w-full flex items-center justify-between px-4 py-2.5 text-sm"
               >
                 <div className="text-left min-w-0">
-                  <p className="font-medium text-foreground truncate">{account.label}</p>
-                  <p className="text-xs text-muted-foreground truncate">{account.accountId}</p>
+                  <p className="font-medium text-foreground truncate">{account.accountName ?? account.appLabel}</p>
+                  {account.accountName ? (
+                    <p className="text-xs text-muted-foreground truncate">{account.appLabel}</p>
+                  ) : null}
                 </div>
               </div>
             ))}
@@ -336,7 +341,8 @@ export function Launchpad({
   const accounts: AccountRow[] = data.selections.map((s) => ({
     appSlug: s.appSlug,
     accountId: s.accountId,
-    label: appLabel(s.appSlug),
+    appLabel: appLabel(s.appSlug),
+    accountName: data.accountNames[s.accountId],
   }))
 
   const getLaunchHandler = (slug: string): (() => void) | undefined => {

--- a/apps/launchpad/hooks/use-launchpad-data.ts
+++ b/apps/launchpad/hooks/use-launchpad-data.ts
@@ -6,6 +6,7 @@ import { authService } from '@/lib/services/auth'
 import { getConfig } from '@/lib/config'
 import { getUserProfile, type UserProfile } from '@/lib/services/user-profile'
 import { getActiveAccounts, type ActiveAccountSelection } from '@/lib/services/active-accounts'
+import { getAccount } from '@/lib/services/account-admin'
 import { LAUNCHPAD_APPS, entitledSlugsFromSelections, fallbackWarnings } from '@/lib/entitlement'
 
 export interface LaunchpadData {
@@ -15,6 +16,12 @@ export interface LaunchpadData {
   entitledSlugs: Set<string>
   /** Active account per app (M16 D7); empty when unavailable. */
   selections: ActiveAccountSelection[]
+  /**
+   * Best-effort accountId → display name, used to label the profile chip with
+   * real account names instead of raw GUIDs (#433). Populated asynchronously
+   * after `selections`; an entry is absent when its name could not be read.
+   */
+  accountNames: Record<string, string>
   /** True when the live read failed and entitlement came from a claims fallback. */
   degraded: boolean
 }
@@ -24,6 +31,7 @@ const EMPTY: LaunchpadData = {
   profile: null,
   entitledSlugs: new Set(),
   selections: [],
+  accountNames: {},
   degraded: false,
 }
 
@@ -83,8 +91,32 @@ export function useLaunchpadData(user: User | null): LaunchpadData {
             profile,
             entitledSlugs,
             selections,
+            accountNames: {},
             degraded: !tilesFromApi || !profileFromApi,
           })
+        }
+
+        // Best-effort: enrich the profile chip with real account names so it
+        // shows "Steve's Portfolio" rather than a raw accountId GUID (#433).
+        // Cosmetic only — failures leave the name absent and never affect
+        // entitlement, the active selection, or access.
+        if (idToken && selections.length > 0) {
+          const named = await Promise.all(
+            selections.map(async (s) => {
+              try {
+                const res = await getAccount(idToken, s.accountId, s.accountId)
+                return [s.accountId, res.account?.name] as const
+              } catch (err) {
+                console.warn('[launchpad] account-name read failed:', s.accountId, err)
+                return [s.accountId, undefined] as const
+              }
+            }),
+          )
+          if (!cancelled) {
+            const accountNames: Record<string, string> = {}
+            for (const [id, name] of named) if (name) accountNames[id] = name
+            setState((prev) => ({ ...prev, accountNames }))
+          }
         }
         return
       }
@@ -95,7 +127,7 @@ export function useLaunchpadData(user: User | null): LaunchpadData {
       }
       const entitledSlugs = await deriveEntitlementFromClaims()
       if (!cancelled) {
-        setState({ loading: false, profile: null, entitledSlugs, selections: [], degraded: true })
+        setState({ loading: false, profile: null, entitledSlugs, selections: [], accountNames: {}, degraded: true })
       }
     }
 


### PR DESCRIPTION
## Summary
Fixes #433. The Launchpad profile-chip "Your accounts" list showed the **app name** in bold and the **raw accountId GUID** as the subtitle — confusing and unreadable. Now it shows the **account name** in bold with the app name as a subtitle.

Root cause: the control-plane active-account selection carries only `{ appSlug, accountId }` (no name), so LP had nothing but the GUID to show. Same class as #429 (SA selector UUIDs).

## Change (runtime-only, mirrors #429)
- `useLaunchpadData` best-effort enriches each selection's account name via the **existing** `GET /accounts/{accountId}` endpoint (reuses `account-admin` `getAccount`), into a new `accountNames` map. Fired *after* the main state set, so it never delays the tiles.
- Profile chip renders `accountName ?? appLabel` in bold; app name as subtitle **only when** a real name resolved. On a failed read it falls back to the app name alone — **never the GUID**.
- Cosmetic only: enrichment failures never affect entitlement, the active selection, or access (errors are caught + `console.warn`'d, not surfaced).

```
Before:  [bold] Budget Tracker
         [grey] aed9dcdf-81b5-47a1-a0d5-5afbae940e93

After:   [bold] Steve's Budget
         [grey] Budget Tracker
```

## Not a contract change
`ActiveAccountSelection` is generated/read-only (`v0-reference/contracts`); this PR does not touch it. It consumes an endpoint that already exists and is already used (`getAccount`, #429). A future option to put `name` on the selection payload itself remains open as a v0-first contract change (noted on #433) — out of scope here.

## Validation
- `tsc --noEmit` (launchpad) ✓ · eslint (changed files) ✓
- launchpad vitest: 28 pass ✓
- `check:v0-contracts` byte-identical ✓ · `git diff --check` clean ✓

## v0 freshness
- [x] No v0 impact

Reason: runtime-only display enrichment via an existing control-plane endpoint (`GET /accounts/{accountId}`); no contract, mock, API, or UI-contract shape change (`ActiveAccountSelection` is untouched).

Refs #433, #429