### PR TITLE
fix(launchpad): grant pre-token Lambda AdminAddUserToGroup so apps claim populates (#437)

### DIFF
--- a/apps/launchpad/infrastructure/launchpad-auth-stack.ts
+++ b/apps/launchpad/infrastructure/launchpad-auth-stack.ts
@@ -1,6 +1,7 @@
 import * as cdk from 'aws-cdk-lib';
 import * as cognito from 'aws-cdk-lib/aws-cognito';
 import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
+import * as iam from 'aws-cdk-lib/aws-iam';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as lambdaNodejs from 'aws-cdk-lib/aws-lambda-nodejs';
 import * as secretsmanager from 'aws-cdk-lib/aws-secretsmanager';
@@ -312,6 +313,25 @@ export class LaunchpadAuthStack extends cdk.Stack {
     this.accountMembersTable.grantReadData(preTokenFn);
     this.accountsTable.grantReadData(preTokenFn);
     this.appAdminGrantsTable.grantReadData(preTokenFn);
+
+    // The pre-token trigger reconciles app-access Cognito group membership from
+    // account memberships: it ADDs a user to an app's access group when they hold
+    // a membership for that app, and REMOVEs them when they no longer do. Without
+    // these grants the reconcile throws AccessDenied, the `apps` claim is never
+    // populated, and membership-only users are denied app access (#437).
+    //
+    // Scoped to the account/region userpool wildcard on purpose: referencing
+    // this.userPool.userPoolArn here would create a circular dependency
+    // (UserPool → trigger Lambda → role policy → UserPool). This Lambda only ever
+    // operates on its own pool — it is that pool's pre-token trigger.
+    const stack = cdk.Stack.of(this);
+    preTokenFn.addToRolePolicy(new iam.PolicyStatement({
+      actions: [
+        'cognito-idp:AdminAddUserToGroup',
+        'cognito-idp:AdminRemoveUserFromGroup',
+      ],
+      resources: [`arn:aws:cognito-idp:${stack.region}:${stack.account}:userpool/*`],
+    }));
 
     this.userPool.addTrigger(cognito.UserPoolOperation.PRE_TOKEN_GENERATION, preTokenFn);
 


### PR DESCRIPTION
## Summary
Fixes #437. Membership-only users were denied app access ("Access to app '<slug>' required") with an empty `apps` claim, even though the Launchpad tile showed.

## Root cause
The pre-token Lambda's `reconcileInvariant` adds a user to an app's access Cognito group when they hold a membership for that app; `buildAppsList` then derives the `apps` claim (which `requireAppAccess` gates on) from those groups. The Lambda's role had DynamoDB read grants but **zero `cognito-idp` permissions**, so `AdminAddUserToGroup` threw `AccessDenied` (swallowed by the reconcile's `catch`), leaving `apps: "[]"`.

**Confirmed on dev:** role inline policy had no cognito actions; `launchpad-pre-token-generation-dev` logged `AccessDeniedException`; a seeded membership-only user was in no groups; Steve works only because he's already in `budget-app-access`/`stock-app-access`.

## Fix
Grant the pre-token Lambda role `cognito-idp:AdminAddUserToGroup` + `AdminRemoveUserFromGroup` (the reconcile also *removes* on the inverse branch) in `launchpad-auth-stack.ts`.

**Scoping:** `arn:aws:cognito-idp:<region>:<account>:userpool/*` rather than `this.userPool.userPoolArn` — referencing the pool ARN here creates a circular dependency (UserPool → trigger Lambda → role policy → UserPool). The Lambda only ever operates on its own pool (it's that pool's pre-token trigger).

After deploy, membership-only users **self-reconcile on next login** — the add succeeds and `apps` is populated in the same token. This unblocks the cross-app smoke (the seed users will gain app access on their next sign-in).

## Validation
- `cdk synth TransformotionDev-LaunchpadAuth` → **exit 0, no circular dependency**; policy renders as the two actions on `…userpool/*`. (CI's synth job only covers the Network stack, so I synthed the Launchpad stack locally.)
- `tsc --noEmit` (infrastructure) ✓ · `git diff --check` clean ✓

## Discipline (§2.1)
No normative-doc change required: `auth.md` (§"App-access groups are derived from account membership") already documents this reconcile as intended behaviour — the fix makes code match the doc. `cdk.md` documents only deploy-role IAM, not per-Lambda grants.

## v0 freshness
- [x] No v0 impact

Reason: infrastructure-only IAM grant on a backend Lambda role; no contract, mock, API, UI, or runtime shape change.

Refs #437, #411