### PR TITLE
feat(m16-p5a): policy layer + claim-source unification (Phase 5 PR-A)

### DIFF
--- a/packages/auth-client/src/cognito-auth.ts
+++ b/packages/auth-client/src/cognito-auth.ts
@@ -11,6 +11,21 @@ import {
 } from 'aws-amplify/auth'
 import type { AuthService, AuthSession, AuthTokens, User, Account, SignInCredentials, SignUpCredentials } from './index'
 
+/**
+ * Parse a Cognito custom claim that the pre-token Lambda emits as a JSON string
+ * array of app slugs (e.g. `'["budget-tracker"]'`). Returns `[]` for an absent
+ * or malformed claim — fail safe, never throw during session hydration.
+ */
+function parseSlugArrayClaim(raw: unknown): string[] {
+  if (typeof raw !== 'string') return []
+  try {
+    const parsed = JSON.parse(raw)
+    return Array.isArray(parsed) ? parsed.filter((s): s is string => typeof s === 'string') : []
+  } catch {
+    return []
+  }
+}
+
 export class CognitoAuthService implements AuthService {
   constructor(private readonly appSlug?: string) {
     Amplify.configure({
@@ -43,12 +58,19 @@ export class CognitoAuthService implements AuthService {
       const email      = claims['email'] as string
       const givenName  = claims['given_name'] as string | undefined
       const familyName = claims['family_name'] as string | undefined
-      const groups     = Array.isArray(claims['cognito:groups']) ? claims['cognito:groups'] as string[] : []
-      const siteAdmin  = claims['site_admin'] === 'true' || groups.includes('site-admin')
+      // M16 D11 addendum (Phase 5): the explicit `site_admin` claim is the SOLE
+      // admin-status source. The legacy `cognito:groups` fallback is removed —
+      // with no claim, admin status fails to `false`. The pre-token Lambda always
+      // stamps `site_admin` from the group, so this is not a behaviour change for
+      // real users; it removes a second, group-derived source of truth.
+      const siteAdmin  = claims['site_admin'] === 'true'
+      // Surface the `app_admin` claim (emitted by the pre-token Lambda; D5) so the
+      // client can gate app-admin surfaces by claim. JSON array of appSlugs.
+      const appAdmin   = parseSlugArrayClaim(claims['app_admin'])
       const name       = (givenName && familyName)
         ? `${givenName} ${familyName}`
         : (givenName ?? email)
-      return { id: cognitoUser.userId, email, name, metadata: { siteAdmin } }
+      return { id: cognitoUser.userId, email, name, metadata: { siteAdmin, appAdmin } }
     } catch {
       return null
     }

--- a/packages/auth-client/src/index.ts
+++ b/packages/auth-client/src/index.ts
@@ -6,6 +6,12 @@ export interface User {
   email: string
   name: string
   avatarUrl?: string
+  /**
+   * Admin status derived from token claims (M16 D11 — claims are the sole source):
+   *  - `siteAdmin: boolean` — from the `site_admin` claim only (no group fallback).
+   *  - `appAdmin: string[]` — app slugs from the `app_admin` claim.
+   * UI gates admin surfaces on these, never on `cognito:groups`.
+   */
   metadata?: Record<string, unknown>
 }
 

--- a/packages/auth-client/src/mock-auth.ts
+++ b/packages/auth-client/src/mock-auth.ts
@@ -7,7 +7,10 @@ const MOCK_USER: User = {
   email: 'user@example.com',
   name: 'Demo User',
   avatarUrl: undefined,
-  metadata: { siteAdmin: true },
+  // Mirrors the Cognito provider's metadata shape (M16 D11): `siteAdmin` from the
+  // sole `site_admin` claim, `appAdmin` from the `app_admin` claim. The mock user
+  // is a site-admin, so `appAdmin` is empty (site-admin already gates admin UI).
+  metadata: { siteAdmin: true, appAdmin: [] as string[] },
 }
 
 const MOCK_ACCOUNTS: Account[] = [

--- a/packages/lambda-middleware/src/auth.ts
+++ b/packages/lambda-middleware/src/auth.ts
@@ -82,7 +82,8 @@ export function requireGroup(claims: AuthClaims, ...groups: string[]): void {
   }
 }
 
-const ROLE_HIERARCHY: AccountRole[] = ['viewer', 'member', 'manager', 'owner'];
+/** Account roles in ascending capability order. Shared with the policy layer. */
+export const ROLE_HIERARCHY: AccountRole[] = ['viewer', 'member', 'manager', 'owner'];
 
 function isSuperUser(auth: AuthClaims): boolean {
   return auth.siteAdmin;

--- a/packages/lambda-middleware/src/index.ts
+++ b/packages/lambda-middleware/src/index.ts
@@ -63,3 +63,41 @@ export type {
   AccountRole,
 } from './types';
 export type { AccountMembershipRow, MembershipLoader } from './auth';
+
+// M16 Phase 5 policy layer (ADR D9) — built additively in PR-A; routes migrate
+// onto requireAccountData / requireAccountAdmin in PR-B (requireAccountAccess deleted then).
+export {
+  // D9 middlewares
+  requireAccountData,
+  requireAccountAdmin,
+  // loader-resolved guards
+  accountRole,
+  requireAccountMember,
+  requireAccountOwnerOrManager,
+  requireAccountOwnerRole,
+  requireAppAdminForApp,
+  requireSupervisorySiteAdmin,
+  // combinators
+  anyOf,
+  allOf,
+  // pure decisions
+  isKnownRole,
+  roleAtLeast,
+  decideMember,
+  decideMinRole,
+  decideOwnerOrManager,
+  decideOwner,
+  decideRoleChange,
+  decideLastOwnerGuard,
+  discoveryScope,
+  UNIFORM_DENY,
+} from './policy';
+export type {
+  PolicyDecision,
+  PolicyGuard,
+  AppAdminLoader,
+  SiteAdminLoader,
+  AccountMembersLoader,
+  InviteeSearchScope,
+  DiscoveryAuthority,
+} from './policy';

--- a/packages/lambda-middleware/src/policy.test.ts
+++ b/packages/lambda-middleware/src/policy.test.ts
@@ -1,0 +1,276 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { AuthClaims } from './types';
+import type { AccountMembershipRow, MembershipLoader } from './auth';
+import { HttpError } from './errors';
+import {
+  isKnownRole,
+  roleAtLeast,
+  decideMember,
+  decideMinRole,
+  decideOwnerOrManager,
+  decideOwner,
+  decideRoleChange,
+  decideLastOwnerGuard,
+  discoveryScope,
+  accountRole,
+  requireAccountMember,
+  requireAccountOwnerOrManager,
+  requireAppAdminForApp,
+  requireSupervisorySiteAdmin,
+  anyOf,
+  allOf,
+  requireAccountData,
+  requireAccountAdmin,
+  UNIFORM_DENY,
+  type PolicyGuard,
+} from './policy';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const row = (role: string, status?: string): AccountMembershipRow =>
+  ({ role, status } as AccountMembershipRow);
+
+const loaderOf = (r: AccountMembershipRow | undefined): MembershipLoader =>
+  vi.fn(async () => r);
+
+const throwingLoader = (): MembershipLoader =>
+  vi.fn(async () => {
+    throw new Error('ProvisionedThroughputExceeded');
+  });
+
+const claims = (accounts: AuthClaims['accounts'] = {}): AuthClaims => ({
+  userId: 'u-1',
+  email: 'u@example.com',
+  groups: [],
+  apps: [],
+  accounts,
+  siteAdmin: false,
+});
+
+async function statusOf(p: Promise<unknown>): Promise<number> {
+  try {
+    await p;
+    return 200;
+  } catch (err) {
+    return err instanceof HttpError ? err.statusCode : -1;
+  }
+}
+
+const pass: PolicyGuard = async () => {};
+const deny403: PolicyGuard = async () => {
+  throw new HttpError(403, 'nope');
+};
+const infra503: PolicyGuard = async () => {
+  throw new HttpError(503, 'infra');
+};
+
+// ---------------------------------------------------------------------------
+// Pure helpers
+// ---------------------------------------------------------------------------
+
+describe('isKnownRole / roleAtLeast', () => {
+  it('accepts the four known roles, rejects anything else', () => {
+    for (const r of ['viewer', 'member', 'manager', 'owner']) expect(isKnownRole(r)).toBe(true);
+    for (const r of ['admin', '', 'OWNER', undefined]) expect(isKnownRole(r as string)).toBe(false);
+  });
+
+  it('ranks ascending viewer<member<manager<owner; unknown is below all', () => {
+    expect(roleAtLeast('owner', 'viewer')).toBe(true);
+    expect(roleAtLeast('member', 'member')).toBe(true);
+    expect(roleAtLeast('viewer', 'member')).toBe(false);
+    expect(roleAtLeast('admin', 'viewer')).toBe(false); // unknown → false
+    expect(roleAtLeast(undefined, 'viewer')).toBe(false);
+  });
+});
+
+describe('decideMember (deny-by-default)', () => {
+  it('allows an active known-role row', () => {
+    expect(decideMember(row('viewer')).allow).toBe(true);
+    expect(decideMember(row('member', 'active')).allow).toBe(true);
+  });
+  it('denies a missing row', () => expect(decideMember(undefined).allow).toBe(false));
+  it('denies a disabled row', () => expect(decideMember(row('member', 'disabled')).allow).toBe(false));
+  it('denies an unknown role (un-backfilled / legacy)', () =>
+    expect(decideMember(row('admin')).allow).toBe(false));
+});
+
+describe('decideMinRole / decideOwnerOrManager / decideOwner', () => {
+  it('decideMinRole enforces the floor', () => {
+    expect(decideMinRole(row('member'), 'member').allow).toBe(true);
+    expect(decideMinRole(row('viewer'), 'member').allow).toBe(false);
+    expect(decideMinRole(undefined, 'viewer').allow).toBe(false);
+  });
+  it('decideOwnerOrManager', () => {
+    expect(decideOwnerOrManager(row('owner')).allow).toBe(true);
+    expect(decideOwnerOrManager(row('manager')).allow).toBe(true);
+    expect(decideOwnerOrManager(row('member')).allow).toBe(false);
+    expect(decideOwnerOrManager(row('viewer', 'disabled')).allow).toBe(false);
+  });
+  it('decideOwner', () => {
+    expect(decideOwner(row('owner')).allow).toBe(true);
+    expect(decideOwner(row('manager')).allow).toBe(false);
+  });
+});
+
+describe('decideRoleChange (matrix)', () => {
+  it('owner may set any role, including owner', () => {
+    for (const nr of ['viewer', 'member', 'manager', 'owner'])
+      expect(decideRoleChange('owner', 'member', nr).allow).toBe(true);
+  });
+  it('manager may set member/viewer/manager but NEVER owner', () => {
+    expect(decideRoleChange('manager', 'member', 'manager').allow).toBe(true);
+    expect(decideRoleChange('manager', 'viewer', 'member').allow).toBe(true);
+    expect(decideRoleChange('manager', 'member', 'owner').allow).toBe(false);
+  });
+  it('manager may not change a target who is currently an owner', () => {
+    expect(decideRoleChange('manager', 'owner', 'manager').allow).toBe(false);
+  });
+  it('members and viewers may not change roles', () => {
+    expect(decideRoleChange('member', 'viewer', 'member').allow).toBe(false);
+    expect(decideRoleChange('viewer', 'viewer', 'member').allow).toBe(false);
+  });
+  it('unknown role on any side denies', () => {
+    expect(decideRoleChange('admin', 'member', 'member').allow).toBe(false);
+    expect(decideRoleChange('owner', 'admin', 'member').allow).toBe(false);
+    expect(decideRoleChange('owner', 'member', 'admin').allow).toBe(false);
+  });
+});
+
+describe('decideLastOwnerGuard', () => {
+  const members = [
+    { userId: 'o1', role: 'owner' },
+    { userId: 'o2', role: 'owner' },
+    { userId: 'm1', role: 'member' },
+  ];
+  it('blocks removing/demoting the SOLE owner', () => {
+    expect(decideLastOwnerGuard([{ userId: 'o1', role: 'owner' }], 'o1').allow).toBe(false);
+  });
+  it('allows when another owner remains', () => {
+    expect(decideLastOwnerGuard(members, 'o1').allow).toBe(true);
+  });
+  it('does not apply to a non-owner target', () => {
+    expect(decideLastOwnerGuard([{ userId: 'o1', role: 'owner' }], 'm1').allow).toBe(true);
+  });
+});
+
+describe('discoveryScope (§8)', () => {
+  it('returns the scope, never a boolean', () => {
+    expect(discoveryScope({ siteAdmin: true, appAdminForApp: false, ownerOrManagerSomewhere: false })).toBe('all');
+    expect(discoveryScope({ siteAdmin: false, appAdminForApp: true, ownerOrManagerSomewhere: false })).toBe('app');
+    expect(discoveryScope({ siteAdmin: false, appAdminForApp: false, ownerOrManagerSomewhere: true })).toBe('managed-accounts');
+    expect(discoveryScope({ siteAdmin: false, appAdminForApp: false, ownerOrManagerSomewhere: false })).toBe('none');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Loader-resolved guards — fail-closed on loader error, unknown role, absent target
+// ---------------------------------------------------------------------------
+
+describe('accountRole', () => {
+  it('resolves the active role', async () =>
+    expect(await accountRole(loaderOf(row('manager')), 'a', 'u')).toBe('manager'));
+  it('returns null for an absent row', async () =>
+    expect(await accountRole(loaderOf(undefined), 'a', 'u')).toBeNull());
+  it('returns null for an unknown role (deny-by-default)', async () =>
+    expect(await accountRole(loaderOf(row('admin')), 'a', 'u')).toBeNull());
+  it('returns null for a disabled row', async () =>
+    expect(await accountRole(loaderOf(row('owner', 'disabled')), 'a', 'u')).toBeNull());
+  it('FAILS CLOSED with 503 when the loader throws', async () =>
+    expect(await statusOf(accountRole(throwingLoader(), 'a', 'u'))).toBe(503));
+});
+
+describe('requireAccountMember / requireAccountOwnerOrManager', () => {
+  it('member passes; absent → uniform 403; loader throw → 503', async () => {
+    expect(await statusOf(requireAccountMember(loaderOf(row('viewer')), 'a', 'u'))).toBe(200);
+    expect(await statusOf(requireAccountMember(loaderOf(undefined), 'a', 'u'))).toBe(403);
+    expect(await statusOf(requireAccountMember(throwingLoader(), 'a', 'u'))).toBe(503);
+  });
+  it('owner-or-manager: member rejected, manager allowed, unknown role rejected', async () => {
+    expect(await statusOf(requireAccountOwnerOrManager(loaderOf(row('member')), 'a', 'u'))).toBe(403);
+    expect(await statusOf(requireAccountOwnerOrManager(loaderOf(row('manager')), 'a', 'u'))).toBe(200);
+    expect(await statusOf(requireAccountOwnerOrManager(loaderOf(row('admin')), 'a', 'u'))).toBe(403);
+  });
+  it('the denial body is uniform (no existence oracle)', async () => {
+    try {
+      await requireAccountMember(loaderOf(undefined), 'a', 'u');
+    } catch (err) {
+      expect((err as HttpError).message).toBe(UNIFORM_DENY);
+    }
+  });
+});
+
+describe('requireAppAdminForApp / requireSupervisorySiteAdmin (live checks)', () => {
+  it('app-admin: granted passes, not-granted uniform 403, loader throw 503', async () => {
+    expect(await statusOf(requireAppAdminForApp(vi.fn(async () => true), 'budget-tracker', 'u'))).toBe(200);
+    expect(await statusOf(requireAppAdminForApp(vi.fn(async () => false), 'budget-tracker', 'u'))).toBe(403);
+    expect(await statusOf(requireAppAdminForApp(vi.fn(async () => { throw new Error('x'); }), 'budget-tracker', 'u'))).toBe(503);
+  });
+  it('supervisory site-admin verified LIVE (loader), not the token claim', async () => {
+    expect(await statusOf(requireSupervisorySiteAdmin(vi.fn(async () => true), 'u'))).toBe(200);
+    expect(await statusOf(requireSupervisorySiteAdmin(vi.fn(async () => false), 'u'))).toBe(403);
+    expect(await statusOf(requireSupervisorySiteAdmin(vi.fn(async () => { throw new Error('x'); }), 'u'))).toBe(503);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Combinators
+// ---------------------------------------------------------------------------
+
+describe('anyOf / allOf (fail-closed precedence)', () => {
+  it('anyOf passes when one guard passes', async () =>
+    expect(await statusOf(anyOf(deny403, pass))).toBe(200));
+  it('anyOf is uniform 403 when all guards 403', async () =>
+    expect(await statusOf(anyOf(deny403, deny403))).toBe(403));
+  it('anyOf surfaces 503 (infra) over a uniform 403 when none passes', async () =>
+    expect(await statusOf(anyOf(deny403, infra503))).toBe(503));
+  it('anyOf still passes if a passing guard precedes a 503', async () =>
+    expect(await statusOf(anyOf(pass, infra503))).toBe(200));
+  it('allOf fails on the first failing guard', async () => {
+    expect(await statusOf(allOf(pass, deny403))).toBe(403);
+    expect(await statusOf(allOf(pass, pass))).toBe(200);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// D9 middlewares
+// ---------------------------------------------------------------------------
+
+describe('requireAccountData (NO site-admin branch)', () => {
+  const guard = requireAccountData('budget-tracker');
+
+  it('read passes with a membership claim, denies without — even for a site-admin', () => {
+    const member = claims({ 'budget-tracker': [{ accountId: 'acc-1', role: 'viewer' }] });
+    expect(() => guard.read(member, 'acc-1')).not.toThrow();
+    expect(() => guard.read(member, 'acc-OTHER')).toThrow();
+
+    // site-admin without a membership claim is denied like anyone else (no bypass).
+    const admin = { ...claims({}), siteAdmin: true };
+    expect(() => guard.read(admin, 'acc-1')).toThrow();
+  });
+
+  it('write delegates to requireAccountWrite: viewer rejected, disabled rejected, member allowed', async () => {
+    const member = claims({ 'budget-tracker': [{ accountId: 'acc-1', role: 'member' }] });
+    expect(await statusOf(guard.write(member, 'acc-1', loaderOf(row('viewer'))))).toBe(403);
+    expect(await statusOf(guard.write(member, 'acc-1', loaderOf(row('member', 'disabled'))))).toBe(403);
+    expect(await statusOf(guard.write(member, 'acc-1', loaderOf(row('member'))))).toBe(200);
+  });
+
+  it('write with no claim is rejected, and a loader throw fails closed (503)', async () => {
+    const member = claims({ 'budget-tracker': [{ accountId: 'acc-1', role: 'member' }] });
+    expect(await statusOf(guard.write(claims({}), 'acc-1', loaderOf(row('member'))))).toBe(403);
+    expect(await statusOf(guard.write(member, 'acc-1', throwingLoader()))).toBe(503);
+  });
+});
+
+describe('requireAccountAdmin', () => {
+  it('denies by default with no guards', async () =>
+    expect(await statusOf(requireAccountAdmin())).toBe(403));
+  it('passes if any guard passes (owner/manager OR supervisory site-admin shape)', async () =>
+    expect(await statusOf(requireAccountAdmin(deny403, pass))).toBe(200));
+  it('uniform 403 when all guards deny', async () =>
+    expect(await statusOf(requireAccountAdmin(deny403, deny403))).toBe(403));
+  it('surfaces 503 when a guard hits infra and none passes', async () =>
+    expect(await statusOf(requireAccountAdmin(deny403, infra503))).toBe(503));
+});

--- a/packages/lambda-middleware/src/policy.ts
+++ b/packages/lambda-middleware/src/policy.ts
@@ -1,0 +1,347 @@
+// @transformotion/lambda-middleware — policy layer (M16 Phase 5 / ADR D9)
+//
+// Table-backed authorization policy for the M16 two-axis model (ADR D9):
+//   - DATA authority  → membership in the account (NO site-admin branch).
+//   - ADMIN authority → control-plane policy evaluated against table state.
+//
+// This module is ADDITIVE in PR-A: the two D9 middlewares (`requireAccountData`,
+// `requireAccountAdmin`) and the policy primitives are built and unit-tested
+// here but are NOT yet wired into any route. Route migration + deletion of the
+// legacy `requireAccountAccess` happen in PR-B.
+//
+// Fail-closed mechanics (ADR D9 "Fail-closed mechanics for every policy helper"):
+//   1. Resolve the target row(s) BEFORE evaluating policy — never trust
+//      request-body claims about the target.
+//   2. Uniform not-found semantics — a nonexistent target and a forbidden target
+//      are indistinguishable to the caller (no 404-vs-403 probing oracle). Every
+//      denial throws `forbidden(UNIFORM_DENY)`.
+//   3. Deny is the default return path — unknown role, unresolvable target,
+//      unrecognised operation → deny. Loader THROW (infra error) → 503 (fail
+//      closed; never skip-and-proceed), matching `requireAccountWrite` (D8).
+//
+// Deferred to Phases 8/9 (invitation semantics; pending the C.2/m17 contract
+// amendment): `canCreateInvitationGrant`, `invitee-only`, `invitee-token-bearer`.
+// They are intentionally NOT implemented here — they slot in as additional
+// guards of the same shape (loader-resolved target → PolicyDecision → uniform
+// deny). The framework below is what they slot into.
+
+import type { AuthClaims, AccountRole, AppName } from './types';
+import { forbidden, HttpError } from './errors';
+import { ROLE_HIERARCHY } from './auth';
+import type { AccountMembershipRow, MembershipLoader } from './auth';
+import { requireAccountWrite } from './auth';
+
+/** Single uniform denial message — keeps nonexistent and forbidden indistinguishable. */
+export const UNIFORM_DENY = 'Not found or access denied';
+
+/** Result of a pure policy evaluation. `reason` is for logging/tests, never the HTTP body. */
+export type PolicyDecision = { allow: true } | { allow: false; reason: string };
+
+const ALLOW: PolicyDecision = { allow: true };
+const deny = (reason: string): PolicyDecision => ({ allow: false, reason });
+
+// ---------------------------------------------------------------------------
+// Injected loaders — keep this package AWS-SDK-free and unit-testable. Each app
+// supplies a function backed by a scoped DynamoDB read.
+// ---------------------------------------------------------------------------
+
+/** Reuse the D8 write-path membership loader (account-members table GetItem). */
+export type { MembershipLoader } from './auth';
+
+/** Whether `userId` holds an app-admin grant for `appSlug` (D5 grants table GetItem). */
+export type AppAdminLoader = (appSlug: string, userId: string) => Promise<boolean>;
+
+/**
+ * Live site-admin status for `userId` — a TABLE/group check, NOT the token claim.
+ * Supervisory operations must verify current status (a revoked admin's stale
+ * token must not retain supervisory power; D8).
+ */
+export type SiteAdminLoader = (userId: string) => Promise<boolean>;
+
+/** All membership rows for an account (`userId` + `role`), for the last-owner guard. */
+export type AccountMembersLoader = (
+  accountId: string,
+) => Promise<ReadonlyArray<{ userId: string; role: string }>>;
+
+// ---------------------------------------------------------------------------
+// Pure helpers (no I/O — exhaustively unit-tested)
+// ---------------------------------------------------------------------------
+
+/** True only for a role string the hierarchy recognises (unknown → false, deny-by-default). */
+export function isKnownRole(role: string | undefined): role is AccountRole {
+  return typeof role === 'string' && ROLE_HIERARCHY.includes(role as AccountRole);
+}
+
+/** `role` ranks at or above `min`. Unknown/absent role → false. */
+export function roleAtLeast(role: string | undefined, min: AccountRole): boolean {
+  if (!isKnownRole(role)) return false;
+  return ROLE_HIERARCHY.indexOf(role) >= ROLE_HIERARCHY.indexOf(min);
+}
+
+/** A row grants active membership: present, active status, recognised role. */
+export function decideMember(row: AccountMembershipRow | undefined): PolicyDecision {
+  if (!row) return deny('no membership row');
+  if (row.status && row.status !== 'active') return deny('membership not active');
+  if (!isKnownRole(row.role)) return deny('unknown role');
+  return ALLOW;
+}
+
+/** Active member with role ≥ `min`. */
+export function decideMinRole(
+  row: AccountMembershipRow | undefined,
+  min: AccountRole,
+): PolicyDecision {
+  const m = decideMember(row);
+  if (!m.allow) return m;
+  return roleAtLeast(row!.role, min) ? ALLOW : deny(`requires role >= ${min}`);
+}
+
+/** Active member who is owner or manager. */
+export function decideOwnerOrManager(row: AccountMembershipRow | undefined): PolicyDecision {
+  const m = decideMember(row);
+  if (!m.allow) return m;
+  return row!.role === 'owner' || row!.role === 'manager'
+    ? ALLOW
+    : deny('owner or manager required');
+}
+
+/** Active member who is owner. */
+export function decideOwner(row: AccountMembershipRow | undefined): PolicyDecision {
+  const m = decideMember(row);
+  if (!m.allow) return m;
+  return row!.role === 'owner' ? ALLOW : deny('owner required');
+}
+
+/**
+ * Role-change legality matrix (permissions model §4.5 + ADR D9):
+ *  - owner   → may set ANY role, including owner.
+ *  - manager → may set member|viewer|manager; NEVER owner; and may not change a
+ *              target who is currently an owner.
+ *  - member/viewer → may not change roles at all.
+ *  - unknown role on any side → deny.
+ * The last-owner guard (demoting the sole owner) is enforced separately by
+ * {@link decideLastOwnerGuard} — this matrix governs grant legality only.
+ */
+export function decideRoleChange(
+  actorRole: string | undefined,
+  currentTargetRole: string | undefined,
+  newRole: string | undefined,
+): PolicyDecision {
+  if (!isKnownRole(actorRole) || !isKnownRole(currentTargetRole) || !isKnownRole(newRole)) {
+    return deny('unknown role');
+  }
+  if (actorRole === 'owner') return ALLOW;
+  if (actorRole === 'manager') {
+    if (newRole === 'owner') return deny('managers cannot grant owner');
+    if (currentTargetRole === 'owner') return deny('managers cannot change an owner');
+    return ALLOW;
+  }
+  return deny('only owner or manager may change roles');
+}
+
+/**
+ * Last-owner guard: the sole remaining owner cannot be removed or demoted
+ * (permissions model §4.5; ADR D9 owner-model supersession). Applies only when
+ * the target is currently an owner.
+ */
+export function decideLastOwnerGuard(
+  members: ReadonlyArray<{ userId: string; role: string }>,
+  targetUserId: string,
+): PolicyDecision {
+  const owners = members.filter((m) => m.role === 'owner');
+  const targetIsOwner = owners.some((m) => m.userId === targetUserId);
+  if (!targetIsOwner) return ALLOW;
+  return owners.length <= 1 ? deny('cannot remove or demote the last owner') : ALLOW;
+}
+
+/** Invitee-discovery search scope (permissions model §8). Phase 7 consumes the scope. */
+export type InviteeSearchScope = 'all' | 'app' | 'managed-accounts' | 'none';
+
+export interface DiscoveryAuthority {
+  siteAdmin: boolean;
+  /** Holds an app-admin grant for the app in context. */
+  appAdminForApp: boolean;
+  /** Holds owner or manager in at least one account (the "managed accounts" basis). */
+  ownerOrManagerSomewhere: boolean;
+}
+
+/**
+ * `canSearchInvitees` — returns the SCOPE of the known-user picker, never a
+ * boolean (permissions model §8 discovery scopes). Seeing someone in a picker
+ * does not authorise inviting them; every grant is still authorized
+ * independently (Phase 8). Phase 7 consumes this scope.
+ */
+export function discoveryScope(authority: DiscoveryAuthority): InviteeSearchScope {
+  if (authority.siteAdmin) return 'all';
+  if (authority.appAdminForApp) return 'app';
+  if (authority.ownerOrManagerSomewhere) return 'managed-accounts';
+  return 'none';
+}
+
+// ---------------------------------------------------------------------------
+// Loader-resolved guards (async; fail closed). Each RESOLVES the target first,
+// then applies a pure decision, then throws a UNIFORM forbidden on denial.
+// ---------------------------------------------------------------------------
+
+/** Wrap a loader call: any throw becomes 503 (fail closed — never skip the check). */
+async function safeLoad<T>(label: string, fn: () => Promise<T>): Promise<T> {
+  try {
+    return await fn();
+  } catch (err) {
+    console.error(`[policy] ${label} load failed:`, err);
+    throw new HttpError(503, 'Could not verify authorization');
+  }
+}
+
+/** Convert a pure decision into a uniform 403 (reason logged, never surfaced). */
+function assertAllow(decision: PolicyDecision): void {
+  if (decision.allow) return;
+  console.warn('[policy] denied:', decision.reason);
+  throw forbidden(UNIFORM_DENY);
+}
+
+/**
+ * Resolve the caller's effective account role, or `null` when there is no active
+ * membership / the role is unknown. Loader throw → 503. The canonical
+ * "resolve the target before evaluating policy" primitive.
+ */
+export async function accountRole(
+  load: MembershipLoader,
+  accountId: string,
+  userId: string,
+): Promise<AccountRole | null> {
+  const row = await safeLoad('membership', () => load(accountId, userId));
+  if (!decideMember(row).allow) return null;
+  return row!.role as AccountRole;
+}
+
+/** Active membership in the account. Uniform deny on absence/forbidden. */
+export async function requireAccountMember(
+  load: MembershipLoader,
+  accountId: string,
+  userId: string,
+): Promise<void> {
+  const row = await safeLoad('membership', () => load(accountId, userId));
+  assertAllow(decideMember(row));
+}
+
+/** Active owner-or-manager of the account. */
+export async function requireAccountOwnerOrManager(
+  load: MembershipLoader,
+  accountId: string,
+  userId: string,
+): Promise<void> {
+  const row = await safeLoad('membership', () => load(accountId, userId));
+  assertAllow(decideOwnerOrManager(row));
+}
+
+/** Active owner of the account. */
+export async function requireAccountOwnerRole(
+  load: MembershipLoader,
+  accountId: string,
+  userId: string,
+): Promise<void> {
+  const row = await safeLoad('membership', () => load(accountId, userId));
+  assertAllow(decideOwner(row));
+}
+
+/** App-admin for `appSlug` per the D5 grants table. Uniform deny when not granted. */
+export async function requireAppAdminForApp(
+  loadAppAdmin: AppAdminLoader,
+  appSlug: string,
+  userId: string,
+): Promise<void> {
+  const granted = await safeLoad('app-admin', () => loadAppAdmin(appSlug, userId));
+  if (!granted) throw forbidden(UNIFORM_DENY);
+}
+
+/**
+ * Supervisory site-admin — verified LIVE (loader), not from the token claim, so
+ * a revoked admin's stale token cannot drive supervisory ops (D8).
+ */
+export async function requireSupervisorySiteAdmin(
+  loadSiteAdmin: SiteAdminLoader,
+  userId: string,
+): Promise<void> {
+  const isAdmin = await safeLoad('site-admin', () => loadSiteAdmin(userId));
+  if (!isAdmin) throw forbidden(UNIFORM_DENY);
+}
+
+// ---------------------------------------------------------------------------
+// Combinators
+// ---------------------------------------------------------------------------
+
+/** A bound, target-resolved policy guard (loaders + ids already closed over). */
+export type PolicyGuard = () => Promise<void>;
+
+/**
+ * Passes iff at least ONE guard passes. Fail-closed precedence: if any guard
+ * raises a 503 (infra/loader error) and none passes, surface the 503 (we could
+ * not verify); otherwise a uniform 403. Used for OR policies, e.g. "owner/manager
+ * OR supervisory site-admin" on a remove-member route.
+ */
+export async function anyOf(...guards: PolicyGuard[]): Promise<void> {
+  let infra: HttpError | undefined;
+  for (const guard of guards) {
+    try {
+      await guard();
+      return;
+    } catch (err) {
+      if (err instanceof HttpError && err.statusCode === 503) infra = err;
+      // 403s are expected denials — keep trying other guards.
+    }
+  }
+  if (infra) throw infra;
+  throw forbidden(UNIFORM_DENY);
+}
+
+/** Passes iff EVERY guard passes (first failure propagates — 503 or uniform 403). */
+export async function allOf(...guards: PolicyGuard[]): Promise<void> {
+  for (const guard of guards) {
+    await guard();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// The two D9 middlewares (built here, UNUSED until PR-B wires routes)
+// ---------------------------------------------------------------------------
+
+/**
+ * D9 DATA-authority middleware for every SA/BT app-data route. There is NO
+ * site-admin branch in this code path — membership is the only grant of data
+ * authority, so there is nothing to misconfigure.
+ *
+ *  - `read`  — claims-only membership check (D8 hot path; zero table reads).
+ *  - `write` — claims + live membership-row read (folds in `requireAccountWrite`):
+ *              viewer / disabled / missing row → 403; loader throw → 503.
+ */
+export function requireAccountData(appSlug: AppName) {
+  return {
+    read(auth: AuthClaims, accountId: string): void {
+      const memberships = auth.accounts[appSlug] ?? [];
+      if (!memberships.some((m) => m.accountId === accountId)) {
+        throw forbidden(UNIFORM_DENY);
+      }
+    },
+    async write(
+      auth: AuthClaims,
+      accountId: string,
+      load: MembershipLoader,
+    ): Promise<void> {
+      await requireAccountWrite(auth, appSlug, accountId, load);
+    },
+  };
+}
+
+/**
+ * D9 ADMIN-authority entry for Launchpad control-plane routes. Composes one or
+ * more target-resolved policy guards with OR semantics (a route is permitted if
+ * any of its accepted authorities is satisfied — e.g. owner/manager OR
+ * supervisory site-admin). Each guard already resolves its own target row(s)
+ * and fails closed; this is the named composition point PR-B wires per the
+ * route-classification table.
+ */
+export async function requireAccountAdmin(...guards: PolicyGuard[]): Promise<void> {
+  if (guards.length === 0) throw forbidden(UNIFORM_DENY); // deny-by-default: no policy = no access
+  await anyOf(...guards);
+}


### PR DESCRIPTION
## Summary
**Phase 5 PR-A of 3.** Additive foundation for the two-axis authorization split (ADR D9). **Near-zero behaviour change** — the new policy layer and the two D9 middlewares are built and unit-tested but **UNUSED**; route migration + deletion of `requireAccountAccess` + pre-token override removal land in **PR-B**.

Refs #416 (phase), #411 (tracking).

## Policy layer — `packages/lambda-middleware/src/policy.ts`
Table-backed, AWS-SDK-free (injected loaders), exhaustively unit-tested.

- **Pure decisions** (deny-by-default): `isKnownRole`, `roleAtLeast`, `decideMember` / `decideMinRole` / `decideOwnerOrManager` / `decideOwner`, `decideRoleChange` (matrix: owner→any incl. owner; manager→member/viewer/manager, **never owner**, never changes an owner; member/viewer→none; unknown→deny), `decideLastOwnerGuard` (sole owner protected), `discoveryScope` (**`canSearchInvitees` returns the SCOPE per §8**, never a boolean — Phase 7 consumes).
- **Loader-resolved guards** (fail closed): `accountRole`, `requireAccountMember`, `requireAccountOwnerOrManager` / `requireAccountOwnerRole`, `requireAppAdminForApp` (D5 grants loader), `requireSupervisorySiteAdmin` (**LIVE** check, not the token claim — a revoked admin's stale token can't drive supervisory ops, D8).
- **Fail-closed mechanics (D9), tested per mode:** resolve the target first; loader **throw → 503** (never skip-and-proceed); **uniform 403** on every denial (no nonexistent-vs-forbidden oracle); unknown role / absent target → deny.
- **Combinators** `anyOf` / `allOf` with fail-closed precedence (infra 503 wins over uniform 403 when nothing passes).

## D9 middlewares (built, unused until PR-B)
- `requireAccountData(appSlug)` — every SA/BT app-data route. `.read` = claims-only membership (D8 hot path); `.write` folds in `requireAccountWrite` (viewer / disabled / missing row → 403). **No site-admin branch exists in this code path** — nothing to misconfigure.
- `requireAccountAdmin(...guards)` — Launchpad control-plane routes. Target-resolved guards composed with OR semantics; **deny-by-default with no guards**.

## Deferred (Phase 8/9) — framework only
`canCreateInvitationGrant`, `invitee-only`, `invitee-token-bearer` are **not** implemented (pending the C.2/m17 invitation contract amendment). The loader→decision→uniform-deny framework is what they slot into as additional guards.

## Claim-source unification (ADR D11 addendum) — `packages/auth-client`
- **Deleted** the `cognito:groups` site-admin fallback: `site_admin` claim is the **sole** admin-status source; with no claim, admin **fails to `false`**. The pre-token Lambda always stamps the claim, so **no behaviour change for real users** — it removes a second, group-derived source of truth.
- **Surfaced** the `app_admin` claim on `User.metadata.appAdmin` (`string[]`); mirrored in the mock provider; metadata shape documented on `User`.

## Validation
- lambda-middleware **91 tests** (51 existing + **40 new policy**) ✓ · auth-client **9** ✓
- Repo-wide `turbo typecheck` **63/63** ✓ (all consumers of the changed shared packages) · lint (changed pkgs) ✓
- `check:v0-contracts` byte-identical ✓ · `git diff --check` clean ✓
- Builds + CDK synth via CI.

## PR-A smoke (post-merge, dev)
Existing behaviour unchanged everywhere (additive); admin UI still gates via the `site_admin` claim (pre-token stamps it; the deleted fallback was redundant). No route uses the new layer yet.

## v0 freshness
- [x] No v0 impact

Reason: backend authorization-helper layer + a runtime claim-derivation change in `auth-client`; no contract, mock, API, WSS, or UI-contract shape change. `packages/contracts` untouched.

Refs #416, #411