### PR TITLE
feat(m16-p5b): route migration + bypass removal (Phase 5 PR-B) — classification first

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -258,9 +258,12 @@ These rules are stronger than local convenience.
    account-scoped data must validate membership before DynamoDB access.
 
 6. Auth middleware is mandatory for protected handlers.
-   Account-scoped handlers use `withAuth`, then call `requireAppAccess` and
-   `requireAccountAccess` or stronger helpers. Auth-only handlers use
-   `withAuthOnly`. Public handlers require an explicit justification.
+   Account-scoped data handlers use `withAuth`, then the data-authority factory
+   `requireAccountData(appSlug).read`/`.write` (D9, M16); supervisory/ownership
+   handlers use `requireAccountAdmin`. There is no site-admin data bypass.
+   Auth-only handlers use `withAuthOnly`. Public handlers require an explicit
+   justification. (`requireAccountAccess`/`requireAccountOwner` were deleted in
+   M16 Phase 5.)
 
 7. IAM boundaries must only get tighter or more explicit.
    Do not broaden IAM permissions to unblock code. If a new permission is

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -992,7 +992,8 @@ Auth follows the same layered architecture as data access. The platform's auth c
 **Helper interface in `packages/lambda-middleware/`.** All Lambda handlers use the canonical helper interface for auth concerns. The interface has two layers:
 
 - **Middleware wrappers** (`middleware.ts`) — `withAuth(handler)` provides JWT plus account context; `withAuthOnly(handler)` provides JWT without account context (for routes that operate on the user themselves rather than account-scoped data). Both internally call `extractAuthClaims` to read raw claims; consumers do not import `extractAuthClaims` directly.
-- **Claim-based helpers** (`auth.ts`) — `requireAppAccess`, `requireAnyAppAccess`, `requireAccountAccess`, `requireAccountOwner`, `requireSiteAdmin`. These operate on the typed `auth` object provided by the wrappers and throw 403 on authorization failure.
+- **Claim-based helpers** (`auth.ts`) — `requireAppAccess`, `requireAnyAppAccess`, `requireSiteAdmin`. These operate on the typed `auth` object provided by the wrappers and throw 403 on authorization failure.
+- **Policy layer** (`policy.ts`, M16 D9) — `requireAccountData(appSlug)` for app-data routes (`.read` = claims-only, viewer passes; `.write` = claims + live members row, viewer denied) and `requireAccountAdmin(...)` for supervisory/ownership routes. There is no site-admin data bypass. The former `requireAccountAccess` / `requireAccountOwner` helpers were deleted in M16 Phase 5.
 
 The full interface and per-helper semantics are documented in `auth.md`.
 

