### PR TITLE
M16 Phase 6 PR-6A: account reads + name + loader wiring

### DIFF
--- a/apps/launchpad/functions/accounts/package.json
+++ b/apps/launchpad/functions/accounts/package.json
@@ -9,6 +9,7 @@
     "lint": "echo \"lint: launchpad accounts\""
   },
   "dependencies": {
+    "@transformotion/contracts": "workspace:*",
     "@transformotion/lambda-middleware": "workspace:*"
   },
   "devDependencies": {

--- a/apps/launchpad/functions/accounts/src/index.ts
+++ b/apps/launchpad/functions/accounts/src/index.ts
@@ -8,7 +8,7 @@ import {
   TransactWriteCommand,
 } from '@aws-sdk/lib-dynamodb';
 import {
-  withAuth,
+  withAuthOnly,
   parseBody,
   getPathParam,
   ok,
@@ -17,8 +17,16 @@ import {
   badRequest,
   forbidden,
   notFound,
+  requireAccountAdmin,
+  requireAccountMember,
+  requireAccountOwnerOrManager,
+  requireAccountOwnerRole,
+  UNIFORM_DENY,
   type APIGatewayProxyEvent,
+  type MembershipLoader,
 } from '@transformotion/lambda-middleware';
+import type { AccountMemberRow, ListAccountMembersResponse } from '@transformotion/contracts/launchpad/invitations';
+import type { AccountRole, UserStatus } from '@transformotion/contracts/_shared/auth';
 import { randomUUID } from 'crypto';
 
 const ddb = DynamoDBDocumentClient.from(new DynamoDBClient({}));
@@ -33,6 +41,47 @@ const APP_CLIENT_TO_SLUG: Record<string, string> = Object.fromEntries(
     slug,
   ]),
 );
+
+/** Raw account-members row shape as stored. */
+interface MemberRecord {
+  userId: string;
+  email?: string;
+  role: string;
+  joinedAt: string;
+  status?: string;
+}
+
+/**
+ * Per-request shared wiring (M16 Phase 6): load the account row and ALL member
+ * rows ONCE, and build an in-memory single-row MembershipLoader closing over the
+ * array — so the policy guards (requireAccountMember / requireAccountOwnerOrManager)
+ * resolve the caller's authority with no second GetItem. Used by R1/R2/R3.
+ */
+async function loadAccountContext(accountId: string): Promise<{
+  account: Record<string, unknown> | undefined;
+  members: MemberRecord[];
+  callerLoader: MembershipLoader;
+}> {
+  const [accountRes, membersRes] = await Promise.all([
+    ddb.send(new GetCommand({ TableName: ACCOUNTS_TABLE, Key: { accountId } })),
+    ddb.send(new QueryCommand({
+      TableName: ACCOUNT_MEMBERS_TABLE,
+      KeyConditionExpression: 'accountId = :aid',
+      ExpressionAttributeValues: { ':aid': accountId },
+    })),
+  ]);
+  const members = (membersRes.Items ?? []) as MemberRecord[];
+  const callerLoader: MembershipLoader = async (_accountId, userId) => {
+    const m = members.find((row) => row.userId === userId);
+    return m ? { role: m.role as AccountRole, status: m.status } : undefined;
+  };
+  return { account: accountRes.Item, members, callerLoader };
+}
+
+// R3 field-guard (ruling #2): managers + owners may set general account settings
+// (today only `name`); ownership/billing fields are owner-only and exposed by no UI.
+const MANAGER_WRITABLE_FIELDS = new Set(['name']);
+const OWNER_ONLY_FIELDS = new Set(['ownerId']);
 
 async function createAccount(event: APIGatewayProxyEvent, userId: string, email: string) {
   const { name } = parseBody<{ name: string }>(event);
@@ -88,32 +137,19 @@ async function createAccount(event: APIGatewayProxyEvent, userId: string, email:
   });
 }
 
