### PR TITLE
docs(contributing): §8 Working Agreement — scope provenance & decision discipline

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1529,7 +1529,53 @@ platform on every platform stack change.
 
 ---
 
-## 8. The status-tag system
+## 8. Working Agreement — scope provenance and decision discipline
+
+This section codifies process lessons from the M11/M16 account-lifecycle
+milestone. It is normative and applies to all phase work.
+
+Every feature, endpoint, or UI surface built in a phase MUST carry a
+**provenance tag**, recorded in the phase brief and the PR body, *before*
+implementation:
+
+- **prototyped** — it exists in the v0 prototype (cite the screen or behaviour).
+- **contracted** — it is defined in the m16/m17 contracts (cite the type, route,
+  or `behaviour.md` clause).
+- **net-new** — neither.
+
+**Rules.**
+
+1. **No net-new work inside a phase.** If an item is net-new, STOP and raise it as
+   a backlog issue — do not build it as part of phase work. Net-new may enter the
+   build path only via the normal route: prototype in v0 → promote to contract →
+   implement. The owner may explicitly fast-track, but only as a recorded,
+   deliberate exception.
+2. **Sub-questions never legitimise an unscoped parent.** Before resolving a detail
+   question about a feature (e.g. "should `deleteAccount` block or cascade?"),
+   confirm the feature itself is prototyped or contracted. If the parent has no
+   provenance, the parent is the issue — raise it; do not answer the sub-question.
+3. **Per-phase gap analysis precedes wiring.** Before a phase's implementation
+   begins, enumerate the phase's needs against the prototype/contract coverage as a
+   single gap list. Anything the phase needs that is not covered is resolved (or
+   explicitly deferred) UP FRONT, not discovered during wire-up. The gap list is the
+   phase's scope boundary: items not in it are out of scope by construction.
+4. **Scope-expanding suggestions must be tagged in the same breath.** Any
+   recommendation that adds scope ("complete the surface", "while we're here", "for
+   consistency", "for parity") MUST state the candidate's provenance tag and flag
+   net-new *before* the recommendation. An untagged additive recommendation is a
+   process violation.
+5. **Verify the artifact, not the report.** Decisions are made against the actual
+   code/contract/prototype state, not against a summary of it. When a report and an
+   artifact could disagree, check the artifact.
+
+**Enforcement.** Phase briefs carry provenance tags per item; PRs restate them;
+reviewers reject untagged or net-new-tagged phase work. These rules are mirrored in
+the project custom instructions that govern the chat-side design partner, since the
+same drift originates there.
+
+---
+
+## 9. The status-tag system
 
 Documents that have a "status" column for findings (the architectural
 inventory; verification reports; audit-style outputs) use a six-tag
@@ -1556,7 +1602,7 @@ six.
 
 ---
 
-## 9. Archived documents
+## 10. Archived documents
 
 Documents that have been superseded live in `/docs/archive/`. Each
 archived document carries a header at the top:
@@ -1584,7 +1630,7 @@ PLAN.md's documentation reconciliation milestone (Stage 0c).
 
 ---
 
-## 10. Changing this document
+## 11. Changing this document
 
 This document is itself operational — changes to ways of working are made
 by changing this document, in PRs.
@@ -1599,8 +1645,9 @@ Changes to Section 3 (repository structure) are coordinated with the
 relevant code reorganisation and ratified through the architecture
 decision process.
 
-Changes to Section 4 (workflow) and Section 7 (operating principles) are
-made when ways of working change. The change itself is a PR and goes
+Changes to Section 4 (workflow), Section 7 (operating principles), and
+Section 8 (Working Agreement — scope provenance and decision discipline)
+are made when ways of working change. The change itself is a PR and goes
 through normal review.
 
 Changes to Section 5 (architectural patterns) and Section 6 (utility
@@ -1609,5 +1656,5 @@ decisions change. Such changes are typically ratified through dedicated
 decision work (e.g., milestone-scoped decision documents) before
 landing in this document.
 
-Changes to Section 8 (status-tag system) and Section 9 (archived
+Changes to Section 9 (status-tag system) and Section 10 (archived
 documents) are mechanical.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1380,7 +1380,7 @@ Can run in parallel with M7 once M2.1 lands. Migration depends on infrastructure
 **Design baseline** (read before any implementation work):
 
 - [`docs/transformotion-user-account-permissions-model.md`](./docs/transformotion-user-account-permissions-model.md) — canonical product/permission model (entities, roles, policy matrix, invitation/redemption lifecycle).
-- [`docs/adr-m16-runtime-architecture.md`](./docs/adr-m16-runtime-architecture.md) — M16 runtime architecture decision document (D1–D11, all confirmed 2026-06-11). Milestone-scoped per CONTRIBUTING §10; decisions ratified into `docs/architecture/auth.md` and `docs/architecture/data.md` as implementing PRs land.
+- [`docs/adr-m16-runtime-architecture.md`](./docs/adr-m16-runtime-architecture.md) — M16 runtime architecture decision document (D1–D11, all confirmed 2026-06-11). Milestone-scoped per CONTRIBUTING §11; decisions ratified into `docs/architecture/auth.md` and `docs/architecture/data.md` as implementing PRs land.
 - [`docs/auth-md-revision-map.md`](./docs/auth-md-revision-map.md) — per-phase normative-document update obligations for `docs/architecture/auth.md`.
 
 **v0 contract baseline:** `m16.0.0` (v0 PR #38, commit `71219385`).

--- a/docs/adr-m16-runtime-architecture.md
+++ b/docs/adr-m16-runtime-architecture.md
@@ -4,11 +4,11 @@
 **Date:** 2026-06-12 (v1.3 — operational-config authorization category, row-class authorization in mixed partitions, and site_admin-claim-as-sole-admin-source; all three owner-confirmed) · 2026-06-11 (v1.2 — §9 items and Goal 4 amendment confirmed)
 **Goals served:** 4 primarily; 3 (per CONTRIBUTING §1.1 convention)
 **Scope:** Physical persistence, authorization mechanics, token/claims strategy, and middleware structure for the M16 runtime implementation in `transformotion/transformotion-apps`.
-**Document type:** Milestone-scoped decision document (CONTRIBUTING §10). Not itself normative; its decisions are **ratified into the normative documents** as the implementing PRs land, per the discipline rule (CONTRIBUTING §2.1):
+**Document type:** Milestone-scoped decision document (CONTRIBUTING §11). Not itself normative; its decisions are **ratified into the normative documents** as the implementing PRs land, per the discipline rule (CONTRIBUTING §2.1):
 
 - Authorization model, claims, middleware, supervisory semantics, invitations → `docs/architecture/auth.md` (per-phase section map in the companion auth.md revision map)
 - Table schemas, GSIs, denormalization rules (D1, D3–D6) → `docs/architecture/data.md`
-- Goal 4 wording in `CONTRIBUTING.md` §1.1 ("app access via Cognito groups") is amended by M16 ("app access derives from account membership"); Section 1 changes are escalated per CONTRIBUTING §10 and require explicit owner sign-off as a standalone, conscious edit.
+- Goal 4 wording in `CONTRIBUTING.md` §1.1 ("app access via Cognito groups") is amended by M16 ("app access derives from account membership"); Section 1 changes are escalated per CONTRIBUTING §11 and require explicit owner sign-off as a standalone, conscious edit.
 
 ## Relationship to canonical sources
 
@@ -198,7 +198,7 @@ App-admin per the model: app-scoped directory/metadata/member-list visibility an
 
 **Owner model supersession.** Current auth.md mandates a single-owner invariant with atomic ownership transfer and lists multi-owner as out of scope. The M16 contracts use a **last-owner guard** ("sole owner cannot be removed/demoted"), which presupposes multiple owners, and "managers cannot grant owner" implies owners can. The contracts win: multi-owner is in, the single-owner invariant, transfer-or-reject semantics, and "owner: exactly one" multiplicity are superseded. One consequence is unresolved — the sole-owner user-deletion path previously handled by site-admin ownership reassignment (a role-grant power D9 removes) — flagged in §9.
 
-**Route classification doubles as documentation verification.** auth.md describes capabilities the runtime audit did not find implemented (manager removal rules, ownership transfer, owner/manager in-app invitations, scheduled invitation expiry). While classifying every route onto the new middlewares, also record which auth.md claims are **Confirmed** vs **Aspirational-never-built** vs **Status uncertain — verify** (CONTRIBUTING §8 tags), feeding the auth.md revision map. One pass, two outputs.
+**Route classification doubles as documentation verification.** auth.md describes capabilities the runtime audit did not find implemented (manager removal rules, ownership transfer, owner/manager in-app invitations, scheduled invitation expiry). While classifying every route onto the new middlewares, also record which auth.md claims are **Confirmed** vs **Aspirational-never-built** vs **Status uncertain — verify** (CONTRIBUTING §9 tags), feeding the auth.md revision map. One pass, two outputs.
 
 **Bundle visibility rule:** an account's member list (including supervisory viewers) may show pending invites *targeting that account*; the **bundle** — which can span accounts — is visible only to its creator and the invitee. Per-account viewers must never see a bundle's other grants.
 
@@ -288,7 +288,7 @@ All three items flagged in v1.1 are confirmed, along with the Goal 4 wording ame
 1. **`admin` → `manager` mapping (D10) — confirmed.** Procedure stands: first verify whether any `admin` membership rows exist at all (the stale vocabulary may be type-level only in `packages/auth-client`). If rows exist, map `admin` → `manager`; promote specific users to `owner` manually only where warranted, by explicit owner instruction.
 2. **Site-admin search as filtered scan (D4) — confirmed.** Documented scaling ceiling stands; revisit only if site-admin user search becomes a frequent surface or user count makes scans slow.
 3. **Sole-owner user-deletion path (D9) — confirmed as option (a).** Site-admin may delete/archive the orphaned account entirely: a destructive supervisory action that never views the data and never self-escalates. No supervisory ownership-transfer exception exists. Until the deletion executes, the existing 409-while-sole-owner behavior applies. Phase 6 implements; auth.md Scenario C is updated accordingly in that PR.
-4. **Goal 4 wording amendment — sign-off recorded.** CONTRIBUTING §1.1 Goal 4 changes from "app access via Cognito groups; account membership and role via DynamoDB" to app access *deriving from account membership*, with Cognito groups maintained as a projection. The escalation requirement (CONTRIBUTING §10) is satisfied by this sign-off; the edit itself still lands as its own standalone PR, referencing this ADR, before or alongside Phase 5.
+4. **Goal 4 wording amendment — sign-off recorded.** CONTRIBUTING §1.1 Goal 4 changes from "app access via Cognito groups; account membership and role via DynamoDB" to app access *deriving from account membership*, with Cognito groups maintained as a projection. The escalation requirement (CONTRIBUTING §11) is satisfied by this sign-off; the edit itself still lands as its own standalone PR, referencing this ADR, before or alongside Phase 5.
 
 ## §10. Known costs accepted
 

--- a/docs/architecture/route-classification-m16.md
+++ b/docs/architecture/route-classification-m16.md
@@ -4,7 +4,7 @@
 **Date:** 2026-06-12
 **Consumes:** ADR v1.3 D5/D8/D9/D11/D12; permissions model §6.3 matrix, §8 discovery, §10 settings; #416 rulings.
 
-This table is the **security-review artifact** for the site-admin-bypass removal (ADR D9): every existing route is mapped to its new middleware. It doubles as the **auth.md verification sweep** (CONTRIBUTING §8 tags). Completeness over speed.
+This table is the **security-review artifact** for the site-admin-bypass removal (ADR D9): every existing route is mapped to its new middleware. It doubles as the **auth.md verification sweep** (CONTRIBUTING §9 tags). Completeness over speed.
 
 ## Legend
 
@@ -17,7 +17,7 @@ This table is the **security-review artifact** for the site-admin-bypass removal
 - `operational-config` — D9 administrative-axis service config (site-admin default / app-admin override); grants no account-data access.
 - `ws-authorizer` / `internal-invoke` / `health` — non-REST-route Lambdas.
 
-**auth.md verification tag** (CONTRIBUTING §8): `Confirmed` · `Aspirational-never-built` · `Status-uncertain-resolved`.
+**auth.md verification tag** (CONTRIBUTING §9): `Confirmed` · `Aspirational-never-built` · `Status-uncertain-resolved`.
 
 **Migrates in:** which phase actually swaps the guard. PR-B = this phase. Phase 6/8/9 = deferred mutation/invitation/redemption surfaces (out of Phase 5 scope). PR-C = AI-config rehoming.
 

--- a/docs/auth-md-revision-map.md
+++ b/docs/auth-md-revision-map.md
@@ -1,6 +1,6 @@
 # auth.md Revision Map — M16
 
-**Purpose:** Per the discipline rule (CONTRIBUTING §2.1), every phase PR that changes documented behavior updates `docs/architecture/auth.md` in the same PR. This map pre-plans those updates so each Claude Code phase brief carries its documentation obligation explicitly. It also records, using the CONTRIBUTING §8 status-tag system, which current auth.md statements are being deliberately superseded (**Stale-by-decision**) versus suspected of never having been implemented (**Status uncertain — verify** / **Aspirational-never-built**).
+**Purpose:** Per the discipline rule (CONTRIBUTING §2.1), every phase PR that changes documented behavior updates `docs/architecture/auth.md` in the same PR. This map pre-plans those updates so each Claude Code phase brief carries its documentation obligation explicitly. It also records, using the CONTRIBUTING §9 status-tag system, which current auth.md statements are being deliberately superseded (**Stale-by-decision**) versus suspected of never having been implemented (**Status uncertain — verify** / **Aspirational-never-built**).
 
 Companion to the M16 runtime architecture decision document (ADR). Decision references (D1–D11, §9) point there.
 
@@ -46,4 +46,4 @@ Companion to the M16 runtime architecture decision document (ADR). Decision refe
 
 ## Standing instruction for phase briefs
 
-Every Claude Code phase brief for M16 includes: *"This PR changes behavior documented in auth.md sections [from the map above]. Update those sections in this PR per CONTRIBUTING §2.1. If implementation reveals the documented current state was never true, pause, tag the finding per CONTRIBUTING §8, and report before proceeding."*
+Every Claude Code phase brief for M16 includes: *"This PR changes behavior documented in auth.md sections [from the map above]. Update those sections in this PR per CONTRIBUTING §2.1. If implementation reveals the documented current state was never true, pause, tag the finding per CONTRIBUTING §9, and report before proceeding."*


### PR DESCRIPTION
Adds a new normative top-level section to `CONTRIBUTING.md` codifying the scope-provenance & decision-discipline process lessons from the M11/M16 milestone. Docs-only. Refs #411.

## New section
**§8. Working Agreement — scope provenance and decision discipline** (placed after §7 Operating principles — the scope-themed home). Every feature/endpoint/UI surface carries a provenance tag (**prototyped** / **contracted** / **net-new**) in the phase brief + PR body before implementation, plus five rules: no net-new in a phase; sub-questions don't legitimise an unscoped parent; per-phase gap analysis precedes wiring; tag scope-expanding suggestions in the same breath; verify the artifact not the report. Enforcement clause mirrors the rules into the chat-side design-partner custom instructions.

## Numbering & cross-refs (the renumber you authorised)
New top-level §8 → the three trailing sections shift:
- §8 The status-tag system → **§9**
- §9 Archived documents → **§10**
- §10 Changing this document → **§11**

Every cross-ref to a renumbered section was updated for consistency:
| Ref | From → To | Files |
|---|---|---|
| status-tag system | §8 → §9 | CONTRIBUTING (self), `adr-m16` ×1, `route-classification-m16` ×2, `auth-md-revision-map` ×2 |
| changing-this-doc / escalation | §10 → §11 | CONTRIBUTING (self), `adr-m16` ×3, `PLAN.md` ×1 |

The archived `DEVELOPMENT_PLAN`'s own "Section 9 (auth model)" reference is intentionally **not** changed (it's not a CONTRIBUTING self-ref).

## Trade-off note (transparency)
A new top-level section before the cited §8/§10 necessarily renumbers them and touches 4 other docs (ADR, PLAN, route-classification, revision-map). A §7.x subsection or an end-appended section would have had zero external churn — but that would have overridden your explicit "new top-level section" choice, so I executed as instructed and absorbed the cross-ref updates.

## Validation
diff --check clean · grep confirms zero stale §8/§10 external refs remain and 9 refs now point to §9/§11 · header sequence §7–§11 contiguous · no AGENTS/CLAUDE change needed (CONTRIBUTING is its own normative doc; root CLAUDE.md describes it in prose without section numbers).

## v0 freshness
- [x] No v0 impact

Reason: documentation-only normative process section + section renumber; no contract/API/UI/runtime change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)