### PR TITLE
M16 Phase 6 PR-6B: destructive member mutations (removeMember + deleteAccount)

### DIFF
--- a/apps/launchpad/functions/accounts/package.json
+++ b/apps/launchpad/functions/accounts/package.json
@@ -13,6 +13,7 @@
     "@transformotion/lambda-middleware": "workspace:*"
   },
   "devDependencies": {
+    "@aws-sdk/client-cognito-identity-provider": "^3",
     "@aws-sdk/client-dynamodb": "^3",
     "@aws-sdk/lib-dynamodb": "^3",
     "@types/aws-lambda": "^8",

--- a/apps/launchpad/functions/accounts/src/index.ts
+++ b/apps/launchpad/functions/accounts/src/index.ts
@@ -8,6 +8,11 @@ import {
   TransactWriteCommand,
 } from '@aws-sdk/lib-dynamodb';
 import {
+  CognitoIdentityProviderClient,
+  AdminUserGlobalSignOutCommand,
+  AdminListGroupsForUserCommand,
+} from '@aws-sdk/client-cognito-identity-provider';
+import {
   withAuthOnly,
   parseBody,
   getPathParam,
@@ -16,23 +21,57 @@ import {
   noContent,
   badRequest,
   forbidden,
-  notFound,
+  conflict,
+  HttpError,
   requireAccountAdmin,
   requireAccountMember,
   requireAccountOwnerOrManager,
   requireAccountOwnerRole,
+  requireSupervisorySiteAdmin,
+  decideRemoval,
+  decideLastOwnerGuard,
+  allOf,
   UNIFORM_DENY,
   type APIGatewayProxyEvent,
   type MembershipLoader,
+  type SiteAdminLoader,
 } from '@transformotion/lambda-middleware';
 import type { AccountMemberRow, ListAccountMembersResponse } from '@transformotion/contracts/launchpad/invitations';
 import type { AccountRole, UserStatus } from '@transformotion/contracts/_shared/auth';
 import { randomUUID } from 'crypto';
 
 const ddb = DynamoDBDocumentClient.from(new DynamoDBClient({}));
+const cognito = new CognitoIdentityProviderClient({});
 
 const ACCOUNTS_TABLE = process.env.ACCOUNTS_TABLE!;
 const ACCOUNT_MEMBERS_TABLE = process.env.ACCOUNT_MEMBERS_TABLE!;
+const USER_POOL_ID = process.env.USER_POOL_ID!;
+
+/**
+ * Live supervisory-site-admin check (D-3): read the `site-admin` group membership
+ * LIVE via AdminListGroupsForUser, NOT from the caller's token — supervisory
+ * removal is a sensitive mutation and must not trust a stale claim. Loader throws
+ * propagate as 503 (fail closed) through requireSupervisorySiteAdmin's safeLoad.
+ */
+const siteAdminLoader: SiteAdminLoader = async (userId: string) => {
+  const res = await cognito.send(new AdminListGroupsForUserCommand({
+    UserPoolId: USER_POOL_ID,
+    Username: userId,
+  }));
+  return (res.Groups ?? []).some((g) => g.GroupName === 'site-admin');
+};
+
+/**
+ * Terminate the target's session (D8). AdminUserGlobalSignOut invalidates refresh
+ * tokens immediately, so the only residual is the bounded ≤1h access-token window.
+ * Failures are SURFACED by the caller (never a silent success).
+ */
+async function globalSignOut(userId: string): Promise<void> {
+  await cognito.send(new AdminUserGlobalSignOutCommand({
+    UserPoolId: USER_POOL_ID,
+    Username: userId,
+  }));
+}
 
 // M16 D3 / Refs #162: appSlug is derived from the Cognito app-client used to obtain the token.
 const APP_CLIENT_TO_SLUG: Record<string, string> = Object.fromEntries(
@@ -223,27 +262,23 @@ async function updateAccount(event: APIGatewayProxyEvent, accountId: string, use
   return ok({ account: { accountId, name: name.trim(), updatedAt: now } });
 }
 
-async function deleteAccount(accountId: string, userId: string) {
-  await requireOwner(accountId, userId);
+// PR-6B — DELETE /accounts/{accountId}: OWNER-ONLY self-service deletion. BLOCKS,
+// does NOT cascade (owner-settled): an owner may delete only an account they have
+// already emptied — sole member (themselves). If other members exist → 409 (empty
+// it first via removeMember). The ONLY sanctioned cascade of a populated account is
+// the ADR §9.3 site-admin orphaned-account cleanup, ruled separately and NOT here —
+// there is intentionally no one-click delete-with-members.
+async function deleteAccount(accountId: string, requesterId: string) {
+  const { account, members, callerLoader } = await loadAccountContext(accountId);
+  await requireAccountAdmin(() => requireAccountOwnerRole(callerLoader, accountId, requesterId));
+  if (!account) throw forbidden(UNIFORM_DENY);
 
-  const membersRes = await ddb.send(new QueryCommand({
-    TableName: ACCOUNT_MEMBERS_TABLE,
-    KeyConditionExpression: 'accountId = :aid',
-    ExpressionAttributeValues: { ':aid': accountId },
-    ProjectionExpression: 'userId',
-  }));
-
-  const memberDeletes = (membersRes.Items ?? []).map(m => ({
-    Delete: {
-      TableName: ACCOUNT_MEMBERS_TABLE,
-      Key: { accountId, userId: m['userId'] as string },
-    },
-  }));
-
-  if (memberDeletes.length > 99) {
-    throw badRequest('Cannot delete an account with more than 99 members via this endpoint');
+  if (members.length > 1) {
+    throw conflict('Account still has other members — remove them first, then delete the account.');
   }
 
+  // Fail-closed ordering (same as removal): delete control-plane state FIRST, then
+  // sign out the sole member. A GlobalSignOut failure is surfaced, never silent.
   await ddb.send(new TransactWriteCommand({
     TransactItems: [
       {
@@ -253,9 +288,18 @@ async function deleteAccount(accountId: string, userId: string) {
           ConditionExpression: 'attribute_exists(accountId)',
         },
       },
-      ...memberDeletes,
+      ...members.map(m => ({
+        Delete: { TableName: ACCOUNT_MEMBERS_TABLE, Key: { accountId, userId: m.userId } },
+      })),
     ],
   }));
+
+  try {
+    for (const m of members) await globalSignOut(m.userId);
+  } catch (err) {
+    console.error('[accounts] GlobalSignOut failed after account deletion:', err);
+    throw new HttpError(502, 'Account deleted, but session termination failed — retry to complete sign-out (the member\'s existing session may persist until token expiry).');
+  }
 
   return noContent();
 }
@@ -285,28 +329,58 @@ async function listMembers(accountId: string, userId: string) {
   });
 }
 
+// PR-6B (R5) — DELETE /accounts/{accountId}/members/{userId}: owner-or-manager with
+// role-scoped removal (decideRemoval), OR supervisory site-admin (verified LIVE).
+// Last-owner FLOOR applies universally; AdminUserGlobalSignOut on success (D8).
 async function removeMember(accountId: string, requesterId: string, targetUserId: string) {
-  await requireOwner(accountId, requesterId);
+  const { account, members, callerLoader } = await loadAccountContext(accountId);
+  if (!account) throw forbidden(UNIFORM_DENY);
 
-  if (targetUserId === requesterId) {
-    throw badRequest('Owner cannot remove themselves - delete the account instead');
+  // Resolve the target first (fail closed): a non-member target is indistinguishable
+  // from no access.
+  const targetRow = members.find(m => m.userId === targetUserId);
+  if (!targetRow) throw forbidden(UNIFORM_DENY);
+
+  const callerRow = members.find(m => m.userId === requesterId);
+  const isSelf = requesterId === targetUserId;
+
+  // Authorization (requireAccountAdmin = anyOf over the branches): (owner-or-manager
+  // AND role-scoped removal legal) OR supervisory site-admin (LIVE group check).
+  // A loader/Cognito error in the supervisory branch surfaces as 503 (fail closed).
+  await requireAccountAdmin(
+    () => allOf(
+      () => requireAccountOwnerOrManager(callerLoader, accountId, requesterId),
+      async () => {
+        if (!decideRemoval(callerRow?.role, targetRow.role, isSelf).allow) {
+          throw forbidden(UNIFORM_DENY);
+        }
+      },
+    ),
+    () => requireSupervisorySiteAdmin(siteAdminLoader, requesterId),
+  );
+
+  // Last-owner FLOOR — applies to EVERYONE incl. supervisory site-admin: you cannot
+  // remove the sole owner and orphan the account; delete the account instead (§9.3).
+  if (!decideLastOwnerGuard(members, targetUserId).allow) {
+    throw conflict('Cannot remove the last owner — transfer ownership or delete the account.');
   }
 
+  // Fail-closed ordering: control-plane removal FIRST (authoritative — app-data writes
+  // fail closed instantly via the live row-check, and the target's next token refresh
+  // drops the account). Then terminate the session; surface a sign-out failure.
   await ddb.send(new DeleteCommand({
     TableName: ACCOUNT_MEMBERS_TABLE,
     Key: { accountId, userId: targetUserId },
   }));
 
-  return noContent();
-}
+  try {
+    await globalSignOut(targetUserId);
+  } catch (err) {
+    console.error('[accounts] GlobalSignOut failed after member removal:', err);
+    throw new HttpError(502, 'Member removed, but session termination failed — retry to complete sign-out (the member\'s existing session may persist until token expiry).');
+  }
 
-async function requireOwner(accountId: string, userId: string) {
-  const res = await ddb.send(new GetCommand({
-    TableName: ACCOUNTS_TABLE,
-    Key: { accountId },
-  }));
-  if (!res.Item) throw notFound(`Account '${accountId}' not found`);
-  if (res.Item['ownerId'] !== userId) throw forbidden('Only the account owner can perform this action');
+  return noContent();
 }
 
 // withAuthOnly (M16 Phase 6, ruling #4): this control-plane handler keys off the
@@ -333,7 +407,7 @@ export const handler = withAuthOnly(async ({ auth, event }) => {
     return listMembers(accountId, userId);
   }
 
-  // 6B: member removal (gate unchanged in 6A).
+  // PR-6B (R5): member removal.
   if (resource === '/accounts/{accountId}/members/{userId}' && event.httpMethod === 'DELETE') {
     const targetUserId = getPathParam(event, 'userId');
     return removeMember(accountId, userId, targetUserId);
@@ -341,7 +415,7 @@ export const handler = withAuthOnly(async ({ auth, event }) => {
 
   if (event.httpMethod === 'GET') return getAccount(accountId, userId);            // R1
   if (event.httpMethod === 'PUT') return updateAccount(event, accountId, userId);  // R3
-  if (event.httpMethod === 'DELETE') return deleteAccount(accountId, userId);      // 6B (unchanged)
+  if (event.httpMethod === 'DELETE') return deleteAccount(accountId, userId);      // PR-6B
 
   throw badRequest(`Unrecognised route: ${event.httpMethod} ${resource}`);
 });

--- a/apps/launchpad/infrastructure/launchpad-control-plane-stack.ts
+++ b/apps/launchpad/infrastructure/launchpad-control-plane-stack.ts
@@ -264,6 +264,7 @@ export class LaunchpadControlPlaneStack extends cdk.Stack {
         APP_CLIENT_STOCK_ANALYSER: stockAnalyserAppClientId,
         APP_CLIENT_BUDGET_TRACKER: budgetTrackerAppClientId,
         APP_SLUGS: appSlugs.join(','),
+        USER_POOL_ID: userPoolId,
       },
       bundling: {
         externalModules: ['@aws-sdk/*'],
@@ -274,6 +275,16 @@ export class LaunchpadControlPlaneStack extends cdk.Stack {
 
     accountsTable.grantReadWriteData(accountsFn);
     accountMembersTable.grantReadWriteData(accountsFn);
+    // M16 Phase 6 (PR-6B): member removal / account deletion terminate the target's
+    // session (AdminUserGlobalSignOut, D8) and verify supervisory site-admin LIVE
+    // (AdminListGroupsForUser, D-3). Scoped to exactly these two actions on the pool.
+    accountsFn.addToRolePolicy(new iam.PolicyStatement({
+      actions: [
+        'cognito-idp:AdminUserGlobalSignOut',
+        'cognito-idp:AdminListGroupsForUser',
+      ],
+      resources: [userPoolArn],
+    }));
 
     // M16 Phase 2 — access summary (site-admin directory of all users with app/account access)
     const accessSummaryFn = new lambdaNodejs.NodejsFunction(this, 'AccessSummaryFn', {

--- a/docs/architecture/auth.md
+++ b/docs/architecture/auth.md
@@ -506,7 +506,7 @@ The auth/control-plane Lambdas have explicit permission models. Each is document
 
 | Lambda | Wrapper | Authorization | IAM scope |
 |---|---|---|---|
-| `apps/launchpad/functions/accounts` | `withAuthOnly` (M16 P6, ruling #4 — keys off **path** `accountId` + `auth.userId`; never reads `X-Account-Id`, so it must not require one) | Per-request shared wiring loads the account row + all member rows once and closes an in-memory `MembershipLoader` over the array; reads (R1 `GET`, R2 `GET …/members/detail`) gate on `requireAccountAdmin(requireAccountMember)`, write (R3 `PUT`) on `requireAccountAdmin(requireAccountOwnerOrManager)` + field-guard whitelist; uniform-deny so account existence is not probeable. Mutations (`removeMember`/`deleteAccount`) → PR-6B. | `launchpad-accounts` RW + `launchpad-account-members` RW |
+| `apps/launchpad/functions/accounts` | `withAuthOnly` (M16 P6, ruling #4 — keys off **path** `accountId` + `auth.userId`; never reads `X-Account-Id`, so it must not require one) | Per-request shared wiring loads the account row + all member rows once and closes an in-memory `MembershipLoader` over the array; reads (R1 `GET`, R2 `GET …/members/detail`) gate on `requireAccountAdmin(requireAccountMember)`, write (R3 `PUT`) on `requireAccountAdmin(requireAccountOwnerOrManager)` + field-guard whitelist; uniform-deny so account existence is not probeable. PR-6B mutations: `removeMember` (owner-or-manager + `decideRemoval` / LIVE supervisory-site-admin + last-owner floor + `AdminUserGlobalSignOut`), `deleteAccount` (owner-only, **block-if-members → 409** + GlobalSignOut). | `launchpad-accounts` RW + `launchpad-account-members` RW + `cognito-idp:AdminUserGlobalSignOut` & `AdminListGroupsForUser` on the user pool ARN |
 | `apps/launchpad/functions/user` | `withAuthOnly` | User owns their own profile/preferences/active-account. Active-account SET verifies membership via table check (D8 control-plane) | `launchpad-users` RW + `launchpad-accounts` R + `launchpad-account-members` R |
 | `apps/launchpad/functions/account-provisioning` | `withAuthOnly` | None — profile-bootstrap; user has JWT but no account yet (M16 D11: no longer creates accounts) | `launchpad-users` RW + `launchpad-account-members` R + `AdminGetUser` on user pool ARN |
 | `apps/launchpad/functions/access-summary` | `withAuthOnly` | `requireSiteAdmin` — site-admin directory only | `launchpad-users` R + `launchpad-accounts` R + `launchpad-account-members` R + `launchpad-app-admin-grants` R + `ListUsersInGroup` on user pool ARN |
@@ -656,23 +656,22 @@ Three revocation scenarios, each with a specific entry point.
 
 ### Scenario A: Removing a user from an account
 
-An account owner or manager removes someone from a specific account.
+An account owner or manager removes someone from a specific account (or a supervisory site-admin removes a member). Implemented in the `accounts` Lambda (M16 Phase 6 / PR-6B).
 
-Endpoint: `DELETE /accounts/{accountId}/members/{userId}`. Lambda: `account-members-remove`.
+Endpoint: `DELETE /accounts/{accountId}/members/{userId}`.
 
-Authorization (supervisory — implemented as the route lands in Phase 6):
-- `requireAccountAdmin(requireAccountOwnerOrManager(...))` — owner/manager of the account, or supervisory site-admin. This is an administrative-authority operation, not a data-path one; it carries no data visibility.
-- If the target `userId` is the `owner` of the account: reject. Ownership must be transferred first.
-- If the caller is a `manager` (not owner) and the target is also a `manager`: reject. Managers cannot remove other managers; only the owner can.
-- Self-removal (caller and target are the same user): allowed if the target is not the owner.
+Authorization — `requireAccountAdmin` (anyOf):
+- **owner-or-manager** of the account AND the removal is role-legal (`decideRemoval`): an owner may remove anyone; a manager may remove `member`/`viewer` members ONLY (never another manager or an owner); self-removal is allowed; OR
+- **supervisory site-admin**, verified **LIVE** via `AdminListGroupsForUser` (not the token claim — supervisory removal is a sensitive mutation that must not trust a stale claim).
+- **Last-owner floor** (`decideLastOwnerGuard`) applies to EVERYONE incl. supervisory site-admin: the sole owner cannot be removed (409 — transfer or delete the account). Orphaning a populated account is only the §9.3 cleanup (separate).
 
-Steps:
-1. Validate authorization per the rules above.
-2. Delete the row in `launchpad-account-members-{stage}` for `(accountId, userId)`.
-3. Update the target user's `custom:accounts` attribute to remove `accountId`.
-4. Call `AdminUserGlobalSignOut` on the target user — refresh tokens invalidated immediately.
+Steps (fail-closed ordering):
+1. Resolve the account + members; authorize per above. Loader/Cognito errors → **503** (never proceed).
+2. Enforce the last-owner floor (409 if the target is the sole owner).
+3. Delete the row in `launchpad-account-members-{stage}` for `(accountId, userId)` — the authoritative control-plane removal. From this instant the removed user's app-data **writes** fail closed via the live row-check (D8), and their next token refresh drops the account.
+4. Call `AdminUserGlobalSignOut` on the target — invalidates refresh tokens immediately. A sign-out failure is **surfaced as 502, never a silent success**; the row-delete is idempotent on retry. (No `custom:accounts` write — D11.)
 
-After this: the target user's existing access token remains valid until expiry (up to 1 hour). On their next token refresh, the pre-token Lambda reads the updated memberships and issues a token without the removed account. If this was the user's last account in a given app, the invariant reconciliation in the pre-token Lambda automatically removes them from that app's `-access` group.
+After this: the target's existing access token remains valid until expiry (≤1h), but writes already fail closed. On next refresh the pre-token Lambda issues a token without the account; if it was the user's last account in an app, the invariant reconciliation removes them from that app's `-access` group.
 
 ### Scenario B: Disabling a user
 
@@ -745,7 +744,7 @@ Launchpad owns the live onboarding, user profile/preference, account administrat
 | `GET /accounts/{accountId}` | `launchpad-accounts-{stage}` | R1 — account + member list to any **active member** (`requireAccountMember`); uniform-deny. |
 | `GET /accounts/{accountId}/members/detail` | `launchpad-accounts-{stage}` | R2 — full `ListAccountMembersResponse` (members with `isLastOwner`; `pendingInvitations: []` until Phase 8) to any active member; the v0 account-management-view target. |
 | `PUT /accounts/{accountId}` | `launchpad-accounts-{stage}` | R3 — updates `name` for **owner-or-manager** + field-guard whitelist (`ownerId`/billing owner-only). |
-| `DELETE /accounts/{accountId}` | `launchpad-accounts-{stage}` | PR-6B — deletes account + member records (owner / supervisory site-admin + GlobalSignOut). |
+| `DELETE /accounts/{accountId}` | `launchpad-accounts-{stage}` | PR-6B — **owner-only**; **BLOCKS if other members exist (409)**, never cascades (empty via removeMember first); + GlobalSignOut. Populated-account cascade is ADR §9.3 only. |
 | `GET /accounts/{accountId}/members` | `launchpad-accounts-{stage}` | Legacy thin member list — retained, unwired-to-UI; superseded by `…/members/detail`. |
 | `DELETE /accounts/{accountId}/members/{userId}` | `launchpad-accounts-{stage}` | Removes a member after owner verification. |
 | `POST /accounts/{accountId}/invitations` | `launchpad-invitations-{stage}` | Creates an invitation after owner verification. |

--- a/docs/architecture/route-classification-m16.md
+++ b/docs/architecture/route-classification-m16.md
@@ -73,8 +73,8 @@ This table is the **security-review artifact** for the site-admin-bypass removal
 | `GET /accounts/{accountId}/members/detail` | accounts | *(new route)* | `requireAccountAdmin(account-member)` | **R2 — full ListAccountMembersResponse (isLastOwner; pendingInvitations:[] until Phase 8)**; v0 account-management-view target; displayName enrichment (D6) deferred | **ruling #3: any member** | **PR-6A** |
 | `GET /accounts/{accountId}/members` | accounts | ad-hoc `members.some` (unchanged) | *(legacy thin — superseded by `/members/detail`)* | legacy thin list; unwired-to-UI; retire once `/members/detail` is the sole reader (see §8 retirement map) | legacy / retire | unwired |
 | `PUT /accounts/{accountId}` | accounts | ad-hoc `ownerId===userId` → owner-or-manager | `requireAccountAdmin(account-owner-or-manager)` + field-guard | R3 — account settings; manager+owner write `{name}`; `ownerId`/billing owner-only (ruling #2 field-guard) | **ruling #2: owner-or-manager** | **PR-6A** |
-| `DELETE /accounts/{accountId}` | accounts | withAuthOnly + ad-hoc owner | `requireAccountAdmin(owner)` + sole-owner deletion (D9 §9.3) + GlobalSignOut | destructive | Status-uncertain-resolved | **Phase 6 / PR-6B** |
-| `DELETE /accounts/{accountId}/members/{userId}` | accounts | withAuthOnly + ad-hoc | `requireAccountAdmin(anyOf(owner-or-manager + last-owner-guard, supervisory-site-admin))` + GlobalSignOut | remove member | Aspirational (manager-removal rules never built) | **Phase 6 / PR-6B** |
+| `DELETE /accounts/{accountId}` | accounts | ad-hoc owner → `requireAccountOwnerRole` | `requireAccountAdmin(owner)` — **BLOCK-if-members (409), never cascade** + GlobalSignOut | destructive; owner-only self-service; sole-member only; populated-account cascade is ADR §9.3 only (separate) | Resolved (block ruling) | **PR-6B** |
+| `DELETE /accounts/{accountId}/members/{userId}` | accounts | ad-hoc owner → policy | `requireAccountAdmin(`owner-or-manager + `decideRemoval` + last-owner-guard`, OR supervisory-site-admin LIVE)` + GlobalSignOut | remove member; manager scope = members/viewers; self-removal allowed; last-owner floor | Resolved | **PR-6B** |
 | `POST /accounts/{accountId}/invitations` | invitations | withAuth + ad-hoc `ownerId===userId` | `requireAccountAdmin(owner-or-manager / canCreateInvitationGrant)` | legacy single-invite | Aspirational (owner/manager in-app invite never built) | **Phase 8** (bundles) |
 | `GET /api/admin/...access-summary` (access-summary) | access-summary | requireSiteAdmin (claim) | `requireAccountAdmin(supervisory-site-admin)` | directory read; app-admin app-scope = Phase 7 | Confirmed (extended P7) | PR-B |
 | `GET /api/admin/ai-runtime-config` | ai-runtime-config | requireSiteAdmin | `operational-config` (supervisory-site-admin read) | platform AI config | Confirmed | PR-B / PR-C |
@@ -182,6 +182,33 @@ half of `launchpadRoutes` is PERMANENT and still consumed.
 
 (See the full read-only legacy-route audit for per-row successor / shape-conflict /
 consumer data.)
+
+### (f) Member-mutation rules (PR-6B, owner-settled)
+
+**removeMember** `DELETE /accounts/{accountId}/members/{userId}` — `requireAccountAdmin`
+of either (owner-or-manager AND `decideRemoval` legal) OR supervisory-site-admin
+verified **LIVE** via `AdminListGroupsForUser` (D-3, never token-only). `decideRemoval`:
+owner removes anyone; manager removes `member`/`viewer` only (never a manager/owner);
+self-removal allowed. The **last-owner floor** (`decideLastOwnerGuard`) applies to
+**everyone incl. supervisory site-admin** — the sole owner cannot be removed (orphaning
+is only the §9.3 cleanup, separate). `AdminUserGlobalSignOut` on success (D8).
+
+**deleteAccount** `DELETE /accounts/{accountId}` — **owner-only** (`requireAccountOwnerRole`),
+and **BLOCKS, never cascades** (owner ruling): an owner may delete only an account they
+have already emptied (**sole member = themselves**); **if other members exist → 409**
+(empty it first via removeMember). The `>99` guard is now `>1`. There is intentionally
+**no one-click delete-with-members**; the ONLY sanctioned cascade of a populated account
+is the ADR §9.3 site-admin orphaned-account cleanup (ruled separately, not this route).
+Ratified here and in the permissions model.
+
+**Fail-closed ordering (both mutations).** (1) Authorize (loader/Cognito errors →
+**503**, never proceed). (2) Resolve target + last-owner / block-if-members. (3)
+**Control-plane state FIRST** — delete the membership row / account+rows. This is the
+authoritative security boundary: from that instant app-data **writes** fail closed via
+the live row-check (D8), and the target's next token refresh drops the account. (4)
+`AdminUserGlobalSignOut` (accelerator — kills refresh tokens so only the bounded ≤1h
+access-token window remains). A sign-out failure is **surfaced as 502, never a silent
+success** (the row is already deleted; retry is idempotent).
 
 ## 8. auth.md verification summary (feeds the revision map)
 

--- a/docs/transformotion-user-account-permissions-model.md
+++ b/docs/transformotion-user-account-permissions-model.md
@@ -264,10 +264,11 @@ The account role model is:
 ### Role rules
 
 - Owners can manage account members, except they cannot remove/demote the last remaining owner.
-- Managers can manage users within allowed limits.
+- Managers can manage users within allowed limits: a manager may remove `member`/`viewer` members only, never another manager or an owner. A manager may remove themselves (self-removal).
 - Managers cannot grant `owner`.
 - Members/viewers cannot invite or manage account membership.
 - Last-owner guard is enforced server-side, not only in UI.
+- **Account deletion BLOCKS, it does not cascade (owner-settled, M16 Phase 6).** Owner-only self-service deletion (`DELETE /accounts/{accountId}`) is permitted only when the account is empty of other members — the owner must be the sole member. If other members remain, the request is rejected (409); the owner empties the account via member removal first. There is intentionally **no one-click delete-with-members**. The only sanctioned cascade of a populated account is the supervisory site-admin orphaned-account cleanup (ADR §9.3), a separate path.
 
 ---
 

--- a/packages/lambda-middleware/src/index.ts
+++ b/packages/lambda-middleware/src/index.ts
@@ -85,6 +85,7 @@ export {
   decideOwnerOrManager,
   decideOwner,
   decideRoleChange,
+  decideRemoval,
   decideLastOwnerGuard,
   discoveryScope,
   UNIFORM_DENY,

--- a/packages/lambda-middleware/src/policy.test.ts
+++ b/packages/lambda-middleware/src/policy.test.ts
@@ -10,6 +10,7 @@ import {
   decideOwnerOrManager,
   decideOwner,
   decideRoleChange,
+  decideRemoval,
   decideLastOwnerGuard,
   discoveryScope,
   accountRole,
@@ -152,6 +153,34 @@ describe('decideLastOwnerGuard', () => {
   });
   it('does not apply to a non-owner target', () => {
     expect(decideLastOwnerGuard([{ userId: 'o1', role: 'owner' }], 'm1').allow).toBe(true);
+  });
+});
+
+describe('decideRemoval (role model §7a)', () => {
+  it('owner may remove anyone', () => {
+    for (const t of ['owner', 'manager', 'member', 'viewer']) {
+      expect(decideRemoval('owner', t, false).allow).toBe(true);
+    }
+  });
+  it('manager may remove member/viewer ONLY', () => {
+    expect(decideRemoval('manager', 'member', false).allow).toBe(true);
+    expect(decideRemoval('manager', 'viewer', false).allow).toBe(true);
+    expect(decideRemoval('manager', 'manager', false).allow).toBe(false); // no peer removal
+    expect(decideRemoval('manager', 'owner', false).allow).toBe(false);
+  });
+  it('member/viewer may not remove anyone', () => {
+    expect(decideRemoval('member', 'viewer', false).allow).toBe(false);
+    expect(decideRemoval('viewer', 'member', false).allow).toBe(false);
+  });
+  it('self-removal is allowed regardless of role (last-owner floor enforced separately)', () => {
+    expect(decideRemoval('manager', 'manager', true).allow).toBe(true); // manager removes self
+    expect(decideRemoval('owner', 'owner', true).allow).toBe(true);     // owner self — last-owner guard blocks sole owner
+    expect(decideRemoval('member', 'member', true).allow).toBe(true);
+  });
+  it('unknown role on either side → deny', () => {
+    expect(decideRemoval('admin', 'member', false).allow).toBe(false);
+    expect(decideRemoval('owner', 'admin', false).allow).toBe(false);
+    expect(decideRemoval(undefined, 'member', false).allow).toBe(false);
   });
 });
 

--- a/packages/lambda-middleware/src/policy.ts
+++ b/packages/lambda-middleware/src/policy.ts
@@ -140,6 +140,34 @@ export function decideRoleChange(
 }
 
 /**
+ * Member-removal legality (role model — route-classification §7a; ADR D9). The
+ * removal-axis sibling of {@link decideRoleChange}, kept aligned with it.
+ *  - self-removal (`isSelf`) → ALLOW — a manager may remove themselves; the
+ *    last-owner FLOOR (a sole owner cannot self-remove) is enforced SEPARATELY by
+ *    {@link decideLastOwnerGuard}.
+ *  - owner actor → may remove anyone.
+ *  - manager actor → may remove `member`/`viewer` ONLY; never a manager or owner.
+ *  - member/viewer actor → may not remove anyone.
+ *  - unknown role on either side → deny (deny-by-default).
+ * Supervisory site-admin removal is authorized separately (not via this decider).
+ */
+export function decideRemoval(
+  actorRole: string | undefined,
+  targetRole: string | undefined,
+  isSelf: boolean,
+): PolicyDecision {
+  if (!isKnownRole(actorRole) || !isKnownRole(targetRole)) return deny('unknown role');
+  if (isSelf) return ALLOW;
+  if (actorRole === 'owner') return ALLOW;
+  if (actorRole === 'manager') {
+    return targetRole === 'member' || targetRole === 'viewer'
+      ? ALLOW
+      : deny('managers may remove only members/viewers');
+  }
+  return deny('only owner or manager may remove members');
+}
+
+/**
  * Last-owner guard: the sole remaining owner cannot be removed or demoted
  * (permissions model §4.5; ADR D9 owner-model supersession). Applies only when
  * the target is currently an owner.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -684,6 +684,9 @@ importers:
         specifier: workspace:*
         version: link:../../../../packages/lambda-middleware
     devDependencies:
+      '@aws-sdk/client-cognito-identity-provider':
+        specifier: ^3
+        version: 3.1032.0
       '@aws-sdk/client-dynamodb':
         specifier: ^3
         version: 3.1032.0


### PR DESCRIPTION
## Summary
The destructive half of Phase 6: `removeMember` (R5) and `deleteAccount`, built per the §7 corrections. Mutations only — the reads/name landed in PR-6A.

## removeMember — `DELETE /accounts/{accountId}/members/{userId}`
`requireAccountAdmin` (anyOf):
- **owner-or-manager** AND role-legal via **`decideRemoval`** (NEW pure decider, unit-tested): owner removes anyone; **manager removes `member`/`viewer` only** (never a manager/owner); **self-removal allowed** (R5 carve-out); OR
- **supervisory site-admin**, verified **LIVE** via `AdminListGroupsForUser` (D-3 — not token-only).
- **Last-owner floor** (`decideLastOwnerGuard`) applies to **everyone incl. supervisory site-admin** — the sole owner cannot be removed (**409**); orphaning is §9.3 only.
- `AdminUserGlobalSignOut` on success.

## deleteAccount — `DELETE /accounts/{accountId}`  (ruling applied)
**Owner-only**, and **BLOCKS, never cascades**: delete only when the owner is the **sole member**; other members → **409** (empty first via removeMember). `>99` guard → `>1`. There is intentionally **no one-click delete-with-members**; the only sanctioned cascade of a populated account is the ADR §9.3 site-admin orphaned-account cleanup (separate, not built). `AdminUserGlobalSignOut` on the sole member.

## Removal / sign-out ordering + failure semantics (fail-closed)
1. Authorize — loader/Cognito errors → **503**, never proceed.
2. Resolve target + last-owner floor / block-if-members.
3. **Control-plane delete FIRST** — the authoritative security boundary: app-data **writes** fail closed instantly via the live row-check (D8), and the target's next token refresh drops the account.
4. `AdminUserGlobalSignOut` — accelerator (kills refresh tokens; only the ≤1h access-token window remains). A sign-out failure is **surfaced as 502, never a silent success**; the row-delete is idempotent on retry.

## Exact IAM granted (scoped to the user pool ARN)
`cognito-idp:AdminUserGlobalSignOut`, `cognito-idp:AdminListGroupsForUser` — exactly these two. (+ `USER_POOL_ID` env on `AccountsFn`.)

## Doc ratifications (two, per the ruling)
- `route-classification-m16.md` §3 rows + new **§7(f)** member-mutation rules & fail-closed ordering.
- `permissions-model` — account-deletion **blocks, not cascades** ratified.
- (auth.md Scenario A rewritten; per-Lambda + onboarding rows updated.)

## Deferred (noted, not built here)
`decideRoleChange` tightening + the `PUT …/members/{userId}/role` route — the role-change route is not in this PR; recorded in §7(c).

## Validation
typecheck 63/63 · lambda-middleware 91/91 (+5 `decideRemoval`) · cdk synth LaunchpadControlPlane exit 0 (both IAM actions confirmed on AccountsFn) · check:v0-contracts byte-identical · diff --check clean.

## v0 freshness
- [x] No v0 impact

Reason: backend handler + CDK IAM/env + docs only; no contract/API/UI/mock shape change (`check:v0-contracts` byte-identical).

🤖 Generated with [Claude Code](https://claude.com/claude-code)