+// R1 — GET /accounts/{accountId}: any ACTIVE member (ruling #3). Uniform-deny on
+// non-member AND on a missing account, so account existence is not probeable.
 async function getAccount(accountId: string, userId: string) {
-  const [accountRes, membersRes] = await Promise.all([
-    ddb.send(new GetCommand({ TableName: ACCOUNTS_TABLE, Key: { accountId } })),
-    ddb.send(new QueryCommand({
-      TableName: ACCOUNT_MEMBERS_TABLE,
-      KeyConditionExpression: 'accountId = :aid',
-      ExpressionAttributeValues: { ':aid': accountId },
-    })),
-  ]);
-
-  if (!accountRes.Item) throw notFound(`Account '${accountId}' not found`);
-
-  const members = (membersRes.Items ?? []) as Array<{
-    userId: string; email?: string; role: string; joinedAt: string;
-  }>;
-
-  if (!members.some(m => m.userId === userId)) {
-    throw forbidden('You are not a member of this account');
-  }
+  const { account, members, callerLoader } = await loadAccountContext(accountId);
+  await requireAccountAdmin(() => requireAccountMember(callerLoader, accountId, userId));
+  if (!account) throw forbidden(UNIFORM_DENY); // same uniform deny — no 404 leak
 
   return ok({
     account: {
-      accountId: accountRes.Item['accountId'] as string,
-      name: accountRes.Item['name'] as string,
-      ownerId: accountRes.Item['ownerId'] as string,
-      createdAt: accountRes.Item['createdAt'] as string,
+      accountId: account['accountId'] as string,
+      name: account['name'] as string,
+      ownerId: account['ownerId'] as string,
+      createdAt: account['createdAt'] as string,
     },
     members: members.map(m => ({
       userId: m.userId,
@@ -124,10 +160,54 @@ async function getAccount(accountId: string, userId: string) {
   });
 }
 
-async function updateAccount(event: APIGatewayProxyEvent, accountId: string, userId: string) {
-  await requireOwner(accountId, userId);
+// R2 — GET /accounts/{accountId}/members/detail: any active member. Returns the
+// full ListAccountMembersResponse (contract) so the v0 account-management-view
+// wires with no adapter. isLastOwner is computed from the loaded members array;
+// pendingInvitations is shape-present but EMPTY until Phase 8 (bundles).
+// (displayName is omitted — optional; read-time enrichment from launchpad-users
+//  per D6 is deferred. The v0 view falls back to email.)
+async function getMembersDetail(accountId: string, userId: string) {
+  const { account, members, callerLoader } = await loadAccountContext(accountId);
+  await requireAccountAdmin(() => requireAccountMember(callerLoader, accountId, userId));
+  if (!account) throw forbidden(UNIFORM_DENY);
 
-  const { name } = parseBody<{ name?: string }>(event);
+  const ownerCount = members.filter(m => m.role === 'owner').length;
+  const memberRows: AccountMemberRow[] = members.map(m => ({
+    userId: m.userId,
+    email: m.email ?? '',
+    status: (m.status as UserStatus | undefined) ?? 'active',
+    role: m.role as AccountRole,
+    joinedAt: m.joinedAt,
+    isLastOwner: m.role === 'owner' && ownerCount === 1,
+  }));
+
+  const response: ListAccountMembersResponse = {
+    accountId,
+    members: memberRows,
+    pendingInvitations: [], // EMPTY until Phase 8 (bundles) — shape present, no data
+  };
+  return ok(response);
+}
+
+// R3 — PUT /accounts/{accountId}: owner-or-manager (ruling #2) + field-guard.
+async function updateAccount(event: APIGatewayProxyEvent, accountId: string, userId: string) {
+  const { account, callerLoader } = await loadAccountContext(accountId);
+  await requireAccountAdmin(() => requireAccountOwnerOrManager(callerLoader, accountId, userId));
+  if (!account) throw forbidden(UNIFORM_DENY);
+
+  const body = parseBody<Record<string, unknown>>(event);
+
+  // Field-guard whitelist: reject unknown fields; re-narrow owner-only fields to owner.
+  for (const key of Object.keys(body)) {
+    if (!MANAGER_WRITABLE_FIELDS.has(key) && !OWNER_ONLY_FIELDS.has(key)) {
+      throw badRequest(`Unsupported field: ${key}`);
+    }
+    if (OWNER_ONLY_FIELDS.has(key)) {
+      await requireAccountAdmin(() => requireAccountOwnerRole(callerLoader, accountId, userId));
+    }
+  }
+
+  const name = body['name'] as string | undefined;
   if (!name?.trim()) throw badRequest('name is required');
 
   const now = new Date().toISOString();
@@ -229,28 +309,39 @@ async function requireOwner(accountId: string, userId: string) {
   if (res.Item['ownerId'] !== userId) throw forbidden('Only the account owner can perform this action');
 }
 
-export const handler = withAuth(async ({ auth, event }) => {
+// withAuthOnly (M16 Phase 6, ruling #4): this control-plane handler keys off the
+// PATH accountId and auth.userId — it never reads the X-Account-Id header, so it
+// must NOT require one (withAuth/resolveAccountContext would 400 POST /accounts).
+export const handler = withAuthOnly(async ({ auth, event }) => {
   const { userId, email } = auth;
   const resource = event.resource ?? '';
 
+  // R7: createAccount — no account context.
   if (resource === '/accounts' && event.httpMethod === 'POST') {
     return createAccount(event, userId, email);
   }
 
   const accountId = getPathParam(event, 'accountId');
 
+  // R2 (NEW): full member detail (ListAccountMembersResponse).
+  if (resource === '/accounts/{accountId}/members/detail' && event.httpMethod === 'GET') {
+    return getMembersDetail(accountId, userId);
+  }
+
+  // Legacy GET /members (thin shape) — retained, unwired-to-UI (see §7 retirement map).
   if (resource === '/accounts/{accountId}/members' && event.httpMethod === 'GET') {
     return listMembers(accountId, userId);
   }
 
+  // 6B: member removal (gate unchanged in 6A).
   if (resource === '/accounts/{accountId}/members/{userId}' && event.httpMethod === 'DELETE') {
     const targetUserId = getPathParam(event, 'userId');
     return removeMember(accountId, userId, targetUserId);
   }
 
-  if (event.httpMethod === 'GET') return getAccount(accountId, userId);
-  if (event.httpMethod === 'PUT') return updateAccount(event, accountId, userId);
-  if (event.httpMethod === 'DELETE') return deleteAccount(accountId, userId);
+  if (event.httpMethod === 'GET') return getAccount(accountId, userId);            // R1
+  if (event.httpMethod === 'PUT') return updateAccount(event, accountId, userId);  // R3
+  if (event.httpMethod === 'DELETE') return deleteAccount(accountId, userId);      // 6B (unchanged)
 
   throw badRequest(`Unrecognised route: ${event.httpMethod} ${resource}`);
 });

--- a/apps/launchpad/infrastructure/launchpad-control-plane-stack.ts
+++ b/apps/launchpad/infrastructure/launchpad-control-plane-stack.ts
@@ -345,6 +345,10 @@ export class LaunchpadControlPlaneStack extends cdk.Stack {
 
     const membersResource = accountResource.addResource('members');
     membersResource.addMethod('GET', accountsIntegration, authOptions);
+    // M16 Phase 6 (R2): full member detail (ListAccountMembersResponse).
+    membersResource
+      .addResource('detail')
+      .addMethod('GET', accountsIntegration, authOptions);
     membersResource
       .addResource('{userId}')
       .addMethod('DELETE', accountsIntegration, authOptions);

--- a/docs/architecture/auth.md
+++ b/docs/architecture/auth.md
@@ -506,7 +506,7 @@ The auth/control-plane Lambdas have explicit permission models. Each is document
 
 | Lambda | Wrapper | Authorization | IAM scope |
 |---|---|---|---|
-| `apps/launchpad/functions/accounts` | `withAuth` | Inline per-route membership/owner checks against account tables | `launchpad-accounts` RW + `launchpad-account-members` RW |
+| `apps/launchpad/functions/accounts` | `withAuthOnly` (M16 P6, ruling #4 — keys off **path** `accountId` + `auth.userId`; never reads `X-Account-Id`, so it must not require one) | Per-request shared wiring loads the account row + all member rows once and closes an in-memory `MembershipLoader` over the array; reads (R1 `GET`, R2 `GET …/members/detail`) gate on `requireAccountAdmin(requireAccountMember)`, write (R3 `PUT`) on `requireAccountAdmin(requireAccountOwnerOrManager)` + field-guard whitelist; uniform-deny so account existence is not probeable. Mutations (`removeMember`/`deleteAccount`) → PR-6B. | `launchpad-accounts` RW + `launchpad-account-members` RW |
 | `apps/launchpad/functions/user` | `withAuthOnly` | User owns their own profile/preferences/active-account. Active-account SET verifies membership via table check (D8 control-plane) | `launchpad-users` RW + `launchpad-accounts` R + `launchpad-account-members` R |
 | `apps/launchpad/functions/account-provisioning` | `withAuthOnly` | None — profile-bootstrap; user has JWT but no account yet (M16 D11: no longer creates accounts) | `launchpad-users` RW + `launchpad-account-members` R + `AdminGetUser` on user pool ARN |
 | `apps/launchpad/functions/access-summary` | `withAuthOnly` | `requireSiteAdmin` — site-admin directory only | `launchpad-users` R + `launchpad-accounts` R + `launchpad-account-members` R + `launchpad-app-admin-grants` R + `ListUsersInGroup` on user pool ARN |
@@ -742,10 +742,11 @@ Launchpad owns the live onboarding, user profile/preference, account administrat
 | `GET /api/user/profile` | `launchpad-user-{stage}` | Reads the caller's profile/preferences from `launchpad-users-{stage}`. |
 | `PUT /api/user/preferences` | `launchpad-user-{stage}` | Merges caller-owned preferences into `launchpad-users-{stage}`. |
 | `POST /accounts` | `launchpad-accounts-{stage}` | Creates a new account and owner membership in Launchpad-owned auth-domain tables. |
-| `GET /accounts/{accountId}` | `launchpad-accounts-{stage}` | Returns account and member list after membership verification. |
-| `PUT /accounts/{accountId}` | `launchpad-accounts-{stage}` | Updates account name after owner verification. |
-| `DELETE /accounts/{accountId}` | `launchpad-accounts-{stage}` | Deletes account and member records after owner verification. |
-| `GET /accounts/{accountId}/members` | `launchpad-accounts-{stage}` | Lists members after membership verification. |
+| `GET /accounts/{accountId}` | `launchpad-accounts-{stage}` | R1 — account + member list to any **active member** (`requireAccountMember`); uniform-deny. |
+| `GET /accounts/{accountId}/members/detail` | `launchpad-accounts-{stage}` | R2 — full `ListAccountMembersResponse` (members with `isLastOwner`; `pendingInvitations: []` until Phase 8) to any active member; the v0 account-management-view target. |
+| `PUT /accounts/{accountId}` | `launchpad-accounts-{stage}` | R3 — updates `name` for **owner-or-manager** + field-guard whitelist (`ownerId`/billing owner-only). |
+| `DELETE /accounts/{accountId}` | `launchpad-accounts-{stage}` | PR-6B — deletes account + member records (owner / supervisory site-admin + GlobalSignOut). |
+| `GET /accounts/{accountId}/members` | `launchpad-accounts-{stage}` | Legacy thin member list — retained, unwired-to-UI; superseded by `…/members/detail`. |
 | `DELETE /accounts/{accountId}/members/{userId}` | `launchpad-accounts-{stage}` | Removes a member after owner verification. |
 | `POST /accounts/{accountId}/invitations` | `launchpad-invitations-{stage}` | Creates an invitation after owner verification. |
 
@@ -779,5 +780,6 @@ The current state has the interface duplicated across `packages/auth-client/`, `
 
 - OAuth resource server custom scopes as an alternative or complement to group-based checks — tracked as Issue #42.
 - Capability-level permissions within an app beyond `view/user/admin`.
-- Multi-owner accounts.
 - Per-browser-session active account (alternative to `custom:active_accounts`).
+
+(Multi-owner accounts are **in scope** as of `m16.0.0` — permitted at contract/policy level with the last-owner guard as a floor; see `route-classification-m16.md` §7b.)

--- a/docs/architecture/route-classification-m16.md
+++ b/docs/architecture/route-classification-m16.md
@@ -68,19 +68,20 @@ This table is the **security-review artifact** for the site-admin-bypass removal
 | `PUT /api/user/preferences` | user | withAuthOnly | `auth-only` (self) | own prefs | Confirmed | PR-B (doc only) |
 | `GET /api/user/active-accounts` | user | withAuthOnly | `auth-only` (self) | own selections (D7) | Confirmed | PR-B (doc only) |
 | `PUT /api/user/active-accounts/{appSlug}` | user | withAuthOnly + table membership verify | `auth-only` (self) + membership verify (D7) | self-service; verifies own membership | Confirmed | PR-B (doc only) |
-| `POST /accounts` | accounts | withAuth | `auth-only` (creator-owns) | **withAuth requires X-Account-Id to CREATE an account — see ruling #4** | Status-uncertain | verify |
-| `GET /accounts/{accountId}` | accounts | withAuth + ad-hoc `members.some` | `requireAccountAdmin(account-member)` | account metadata; used by app selectors | **ruling #3: any member** | **Phase 6** † |
-| `GET /accounts/{accountId}/members` | accounts | withAuth + ad-hoc `members.some` | `requireAccountAdmin(account-member)` | member list | **ruling #3: any member** | **Phase 6** † |
-| `PUT /accounts/{accountId}` | accounts | withAuth + ad-hoc `ownerId===userId` | `requireAccountAdmin(account-owner-or-manager)` | account settings | **ruling #2: owner-or-manager** | **Phase 6** † |
-| `DELETE /accounts/{accountId}` | accounts | withAuth + ad-hoc owner | `requireAccountAdmin(owner)` + sole-owner deletion (D9 §9.3) | destructive | Status-uncertain-resolved | **Phase 6** (mutation) |
-| `DELETE /accounts/{accountId}/members/{userId}` | accounts | withAuth + ad-hoc | `requireAccountAdmin(anyOf(owner-or-manager + last-owner-guard, supervisory-site-admin))` | remove member | Aspirational (manager-removal rules never built) | **Phase 6** (mutation) |
+| `POST /accounts` | accounts | ~~withAuth~~ → `withAuthOnly` | `auth-only` (creator-owns) | **ruling #4 CONFIRMED & FIXED: withAuth forced X-Account-Id via resolveAccountContext; create has no account → switched handler to withAuthOnly** | Resolved | **PR-6A** |
+| `GET /accounts/{accountId}` | accounts | ad-hoc `members.some` + 404 leak → `requireAccountMember` | `requireAccountAdmin(account-member)` | R1 — account metadata (app selectors); uniform-deny (existence not probeable) | **ruling #3: any member** | **PR-6A** |
+| `GET /accounts/{accountId}/members/detail` | accounts | *(new route)* | `requireAccountAdmin(account-member)` | **R2 — full ListAccountMembersResponse (isLastOwner; pendingInvitations:[] until Phase 8)**; v0 account-management-view target; displayName enrichment (D6) deferred | **ruling #3: any member** | **PR-6A** |
+| `GET /accounts/{accountId}/members` | accounts | ad-hoc `members.some` (unchanged) | *(legacy thin — superseded by `/members/detail`)* | legacy thin list; unwired-to-UI; retire once `/members/detail` is the sole reader (see §8 retirement map) | legacy / retire | unwired |
+| `PUT /accounts/{accountId}` | accounts | ad-hoc `ownerId===userId` → owner-or-manager | `requireAccountAdmin(account-owner-or-manager)` + field-guard | R3 — account settings; manager+owner write `{name}`; `ownerId`/billing owner-only (ruling #2 field-guard) | **ruling #2: owner-or-manager** | **PR-6A** |
+| `DELETE /accounts/{accountId}` | accounts | withAuthOnly + ad-hoc owner | `requireAccountAdmin(owner)` + sole-owner deletion (D9 §9.3) + GlobalSignOut | destructive | Status-uncertain-resolved | **Phase 6 / PR-6B** |
+| `DELETE /accounts/{accountId}/members/{userId}` | accounts | withAuthOnly + ad-hoc | `requireAccountAdmin(anyOf(owner-or-manager + last-owner-guard, supervisory-site-admin))` + GlobalSignOut | remove member | Aspirational (manager-removal rules never built) | **Phase 6 / PR-6B** |
 | `POST /accounts/{accountId}/invitations` | invitations | withAuth + ad-hoc `ownerId===userId` | `requireAccountAdmin(owner-or-manager / canCreateInvitationGrant)` | legacy single-invite | Aspirational (owner/manager in-app invite never built) | **Phase 8** (bundles) |
 | `GET /api/admin/...access-summary` (access-summary) | access-summary | requireSiteAdmin (claim) | `requireAccountAdmin(supervisory-site-admin)` | directory read; app-admin app-scope = Phase 7 | Confirmed (extended P7) | PR-B |
 | `GET /api/admin/ai-runtime-config` | ai-runtime-config | requireSiteAdmin | `operational-config` (supervisory-site-admin read) | platform AI config | Confirmed | PR-B / PR-C |
 | `PUT …/ai-runtime-config/platform-default` | ai-runtime-config | requireSiteAdmin | `operational-config` (site-admin **default**, D9) | platform default | Confirmed | PR-B / PR-C |
 | `PUT/DELETE …/ai-runtime-config/apps/{appSlug}/override` | ai-runtime-config | requireSiteAdmin | `operational-config` → **app-admin override** (D9) | per-app override | Status-uncertain-resolved | **PR-C** |
 
-> **† PR-B scope boundary (launchpad `accounts` handler).** The `accounts` Lambda co-locates the read/settings routes above with the **member-management mutation** routes (`removeMember`, `deleteAccount`) that are explicitly **Phase 6**, plus `createAccount`. Migrating it onto `requireAccountAdmin` is done as **one coherent pass in Phase 6** rather than partially in PR-B, to avoid touching the Phase-6 mutation paths in this security PR. Its current ad-hoc checks (`ownerId===userId`, `members.some`) are **not** a site-admin bypass — they already gate on ownership/membership — so the D9 site-admin-bypass-removal goal is fully met by PR-B without them. The rulings above are recorded as the authority for that Phase-6 migration. `access-summary` (site-admin) and the `/api/user/*` self routes ARE correct as-is and need no migration.
+> **Phase-6 split (launchpad `accounts` handler).** The `accounts` Lambda was deferred whole from PR-B (its ad-hoc `ownerId===userId` / `members.some` checks were never a site-admin bypass, so PR-B's D9 goal was met without it). Phase 6 migrates it in two PRs: **PR-6A** (this PR) does the non-destructive reads + name + loader wiring — R1 `GET /accounts/{accountId}`, R2 the new `GET …/members/detail`, R3 `PUT …` with the field-guard, and R7 the `withAuthOnly` fix; **PR-6B** does the destructive mutations — `removeMember` and `deleteAccount` with `requireAccountAdmin`, last-owner/sole-owner guards, and `AdminUserGlobalSignOut`. `access-summary` (site-admin) and the `/api/user/*` self routes are correct as-is.
 
 ## 4. Non-REST-route functions (no route classification; documented for completeness)
 
@@ -116,7 +117,73 @@ This table is the **security-review artifact** for the site-admin-bypass removal
 - **Pre-token Lambda (D11.1):** remove the site-admin group-retention override in `reconcileInvariant` — the invariant applies uniformly; the `site-admin` Cognito group drives supervisory surfaces only. (M16 Phase 6 additionally removes the `site_admin` token claim — admin status is read from the group.)
 - **Group-based admin sweep (#416):** `cognito:groups` site-admin fallback already removed in PR-A (auth-client). PR-B confirms no remaining group-based authorization in backend handlers (only `requireSiteAdmin`, which reads the `siteAdmin` claim — Confirmed, not group-based).
 
-## 7. auth.md verification summary (feeds the revision map)
+## 7. Role model & Phase-6 decisions (PR-6A)
+
+### (a) Role model (canonical, owner-settled)
+
+`owner > manager > member/viewer`. An actor may only manage roles **strictly
+below** their own.
+
+- **Owner** — full control: change any role, remove anyone (bounded only by the
+  last-owner floor); ownership transfer is deferred (see R6).
+- **Manager** — change roles **within `{member, viewer}`**, remove members/viewers,
+  and **may self-demote** (manager → member/viewer). MAY NOT create, modify, or
+  remove another manager or an owner; MAY NOT promote anyone to manager or owner.
+- **Member / viewer** — no management powers.
+
+Removal symmetry (keep remove + role-change aligned): a manager may remove
+members/viewers only; only an **owner** removes or demotes a manager or owner;
+manager self-removal/self-demote is allowed (still subject to the last-owner floor).
+
+### (b) Multi-owner affirmation
+
+Multi-owner is **permitted** at the contract + policy-helper level. The last-owner
+guard is a **FLOOR** (an account must retain ≥1 owner; never zero) — **NOT a cap**.
+No product path that **creates a second owner** or **transfers ownership** is built
+yet; it is deferred with role-change (R6). In practice every account has exactly one
+owner because no feature mints another. This is intentional, not an oversight — do
+not add a single-owner cap, and do not change `decideLastOwnerGuard` /
+`decideRoleChange` to enforce `=1`.
+
+### (c) `decideRoleChange` correction (carried into PR-6B)
+
+`packages/lambda-middleware/src/policy.ts:decideRoleChange` is currently **broader
+than the model in (a)**: its manager branch allows `member→manager` promotion and
+editing peer managers (it only denies `newRole==='owner'` and changing an existing
+owner). It has **zero callers** today (role-change route is not built). When **PR-6B**
+wires `PUT /accounts/{accountId}/members/{userId}/role`, `decideRoleChange` MUST be
+tightened to: manager may act only when **both** `currentTargetRole ∈ {member,viewer}`
+**and** `newRole ∈ {member,viewer}`; deny otherwise. Plus a **handler-level
+self-demote carve-out** (actor === target may lower their own role) and the **R5
+self-removal carve-out** (a manager may remove themselves; last-owner floor still
+applies). `decideLastOwnerGuard` is floor-based and correct as-is.
+
+### (d) Phantom-resolution note (6A0)
+
+The missing **"Admin"** menu entry on the live launchpad is **EXPECTED, not a
+regression** — the admin UI / nav shell is unmerged (it lives in the v0 repo), so
+nothing sits behind the site-admin gate yet. 6A0 group-derivation is **verified
+correct** on a real native-array `cognito:groups` token (`siteAdmin=true` end-to-end,
+confirmed via fresh-incognito console). `parseCognitoGroups`, the `site_admin` claim
+removal, and the group-derivation are confirmed correct.
+
+### (e) Legacy-row retirement map (`launchpadRoutes`)
+
+A future collapse is a **real migration with a tail**, NOT a clean delete — roughly
+half of `launchpadRoutes` is PERMANENT and still consumed.
+
+| Legacy route | Retires when | Owning PR |
+|---|---|---|
+| `GET /accounts/{accountId}/members` (thin) | `/members/detail` is the sole reader | retireable as of **PR-6A** (successor shipped) |
+| `DELETE /accounts/{accountId}/members/{userId}` | API-table policy version + GlobalSignOut ships | **PR-6B** |
+| `PUT /accounts/{accountId}` / `DELETE /accounts/{accountId}` | 6A/6B successors live + zero consumers | **PR-6A (PUT) / PR-6B (DELETE)** |
+| `POST` / `GET /accounts/{accountId}/invitations` (single-invite) | bundle routes ship | **Phase 8** |
+| **PERMANENT — not retirement candidates** (distinct responsibility, still consumed): `/health`, `/auth/lookup-provider`, `/auth/setup`, `/api/user/profile`, `/api/user/preferences`, `GET /api/admin/ai-runtime-config`, `PUT …/platform-default`, and `GET /accounts/{accountId}` (account-metadata for selectors). | — | — |
+
+(See the full read-only legacy-route audit for per-row successor / shape-conflict /
+consumer data.)
+
+## 8. auth.md verification summary (feeds the revision map)
 
 - **Confirmed:** all SA/BT data routes; user self routes; ws-authorizer claims check; access-summary site-admin; auth/setup; lookup-provider public.
 - **Aspirational-never-built:** owner/manager in-app invitations (invitations handler is owner-only single-invite, not the bundle model); manager member-removal rules; site-admin write of per-account AI config (was permitted by `requireSiteAdmin` but contradicts D9 — corrected via PR-C).

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -677,6 +677,9 @@ importers:
 
   apps/launchpad/functions/accounts:
     dependencies:
+      '@transformotion/contracts':
+        specifier: workspace:*
+        version: link:../../../../packages/contracts
       '@transformotion/lambda-middleware':
         specifier: workspace:*
         version: link:../../../../packages/lambda-middleware


### PR DESCRIPTION
## Summary
Non-destructive account reads + name update + policy-loader wiring, built to the renamed `launchpadApiRoutes` contract. (Mutations — removeMember/deleteAccount — are PR-6B.)

## STEP 0 — R7 (ruling #4) CONFIRMED & FIXED
`withAuth` calls `resolveAccountContext`, which **400s when `X-Account-Id` is absent** — so `POST /accounts` (no account to name) was broken. The handler keys off **path** `accountId` + `auth.userId` and never reads the header → switched to **`withAuthOnly`**.

## Routes
- **R1** `GET /accounts/{accountId}` → `requireAccountAdmin(requireAccountMember)`; uniform-deny on non-member AND missing account (404 leak killed — existence not probeable).
- **R2 (NEW)** `GET /accounts/{accountId}/members/detail` → full `ListAccountMembersResponse`: members with `isLastOwner` (computed from the loaded array), `pendingInvitations: []` (shape present, empty until Phase 8). Built to the contract so the v0 account-management-view wires with **no adapter**. `displayName` (D6 read-time enrichment) deferred — optional, view falls back to email. CDK route added.
- **R3** `PUT /accounts/{accountId}` → `requireAccountAdmin(requireAccountOwnerOrManager)` + field-guard whitelist (`{name}` manager-writable; `ownerId`/billing owner-only via `requireAccountOwnerRole`; unknown → 400).

Per-request shared wiring: `loadAccountContext` loads account + all members once and closes an in-memory `MembershipLoader` (no 2nd GetItem). Legacy `GET /members`, `removeMember`, `deleteAccount` unchanged (6B / legacy-unwired).

## §7 WRITTEN (non-negotiable) — route-classification-m16.md
All five items: (a) role model, (b) multi-owner affirmation (last-owner = floor, not cap), (c) decideRoleChange correction carried to 6B, (d) phantom-resolution note, (e) legacy-row retirement map. Plus §3 Migrates flips and auth.md updates.

## Validation
typecheck 63/63 · lambda-middleware 86/86 · cdk synth LaunchpadControlPlane (✅ /members/detail wired) · check:v0-contracts byte-identical · diff --check clean.

## Acceptance (owner-gated smoke, post-merge/deploy)
viewer/member GET 200; non-member → uniform-deny == missing-account code; `…/members/detail` full shape incl. `isLastOwner` + empty `pendingInvitations`; manager PUT `{name}` 200; member PUT 403; PUT `{ownerId}` rejected; createAccount works without `X-Account-Id`.

## v0 freshness
- [x] No v0 impact

Reason: backend handler + CDK + docs only; no UI/contract/mock shape changes (`check:v0-contracts` byte-identical).

🤖 Generated with [Claude Code](https://claude.com/claude-code)