### PR TITLE
fix(launchpad): self-heal activeAccounts map so account switch persists (#435)

### DIFF
--- a/apps/launchpad/functions/user/src/index.test.ts
+++ b/apps/launchpad/functions/user/src/index.test.ts
@@ -13,6 +13,8 @@ interface MockStore {
   accounts?: Record<string, Item>;
   members?: Record<string, Item>;      // key: `${accountId}|${userId}`
   memberQueryByUserId?: Record<string, Item[]>;  // key: userId
+  /** Captures every UpdateCommand input the handler issues, in order. */
+  updates?: Array<Record<string, unknown>>;
 }
 
 function makeDdb(store: MockStore = {}): DynamoDBDocumentClient {
@@ -54,6 +56,7 @@ function makeDdb(store: MockStore = {}): DynamoDBDocumentClient {
       }
 
       if (name === 'UpdateCommand') {
+        store.updates?.push(input);
         return {};
       }
 
@@ -300,6 +303,38 @@ describe('setActiveAccount fail-closed', () => {
     )) as { statusCode: number; body: string };
     expect(res.statusCode).toBe(200);
     expect(body(res).selections).toContainEqual({ appSlug: 'stock-analyser', accountId: 'acc-1' });
+  });
+
+  it('self-heals: inits the activeAccounts map before the nested set when absent (#435)', async () => {
+    const updates: Array<Record<string, unknown>> = [];
+    const handler = makeHandler({
+      // User record WITHOUT an activeAccounts map (provisioned before #435 init).
+      users: { 'user-1': { userId: 'user-1', email: 'user@example.com' } },
+      members: {
+        'acc-1|user-1': { accountId: 'acc-1', userId: 'user-1', appSlug: 'budget-tracker', role: 'owner' },
+      },
+      memberQueryByUserId: {
+        'user-1': [{ accountId: 'acc-1', userId: 'user-1', appSlug: 'budget-tracker', role: 'owner' }],
+      },
+      updates,
+    });
+    const res = await handler(event(
+      '/api/user/active-accounts/{appSlug}',
+      'PUT',
+      {
+        pathParameters: { appSlug: 'budget-tracker' },
+        body: { accountId: 'acc-1' },
+        userId: 'user-1',
+      },
+    )) as { statusCode: number; body: string };
+
+    expect(res.statusCode).toBe(200);
+    // Two writes, in order: idempotent map-init guard, then the nested per-app set.
+    // The init must come first — a bare nested set throws ValidationException when
+    // the parent map is absent.
+    expect(updates).toHaveLength(2);
+    expect(updates[0]!.UpdateExpression).toContain('if_not_exists(activeAccounts');
+    expect(updates[1]!.UpdateExpression).toContain('activeAccounts.#app');
   });
 });
 

--- a/apps/launchpad/functions/user/src/index.ts
+++ b/apps/launchpad/functions/user/src/index.ts
@@ -267,6 +267,19 @@ export function createHandler(deps: HandlerDeps) {
     }
 
     const now = new Date().toISOString();
+
+    // Ensure the `activeAccounts` map exists before the nested-path write below.
+    // A nested SET (`activeAccounts.#app`) throws ValidationException ("document
+    // path … invalid for update") when the parent map is absent — which it is
+    // for users provisioned before `activeAccounts` was initialized (#435).
+    // This idempotent step lets those users self-heal on their first switch.
+    await ddb.send(new UpdateCommand({
+      TableName: usersTable,
+      Key: { userId },
+      UpdateExpression: 'SET activeAccounts = if_not_exists(activeAccounts, :empty)',
+      ExpressionAttributeValues: { ':empty': {} },
+    }));
+
     await ddb.send(new UpdateCommand({
       TableName: usersTable,
       Key: { userId },

--- a/apps/launchpad/functions/user/vitest.config.ts
+++ b/apps/launchpad/functions/user/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    // Required: without a local config this package inherits
+    // apps/launchpad/vitest.config.ts, whose `include: ['lib/**']` does not
+    // match these co-located src tests — so they (and any new ones) are silently
+    // skipped by `vitest run` / `turbo test`. Discovered alongside #435.
+    include: ['src/**/*.test.ts'],
+  },
+});


### PR DESCRIPTION
## Summary
Fixes #435. Selecting a different account silently reverted to the previous one because `PUT /api/user/active-accounts/{appSlug}` 500s for any user whose record has no `activeAccounts` map.

## Root cause
`setActiveAccount` persisted the choice with a **nested-path** update:
```ts
SET activeAccounts.#app = :accountId
```
DynamoDB rejects a nested `SET` when the parent map is absent →
`ValidationException: The document path provided in the update expression is invalid for update` → Lambda 500 → the client store catches it and reverts the optimistic switch. With an empty map, `GET /active-accounts` falls back to the deterministic default, so the switch can never stick.

**Confirmed on dev:** affected user record had no `activeAccounts` map; `launchpad-user-dev` logs showed two matching `ValidationException`s at the switch timestamps.

## Fix
- Before the nested write, issue an idempotent guard so the parent map exists:
  ```ts
  SET activeAccounts = if_not_exists(activeAccounts, :empty)
  ```
  then the existing nested `SET activeAccounts.#app = :accountId`. Existing users **self-heal** on their first switch.
- No provisioning change: `account-provisioning` already initializes `activeAccounts: {}` for new users (index.ts:78). Pre-existing records (e.g. created before that) are the only affected set, and the self-heal covers them.

## Test-runner fix (in-scope, required to verify)
The user function package had **no local vitest config**, so it inherited `apps/launchpad/vitest.config.ts` (`include: ['lib/**']`) and its co-located `src/` tests were **silently skipped** — `turbo test --filter @transformotion/fn-launchpad-user` was failing with "No test files found". Added a local `vitest.config.ts` (`include: ['src/**/*.test.ts']`). The package's **20 tests now run and pass**, including a new test asserting the map-init precedes the nested set.

> Note: the same inheritance gap likely affects other `apps/launchpad/functions/*` packages with src tests. Out of scope here; flagged for a follow-up sweep.

## Validation
- `turbo test` (fn-launchpad-user): **20 pass** (was: no tests discovered) ✓
- `turbo typecheck` (fn-launchpad-user) ✓ · `git diff --check` clean ✓
- Not contract-changing: request/response and stored map shapes unchanged. `functions/` is not a v0-freshness-gated path.

## v0 freshness
- [x] No v0 impact

Reason: backend Lambda bug fix (DynamoDB update-expression) plus a test-config file; no contract, mock, API, UI, or runtime shape change.

Refs #435, #411