--- a/apps/budget-tracker/AGENTS.md
+++ b/apps/budget-tracker/AGENTS.md
@@ -75,17 +75,18 @@ WebSocket connection state is in `budget-tracker.ws-connections-{stage}` (owned 
 
 ## Authorization requirement
 
-All Lambda handlers use helpers from `packages/lambda-middleware`. The four available helpers and when to apply each:
+All Lambda handlers use helpers from `packages/lambda-middleware`. App-data routes use the **data-authority factory** `requireAccountData` (D9, M16); supervisory/ownership routes use `requireAccountAdmin`:
 
 ```typescript
-requireSiteAdmin(auth)                                             // platform admin ops only
-requireAppAccess(auth, 'budget-tracker')                          // entry-point check (every handler)
-requireAccountAccess(auth, 'budget-tracker', accountId)           // standard read/write ops
-requireAccountAccess(auth, 'budget-tracker', accountId, 'manager') // elevated ops (bulk delete, settings wipe, etc.)
-requireAccountOwner(auth, 'budget-tracker', accountId)            // ownership-transfer ops
+const btData = requireAccountData('budget-tracker');               // module scope
+
+btData.read(auth, accountId);                                      // read tier — claims only, viewer passes
+await btData.write(auth, accountId, membershipLoader);            // write tier — claims + live members row, viewer denied
+requireAccountAdmin(/* owner / manager / supervisory guards */);  // supervisory & ownership ops
+requireSiteAdmin(auth);                                            // platform admin ops only
 ```
 
-Call `requireAppAccess` at the top of every handler, then `requireAccountAccess` (or `requireAccountOwner`) before each DynamoDB operation. Do not call `requireGroup` directly. See [auth.md](/docs/architecture/auth.md) for full middleware helper documentation.
+Construct `requireAccountData('budget-tracker')` at module scope, then call `.read` on GET branches and `.write` (with a `dynamoMembershipLoader`) before each mutation. There is **no site-admin data bypass** — membership is the only grant of data authority. `requireAccountAccess` and `requireAccountOwner` were **deleted** in M16 Phase 5. Do not call `requireGroup` directly. See [auth.md](/docs/architecture/auth.md) and [route-classification-m16.md](/docs/architecture/route-classification-m16.md).
 
 ## Adaptor pattern — mandatory constraint
 
@@ -179,7 +180,7 @@ Provider is selected via `config.ai.provider` (`'mock'` or `'claude'`), resolved
 **Adding a new AI feature:**
 1. Add the method to the `AIService` interface in `lib/services/ai/index.ts`
 2. Update the contract in the v0 repo (`transformotion-apps-b8/contracts/budget-tracker/`), commit and push that v0 change, then run `pnpm sync:v0`
-3. Add a matching Lambda route to `apps/budget-tracker/functions/budget-ai/src/index.ts` with `requireAppAccess` + `requireAccountAccess`
+3. Add a matching Lambda route to `apps/budget-tracker/functions/budget-ai/src/index.ts` gated by `requireAccountData('budget-tracker').write` (AI routes are member-tier, owner ruling #1)
 4. Implement the method in `MockAIService` (mock-ai.ts) and `ClaudeAIService` (claude-ai.ts)
 5. Add prompt text in the Lambda (server-side only — never in client code)
 

--- a/apps/budget-tracker/CLAUDE.md
+++ b/apps/budget-tracker/CLAUDE.md
@@ -78,17 +78,18 @@ WebSocket connection state is in `budget-tracker.ws-connections-{stage}` (owned 
 
 ## Authorization requirement
 
-All Lambda handlers use helpers from `packages/lambda-middleware`. The four available helpers and when to apply each:
+All Lambda handlers use helpers from `packages/lambda-middleware`. App-data routes use the **data-authority factory** `requireAccountData` (D9, M16); supervisory/ownership routes use `requireAccountAdmin`:
 
 ```typescript
-requireSiteAdmin(auth)                                             // platform admin ops only
-requireAppAccess(auth, 'budget-tracker')                          // entry-point check (every handler)
-requireAccountAccess(auth, 'budget-tracker', accountId)           // standard read/write ops
-requireAccountAccess(auth, 'budget-tracker', accountId, 'manager') // elevated ops (bulk delete, settings wipe, etc.)
-requireAccountOwner(auth, 'budget-tracker', accountId)            // ownership-transfer ops
+const btData = requireAccountData('budget-tracker');               // module scope
+
+btData.read(auth, accountId);                                      // read tier — claims only, viewer passes
+await btData.write(auth, accountId, membershipLoader);            // write tier — claims + live members row, viewer denied
+requireAccountAdmin(/* owner / manager / supervisory guards */);  // supervisory & ownership ops
+requireSiteAdmin(auth);                                            // platform admin ops only
 ```
 
-Call `requireAppAccess` at the top of every handler, then `requireAccountAccess` (or `requireAccountOwner`) before each DynamoDB operation. Do not call `requireGroup` directly. See [auth.md](/docs/architecture/auth.md) for full middleware helper documentation.
+Construct `requireAccountData('budget-tracker')` at module scope, then call `.read` on GET branches and `.write` (with a `dynamoMembershipLoader`) before each mutation. There is **no site-admin data bypass** — membership is the only grant of data authority. `requireAccountAccess` and `requireAccountOwner` were **deleted** in M16 Phase 5. Do not call `requireGroup` directly. See [auth.md](/docs/architecture/auth.md) and [route-classification-m16.md](/docs/architecture/route-classification-m16.md).
 
 ## Adaptor pattern — mandatory constraint
 
@@ -182,7 +183,7 @@ Provider is selected via `config.ai.provider` (`'mock'` or `'claude'`), resolved
 **Adding a new AI feature:**
 1. Add the method to the `AIService` interface in `lib/services/ai/index.ts`
 2. Update the contract in the v0 repo (`transformotion-apps-b8/contracts/budget-tracker/`), commit and push that v0 change, then run `pnpm sync:v0`
-3. Add a matching Lambda route to `apps/budget-tracker/functions/budget-ai/src/index.ts` with `requireAppAccess` + `requireAccountAccess`
+3. Add a matching Lambda route to `apps/budget-tracker/functions/budget-ai/src/index.ts` gated by `requireAccountData('budget-tracker').write` (AI routes are member-tier, owner ruling #1)
 4. Implement the method in `MockAIService` (mock-ai.ts) and `ClaudeAIService` (claude-ai.ts)
 5. Add prompt text in the Lambda (server-side only — never in client code)
 

--- a/apps/budget-tracker/functions/budget-ai-config/src/index.ts
+++ b/apps/budget-tracker/functions/budget-ai-config/src/index.ts
@@ -150,10 +150,12 @@ async function resetOverride(deps: Dependencies, accountId: string) {
   return noContent();
 }
 
-  // D9 data-tier gate (no site-admin branch) for the read; the override is
-  // operational-config (D9) — interim member + site-admin, rehomed to app-level
-  // app-admin config in PR-C.
-  const btData = requireAccountData(APP_SLUG);
+// D9 data-tier gate (no site-admin branch) for the read; the override is
+// operational-config (D9) — interim member + site-admin, rehomed to app-level
+// app-admin config in PR-C.
+const btData = requireAccountData(APP_SLUG);
+
+export function createHandler(deps: Dependencies = defaultDependencies) {
   return withAuth(async ({ auth, account, event }) => {
     const resource = event.resource ?? '';
     if (resource === '/api/budget/v1/ai-config' && event.httpMethod === 'GET') {

--- a/apps/budget-tracker/functions/budget-ai-config/src/index.ts
+++ b/apps/budget-tracker/functions/budget-ai-config/src/index.ts
@@ -5,8 +5,7 @@ import {
   noContent,
   ok,
   parseBody,
-  requireAccountAccess,
-  requireAppAccess,
+  requireAccountData,
   requireSiteAdmin,
   withAuth,
   type APIGatewayProxyEvent,
@@ -151,22 +150,25 @@ async function resetOverride(deps: Dependencies, accountId: string) {
   return noContent();
 }
 
-export function createHandler(deps: Dependencies = defaultDependencies) {
+  // D9 data-tier gate (no site-admin branch) for the read; the override is
+  // operational-config (D9) — interim member + site-admin, rehomed to app-level
+  // app-admin config in PR-C.
+  const btData = requireAccountData(APP_SLUG);
   return withAuth(async ({ auth, account, event }) => {
-    requireAppAccess(auth, APP_SLUG);
-    requireAccountAccess(auth, APP_SLUG, account.accountId);
-
     const resource = event.resource ?? '';
     if (resource === '/api/budget/v1/ai-config' && event.httpMethod === 'GET') {
+      btData.read(auth, account.accountId);
       return readConfig(deps, account.accountId);
     }
 
     if (resource === '/api/budget/v1/ai-config/override' && event.httpMethod === 'PUT') {
+      btData.read(auth, account.accountId);
       requireSiteAdmin(auth);
       return updateOverride(deps, event, account.accountId);
     }
 
     if (resource === '/api/budget/v1/ai-config/override' && event.httpMethod === 'DELETE') {
+      btData.read(auth, account.accountId);
       requireSiteAdmin(auth);
       return resetOverride(deps, account.accountId);
     }

--- a/apps/budget-tracker/functions/budget-ai/package.json
+++ b/apps/budget-tracker/functions/budget-ai/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@transformotion/budget-domain": "workspace:*",
+    "@transformotion/fn-account-membership": "workspace:*",
     "@transformotion/lambda-middleware": "workspace:*"
   },
   "devDependencies": {

--- a/apps/budget-tracker/functions/budget-ai/src/index.ts
+++ b/apps/budget-tracker/functions/budget-ai/src/index.ts
@@ -1,7 +1,17 @@
-import { withAuth, requireAppAccess, requireAccountAccess } from '@transformotion/lambda-middleware';
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
+import { withAuth, requireAccountData } from '@transformotion/lambda-middleware';
+import { dynamoMembershipLoader } from '@transformotion/fn-account-membership';
 import { reviewStart } from './review-start';
 import { runReviewWorker, type ReviewWorkerPayload } from './review-worker';
 import { csvAnalysis } from './csv-analysis';
+
+// D9 + ruling #1 (route-classification §5): the AI routes are member-tier ACTIONS
+// (run AI over the caller's transactions, write a job row, consume provider cost),
+// so they take the WRITE tier — claims + live membership row, viewer rejected.
+const btData = requireAccountData('budget-tracker');
+const ddb = DynamoDBDocumentClient.from(new DynamoDBClient({}));
+const membershipLoader = dynamoMembershipLoader(ddb, process.env.ACCOUNT_MEMBERS_TABLE!);
 
 // ── Handler ───────────────────────────────────────────────────────────────────
 //
@@ -20,8 +30,7 @@ export const handler = async (event: unknown) => {
 
   // Normal HTTP path
   return withAuth(async ({ auth, account, event: apiEvent }) => {
-    requireAppAccess(auth, 'budget-tracker');
-    requireAccountAccess(auth, 'budget-tracker', account.accountId);
+    await btData.write(auth, account.accountId, membershipLoader);
     const resource = apiEvent.resource ?? '';
 
     if (resource === '/api/budget/v1/ai/review')       return reviewStart(auth, account.accountId, apiEvent);

--- a/apps/budget-tracker/functions/budget-ai/src/review-start.ts
+++ b/apps/budget-tracker/functions/budget-ai/src/review-start.ts
@@ -1,13 +1,14 @@
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { DynamoDBDocumentClient, PutCommand, QueryCommand } from '@aws-sdk/lib-dynamodb';
 import { LambdaClient, InvokeCommand } from '@aws-sdk/client-lambda';
-import { ok, parseBody } from '@transformotion/lambda-middleware';
+import { ok, parseBody, requireAccountData } from '@transformotion/lambda-middleware';
 import type { AuthClaims } from '@transformotion/lambda-middleware';
 import type { Category } from '@transformotion/budget-domain';
 import type { ReviewWorkerPayload } from './review-worker';
 
 const ddb          = DynamoDBDocumentClient.from(new DynamoDBClient({}));
 const lambdaClient = new LambdaClient({});
+const btData       = requireAccountData('budget-tracker');
 
 const JOBS_TABLE  = process.env.AI_JOBS_TABLE!;
 const CONN_TABLE  = process.env.WS_CONNECTIONS_TABLE!;
@@ -20,6 +21,9 @@ export async function reviewStart(
 ): Promise<ReturnType<typeof ok>> {
   // Authorization is performed by the handler entry gate (btData.write, D9
   // member-tier). Reaching here means the caller is an active non-viewer member.
+  // Defense-in-depth: re-assert account membership (claims-only) before this
+  // file's own DynamoDB work, per the file-level handler-authz contract.
+  btData.read(auth, accountId);
 
   const { transactions, categories, settings, forceFullSearch } = parseBody<{
     transactions: Array<{ index: number; description: string; amount: string }>;

--- a/apps/budget-tracker/functions/budget-ai/src/review-start.ts
+++ b/apps/budget-tracker/functions/budget-ai/src/review-start.ts
@@ -1,7 +1,7 @@
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { DynamoDBDocumentClient, PutCommand, QueryCommand } from '@aws-sdk/lib-dynamodb';
 import { LambdaClient, InvokeCommand } from '@aws-sdk/client-lambda';
-import { ok, parseBody, requireAccountAccess } from '@transformotion/lambda-middleware';
+import { ok, parseBody } from '@transformotion/lambda-middleware';
 import type { AuthClaims } from '@transformotion/lambda-middleware';
 import type { Category } from '@transformotion/budget-domain';
 import type { ReviewWorkerPayload } from './review-worker';
@@ -18,7 +18,8 @@ export async function reviewStart(
   accountId: string,
   event: Parameters<typeof parseBody>[0],
 ): Promise<ReturnType<typeof ok>> {
-  requireAccountAccess(auth, 'budget-tracker', accountId);
+  // Authorization is performed by the handler entry gate (btData.write, D9
+  // member-tier). Reaching here means the caller is an active non-viewer member.
 
   const { transactions, categories, settings, forceFullSearch } = parseBody<{
     transactions: Array<{ index: number; description: string; amount: string }>;

--- a/apps/budget-tracker/functions/budget-data/src/index.ts
+++ b/apps/budget-tracker/functions/budget-data/src/index.ts
@@ -1,6 +1,6 @@
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { DynamoDBDocumentClient, QueryCommand, PutCommand } from '@aws-sdk/lib-dynamodb';
-import { withAuth, parseBody, ok, requireAppAccess, requireAccountAccess, requireAccountWrite } from '@transformotion/lambda-middleware';
+import { withAuth, parseBody, ok, requireAccountData } from '@transformotion/lambda-middleware';
 import { dynamoMembershipLoader } from '@transformotion/fn-account-membership';
 import type { BudgetData, Category } from '@transformotion/budget-domain';
 
@@ -107,15 +107,18 @@ async function patchBudgetData(event: Parameters<typeof parseBody>[0], accountId
   return getBudgetData(accountId);
 }
 
+const btData = requireAccountData('budget-tracker');
+
 export const handler = withAuth(async ({ auth, account, event }) => {
-  requireAppAccess(auth, 'budget-tracker');
-  requireAccountAccess(auth, 'budget-tracker', account.accountId);
   const { accountId } = account;
 
-  if (event.httpMethod === 'GET')   return getBudgetData(accountId);
+  if (event.httpMethod === 'GET') {
+    btData.read(auth, accountId);
+    return getBudgetData(accountId);
+  }
   if (event.httpMethod === 'PATCH') {
-    // Account-shared budget config (PK=accountId, SK=concept) → D8 write check.
-    await requireAccountWrite(auth, 'budget-tracker', accountId, membershipLoader);
+    // Account-shared budget config (PK=accountId, SK=concept) → D9 write tier.
+    await btData.write(auth, accountId, membershipLoader);
     return patchBudgetData(event, accountId);
   }
   throw { statusCode: 400, message: `Unrecognised route: ${event.httpMethod}` };

--- a/apps/budget-tracker/functions/budget-export/src/index.ts
+++ b/apps/budget-tracker/functions/budget-export/src/index.ts
@@ -1,6 +1,6 @@
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { DynamoDBDocumentClient, QueryCommand } from '@aws-sdk/lib-dynamodb';
-import { withAuth, getQueryParam, requireAppAccess, requireAccountAccess } from '@transformotion/lambda-middleware';
+import { withAuth, getQueryParam, requireAccountData } from '@transformotion/lambda-middleware';
 import type { Transaction } from '@transformotion/budget-domain';
 
 const ddb = DynamoDBDocumentClient.from(new DynamoDBClient({}));
@@ -12,10 +12,11 @@ function toIso(ddmmyyyy: string): string {
   return p.length === 3 ? `${p[2]}-${p[1]}-${p[0]}` : ddmmyyyy;
 }
 
-// GET /api/budget/v1/business-export
+const btData = requireAccountData('budget-tracker');
+
+// GET /api/budget/v1/business-export — export = read tier (viewer allowed)
 export const handler = withAuth(async ({ auth, account, event }) => {
-  requireAppAccess(auth, 'budget-tracker');
-  requireAccountAccess(auth, 'budget-tracker', account.accountId);
+  btData.read(auth, account.accountId);
   const { accountId } = account;
 
   const from = getQueryParam(event, 'from', false);

--- a/apps/budget-tracker/functions/budget-rules/src/index.ts
+++ b/apps/budget-tracker/functions/budget-rules/src/index.ts
@@ -12,9 +12,7 @@ import {
   getPathParam,
   ok,
   notFound,
-  requireAppAccess,
-  requireAccountAccess,
-  requireAccountWrite,
+  requireAccountData,
   type APIGatewayProxyEvent,
 } from '@transformotion/lambda-middleware';
 import { dynamoMembershipLoader } from '@transformotion/fn-account-membership';
@@ -128,17 +126,18 @@ async function deleteRule(accountId: string, ruleId: string) {
 }
 
 // ── Handler ───────────────────────────────────────────────────────────────────
+const btData = requireAccountData('budget-tracker');
+
 export const handler = withAuth(async ({ auth, account, event }) => {
-  requireAppAccess(auth, 'budget-tracker');
-  requireAccountAccess(auth, 'budget-tracker', account.accountId);
   const { accountId } = account;
+  btData.read(auth, accountId); // D9 read tier (claims membership; viewer allowed)
   const method   = event.httpMethod;
   const resource = event.resource ?? '';
 
   if (resource === '/api/budget/v1/rules' && method === 'GET')  return listRules(accountId);
 
-  // Writes below — D8 live membership-row check (viewer/disabled/removed → 403).
-  await requireAccountWrite(auth, 'budget-tracker', accountId, membershipLoader);
+  // Writes below — D9 write tier: live membership-row check (viewer/disabled/removed → 403).
+  await btData.write(auth, accountId, membershipLoader);
 
   if (resource === '/api/budget/v1/rules' && method === 'POST') return createRule(event, accountId);
 

--- a/apps/budget-tracker/functions/budget-settings/src/index.ts
+++ b/apps/budget-tracker/functions/budget-settings/src/index.ts
@@ -1,6 +1,6 @@
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { DynamoDBDocumentClient, QueryCommand, PutCommand } from '@aws-sdk/lib-dynamodb';
-import { withAuth, parseBody, ok, requireAppAccess, requireAccountAccess, requireAccountWrite } from '@transformotion/lambda-middleware';
+import { withAuth, parseBody, ok, requireAccountData } from '@transformotion/lambda-middleware';
 import { dynamoMembershipLoader } from '@transformotion/fn-account-membership';
 import type { BudgetSettings } from '@transformotion/budget-domain';
 
@@ -56,14 +56,17 @@ async function updateSettings(event: Parameters<typeof parseBody>[0], accountId:
   return getSettings(accountId);
 }
 
+const btData = requireAccountData('budget-tracker');
+
 export const handler = withAuth(async ({ auth, account, event }) => {
-  requireAppAccess(auth, 'budget-tracker');
-  requireAccountAccess(auth, 'budget-tracker', account.accountId);
   const { accountId } = account;
-  if (event.httpMethod === 'GET')   return getSettings(accountId);
+  if (event.httpMethod === 'GET') {
+    btData.read(auth, accountId);
+    return getSettings(accountId);
+  }
   if (event.httpMethod === 'PATCH') {
-    // Account-SHARED settings (PK=accountId, SK=settingKey, no userId) → D8 write check.
-    await requireAccountWrite(auth, 'budget-tracker', accountId, membershipLoader);
+    // Account-SHARED settings (PK=accountId, SK=settingKey, no userId) → D9 write tier.
+    await btData.write(auth, accountId, membershipLoader);
     return updateSettings(event, accountId);
   }
   throw { statusCode: 400, message: `Unrecognised route: ${event.httpMethod}` };

--- a/apps/budget-tracker/functions/budget-transactions/src/index.ts
+++ b/apps/budget-tracker/functions/budget-transactions/src/index.ts
@@ -14,9 +14,7 @@ import {
   getQueryParam,
   ok,
   notFound,
-  requireAppAccess,
-  requireAccountAccess,
-  requireAccountWrite,
+  requireAccountData,
   type APIGatewayProxyEvent,
 } from '@transformotion/lambda-middleware';
 import { dynamoMembershipLoader } from '@transformotion/fn-account-membership';
@@ -178,18 +176,19 @@ async function deleteTransaction(accountId: string, transactionId: string) {
 }
 
 // ── Handler ───────────────────────────────────────────────────────────────────
+const btData = requireAccountData('budget-tracker');
+
 export const handler = withAuth(async ({ auth, account, event }) => {
-  requireAppAccess(auth, 'budget-tracker');
-  requireAccountAccess(auth, 'budget-tracker', account.accountId);
   const { accountId } = account;
+  btData.read(auth, accountId); // D9 read tier (claims membership; viewer allowed)
   const method   = event.httpMethod;
   const resource = event.resource ?? '';
 
   if (resource === '/api/budget/v1/transactions'      && method === 'GET')  return listTransactions(event, accountId);
 
-  // Everything below mutates account data → D8 live membership-row check
-  // (viewer/disabled/removed → 403; fail closed on missing row or loader error).
-  await requireAccountWrite(auth, 'budget-tracker', accountId, membershipLoader);
+  // Everything below mutates account data → D9 write tier: live membership-row
+  // check (viewer/disabled/removed → 403; fail closed on missing row or loader error).
+  await btData.write(auth, accountId, membershipLoader);
 
   if (resource === '/api/budget/v1/transactions/bulk' && method === 'POST') return bulkUpsert(event, accountId);
 

--- a/apps/budget-tracker/infrastructure/budget-tracker-api-stack.ts
+++ b/apps/budget-tracker/infrastructure/budget-tracker-api-stack.ts
@@ -235,6 +235,7 @@ export class BudgetTrackerApiStack extends cdk.Stack {
     }));
     aiJobsTable.grantReadWriteData(aiFn);
     wsConnectionsTable.grantReadData(aiFn);
+    grantMembershipRead(aiFn); // D9 member-tier (ruling #1) — live membership-row check
     // grantReadData on a Table imported via fromTableName covers the base table ARN but not GSI ARNs,
     // because CDK has no schema knowledge of imported tables. Explicit grant for the userId-index GSI
     // used by the connectionId lookup (budget-ai-handler queries by userId to find the caller's WSS connectionId).

--- a/apps/launchpad/functions/pre-token-generation/src/index.ts
+++ b/apps/launchpad/functions/pre-token-generation/src/index.ts
@@ -122,7 +122,6 @@ async function reconcileInvariant(
   userPoolId: string,
   currentGroups: string[],
   accountsByApp: Record<string, Array<{ accountId: string; role: string }>>,
-  isSiteAdmin: boolean,
 ): Promise<string[]> {
   const groups = [...currentGroups];
 
@@ -131,8 +130,11 @@ async function reconcileInvariant(
     const hasAccounts = (accountsByApp[slug]?.length ?? 0) > 0;
     const inGroup = groups.includes(accessGroup);
 
-    // D11 item 1 NOTE: site-admin override removal (isSiteAdmin bypass on the
-    // !hasAccounts branch) is Phase 5 work. It is intentionally NOT removed here.
+    // D11 item 1 (Phase 5): the site-admin override is REMOVED — the invariant
+    // (group membership ⇔ ≥1 account for the app) applies uniformly. A site-admin
+    // with no accounts for an app is removed from its access group like anyone
+    // else; site-admin's supervisory power rides the site_admin claim, not
+    // app-access groups.
     if (hasAccounts && !inGroup) {
       console.log(`[launchpad-pre-token] reconcile: adding ${userId} to ${accessGroup}`);
       try {
@@ -145,7 +147,7 @@ async function reconcileInvariant(
       } catch (err) {
         console.error(`[launchpad-pre-token] reconcile: failed to add ${userId} to ${accessGroup}:`, err);
       }
-    } else if (!hasAccounts && inGroup && !isSiteAdmin) {
+    } else if (!hasAccounts && inGroup) {
       console.log(`[launchpad-pre-token] reconcile: removing ${userId} from ${accessGroup}`);
       try {
         await cognito.send(new AdminRemoveUserFromGroupCommand({
@@ -164,8 +166,11 @@ async function reconcileInvariant(
   return groups;
 }
 
-function buildAppsList(reconciledGroups: string[], isSiteAdmin: boolean): string[] {
-  if (isSiteAdmin) return [...APP_SLUGS];
+function buildAppsList(reconciledGroups: string[]): string[] {
+  // D11 item 1 (Phase 5): no site-admin all-apps shortcut — the apps claim
+  // reflects the reconciled (membership-derived) access groups uniformly. A
+  // site-admin without membership does not receive app-data access; supervisory
+  // surfaces are driven by the site_admin claim, not the apps claim.
   return APP_SLUGS.filter(slug => reconciledGroups.includes(ACCESS_GROUP[slug]));
 }
 
@@ -198,7 +203,6 @@ export const handler = async (
       userPoolId,
       currentGroups,
       accountsByApp,
-      isSiteAdmin,
     );
 
     // M16 D8: app_admin claim — array of appSlugs where user is app-admin
@@ -207,7 +211,7 @@ export const handler = async (
       .filter(slug => APP_SLUGS.includes(slug));
 
     const claims: Record<string, string> = {
-      apps: JSON.stringify(buildAppsList(reconciledGroups, isSiteAdmin)),
+      apps: JSON.stringify(buildAppsList(reconciledGroups)),
       accounts: JSON.stringify(accountsByApp),
       site_admin: String(isSiteAdmin),
       app_admin: JSON.stringify(appAdminSlugs),

--- a/apps/stock-analyser/AGENTS.md
+++ b/apps/stock-analyser/AGENTS.md
@@ -68,17 +68,18 @@ Analysis cache is accessed by `transformotion-analysis-cache-{stage}` (read/dele
 
 ## Authorization requirement
 
-All Lambda handlers use helpers from `packages/lambda-middleware`. The four available helpers and when to apply each:
+All Lambda handlers use helpers from `packages/lambda-middleware`. App-data routes use the **data-authority factory** `requireAccountData` (D9, M16); supervisory/ownership routes use `requireAccountAdmin`:
 
 ```typescript
-requireSiteAdmin(auth)                                           // platform admin ops only
-requireAppAccess(auth, 'stock-analyser')                          // entry-point check (every handler)
-requireAccountAccess(auth, 'stock-analyser', accountId)           // standard read/write ops
-requireAccountAccess(auth, 'stock-analyser', accountId, 'manager') // elevated ops (bulk delete, etc.)
-requireAccountOwner(auth, 'stock-analyser', accountId)            // ownership-transfer ops
+const saData = requireAccountData('stock-analyser');             // module scope
+
+saData.read(auth, accountId);                                    // read tier — claims only, viewer passes
+await saData.write(auth, accountId, membershipLoader);          // write tier — claims + live members row, viewer denied
+requireAccountAdmin(/* owner / manager / supervisory guards */); // supervisory & ownership ops
+requireSiteAdmin(auth);                                          // platform admin ops only
 ```
 
-Call `requireAppAccess` at the top of every handler, then `requireAccountAccess` (or `requireAccountOwner`) before each DynamoDB operation. Do not call `requireGroup` directly. See [auth.md](/docs/architecture/auth.md) for full middleware helper documentation.
+Construct `requireAccountData('stock-analyser')` at module scope, then call `.read` on GET branches and `.write` (with a `dynamoMembershipLoader`) before each mutation. There is **no site-admin data bypass** — membership is the only grant of data authority. Per-user rows within an account (settings preferences, D12) use `.read` for the owner's own writes. `requireAccountAccess` and `requireAccountOwner` were **deleted** in M16 Phase 5. Do not call `requireGroup` directly. See [auth.md](/docs/architecture/auth.md) and [route-classification-m16.md](/docs/architecture/route-classification-m16.md).
 
 ## Service layer and data contracts
 

--- a/apps/stock-analyser/CLAUDE.md
+++ b/apps/stock-analyser/CLAUDE.md
@@ -71,17 +71,18 @@ Analysis cache is accessed by `transformotion-analysis-cache-{stage}` (read/dele
 
 ## Authorization requirement
 
-All Lambda handlers use helpers from `packages/lambda-middleware`. The four available helpers and when to apply each:
+All Lambda handlers use helpers from `packages/lambda-middleware`. App-data routes use the **data-authority factory** `requireAccountData` (D9, M16); supervisory/ownership routes use `requireAccountAdmin`:
 
 ```typescript
-requireSiteAdmin(auth)                                           // platform admin ops only
-requireAppAccess(auth, 'stock-analyser')                          // entry-point check (every handler)
-requireAccountAccess(auth, 'stock-analyser', accountId)           // standard read/write ops
-requireAccountAccess(auth, 'stock-analyser', accountId, 'manager') // elevated ops (bulk delete, etc.)
-requireAccountOwner(auth, 'stock-analyser', accountId)            // ownership-transfer ops
+const saData = requireAccountData('stock-analyser');             // module scope
+
+saData.read(auth, accountId);                                    // read tier — claims only, viewer passes
+await saData.write(auth, accountId, membershipLoader);          // write tier — claims + live members row, viewer denied
+requireAccountAdmin(/* owner / manager / supervisory guards */); // supervisory & ownership ops
+requireSiteAdmin(auth);                                          // platform admin ops only
 ```
 
-Call `requireAppAccess` at the top of every handler, then `requireAccountAccess` (or `requireAccountOwner`) before each DynamoDB operation. Do not call `requireGroup` directly. See [auth.md](/docs/architecture/auth.md) for full middleware helper documentation.
+Construct `requireAccountData('stock-analyser')` at module scope, then call `.read` on GET branches and `.write` (with a `dynamoMembershipLoader`) before each mutation. There is **no site-admin data bypass** — membership is the only grant of data authority. Per-user rows within an account (settings preferences, D12) use `.read` for the owner's own writes. `requireAccountAccess` and `requireAccountOwner` were **deleted** in M16 Phase 5. Do not call `requireGroup` directly. See [auth.md](/docs/architecture/auth.md) and [route-classification-m16.md](/docs/architecture/route-classification-m16.md).
 
 ## Service layer and data contracts
 

--- a/apps/stock-analyser/functions/analysis-cache/package.json
+++ b/apps/stock-analyser/functions/analysis-cache/package.json
@@ -10,6 +10,7 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@transformotion/fn-account-membership": "workspace:*",
     "@transformotion/lambda-middleware": "workspace:*"
   },
   "devDependencies": {

--- a/apps/stock-analyser/functions/analysis-cache/src/index.ts
+++ b/apps/stock-analyser/functions/analysis-cache/src/index.ts
@@ -8,13 +8,17 @@ import {
   noContent,
   notFound,
   badRequest,
-  requireAppAccess,
-  requireAccountAccess,
+  requireAccountData,
 } from '@transformotion/lambda-middleware';
+import { dynamoMembershipLoader } from '@transformotion/fn-account-membership';
 
 const ddb = DynamoDBDocumentClient.from(new DynamoDBClient({}));
 const TABLE             = process.env.CACHE_TABLE!;
 const JOB_RESULTS_TABLE = process.env.JOB_RESULTS_TABLE!;
+// D9 data-tier gate (no site-admin branch): GET = .read (viewer allowed);
+// PUT/DELETE = .write (claims + live membership row, viewer/disabled/removed → 403).
+const saData = requireAccountData('stock-analyser');
+const membershipLoader = dynamoMembershipLoader(ddb, process.env.ACCOUNT_MEMBERS_TABLE!);
 
 // Special partition key used for data shared across all accounts.
 // Market analysis, recommendations, ETFs, metals, and stock analyses
@@ -79,14 +83,13 @@ function resolveWriteAccountId(cacheKey: string, fallbackAccountId: string, clie
 }
 
 export const handler = withAuth(async ({ auth, account, event }) => {
-  requireAppAccess(auth, 'stock-analyser');
-  requireAccountAccess(auth, 'stock-analyser', account.accountId);
   const { accountId } = account;
   // URL-decode the key so clients can send MARKET%23Global and the DDB key is MARKET#Global.
   const cacheKey = decodeURIComponent(getPathParam(event, 'key'));
 
   // ── GET /analysis-cache/{key} ─────────────────────────────────────────────
   if (event.httpMethod === 'GET') {
+    saData.read(auth, accountId);
     // job-* keys are app-owned async job records written by the SA AI proxy.
     // After #366 they live in stock-analyser.job-results-{stage}; platform
     // job-results may exist only as legacy/rollback until #372.
@@ -122,6 +125,7 @@ export const handler = withAuth(async ({ auth, account, event }) => {
 
   // ── DELETE /analysis-cache/{key} ──────────────────────────────────────────
   if (event.httpMethod === 'DELETE') {
+    await saData.write(auth, accountId, membershipLoader);
     // Delete from both partitions in case legacy items exist
     await Promise.allSettled([
       ddb.send(new DeleteCommand({ TableName: TABLE, Key: { accountId: SHARED, cacheKey } })),
@@ -132,6 +136,7 @@ export const handler = withAuth(async ({ auth, account, event }) => {
   }
 
   // ── PUT /analysis-cache/{key} ─────────────────────────────────────────────
+  await saData.write(auth, accountId, membershipLoader);
   const {
     data,
     ttlSeconds,

--- a/apps/stock-analyser/functions/cycle-data/src/index.ts
+++ b/apps/stock-analyser/functions/cycle-data/src/index.ts
@@ -4,13 +4,15 @@ import {
   withAuth,
   ok,
   badRequest,
-  requireAppAccess,
-  requireAccountAccess,
+  requireAccountData,
   HttpError,
 } from '@transformotion/lambda-middleware';
 import { fetchOhlcv } from '../../_shared/market-data-fetcher';
 import { computeCyclePosition } from '../../../lib/cycle';
 
+// D9 data-tier gate (no site-admin branch). cycle-data is a READ of shared market
+// data; a viewer member may read it.
+const saData = requireAccountData('stock-analyser');
 const ddb = DynamoDBDocumentClient.from(new DynamoDBClient({}));
 const TABLE          = process.env.ANALYSIS_CACHE_TABLE!;
 const SHARED         = 'SHARED';
@@ -18,8 +20,7 @@ const CYCLE_TTL      = 3600;  // 1 hour — computed result
 const MARKET_TTL     = 28800; // 8 hours — shared raw OHLCV
 
 export const handler = withAuth(async ({ auth, account, event }) => {
-  requireAppAccess(auth, 'stock-analyser');
-  requireAccountAccess(auth, 'stock-analyser', account.accountId);
+  saData.read(auth, account.accountId);
 
   const ticker = event.queryStringParameters?.ticker;
   if (!ticker) throw badRequest('ticker is required');

--- a/apps/stock-analyser/functions/market-data/src/index.ts
+++ b/apps/stock-analyser/functions/market-data/src/index.ts
@@ -4,12 +4,14 @@ import {
   withAuth,
   ok,
   badRequest,
-  requireAppAccess,
-  requireAccountAccess,
+  requireAccountData,
   HttpError,
 } from '@transformotion/lambda-middleware';
 import { fetchOhlcv } from '../../_shared/market-data-fetcher';
 
+// D9 data-tier gate (no site-admin branch). market-data is a READ of shared
+// market data; a viewer member may read it.
+const saData = requireAccountData('stock-analyser');
 const ddb = DynamoDBDocumentClient.from(new DynamoDBClient({}));
 const TABLE    = process.env.ANALYSIS_CACHE_TABLE!;
 const SHARED   = 'SHARED';
@@ -19,8 +21,7 @@ const VALID_RANGES    = new Set(['1mo', '3mo', '6mo', '1y', '5y', 'max']);
 const VALID_INTERVALS = new Set(['1d', '1wk', '1mo']);
 
 export const handler = withAuth(async ({ auth, account, event }) => {
-  requireAppAccess(auth, 'stock-analyser');
-  requireAccountAccess(auth, 'stock-analyser', account.accountId);
+  saData.read(auth, account.accountId);
 
   const { ticker, range = '1y', interval = '1d' } = event.queryStringParameters ?? {};
   if (!ticker) throw badRequest('ticker is required');

--- a/apps/stock-analyser/functions/portfolio/src/index.ts
+++ b/apps/stock-analyser/functions/portfolio/src/index.ts
@@ -10,25 +10,25 @@ import {
   parseBody,
   ok,
   badRequest,
-  requireAppAccess,
-  requireAccountAccess,
-  requireAccountWrite,
+  requireAccountData,
 } from '@transformotion/lambda-middleware';
 import { dynamoMembershipLoader } from '@transformotion/fn-account-membership';
 import type { PortfolioHolding } from './types';
 
 const ddb = DynamoDBDocumentClient.from(new DynamoDBClient({}));
 const TABLE = process.env.PORTFOLIO_TABLE!;
+// D9 data-tier gate (no site-admin branch): .read = claims-only (viewer allowed);
+// .write = claims + live membership-row read (viewer/disabled/removed → 403).
+const saData = requireAccountData('stock-analyser');
 // D8 write-path membership loader (scoped GetItem on launchpad-account-members).
 const membershipLoader = dynamoMembershipLoader(ddb, process.env.ACCOUNT_MEMBERS_TABLE!);
 
 export const handler = withAuth(async ({ auth, account, event }) => {
-  requireAppAccess(auth, 'stock-analyser');
-  requireAccountAccess(auth, 'stock-analyser', account.accountId);
   const { accountId } = account;
 
   // ── GET /portfolio ──────────────────────────────────────────────────────── (read: claims-only)
   if (event.httpMethod === 'GET') {
+    saData.read(auth, accountId);
     const res = await ddb.send(new QueryCommand({
       TableName: TABLE,
       KeyConditionExpression: 'accountId = :aid',
@@ -40,9 +40,9 @@ export const handler = withAuth(async ({ auth, account, event }) => {
   }
 
   // ── PUT /portfolio ──────────────────────────────────────────────────────── (write: live row check)
-  // D8: claims + live membership-row read. Rejects viewer/disabled/removed and
-  // fails closed on a loader error. Reads above stay claims-only.
-  await requireAccountWrite(auth, 'stock-analyser', accountId, membershipLoader);
+  // D9 write tier: claims + live membership-row read. Rejects viewer/disabled/
+  // removed and fails closed on a loader error. Reads above stay claims-only.
+  await saData.write(auth, accountId, membershipLoader);
 
   const { holdings } = parseBody<{ holdings: PortfolioHolding[] }>(event);
 

--- a/apps/stock-analyser/functions/settings/src/index.ts
+++ b/apps/stock-analyser/functions/settings/src/index.ts
@@ -5,8 +5,7 @@ import {
   noContent,
   ok,
   parseBody,
-  requireAccountAccess,
-  requireAppAccess,
+  requireAccountData,
   requireSiteAdmin,
   withAuth,
   type APIGatewayProxyEvent,
@@ -214,26 +213,35 @@ async function resetOverride(deps: Dependencies, accountId: string) {
   return noContent();
 }
 
-export function createHandler(deps: Dependencies = defaultDependencies) {
+  // D9 data-tier gate (no site-admin branch). Settings rows are D12 user-scoped
+  // (SK=USER#{userId}#PREFERENCES): a viewer MAY read AND write their OWN prefs,
+  // so both /settings GET and PATCH use .read (membership) — the handler keys by
+  // auth.userId, enforcing the SK-owner match by construction.
+  const saData = requireAccountData(APP_SLUG);
   return withAuth(async ({ auth, account, event }) => {
-    requireAppAccess(auth, APP_SLUG);
-    requireAccountAccess(auth, APP_SLUG, account.accountId);
-
     const resource = event.resource ?? '';
     if (resource === '/settings' && event.httpMethod === 'GET') {
+      saData.read(auth, account.accountId);
       return readSettings(deps, account.accountId, auth.userId);
     }
     if (resource === '/settings' && event.httpMethod === 'PATCH') {
+      saData.read(auth, account.accountId); // D12 user-scoped own-prefs write — viewer permitted
       return patchSettings(deps, event, account.accountId, auth.userId);
     }
     if (resource === '/ai-config' && event.httpMethod === 'GET') {
+      saData.read(auth, account.accountId);
       return readAiConfig(deps, account.accountId);
     }
+    // /ai-config/override is operational-config (D9) — site-admin write of an
+    // account-shared config row. Interim: preserve current behaviour (member +
+    // site-admin). PR-C rehomes this to app-level config gated by app-admin.
     if (resource === '/ai-config/override' && event.httpMethod === 'PUT') {
+      saData.read(auth, account.accountId);
       requireSiteAdmin(auth);
       return updateOverride(deps, event, account.accountId);
     }
     if (resource === '/ai-config/override' && event.httpMethod === 'DELETE') {
+      saData.read(auth, account.accountId);
       requireSiteAdmin(auth);
       return resetOverride(deps, account.accountId);
     }

--- a/apps/stock-analyser/functions/settings/src/index.ts
+++ b/apps/stock-analyser/functions/settings/src/index.ts
@@ -213,11 +213,13 @@ async function resetOverride(deps: Dependencies, accountId: string) {
   return noContent();
 }
 
-  // D9 data-tier gate (no site-admin branch). Settings rows are D12 user-scoped
-  // (SK=USER#{userId}#PREFERENCES): a viewer MAY read AND write their OWN prefs,
-  // so both /settings GET and PATCH use .read (membership) — the handler keys by
-  // auth.userId, enforcing the SK-owner match by construction.
-  const saData = requireAccountData(APP_SLUG);
+// D9 data-tier gate (no site-admin branch). Settings rows are D12 user-scoped
+// (SK=USER#{userId}#PREFERENCES): a viewer MAY read AND write their OWN prefs,
+// so both /settings GET and PATCH use .read (membership) — the handler keys by
+// auth.userId, enforcing the SK-owner match by construction.
+const saData = requireAccountData(APP_SLUG);
+
+export function createHandler(deps: Dependencies = defaultDependencies) {
   return withAuth(async ({ auth, account, event }) => {
     const resource = event.resource ?? '';
     if (resource === '/settings' && event.httpMethod === 'GET') {

--- a/apps/stock-analyser/functions/watchlist/src/index.ts
+++ b/apps/stock-analyser/functions/watchlist/src/index.ts
@@ -10,25 +10,24 @@ import {
   parseBody,
   ok,
   badRequest,
-  requireAppAccess,
-  requireAccountAccess,
-  requireAccountWrite,
+  requireAccountData,
 } from '@transformotion/lambda-middleware';
 import { dynamoMembershipLoader } from '@transformotion/fn-account-membership';
 import type { WatchlistItem } from './types';
 
 const ddb = DynamoDBDocumentClient.from(new DynamoDBClient({}));
 const TABLE = process.env.WATCHLIST_TABLE!;
+// D9 data-tier gate (no site-admin branch): .read claims-only / .write claims + row.
+const saData = requireAccountData('stock-analyser');
 // D8 write-path membership loader (scoped GetItem on launchpad-account-members).
 const membershipLoader = dynamoMembershipLoader(ddb, process.env.ACCOUNT_MEMBERS_TABLE!);
 
 export const handler = withAuth(async ({ auth, account, event }) => {
-  requireAppAccess(auth, 'stock-analyser');
-  requireAccountAccess(auth, 'stock-analyser', account.accountId);
   const { accountId } = account;
 
   // ── GET /watchlist ──────────────────────────────────────────────────────── (read: claims-only)
   if (event.httpMethod === 'GET') {
+    saData.read(auth, accountId);
     const res = await ddb.send(new QueryCommand({
       TableName: TABLE,
       KeyConditionExpression: 'accountId = :aid',
@@ -40,7 +39,7 @@ export const handler = withAuth(async ({ auth, account, event }) => {
   }
 
   // ── PUT /watchlist ──────────────────────────────────────────────────────── (write: live row check)
-  await requireAccountWrite(auth, 'stock-analyser', accountId, membershipLoader);
+  await saData.write(auth, accountId, membershipLoader);
 
   const { items } = parseBody<{ items: WatchlistItem[] }>(event);
 

--- a/apps/stock-analyser/infrastructure/stock-analyser-api-stack.ts
+++ b/apps/stock-analyser/infrastructure/stock-analyser-api-stack.ts
@@ -143,6 +143,7 @@ export class StockAnalyserApiStack extends cdk.Stack {
     });
     analysisCacheTable.grantReadWriteData(cacheFn);
     jobResultsTable.grantReadData(cacheFn);
+    grantMembershipRead(cacheFn); // D9 write tier on PUT/DELETE — live membership-row check
 
     const cacheIntegration = new apigateway.LambdaIntegration(cacheFn, { proxy: true });
     const cacheKey = this.api.root

--- a/docs/architecture/auth.md
+++ b/docs/architecture/auth.md
@@ -207,12 +207,12 @@ Account membership is stored in `launchpad-account-members-{stage}` (PK: `accoun
 
 **Ownership transfer.** The current owner can transfer ownership to any other member or manager of the account. The previous owner becomes a manager; they can choose to remove themselves afterwards. The account retains exactly one owner throughout.
 
-**Role hierarchy** (for `requireAccountAccess` minRole checks):
-`owner > manager > member > viewer`. A check for `minRole: 'manager'` succeeds for `owner` and `manager`; fails for `member` and `viewer`.
+**Role hierarchy** (exported as `ROLE_HIERARCHY` from `packages/lambda-middleware`, consumed by the policy layer):
+`owner > manager > member > viewer`. A minimum-role check for `manager` succeeds for `owner` and `manager`; fails for `member` and `viewer`. The policy layer's `roleAtLeast` / `decideMinRole` (D9) evaluate against this ordering; `viewer` is the read floor (read-only), `member` the write floor.
 
-**Write-path row check (D8, M16).** App-data **writes** (Stock Analyser / Budget Tracker mutations) go through `requireAccountWrite` (`packages/lambda-middleware`): the claims membership check **plus** a live read of the caller's `launchpad-account-members` row. The live row is the authority because claims can be stale — a user demoted to `viewer`, disabled, or removed after token issuance still carries the old claim for up to the access-token lifetime. The write is rejected (403) when the row is missing (**fail closed**), the row's `status` is not `active`, or the role is `viewer` (read-only). There is **no site-admin bypass** on this path: membership is the only grant of data authority (D9). Reads stay claims-only — no table read on the hot path. (Layered on the existing claims helpers; folds into the Phase 5 `requireAccountData`/`requireAccountAdmin` split.)
+**Write-path row check (D8, M16).** App-data **writes** (Stock Analyser / Budget Tracker mutations) go through the policy layer's `requireAccountData(appSlug).write(...)` (`packages/lambda-middleware`), which folds `requireAccountWrite`: the claims membership check **plus** a live read of the caller's `launchpad-account-members` row. The live row is the authority because claims can be stale — a user demoted to `viewer`, disabled, or removed after token issuance still carries the old claim for up to the access-token lifetime. The write is rejected (403) when the row is missing (**fail closed**), the row's `status` is not `active`, or the role is `viewer` (read-only). There is **no site-admin bypass** on this path: membership is the only grant of data authority (D9). Reads go through `requireAccountData(appSlug).read(...)` — claims-only, no table read on the hot path, and a `viewer` claim passes (read visibility).
 
-The gate applies to handlers that mutate **account-shared** data, classified by the item's key shape, not by the route alone. Worked examples (Phase 4): Stock Analyser portfolio/watchlist and Budget Tracker transactions/rules/budget-data are gated; **Budget Tracker settings is gated** because its rows are account-scoped (`PK=accountId, SK=settingKey`, no user dimension), whereas **Stock Analyser settings is NOT gated** because its rows are per-user within the account (`SK=USER#{userId}#PREFERENCES`) — a viewer may set their own preference. Read-path cache writes (SA analysis-cache) and site-admin-only AI-config overrides are likewise excluded; the latter is tracked for the Phase 5 two-axis sweep (#416).
+The write gate applies to handlers that mutate **account-shared** data, classified by the item's key shape, not by the route alone (see `docs/architecture/route-classification-m16.md` for the per-route migration record). Worked examples: Stock Analyser portfolio/watchlist and Budget Tracker transactions/rules/budget-data/settings/export are write-gated; **Budget Tracker settings is gated** because its rows are account-scoped (`PK=accountId, SK=settingKey`, no user dimension), whereas **Stock Analyser settings is NOT write-gated** because its rows are per-user within the account (`SK=USER#{userId}#PREFERENCES`, D12) — a viewer may set their own preference. SA analysis-cache writes are now write-gated (member-tier; previously had no row check). Budget Tracker AI routes are write-gated (member-tier, owner ruling #1). AI-config overrides remain member-tier write plus an interim `requireSiteAdmin`; the operational-config admin axis rehomes them in PR-C (#416).
 
 ### Conflict resolution between dimensions
 
@@ -226,7 +226,12 @@ The resolution rule is: **Dimension A is the ceiling.**
 
 In practice: Dimension A governs *whether the user can use the app at all*. Dimension B governs *what operations they can perform on a specific account's data*.
 
-**`site-admin` bypasses both dimensions.** A site-admin user can perform any operation on any app's data on any account, even without explicit app-access group or account membership. Every authorization helper checks site-admin first as an override.
+**`site-admin` does NOT grant data authority (D9, M16 — reversed).** This is the single largest normative change in M16. The platform now operates on two distinct axes:
+
+- **Data authority** — the right to read or write an account's app data. **Membership is the only grant of data authority.** A site-admin with no membership row on an account is denied (404/403) on that account's data, exactly as any non-member is. `requireAccountData` has **no site-admin branch**. The superseded model — "every authorization helper checks site-admin first as an override" — is deleted.
+- **Administrative authority** — supervisory and operational-config operations (member removal, account disable/delete, cross-app directory, app-admin config). These are governed by `requireAccountAdmin` and the `requireSiteAdmin` / app-admin policy guards. Site-admin is supervisory here: it can *remove* members and disable/delete accounts, but it can **never grant itself a role or write account data**. A supervisory action carries no data visibility.
+
+Dimension A (app access) remains the ceiling for data operations as described above. The reversal concerns only the former blanket site-admin data bypass.
 
 ---
 
@@ -242,8 +247,8 @@ In practice: Dimension A governs *whether the user can use the app at all*. Dime
 3. **Reconcile the app-access invariant.** For each app slug (`stock-analyser`, `budget-tracker`):
    - If user has any accounts for the app but is not in `<app>-access`: call `AdminAddUserToGroup`, update the in-memory group list for claim construction.
    - If user is in `<app>-access` but has no accounts: call `AdminRemoveUserFromGroup`, update the in-memory list.
-   - `site-admin` membership overrides the "no accounts" removal — site-admin keeps all access regardless of account memberships.
-4. Build the `apps` claim: JSON-stringified array of app slugs the user has access to (derived from reconciled groups plus site-admin override).
+   - The invariant applies **uniformly** (D11.1, M16): the former `site-admin` override — which retained app-access groups for site-admins regardless of membership — is **removed**. Group membership now tracks account membership for every user. The `site_admin` claim drives supervisory surfaces; it does not retain app-access groups or app-data authority.
+4. Build the `apps` claim: JSON-stringified array of app slugs the user has access to (derived from reconciled groups only — no site-admin all-apps shortcut).
 5. Build the `accounts` claim: JSON-stringified map of app slug to `[{accountId, role}]`, grouped from the membership query results.
 6. Build `site_admin`: the string `"true"` or `"false"` (Cognito requires claim values to be strings).
 7. Set `event.response.claimsAndScopeOverrideDetails.accessTokenGeneration.claimsToAddOrOverride` with the three claims.
@@ -402,26 +407,39 @@ requireAnyAppAccess(auth, appSlugs)
 // Throws 403 unless auth.apps includes at least one of appSlugs OR auth.siteAdmin === true.
 // Use only in platform handlers that serve multiple apps (currently: claude-proxy).
 
-requireAccountAccess(auth, appSlug, accountId, minRole?)
-// Throws 403 unless the caller is a member of accountId for appSlug
-// with role >= minRole (or is site-admin).
-// Role hierarchy (ascending): viewer < member < manager < owner.
-// Default minRole is 'member'. Use before any DynamoDB query for account-scoped data.
+requireAccountData(appSlug)
+// The data-authority middleware factory (D9). Returns an object with:
+//   .read(auth, accountId)          — claims-only membership check; viewer passes
+//                                      (read visibility). No table read on the hot path.
+//   .write(auth, accountId, loader) — folds requireAccountWrite: claims membership
+//                                      PLUS a live members-row read via `loader`.
+//                                      Rejects (403) on missing row (fail closed),
+//                                      non-active status, or viewer role.
+// NO site-admin branch — membership is the only grant of data authority.
+// Replaces requireAccountAccess for all app-data routes.
 
-requireAccountOwner(auth, appSlug, accountId)
-// Throws 403 unless caller is the owner of accountId for appSlug
-// (or is site-admin).
-// Use for account deletion, ownership transfer, and similar
-// operations only the owner can perform.
+requireAccountAdmin(...guards)
+// Administrative-authority composition (D9), built from anyOf(...) over policy
+// guards (requireAccountOwnerRole, requireAccountOwnerOrManager,
+// requireSupervisorySiteAdmin, requireAppAdminForApp, ...). Use for supervisory
+// and ownership-class operations. Replaces requireAccountOwner.
 ```
 
-All helpers check `auth.siteAdmin` first as an override. A site-admin caller passes all authorization checks regardless of app-access or account membership.
+**`requireAccountAccess` and `requireAccountOwner` were deleted in M16 Phase 5 (D9)** — not deprecated, deleted, with zero remaining callers. Both folded a blanket site-admin override that the two-axis model removes. App-data routes use `requireAccountData`; supervisory/ownership routes use `requireAccountAdmin`. The full per-route migration is recorded in `docs/architecture/route-classification-m16.md`.
 
-**Fail-closed semantics.** When `auth.apps` or `auth.accounts` are absent or empty (e.g., due to a pre-token Lambda failure), helpers deny access rather than granting it. The pre-token Lambda documents this under "On failure" above.
+**Authorization tier table (D8/D9).** Three tiers, distinguished by what they consult:
+
+| Tier | Helper | Consults | Site-admin |
+|---|---|---|---|
+| App-data read | `requireAccountData(app).read` | Claims only (`auth.accounts`) | No branch — membership only |
+| App-data write | `requireAccountData(app).write` | Claims **+ live members row** | No branch — membership only |
+| Control-plane / supervisory | `requireAccountAdmin(...)`, `requireSiteAdmin` | Policy guards (live tables / `site_admin` claim) | Supervisory: can remove/disable, never grants data authority |
+
+**Fail-closed semantics.** When `auth.apps` or `auth.accounts` are absent or empty (e.g., due to a pre-token Lambda failure), helpers deny access rather than granting it. The data-path policy guards additionally resolve the target first and return a **uniform not-found** response so missing-membership and missing-resource are indistinguishable. The pre-token Lambda documents the empty-claims case under "On failure" above.
 
 ### Claim-consumption layering
 
-Raw JWT claim reads occur only in the middleware layer (`packages/lambda-middleware/`). Business-logic Lambdas access claims via the typed `auth` object provided by `withAuth` / `withAuthOnly`, using documented helpers (`requireAccountAccess`, `requireAppAccess`, `requireSiteAdmin`, etc.) when authorization decisions are needed. New Lambdas never read claims directly; the middleware layer is the only place raw claim access belongs.
+Raw JWT claim reads occur only in the middleware layer (`packages/lambda-middleware/`). Business-logic Lambdas access claims via the typed `auth` object provided by `withAuth` / `withAuthOnly`, using documented helpers (`requireAccountData`, `requireAccountAdmin`, `requireAppAccess`, `requireSiteAdmin`, etc.) when authorization decisions are needed. New Lambdas never read claims directly; the middleware layer is the only place raw claim access belongs.
 
 This is a layering rule of the same shape as the data-access layered architecture (see `CONTRIBUTING.md` Section 5). Concerns are separated by layer: the middleware layer encapsulates raw-claim concerns; business logic operates on typed values.
 
@@ -438,16 +456,27 @@ Handlers do NOT call `requireGroup` for new work.
 
 Every Lambda handler follows this pattern. Deviations require a written justification in the handler's code.
 
-### Standard app-scoped handler
+### Standard app-scoped handler (data routes)
+
+The data-authority middleware factory is constructed once at module scope, then `.read` / `.write` is called per branch:
 
 ```typescript
-export const handler = withAuth(async ({ auth, account, event }) => {
-  requireAppAccess(auth, 'app-slug');                         // (1) fail fast if user lacks app access
-  requireAccountAccess(auth, 'app-slug', account.accountId); // (2) verify account membership before any data access
+const appData = requireAccountData('app-slug');               // module scope
+const membershipLoader = dynamoMembershipLoader(ddb, process.env.ACCOUNT_MEMBERS_TABLE!);
 
-  // ... handler logic uses account.accountId for all DynamoDB keys
+export const handler = withAuth(async ({ auth, account, event }) => {
+  if (event.requestContext.http.method === 'GET') {
+    appData.read(auth, account.accountId);                    // read tier: claims-only, viewer passes
+    // ... read logic
+  } else {
+    await appData.write(auth, account.accountId, membershipLoader); // write tier: claims + live row, viewer denied
+    // ... mutation logic
+  }
+  // accountId comes from request context; all DynamoDB keys use account.accountId
 });
 ```
+
+`requireAppAccess` is no longer the explicit first call on data routes: `requireAccountData` subsumes app-access (a user with no membership for the app has no account row to match). Supervisory/ownership routes use `requireAccountAdmin(...)` instead of the data factory.
 
 ### Multi-app platform handler (currently: claude-proxy only)
 
@@ -461,13 +490,12 @@ export const handler = withAuth(async ({ auth, account, event }) => {
 
 ### Rules
 
-1. **`requireAppAccess` (or `requireAnyAppAccess`) is the first call in every handler**, before any business logic or DynamoDB access.
-2. **`requireAccountAccess` is called before every DynamoDB read or write** that operates on account-scoped data.
-3. **`accountId` always comes from request context** (`account.accountId`, which is sourced from the `X-Account-Id` request header). Never derive `accountId` from `auth.accounts` or any other JWT claim.
-4. **Elevated operations** (bulk delete, admin overrides) use `requireAccountAccess(auth, appSlug, accountId, 'manager')`.
-5. **Ownership-only operations** (account deletion, ownership transfer) use `requireAccountOwner`.
-6. **Platform-admin operations** (cross-app user management, user disable/delete) use `requireSiteAdmin`.
-7. **`requireGroup` must not appear in new handler code.** It is deprecated and will be removed at 7e-cleanup.
+1. **A policy guard runs before any DynamoDB access.** Data routes call `requireAccountData(app).read`/`.write`; supervisory/ownership routes call `requireAccountAdmin(...)`; platform routes call `requireSiteAdmin`. Multi-app platform handlers (claude-proxy) still call `requireAnyAppAccess` first.
+2. **Read vs write is a tier decision, not a route decision.** Reads use `.read` (claims-only, viewer passes); mutations of account-shared data use `.write` (claims + live members row, viewer denied). User-scoped rows within an account (e.g. SA per-user preferences, D12) use `.read` for the owner's own writes.
+3. **`accountId` always comes from request context** (`account.accountId`, sourced from the `X-Account-Id` request header). Never derive `accountId` from `auth.accounts` or any other JWT claim.
+4. **Elevated / supervisory operations** (member removal, account disable/delete) use `requireAccountAdmin(...)` composed from the relevant policy guards. There is no site-admin data bypass.
+5. **Platform-admin operations** (cross-app user management, user disable/delete, cross-app directory) use `requireSiteAdmin`.
+6. **`requireGroup` must not appear in new handler code.** It is deprecated and will be removed at 7e-cleanup.
 
 ---
 
@@ -631,8 +659,8 @@ An account owner or manager removes someone from a specific account.
 
 Endpoint: `DELETE /accounts/{accountId}/members/{userId}`. Lambda: `account-members-remove`.
 
-Authorization:
-- `requireAccountAccess(auth, appSlug, accountId, minRole: 'manager')`
+Authorization (supervisory — implemented as the route lands in Phase 6):
+- `requireAccountAdmin(requireAccountOwnerOrManager(...))` — owner/manager of the account, or supervisory site-admin. This is an administrative-authority operation, not a data-path one; it carries no data visibility.
 - If the target `userId` is the `owner` of the account: reject. Ownership must be transferred first.
 - If the caller is a `manager` (not owner) and the target is also a `manager`: reject. Managers cannot remove other managers; only the owner can.
 - Self-removal (caller and target are the same user): allowed if the target is not the owner.

--- a/docs/architecture/data.md
+++ b/docs/architecture/data.md
@@ -309,16 +309,31 @@ Every record in a per-app data table must be keyed by `accountId`. Every
 handler that reads or writes per-app data must verify the caller's membership
 in that account before touching DynamoDB.
 
-Handlers enforce this by calling:
+Handlers enforce this with the data-authority factory (D9, M16):
 
 ```typescript
-requireAccountAccess(auth, 'stock-analyser', accountId)
-// or
-requireAccountAccess(auth, 'budget-tracker', accountId, 'member')
+const saData = requireAccountData('stock-analyser');
+saData.read(auth, accountId);                          // read tier — claims only, viewer passes
+await saData.write(auth, accountId, membershipLoader); // write tier — claims + live members row
 ```
 
-The `accountId` used in DynamoDB operations is always the one already verified
-against the caller's LaunchpadAuth-issued `accounts` claim.
+There is **no site-admin data bypass** — membership is the only grant of data
+authority. The `accountId` used in DynamoDB operations is always the one
+already verified against the caller's LaunchpadAuth-issued `accounts` claim.
+(`requireAccountAccess` was deleted in M16 Phase 5.)
+
+**Row-class authorization in mixed partitions (D12).** Within a single per-app
+table, item key shape determines the authorization tier, not the route:
+
+- **Account-shared rows** (`PK=accountId`, no user dimension — e.g. Budget
+  Tracker transactions/rules/budget-data/settings) are governed by the D8 write
+  tier: a `viewer` reads but cannot write.
+- **User-scoped rows** (`SK` carries the user, e.g. Stock Analyser settings
+  `SK=USER#{userId}#PREFERENCES`) require membership **and** an SK-owner match.
+  A `viewer` may write their **own** preference row because the write affects
+  only their own data; cross-user writes within the account are denied. These
+  routes therefore use `.read` (membership floor), with the per-user SK scoping
+  the mutation to the caller.
 
 ## Account relationships example
 

--- a/docs/architecture/inventory.md
+++ b/docs/architecture/inventory.md
@@ -181,3 +181,27 @@ After Platform auth decommission deploy:
 - Migration Utilities authorize LaunchpadAuth tokens.
 - Platform deploy manages substrate only plus the one-time empty legacy stack
   templates needed to delete former resources.
+
+## M16 Authorization Model (Phase 5)
+
+Current authorization state after the two-axis policy foundation lands
+(`docs/adr-m16-runtime-architecture.md` D9/D11; PR #440):
+
+- **Data authority is membership-only.** App-data routes in Stock Analyser and
+  Budget Tracker are gated by the `requireAccountData(appSlug)` factory in
+  `packages/lambda-middleware` (`.read` = claims-only, viewer passes; `.write` =
+  claims + live `launchpad-account-members` row, viewer denied). There is no
+  site-admin branch on the data path. The per-route migration record is
+  `docs/architecture/route-classification-m16.md`.
+- **`requireAccountAccess` and `requireAccountOwner` are deleted** (not
+  deprecated) from `packages/lambda-middleware`; zero remaining callers.
+  Supervisory/ownership routes use `requireAccountAdmin(...)`.
+- **Pre-token site-admin override removed (D11.1).** The app-access invariant in
+  `launchpad-pre-token-generation-{stage}` now applies uniformly; the former
+  site-admin group-retention and all-apps shortcuts are gone. `site_admin` is
+  sourced solely from the claim path and drives supervisory surfaces only.
+- **Cache and AI write gates added.** SA `analysis-cache` writes and BT
+  `budget-ai` routes are now write-gated (member-tier) and granted GetItem on
+  `launchpad-account-members-{stage}` via `grantMembershipRead`. AI-config
+  overrides remain member-tier write + interim `requireSiteAdmin` pending the
+  operational-config admin axis (PR-C, #416).

--- a/docs/architecture/route-classification-m16.md
+++ b/docs/architecture/route-classification-m16.md
@@ -100,7 +100,7 @@ This table is the **security-review artifact** for the site-admin-bypass removal
 
 1. **BT AI routes — `POST /ai/review`, `POST /ai/csv-analysis` (budget-ai).** **RULING: member-tier (`requireAccountData.write` semantics)** — claims + live membership row, **viewer rejected**. Running AI consumes provider cost and writes a job row; viewers stay read-only. *Implementation note: budget-ai gains a membership loader + `dynamodb:GetItem` grant on `launchpad-account-members-{stage}` (it previously had claims only).*
 
-2. **`PUT /accounts/{accountId}` (updateAccount).** **RULING: owner-or-manager** → `requireAccountAdmin(account-owner-or-manager)`. Managers may edit account settings (matrix default).
+2. **`PUT /accounts/{accountId}` (updateAccount).** **RULING: owner-or-manager** → `requireAccountAdmin(account-owner-or-manager)`. Managers may edit account settings (matrix default). *Field-guard caveat: owner-or-manager applies to general account settings ONLY. Ownership and billing fields (e.g. `ownerId`, ownership transfer) remain owner-only and MUST be enforced via a field-level guard inside the Phase-6 updateAccount handler. A manager must not be able to PUT a change to `ownerId`.*
 
 3. **`GET /accounts/{accountId}` and `GET …/members`.** **RULING: any active member** → `requireAccountAdmin(account-member)`. Any active member may view their account's metadata + member list.
 

--- a/docs/architecture/route-classification-m16.md
+++ b/docs/architecture/route-classification-m16.md
@@ -69,9 +69,9 @@ This table is the **security-review artifact** for the site-admin-bypass removal
 | `GET /api/user/active-accounts` | user | withAuthOnly | `auth-only` (self) | own selections (D7) | Confirmed | PR-B (doc only) |
 | `PUT /api/user/active-accounts/{appSlug}` | user | withAuthOnly + table membership verify | `auth-only` (self) + membership verify (D7) | self-service; verifies own membership | Confirmed | PR-B (doc only) |
 | `POST /accounts` | accounts | withAuth | `auth-only` (creator-owns) | **withAuth requires X-Account-Id to CREATE an account — see ruling #4** | Status-uncertain | verify |
-| `GET /accounts/{accountId}` | accounts | withAuth + ad-hoc `members.some` | `requireAccountAdmin(account-member)` | account metadata; used by app selectors | **see ruling #3** | PR-B |
-| `GET /accounts/{accountId}/members` | accounts | withAuth + ad-hoc `members.some` | `requireAccountAdmin(account-member)` | member list | **see ruling #3** | PR-B |
-| `PUT /accounts/{accountId}` | accounts | withAuth + ad-hoc `ownerId===userId` | `requireAccountAdmin(owner-or-manager)` | account settings | **see ruling #2** (manager scope) | PR-B |
+| `GET /accounts/{accountId}` | accounts | withAuth + ad-hoc `members.some` | `requireAccountAdmin(account-member)` | account metadata; used by app selectors | **ruling #3: any member** | **Phase 6** † |
+| `GET /accounts/{accountId}/members` | accounts | withAuth + ad-hoc `members.some` | `requireAccountAdmin(account-member)` | member list | **ruling #3: any member** | **Phase 6** † |
+| `PUT /accounts/{accountId}` | accounts | withAuth + ad-hoc `ownerId===userId` | `requireAccountAdmin(account-owner-or-manager)` | account settings | **ruling #2: owner-or-manager** | **Phase 6** † |
 | `DELETE /accounts/{accountId}` | accounts | withAuth + ad-hoc owner | `requireAccountAdmin(owner)` + sole-owner deletion (D9 §9.3) | destructive | Status-uncertain-resolved | **Phase 6** (mutation) |
 | `DELETE /accounts/{accountId}/members/{userId}` | accounts | withAuth + ad-hoc | `requireAccountAdmin(anyOf(owner-or-manager + last-owner-guard, supervisory-site-admin))` | remove member | Aspirational (manager-removal rules never built) | **Phase 6** (mutation) |
 | `POST /accounts/{accountId}/invitations` | invitations | withAuth + ad-hoc `ownerId===userId` | `requireAccountAdmin(owner-or-manager / canCreateInvitationGrant)` | legacy single-invite | Aspirational (owner/manager in-app invite never built) | **Phase 8** (bundles) |
@@ -79,6 +79,8 @@ This table is the **security-review artifact** for the site-admin-bypass removal
 | `GET /api/admin/ai-runtime-config` | ai-runtime-config | requireSiteAdmin | `operational-config` (supervisory-site-admin read) | platform AI config | Confirmed | PR-B / PR-C |
 | `PUT …/ai-runtime-config/platform-default` | ai-runtime-config | requireSiteAdmin | `operational-config` (site-admin **default**, D9) | platform default | Confirmed | PR-B / PR-C |
 | `PUT/DELETE …/ai-runtime-config/apps/{appSlug}/override` | ai-runtime-config | requireSiteAdmin | `operational-config` → **app-admin override** (D9) | per-app override | Status-uncertain-resolved | **PR-C** |
+
+> **† PR-B scope boundary (launchpad `accounts` handler).** The `accounts` Lambda co-locates the read/settings routes above with the **member-management mutation** routes (`removeMember`, `deleteAccount`) that are explicitly **Phase 6**, plus `createAccount`. Migrating it onto `requireAccountAdmin` is done as **one coherent pass in Phase 6** rather than partially in PR-B, to avoid touching the Phase-6 mutation paths in this security PR. Its current ad-hoc checks (`ownerId===userId`, `members.some`) are **not** a site-admin bypass — they already gate on ownership/membership — so the D9 site-admin-bypass-removal goal is fully met by PR-B without them. The rulings above are recorded as the authority for that Phase-6 migration. `access-summary` (site-admin) and the `/api/user/*` self routes ARE correct as-is and need no migration.
 
 ## 4. Non-REST-route functions (no route classification; documented for completeness)
 
@@ -92,17 +94,17 @@ This table is the **security-review artifact** for the site-admin-bypass removal
 
 ---
 
-## 5. Needs owner ruling (HOLD — bulk migration proceeds on the rest)
+## 5. Owner rulings — RESOLVED (2026-06-12)
 
-> Per instruction: routes that resist clean classification are listed here for adjudication; everything else is classified and ready to migrate.
+> Adjudicated by owner before the bulk migration. Recorded here as the authority for PR-B.
 
-1. **BT AI routes — `POST /ai/review`, `POST /ai/csv-analysis` (budget-ai).** These are **actions** (run AI over the caller's transactions, stream suggestions, create a job row keyed by account) — neither a pure read nor an account-data mutation. They fit neither `.read` (a POST that creates a job) nor cleanly `.write` (they don't mutate stored account data, but gating as write **excludes viewers** from a read-like analysis). **Ruling needed:** is running AI review a **member-tier action** (viewer excluded → `requireAccountData.write` semantics: claims + live row, viewer-reject) or a **viewer-permitted read-like op** (`requireAccountData.read`)? *Recommendation: member-tier (`.write`) — it consumes provider cost and writes a job row; viewers stay read-only.* Marked HOLD pending your call.
+1. **BT AI routes — `POST /ai/review`, `POST /ai/csv-analysis` (budget-ai).** **RULING: member-tier (`requireAccountData.write` semantics)** — claims + live membership row, **viewer rejected**. Running AI consumes provider cost and writes a job row; viewers stay read-only. *Implementation note: budget-ai gains a membership loader + `dynamodb:GetItem` grant on `launchpad-account-members-{stage}` (it previously had claims only).*
 
-2. **`PUT /accounts/{accountId}` (updateAccount) — manager scope.** Code today is **owner-only** (ad-hoc `ownerId===userId`). Matrix §6.3 "Change account settings" = owner **Yes**, manager **"Yes, if allowed"** — the "if allowed" product rule is undefined. **Ruling needed:** may a **manager** edit account settings, or owner-only? *Recommendation: owner-or-manager (matrix default), but confirm.*
+2. **`PUT /accounts/{accountId}` (updateAccount).** **RULING: owner-or-manager** → `requireAccountAdmin(account-owner-or-manager)`. Managers may edit account settings (matrix default).
 
-3. **`GET /accounts/{accountId}` and `GET …/members` — visibility tier.** Code today allows **any member** to read account metadata + the member list. The matrix is silent on plain-member member-list visibility (only "view users known through managed accounts" = owner/manager). The bundle-visibility rule (D9) says a member list *may* be shown but doesn't say to whom. **Ruling needed:** is the member list visible to **any member** (current) or **owner/manager only**? *Recommendation: any active member can view their own account's members (account-member); confirm.*
+3. **`GET /accounts/{accountId}` and `GET …/members`.** **RULING: any active member** → `requireAccountAdmin(account-member)`. Any active member may view their account's metadata + member list.
 
-4. **`POST /accounts` under `withAuth` (createAccount).** `withAuth` resolves and requires an `X-Account-Id` header — but creating a *new* account has no existing account context. **Verify:** does this route actually require a (stale/arbitrary) `X-Account-Id` to create an account? If so it is a latent bug (should be `withAuthOnly`). Flagged for verification during migration; not blocking.
+4. **`POST /accounts` under `withAuth` (createAccount).** Verify during migration whether account creation wrongly requires an `X-Account-Id` (should be `withAuthOnly`). Not a policy ruling — a code-fact check; if confirmed a latent bug, fix in PR-B, else note.
 
 ---
 

--- a/docs/architecture/route-classification-m16.md
+++ b/docs/architecture/route-classification-m16.md
@@ -1,0 +1,121 @@
+# M16 Route Classification (Phase 5 / ADR D9)
+
+**Status:** Draft for owner adjudication — produced as the first artifact of Phase 5 PR-B, *before* the bulk route migration, so disagreements surface here rather than inside a large diff (per owner instruction).
+**Date:** 2026-06-12
+**Consumes:** ADR v1.3 D5/D8/D9/D11/D12; permissions model §6.3 matrix, §8 discovery, §10 settings; #416 rulings.
+
+This table is the **security-review artifact** for the site-admin-bypass removal (ADR D9): every existing route is mapped to its new middleware. It doubles as the **auth.md verification sweep** (CONTRIBUTING §8 tags). Completeness over speed.
+
+## Legend
+
+**New middleware / policy**
+- `requireAccountData(app).read` — D9 data tier, claims-only membership (viewer **allowed**). **No site-admin branch.**
+- `requireAccountData(app).write` — D9 data tier, claims + live row read; viewer / disabled / missing → 403. **No site-admin branch.**
+- `requireAccountAdmin(policy)` — D9 admin tier (Launchpad control plane); target-resolved table policy.
+- `auth-only` — authenticated, self-scoped (no account target).
+- `public` — no auth.
+- `operational-config` — D9 administrative-axis service config (site-admin default / app-admin override); grants no account-data access.
+- `ws-authorizer` / `internal-invoke` / `health` — non-REST-route Lambdas.
+
+**auth.md verification tag** (CONTRIBUTING §8): `Confirmed` · `Aspirational-never-built` · `Status-uncertain-resolved`.
+
+**Migrates in:** which phase actually swaps the guard. PR-B = this phase. Phase 6/8/9 = deferred mutation/invitation/redemption surfaces (out of Phase 5 scope). PR-C = AI-config rehoming.
+
+---
+
+## 1. Stock Analyser — app-data routes (`requireAccountData('stock-analyser')`)
+
+| Route | Handler | Current guard | New middleware | Row-class / notes | Tag | Migrates |
+|---|---|---|---|---|---|---|
+| `GET /cycle-data` | cycle-data | requireAppAccess + requireAccountAccess(member) | `requireAccountData.read` | account-scoped read | Confirmed | PR-B |
+| `GET /market-data` | market-data | requireAppAccess + requireAccountAccess(member) | `requireAccountData.read` | account-scoped read | Confirmed | PR-B |
+| `GET /portfolio` | portfolio | …+ requireAccountAccess(member) | `requireAccountData.read` | account-shared read | Confirmed | PR-B |
+| `POST/PATCH/DELETE /portfolio` | portfolio | …+ requireAccountWrite | `requireAccountData.write` | account-shared write | Confirmed | PR-B |
+| `GET /watchlist` | watchlist | …+ requireAccountAccess(member) | `requireAccountData.read` | account-shared read | Confirmed | PR-B |
+| `POST/PATCH/DELETE /watchlist` | watchlist | …+ requireAccountWrite | `requireAccountData.write` | account-shared write | Confirmed | PR-B |
+| `GET /analysis-cache/{key}` | analysis-cache | …+ requireAccountAccess(member) | `requireAccountData.read` | account-scoped cache read | Confirmed | PR-B |
+| `PUT/DELETE /analysis-cache/{key}` | analysis-cache | …+ requireAccountAccess(member) **only** | `requireAccountData.write` | **cache WRITE currently has no row-check** — write tier adds it | Status-uncertain-resolved | PR-B |
+| `GET /settings` | settings | …+ requireAccountAccess(member) | `requireAccountData.read` | **D12 user-scoped** `SK=USER#{userId}#PREFERENCES` | Confirmed | PR-B |
+| `PATCH /settings` | settings | …+ requireAccountAccess(member) | `requireAccountData.read` **+ handler SK-owner match** | **D12 user-scoped: viewer MAY write OWN prefs** — NOT `.write` (which rejects viewer) | Confirmed | PR-B |
+| `GET /ai-config` | settings | …+ requireAccountAccess(member) | `operational-config` (read) | effective AI config; retiring | Status-uncertain-resolved | PR-C |
+| `PUT/DELETE /ai-config/override` | settings | …+ **requireSiteAdmin** | `operational-config` → **app-admin** (D9) | per-account `APP#AI_RUNTIME`; **rehomed app-level** | Aspirational-never-built (site-admin write of account config) | PR-C |
+
+## 2. Budget Tracker — app-data routes (`requireAccountData('budget-tracker')`)
+
+| Route | Handler | Current guard | New middleware | Row-class / notes | Tag | Migrates |
+|---|---|---|---|---|---|---|
+| `GET /api/budget/v1/transactions` | budget-transactions | …+ requireAccountAccess(member) | `requireAccountData.read` | account-shared read | Confirmed | PR-B |
+| `POST(bulk)/PATCH/DELETE …/transactions` | budget-transactions | …+ requireAccountWrite | `requireAccountData.write` | account-shared write | Confirmed | PR-B |
+| `GET /api/budget/v1/rules` | budget-rules | …+ requireAccountAccess(member) | `requireAccountData.read` | account-shared read | Confirmed | PR-B |
+| `POST/PATCH/DELETE …/rules` | budget-rules | …+ requireAccountWrite | `requireAccountData.write` | account-shared write | Confirmed | PR-B |
+| `GET /api/budget/v1/budget-data` | budget-data | …+ requireAccountAccess(member) | `requireAccountData.read` | account-shared read | Confirmed | PR-B |
+| `PATCH /api/budget/v1/budget-data` | budget-data | …+ requireAccountWrite | `requireAccountData.write` | account-shared write | Confirmed | PR-B |
+| `GET /api/budget/v1/settings` | budget-settings | …+ requireAccountAccess(member) | `requireAccountData.read` | **D12 account-shared** `SK=settingKey` | Confirmed | PR-B |
+| `PATCH /api/budget/v1/settings` | budget-settings | …+ requireAccountWrite | `requireAccountData.write` | **D12 account-shared → viewer rejected** | Confirmed | PR-B |
+| `GET /api/budget/v1/business-export` | budget-export | …+ requireAccountAccess(member) | `requireAccountData.read` | export = read tier | Confirmed | PR-B |
+| `POST /api/budget/v1/ai/review` | budget-ai | …+ requireAccountAccess(member) | **see Needs-owner-ruling #1** | AI action; not a data mutation | Status-uncertain | **HOLD** |
+| `POST /api/budget/v1/ai/csv-analysis` | budget-ai | …+ requireAccountAccess(member) | **see Needs-owner-ruling #1** | AI action | Status-uncertain | **HOLD** |
+| `GET /api/budget/v1/ai-config` | budget-ai-config | …+ requireAccountAccess(member) | `operational-config` (read) | effective AI config; retiring | Status-uncertain-resolved | PR-C |
+| `PUT/DELETE …/ai-config/override` | budget-ai-config | …+ **requireSiteAdmin** | `operational-config` → **app-admin** (D9) | per-account `AI_CONFIG#APP#budget-tracker`; **rehomed app-level** | Aspirational-never-built | PR-C |
+
+## 3. Launchpad — control-plane routes
+
+| Route | Handler | Current guard | New middleware | Notes | Tag | Migrates |
+|---|---|---|---|---|---|---|
+| `POST /auth/lookup-provider` | forgot-provider | none (generic OK) | `public` | no enumeration oracle | Confirmed | PR-B (doc only) |
+| `POST /auth/setup` | account-provisioning | withAuthOnly | `auth-only` (self bootstrap) | D11 profile bootstrap | Confirmed | PR-B (doc only) |
+| `GET /api/user/profile` | user | withAuthOnly | `auth-only` (self) | own profile | Confirmed | PR-B (doc only) |
+| `PUT /api/user/preferences` | user | withAuthOnly | `auth-only` (self) | own prefs | Confirmed | PR-B (doc only) |
+| `GET /api/user/active-accounts` | user | withAuthOnly | `auth-only` (self) | own selections (D7) | Confirmed | PR-B (doc only) |
+| `PUT /api/user/active-accounts/{appSlug}` | user | withAuthOnly + table membership verify | `auth-only` (self) + membership verify (D7) | self-service; verifies own membership | Confirmed | PR-B (doc only) |
+| `POST /accounts` | accounts | withAuth | `auth-only` (creator-owns) | **withAuth requires X-Account-Id to CREATE an account — see ruling #4** | Status-uncertain | verify |
+| `GET /accounts/{accountId}` | accounts | withAuth + ad-hoc `members.some` | `requireAccountAdmin(account-member)` | account metadata; used by app selectors | **see ruling #3** | PR-B |
+| `GET /accounts/{accountId}/members` | accounts | withAuth + ad-hoc `members.some` | `requireAccountAdmin(account-member)` | member list | **see ruling #3** | PR-B |
+| `PUT /accounts/{accountId}` | accounts | withAuth + ad-hoc `ownerId===userId` | `requireAccountAdmin(owner-or-manager)` | account settings | **see ruling #2** (manager scope) | PR-B |
+| `DELETE /accounts/{accountId}` | accounts | withAuth + ad-hoc owner | `requireAccountAdmin(owner)` + sole-owner deletion (D9 §9.3) | destructive | Status-uncertain-resolved | **Phase 6** (mutation) |
+| `DELETE /accounts/{accountId}/members/{userId}` | accounts | withAuth + ad-hoc | `requireAccountAdmin(anyOf(owner-or-manager + last-owner-guard, supervisory-site-admin))` | remove member | Aspirational (manager-removal rules never built) | **Phase 6** (mutation) |
+| `POST /accounts/{accountId}/invitations` | invitations | withAuth + ad-hoc `ownerId===userId` | `requireAccountAdmin(owner-or-manager / canCreateInvitationGrant)` | legacy single-invite | Aspirational (owner/manager in-app invite never built) | **Phase 8** (bundles) |
+| `GET /api/admin/...access-summary` (access-summary) | access-summary | requireSiteAdmin (claim) | `requireAccountAdmin(supervisory-site-admin)` | directory read; app-admin app-scope = Phase 7 | Confirmed (extended P7) | PR-B |
+| `GET /api/admin/ai-runtime-config` | ai-runtime-config | requireSiteAdmin | `operational-config` (supervisory-site-admin read) | platform AI config | Confirmed | PR-B / PR-C |
+| `PUT …/ai-runtime-config/platform-default` | ai-runtime-config | requireSiteAdmin | `operational-config` (site-admin **default**, D9) | platform default | Confirmed | PR-B / PR-C |
+| `PUT/DELETE …/ai-runtime-config/apps/{appSlug}/override` | ai-runtime-config | requireSiteAdmin | `operational-config` → **app-admin override** (D9) | per-app override | Status-uncertain-resolved | **PR-C** |
+
+## 4. Non-REST-route functions (no route classification; documented for completeness)
+
+| Function | Type | Auth mechanism | Notes |
+|---|---|---|---|
+| SA/BT `ws-authorizer` | ws-authorizer | jwtVerify + `accountId ∈ token.accounts[app]` (claims membership) | WS-handshake equivalent of `requireAccountData.read`; **no site-admin branch** — Confirmed |
+| SA/BT `ws-connect` / `ws-disconnect` / `ws-default` | post-authorizer | consume authorizer context | no independent auth decision |
+| SA/BT `ai-proxy` | internal-invoke | none (sync Lambda invoke) | caller (data route) already gated; not API-exposed |
+| BT `budget-ai/review-worker` | internal-invoke | none (async Event invoke) | dispatched by reviewStart after its gate |
+| SA `cycle-check` | health | none | returns 200; no account data |
+
+---
+
+## 5. Needs owner ruling (HOLD — bulk migration proceeds on the rest)
+
+> Per instruction: routes that resist clean classification are listed here for adjudication; everything else is classified and ready to migrate.
+
+1. **BT AI routes — `POST /ai/review`, `POST /ai/csv-analysis` (budget-ai).** These are **actions** (run AI over the caller's transactions, stream suggestions, create a job row keyed by account) — neither a pure read nor an account-data mutation. They fit neither `.read` (a POST that creates a job) nor cleanly `.write` (they don't mutate stored account data, but gating as write **excludes viewers** from a read-like analysis). **Ruling needed:** is running AI review a **member-tier action** (viewer excluded → `requireAccountData.write` semantics: claims + live row, viewer-reject) or a **viewer-permitted read-like op** (`requireAccountData.read`)? *Recommendation: member-tier (`.write`) — it consumes provider cost and writes a job row; viewers stay read-only.* Marked HOLD pending your call.
+
+2. **`PUT /accounts/{accountId}` (updateAccount) — manager scope.** Code today is **owner-only** (ad-hoc `ownerId===userId`). Matrix §6.3 "Change account settings" = owner **Yes**, manager **"Yes, if allowed"** — the "if allowed" product rule is undefined. **Ruling needed:** may a **manager** edit account settings, or owner-only? *Recommendation: owner-or-manager (matrix default), but confirm.*
+
+3. **`GET /accounts/{accountId}` and `GET …/members` — visibility tier.** Code today allows **any member** to read account metadata + the member list. The matrix is silent on plain-member member-list visibility (only "view users known through managed accounts" = owner/manager). The bundle-visibility rule (D9) says a member list *may* be shown but doesn't say to whom. **Ruling needed:** is the member list visible to **any member** (current) or **owner/manager only**? *Recommendation: any active member can view their own account's members (account-member); confirm.*
+
+4. **`POST /accounts` under `withAuth` (createAccount).** `withAuth` resolves and requires an `X-Account-Id` header — but creating a *new* account has no existing account context. **Verify:** does this route actually require a (stale/arbitrary) `X-Account-Id` to create an account? If so it is a latent bug (should be `withAuthOnly`). Flagged for verification during migration; not blocking.
+
+---
+
+## 6. Deletion & sweep scope (PR-B)
+
+- **`requireAccountAccess` — DELETE.** 14 callers (all SA/BT app-data handlers above) migrate to `requireAccountData`. Zero callers remain → helper deleted from `packages/lambda-middleware/src/auth.ts`.
+- **`requireAccountOwner` — DELETE.** **0 callers** in the repo (launchpad uses ad-hoc `ownerId` checks, migrated to `requireAccountAdmin(owner…)`). Clean delete.
+- **`requireAppAccess` — RETAINED**, but no longer on app-data routes: `requireAccountData.read/write` checks `accounts[app]` membership, which subsumes app entitlement. Its site-admin branch therefore no longer sits on any app-data path. (Still used by `requireAnyAppAccess`/legacy; not in scope to delete.)
+- **Pre-token Lambda (D11.1):** remove the site-admin group-retention override in `reconcileInvariant` — the invariant applies uniformly; `site_admin` claim continues to drive supervisory surfaces only.
+- **Group-based admin sweep (#416):** `cognito:groups` site-admin fallback already removed in PR-A (auth-client). PR-B confirms no remaining group-based authorization in backend handlers (only `requireSiteAdmin`, which reads the `siteAdmin` claim — Confirmed, not group-based).
+
+## 7. auth.md verification summary (feeds the revision map)
+
+- **Confirmed:** all SA/BT data routes; user self routes; ws-authorizer claims check; access-summary site-admin; auth/setup; lookup-provider public.
+- **Aspirational-never-built:** owner/manager in-app invitations (invitations handler is owner-only single-invite, not the bundle model); manager member-removal rules; site-admin write of per-account AI config (was permitted by `requireSiteAdmin` but contradicts D9 — corrected via PR-C).
+- **Status-uncertain-resolved:** analysis-cache write row-check (added); member-list/account-metadata visibility (ruling #3); ai-config read tier (PR-C); createAccount account-context requirement (ruling #4).

--- a/migration-utilities/budget-tracker/budget-data/package.json
+++ b/migration-utilities/budget-tracker/budget-data/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@transformotion/budget-domain": "workspace:*",
+    "@transformotion/fn-account-membership": "workspace:*",
     "@transformotion/lambda-middleware": "workspace:*"
   },
   "devDependencies": {

--- a/migration-utilities/budget-tracker/budget-data/src/index.ts
+++ b/migration-utilities/budget-tracker/budget-data/src/index.ts
@@ -25,13 +25,19 @@ import {
   UpdateCommand,
   GetCommand,
 } from '@aws-sdk/lib-dynamodb';
-import { withAuth, parseBody, ok, requireAppAccess, requireAccountAccess } from '@transformotion/lambda-middleware';
+import { withAuth, parseBody, ok, requireAccountData } from '@transformotion/lambda-middleware';
+import { dynamoMembershipLoader } from '@transformotion/fn-account-membership';
 import { randomUUID } from 'crypto';
 import type { Category, Subcategory } from '@transformotion/budget-domain';
 
 const ddb = DynamoDBDocumentClient.from(new DynamoDBClient({}));
 const TRANSACTIONS_TABLE = process.env.TRANSACTIONS_TABLE!;
 const RULES_TABLE        = process.env.RULES_TABLE!;
+// D9: this import writes account data → write tier (live membership row; viewer/
+// disabled/removed → 403). No site-admin bypass — a migration is a data write
+// and requires account membership like any other write.
+const btData = requireAccountData('budget-tracker');
+const membershipLoader = dynamoMembershipLoader(ddb, process.env.ACCOUNT_MEMBERS_TABLE!);
 const SETTINGS_TABLE     = process.env.SETTINGS_TABLE!;
 const BUDGET_DATA_TABLE  = process.env.BUDGET_DATA_TABLE!;
 
@@ -309,8 +315,7 @@ function resolveSubcategoryId(
 // ── Handler ───────────────────────────────────────────────────────────────────
 
 export const handler = withAuth(async ({ auth, account, event }) => {
-  requireAppAccess(auth, 'budget-tracker');
-  requireAccountAccess(auth, 'budget-tracker', account.accountId);
+  await btData.write(auth, account.accountId, membershipLoader);
   const { accountId } = account;
 
   const body = parseBody<{ dryRun?: boolean }>(event);

--- a/migration-utilities/budget-tracker/transactions/package.json
+++ b/migration-utilities/budget-tracker/transactions/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@transformotion/budget-domain": "workspace:*",
+    "@transformotion/fn-account-membership": "workspace:*",
     "@transformotion/lambda-middleware": "workspace:*"
   },
   "devDependencies": {

--- a/migration-utilities/budget-tracker/transactions/src/index.ts
+++ b/migration-utilities/budget-tracker/transactions/src/index.ts
@@ -5,11 +5,15 @@ import {
   BatchWriteCommand,
 } from '@aws-sdk/lib-dynamodb';
 import { S3Client, GetObjectCommand } from '@aws-sdk/client-s3';
-import { withAuth, parseBody, ok, requireAppAccess, requireAccountAccess } from '@transformotion/lambda-middleware';
+import { withAuth, parseBody, ok, requireAccountData } from '@transformotion/lambda-middleware';
+import { dynamoMembershipLoader } from '@transformotion/fn-account-membership';
 import { randomUUID } from 'crypto';
 import type { Transaction } from '@transformotion/budget-domain';
 
 const ddb = DynamoDBDocumentClient.from(new DynamoDBClient({}));
+// D9: migration import writes account data → write tier (no site-admin bypass).
+const btData = requireAccountData('budget-tracker');
+const membershipLoader = dynamoMembershipLoader(ddb, process.env.ACCOUNT_MEMBERS_TABLE!);
 const s3  = new S3Client({});
 const TRANSACTIONS_TABLE       = process.env.TRANSACTIONS_TABLE!;
 const MIGRATION_UPLOADS_BUCKET = process.env.MIGRATION_UPLOADS_BUCKET!;
@@ -44,8 +48,7 @@ async function batchWrite(table: string, items: Record<string, unknown>[]) {
 
 // POST /api/migrations/budget-tracker/transactions/import
 export const handler = withAuth(async ({ auth, account, event }) => {
-  requireAppAccess(auth, 'budget-tracker');
-  requireAccountAccess(auth, 'budget-tracker', account.accountId);
+  await btData.write(auth, account.accountId, membershipLoader);
   const { accountId } = account;
 
   const { s3Key } = parseBody<{ s3Key: string }>(event);

--- a/packages/lambda-middleware/src/auth.test.ts
+++ b/packages/lambda-middleware/src/auth.test.ts
@@ -3,8 +3,6 @@ import {
   requireSiteAdmin,
   requireAppAccess,
   requireAnyAppAccess,
-  requireAccountAccess,
-  requireAccountOwner,
   requireAccountWrite,
   requireGroup,
   extractAuthClaims,
@@ -172,100 +170,9 @@ describe('requireAnyAppAccess', () => {
   });
 });
 
-// ── requireAccountAccess ──────────────────────────────────────────────────────
-
-describe('requireAccountAccess', () => {
-  it('passes when user has member access to account', () => {
-    expect(() => requireAccountAccess(
-      makeClaims({ accounts: { 'budget-tracker': [{ accountId: 'acc-1', role: 'member' }] } }),
-      'budget-tracker', 'acc-1',
-    )).not.toThrow();
-  });
-
-  it('passes when user has viewer access and viewer is required', () => {
-    expect(() => requireAccountAccess(
-      makeClaims({ accounts: { 'budget-tracker': [{ accountId: 'acc-1', role: 'viewer' }] } }),
-      'budget-tracker', 'acc-1', 'viewer',
-    )).not.toThrow();
-  });
-
-  it('throws 403 when user has viewer but member is required', () => {
-    expect(() => requireAccountAccess(
-      makeClaims({ accounts: { 'budget-tracker': [{ accountId: 'acc-1', role: 'viewer' }] } }),
-      'budget-tracker', 'acc-1', 'member',
-    )).toThrow(HttpError);
-  });
-
-  it('passes when user has manager access and member is required', () => {
-    expect(() => requireAccountAccess(
-      makeClaims({ accounts: { 'budget-tracker': [{ accountId: 'acc-1', role: 'manager' }] } }),
-      'budget-tracker', 'acc-1', 'member',
-    )).not.toThrow();
-  });
-
-  it('passes when user has owner access and manager is required', () => {
-    expect(() => requireAccountAccess(
-      makeClaims({ accounts: { 'budget-tracker': [{ accountId: 'acc-1', role: 'owner' }] } }),
-      'budget-tracker', 'acc-1', 'manager',
-    )).not.toThrow();
-  });
-
-  it('throws 403 when user has member but manager is required', () => {
-    expect(() => requireAccountAccess(
-      makeClaims({ accounts: { 'budget-tracker': [{ accountId: 'acc-1', role: 'member' }] } }),
-      'budget-tracker', 'acc-1', 'manager',
-    )).toThrow(HttpError);
-  });
-
-  it('throws 403 when user has access to different account only', () => {
-    expect(() => requireAccountAccess(
-      makeClaims({ accounts: { 'budget-tracker': [{ accountId: 'acc-2', role: 'member' }] } }),
-      'budget-tracker', 'acc-1',
-    )).toThrow(HttpError);
-  });
-
-  it('throws 403 when accounts claim is empty (fail closed — no group fallback)', () => {
-    expect(() => requireAccountAccess(
-      makeClaims({ groups: ['budget-app'] }), 'budget-tracker', 'acc-1',
-    )).toThrow(HttpError);
-  });
-
-  it('throws 403 when accounts claim is empty', () => {
-    expect(() => requireAccountAccess(makeClaims(), 'budget-tracker', 'acc-1')).toThrow(HttpError);
-  });
-
-  it('passes for site admin', () => {
-    expect(() => requireAccountAccess(
-      makeClaims({ siteAdmin: true }), 'budget-tracker', 'acc-1',
-    )).not.toThrow();
-  });
-});
-
-// ── requireAccountOwner ───────────────────────────────────────────────────────
-
-describe('requireAccountOwner', () => {
-  it('passes when user has owner role', () => {
-    expect(() => requireAccountOwner(
-      makeClaims({ accounts: { 'budget-tracker': [{ accountId: 'acc-1', role: 'owner' }] } }),
-      'budget-tracker', 'acc-1',
-    )).not.toThrow();
-  });
-
-  it('throws 403 when user has manager but not owner', () => {
-    expect(() => requireAccountOwner(
-      makeClaims({ accounts: { 'budget-tracker': [{ accountId: 'acc-1', role: 'manager' }] } }),
-      'budget-tracker', 'acc-1',
-    )).toThrow(HttpError);
-  });
-
-  it('throws 403 when accounts claim is empty', () => {
-    expect(() => requireAccountOwner(makeClaims(), 'budget-tracker', 'acc-1')).toThrow(HttpError);
-  });
-
-  it('passes for site admin', () => {
-    expect(() => requireAccountOwner(makeClaims({ siteAdmin: true }), 'budget-tracker', 'acc-1')).not.toThrow();
-  });
-});
+// requireAccountAccess and requireAccountOwner were DELETED in M16 Phase 5 (D9).
+// Their replacements (requireAccountData / requireAccountAdmin + policy guards)
+// are covered by policy.test.ts. No site-admin data bypass exists any more.
 
 // ── resolveAccountContext ─────────────────────────────────────────────────────
 

--- a/packages/lambda-middleware/src/auth.ts
+++ b/packages/lambda-middleware/src/auth.ts
@@ -89,11 +89,6 @@ function isSuperUser(auth: AuthClaims): boolean {
   return auth.siteAdmin;
 }
 
-function hasRequiredRole(roles: string[], minRole: AccountRole): boolean {
-  const minIdx = ROLE_HIERARCHY.indexOf(minRole);
-  return roles.some(r => ROLE_HIERARCHY.indexOf(r as AccountRole) >= minIdx);
-}
-
 /**
  * Throws HttpError(403) unless the user has the site_admin claim or is in the
  * legacy 'admin' / 'site-admin' Cognito group.
@@ -126,26 +121,6 @@ export function requireAnyAppAccess(auth: AuthClaims, apps: string[]): void {
   if (isSuperUser(auth)) return;
   if (apps.some(app => auth.apps.includes(app as EntitledAppSlug))) return;
   throw forbidden(`Access to one of [${apps.join(', ')}] required`);
-}
-
-/**
- * Throws HttpError(403) unless the user has at least `minRole` access to
- * `accountId` within `app`.
- * Passes if `auth.siteAdmin === true`, or `auth.accounts[app]` contains a
- * membership for `accountId` with role ≥ minRole.
- * Role hierarchy (ascending): viewer < member < manager < owner.
- */
-export function requireAccountAccess(
-  auth: AuthClaims,
-  app: AppName,
-  accountId: string,
-  minRole: AccountRole = 'member',
-): void {
-  if (isSuperUser(auth)) return;
-  const appAccounts = auth.accounts[app] ?? [];
-  const membership = appAccounts.find(m => m.accountId === accountId);
-  if (membership && hasRequiredRole([membership.role], minRole)) return;
-  throw forbidden(`Account access required (accountId: ${accountId}, minRole: ${minRole})`);
 }
 
 /** A live membership row, loaded from the account-members table by the caller. */
@@ -219,21 +194,8 @@ export async function requireAccountWrite(
   }
 }
 
-/**
- * Throws HttpError(403) unless the user is the owner of `accountId` within `app`.
- *
- * Checks (in order):
- *   1. site_admin / admin group → always passes
- *   2. `auth.accounts[app]` has a membership for `accountId` with role 'owner'
- */
-export function requireAccountOwner(
-  auth: AuthClaims,
-  app: AppName,
-  accountId: string,
-): void {
-  if (isSuperUser(auth)) return;
-  const appAccounts = auth.accounts[app] ?? [];
-  const membership = appAccounts.find(m => m.accountId === accountId);
-  if (membership?.role === 'owner') return;
-  throw forbidden(`Account ownership required (accountId: ${accountId})`);
-}
+// requireAccountAccess and requireAccountOwner were DELETED in M16 Phase 5 (D9):
+// the site-admin-bypassing data-tier check is replaced by requireAccountData
+// (no site-admin branch) for app data, and by requireAccountAdmin(...) policies
+// for control-plane ownership/role operations. See policy.ts and
+// docs/architecture/route-classification-m16.md.

--- a/packages/lambda-middleware/src/index.ts
+++ b/packages/lambda-middleware/src/index.ts
@@ -31,9 +31,8 @@
 //   requireSiteAdmin(auth)                              — throws 403 unless site admin
 //   requireAppAccess(auth, app)                         — throws 403 unless user has app access
 //   requireAnyAppAccess(auth, apps)                     — throws 403 unless user has access to any of the apps
-//   requireAccountAccess(auth, app, accountId, minRole) — throws 403 unless user has account access
-//   requireAccountOwner(auth, app, accountId)           — throws 403 unless user owns account
 //   requireAccountWrite(auth, app, accountId, loader)   — D8 write-path: claims + live row (viewer/disabled/missing → 403)
+//   (requireAccountAccess / requireAccountOwner were DELETED in M16 Phase 5 — use the policy layer below)
 
 export { withAuth, withAuthOnly, withPublic }            from './middleware';
 export { ok, created, noContent, errorResponse }        from './response';
@@ -45,8 +44,6 @@ export {
   requireSiteAdmin,
   requireAppAccess,
   requireAnyAppAccess,
-  requireAccountAccess,
-  requireAccountOwner,
   requireAccountWrite,
 }                                                       from './auth';
 export type {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -289,6 +289,9 @@ importers:
       '@transformotion/budget-domain':
         specifier: workspace:*
         version: link:../../../../packages/budget-domain
+      '@transformotion/fn-account-membership':
+        specifier: workspace:*
+        version: link:../../../../packages/fn-account-membership
       '@transformotion/lambda-middleware':
         specifier: workspace:*
         version: link:../../../../packages/lambda-middleware
@@ -1053,6 +1056,9 @@ importers:
 
   apps/stock-analyser/functions/analysis-cache:
     dependencies:
+      '@transformotion/fn-account-membership':
+        specifier: workspace:*
+        version: link:../../../../packages/fn-account-membership
       '@transformotion/lambda-middleware':
         specifier: workspace:*
         version: link:../../../../packages/lambda-middleware
@@ -1273,6 +1279,9 @@ importers:
       '@transformotion/budget-domain':
         specifier: workspace:*
         version: link:../../../packages/budget-domain
+      '@transformotion/fn-account-membership':
+        specifier: workspace:*
+        version: link:../../../packages/fn-account-membership
       '@transformotion/lambda-middleware':
         specifier: workspace:*
         version: link:../../../packages/lambda-middleware
@@ -1298,6 +1307,9 @@ importers:
       '@transformotion/budget-domain':
         specifier: workspace:*
         version: link:../../../packages/budget-domain
+      '@transformotion/fn-account-membership':
+        specifier: workspace:*
+        version: link:../../../packages/fn-account-membership
       '@transformotion/lambda-middleware':
         specifier: workspace:*
         version: link:../../../packages/lambda-middleware

--- a/scripts/ci/check-handler-authz-pattern.sh
+++ b/scripts/ci/check-handler-authz-pattern.sh
@@ -11,8 +11,10 @@
 #   (also matches the @aws-sdk/lib-dynamodb Document client variants)
 #
 # Authorization helpers that satisfy the check:
-#   requireAppAccess, requireAnyAppAccess, requireAccountAccess,
-#   requireAccountOwner, requireSiteAdmin
+#   requireAppAccess, requireAnyAppAccess, requireAccountData,
+#   requireAccountAdmin, requireSiteAdmin
+#   (requireAccountAccess / requireAccountOwner were deleted in M16 Phase 5,
+#    D9 — superseded by the requireAccountData / requireAccountAdmin factories.)
 #
 # This is a coarse file-level check - it confirms authorization helpers are
 # present in any file that performs DynamoDB work. It does not verify call
@@ -49,7 +51,7 @@ EXEMPT_PATH_PREFIXES=(
 )
 
 DYNAMO_PATTERN='PutItemCommand|GetItemCommand|QueryCommand|ScanCommand|UpdateItemCommand|DeleteItemCommand|TransactWriteCommand|BatchGetCommand|BatchWriteCommand'
-AUTHZ_PATTERN='requireAppAccess|requireAnyAppAccess|requireAccountAccess|requireAccountOwner|requireSiteAdmin'
+AUTHZ_PATTERN='requireAppAccess|requireAnyAppAccess|requireAccountData|requireAccountAdmin|requireSiteAdmin'
 
 echo "Checking handler authorization patterns..."
 
@@ -90,7 +92,7 @@ fi
 echo ""
 echo "ERROR: The following handlers perform DynamoDB operations without calling"
 echo "an authorization helper (requireAppAccess, requireAnyAppAccess,"
-echo "requireAccountAccess, requireAccountOwner, or requireSiteAdmin)."
+echo "requireAccountData, requireAccountAdmin, or requireSiteAdmin)."
 echo ""
 echo "Violations:"
 for f in "${VIOLATIONS[@]}"; do


### PR DESCRIPTION
## Phase 5 PR-B — route classification (first), then bulk migration

Per owner instruction, the **route-classification table is the first commit** and is presented for review/adjudication **before** the bulk route migration, so disagreements surface here rather than inside a ~15-handler diff.

**First commit:** `docs/architecture/route-classification-m16.md` — every route across launchpad/SA/BT → its new middleware, with D12 row-class notes and auth.md verification tags. This is the D9 security-review artifact for the site-admin-bypass removal.

### Deletion / sweep scope (confirmed)
- `requireAccountAccess` — **14 callers** (all SA/BT app-data handlers) → migrate to `requireAccountData`; then delete (zero callers).
- `requireAccountOwner` — **0 callers** → clean delete.
- Pre-token Lambda: remove the site-admin group-retention override (D11.1).
- `cognito:groups` admin fallback already gone (PR-A); no other group-based authorization in backend handlers.

### ⚠️ HOLD — needs owner ruling before migration (§5 of the table)
1. **BT AI routes** (`POST /ai/review`, `/ai/csv-analysis`) — action tier: viewer-excluded (`.write`) or viewer-permitted (`.read`)? *Rec: member-tier `.write`.*
2. **`PUT /accounts/{id}`** — may a **manager** edit account settings, or owner-only? (Matrix says "manager: yes, if allowed" — undefined.) *Rec: owner-or-manager.*
3. **`GET /accounts/{id}` + `…/members`** — member-list/metadata visible to **any member** (current) or owner/manager only? *Rec: any active member.*
4. **`POST /accounts`** under `withAuth` — does account creation wrongly require `X-Account-Id`? (verify; likely should be `withAuthOnly`).

### Not in this PR (scope guards)
Member-management mutations (removeMember, deleteAccount) → **Phase 6**; invitations → **Phase 8**; AI-config rehoming + operational-config regating → **PR-C**. These routes are *classified* here but their guards migrate in their owning phase.

## Next step
**STOPPING for review of the classification + the 4 rulings.** On your adjudication I'll: migrate the SA/BT data routes to `requireAccountData`, delete `requireAccountAccess`/`requireAccountOwner`, remove the pre-token override, and ride the auth.md + inventory.md updates — then validate, push onto this PR, and STOP again before merge.

## v0 freshness
- [x] No v0 impact

Reason: no UI-affecting paths across the full PR — route-classification doc, SA/BT data-route migration to requireAccountData, helper deletion, pre-token override, and architecture docs only. Changed surfaces: packages/lambda-middleware, apps/*/functions, apps/*/infrastructure, docs. No contract, mock, API payload, WSS, or UI change.

Refs #416, #411