### PR TITLE
docs(contributing): Goal 4 — app access derives from account membership (ADR §9.4)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,9 +47,10 @@ make the trade-off visible.
   platform level, not just per-app.
 
 - **Goal 4 — Invite people in based on the permissions model.** The
-  multi-dimensional permission model (app access via Cognito groups;
-  account membership and role via DynamoDB) is the canonical way users
-  reach app data. Invitation flows, account switching, and role
+  multi-dimensional permission model (app access **derives from account
+  membership**, with Cognito groups maintained as a projection of that
+  membership; account membership and role via DynamoDB) is the canonical
+  way users reach app data. Invitation flows, account switching, and role
   enforcement are first-class platform capabilities, not app-specific
   features.
 


### PR DESCRIPTION
The standalone Goal 4 wording correction the ADR §9.4 required (owner sign-off 2026-06-11), never cut during Phase 5.

`CONTRIBUTING.md` §1.1 Goal 4: **"app access via Cognito groups"** → **"app access derives from account membership; Cognito groups maintained as a projection of that membership."**

One-line normative correction. The running M16 model already works this way (the pre-token Lambda reconciles `-access` groups *from* account membership); the prior text was contradicted by the live system.

Refs #411, ADR §9.4.

## v0 freshness
- [x] No v0 impact

Reason: documentation-only normative wording correction; no contract/API/UI/runtime change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)