### PR TITLE
ci(auth-mirror): runtime-side sync PR-opener + freshness gate for the v0 mirror

### DIFF
--- a/.github/workflows/auth-model-freshness.yml
+++ b/.github/workflows/auth-model-freshness.yml
@@ -1,0 +1,69 @@
+name: Auth Model Mirror Freshness
+
+# PART B — the GATE. Fails (red) when the v0 repo's COMMITTED
+# contracts/auth-model.md differs from a fresh extraction of THIS repo's auth.md
+# fenced span. It compares the v0 mirror against the runtime auth.md SOURCE — it
+# never regenerates-then-self-diffs (that pattern always passes).
+#
+# Home: this runs in the RUNTIME repo (clobber-proof — a v0-tool push cannot
+# remove it). It reuses v0's check-auth-model-synced.sh, which regenerates from
+# runtime auth.md via the shared generator and diffs the committed v0 file, so
+# the source side and the v0 side agree by construction.
+#
+# Status-check name (require this on RUNTIME main branch protection):
+#   Auth Model Mirror Freshness / freshness
+#
+# Triggers: after auth.md lands on main (so a stale mirror shows red until the
+# Part A sync PR is merged), plus a daily drift sweep and manual dispatch. It is
+# deliberately NOT a blocking check on auth.md PRs (the mirror updates only after
+# merge, which would otherwise deadlock).
+#
+# Required Actions secrets (same App as Part A; read access is sufficient here):
+#   AUTH_MODEL_SYNC_APP_ID, AUTH_MODEL_SYNC_PRIVATE_KEY
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - docs/architecture/auth.md
+  schedule:
+    - cron: '17 6 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  freshness:
+    name: freshness
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout runtime (auth.md source)
+        uses: actions/checkout@v4
+        with:
+          path: runtime
+
+      - name: Mint GitHub App token (read the v0 repo)
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.AUTH_MODEL_SYNC_APP_ID }}
+          private-key: ${{ secrets.AUTH_MODEL_SYNC_PRIVATE_KEY }}
+          owner: transformotion
+          repositories: transformotion-apps-b8
+
+      - name: Clone v0 repo (its committed mirror) with the App token
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          git clone --depth 1 "https://x-access-token:${GH_TOKEN}@github.com/transformotion/transformotion-apps-b8.git" v0
+
+      - name: Compare v0's committed mirror against the runtime auth.md source
+        env:
+          RUNTIME_REPO_PATH: ${{ github.workspace }}/runtime
+        run: |
+          # check-auth-model-synced.sh regenerates from runtime auth.md (via the
+          # shared generator) and diffs the COMMITTED v0 contracts/auth-model.md.
+          # Red when they differ — i.e. auth.md changed but the mirror has not
+          # been regenerated/merged, or the mirror was hand-edited.
+          bash v0/scripts/ci/check-auth-model-synced.sh

--- a/.github/workflows/auth-model-sync.yml
+++ b/.github/workflows/auth-model-sync.yml
@@ -1,0 +1,92 @@
+name: Auth Model Mirror Sync
+
+# PART A — when the canonical auth.md changes on main, regenerate the v0 mirror
+# (contracts/auth-model.md in transformotion-apps-b8) and open a PR there.
+#
+# Direction: runtime owns auth.md and syncs DOWN to v0. The runtime repo is
+# PUBLIC; the WRITE into the PRIVATE v0 repo uses a GitHub App installation token
+# (App: auth-model-mirror-sync, scoped contents:write + pull-requests:write on
+# transformotion-apps-b8 only). The token is minted per-run and is short-lived.
+#
+# Required Actions secrets in THIS (runtime) repo:
+#   AUTH_MODEL_SYNC_APP_ID        — the GitHub App ID (4063106)
+#   AUTH_MODEL_SYNC_PRIVATE_KEY   — the GitHub App private key (PEM)
+# (Installation 140534760 is auto-resolved by the token action from app-id +
+#  owner + repositories; it does not need to be stored.)
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - docs/architecture/auth.md
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  sync:
+    name: sync
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout runtime (auth.md source)
+        uses: actions/checkout@v4
+        with:
+          path: runtime
+
+      - name: Mint GitHub App token (scoped to the v0 repo)
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.AUTH_MODEL_SYNC_APP_ID }}
+          private-key: ${{ secrets.AUTH_MODEL_SYNC_PRIVATE_KEY }}
+          owner: transformotion
+          repositories: transformotion-apps-b8
+
+      - name: Clone v0 repo (target) with the App token
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          git clone "https://x-access-token:${GH_TOKEN}@github.com/transformotion/transformotion-apps-b8.git" v0
+
+      - name: Regenerate the mirror with v0's own generator (single source of logic)
+        env:
+          RUNTIME_REPO_PATH: ${{ github.workspace }}/runtime
+        run: |
+          # sync-auth-model.sh extracts the mirror:start/end span from
+          # runtime auth.md and writes v0/contracts/auth-model.md — the exact
+          # generator the v0 freshness check uses, so source and check agree.
+          bash v0/scripts/sync-auth-model.sh
+
+      - name: Open a PR into the v0 repo if the mirror changed
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          cd v0
+          if git diff --quiet -- contracts/auth-model.md; then
+            echo "Mirror already in sync with auth.md; nothing to open."
+            exit 0
+          fi
+
+          SHORT_SHA="$(git -C "$GITHUB_WORKSPACE/runtime" rev-parse --short HEAD)"
+          FULL_SHA="$(git -C "$GITHUB_WORKSPACE/runtime" rev-parse HEAD)"
+          BRANCH="auth-model-sync/${SHORT_SHA}"
+
+          git config user.name "auth-model-mirror-sync[bot]"
+          git config user.email "auth-model-mirror-sync[bot]@users.noreply.github.com"
+          git checkout -B "$BRANCH"
+          git add contracts/auth-model.md
+          git commit -m "chore: regenerate auth-model mirror from auth.md@${SHORT_SHA}"
+          git push --force-with-lease origin "$BRANCH"
+
+          # Create the PR only if one is not already open for this branch.
+          if [ -z "$(gh pr list --repo transformotion/transformotion-apps-b8 --head "$BRANCH" --state open --json number --jq '.[].number')" ]; then
+            gh pr create \
+              --repo transformotion/transformotion-apps-b8 \
+              --base main \
+              --head "$BRANCH" \
+              --title "chore: regenerate auth-model mirror from auth.md@${SHORT_SHA}" \
+              --body "$(printf 'Regenerated %s from the runtime source of truth.\n\nSource: transformotion/transformotion-apps@%s\n  docs/architecture/auth.md (mirror:start/end span)\n\nSingle-file change; one-click merge after the freshness check passes. Do not edit the file by hand — it is generated; raise changes against the runtime auth.md.\n\n🤖 auth-model-mirror-sync' 'contracts/auth-model.md' "${FULL_SHA}")"
+          else
+            echo "An open PR already exists for ${BRANCH}; updated its branch."
+          fi


### PR DESCRIPTION
Builds the **runtime → v0** auth-model mirror automation: runtime owns `docs/architecture/auth.md`; v0 (`transformotion-apps-b8`) holds a generated copy at `contracts/auth-model.md`. Both jobs authenticate as the **auth-model-mirror-sync** GitHub App and **reuse the v0 repo's own generator/check scripts**, so the source side and the v0 freshness check agree by construction. Refs #411.

## App-token action
`actions/create-github-app-token@v1` (GitHub-maintained). It mints a short-lived installation token from the App ID + private key, scoped to `transformotion-apps-b8` via `owner` + `repositories` (installation 140534760 is auto-resolved; not stored).

## PART A — `auth-model-sync.yml` (PR opener)
Trigger: push to `main` changing `docs/architecture/auth.md` (+ `workflow_dispatch`). Mints the token, clones the v0 repo, runs `v0/scripts/sync-auth-model.sh` with `RUNTIME_REPO_PATH` = this checkout to regenerate `contracts/auth-model.md`. **Byte-identical → exit 0, opens nothing.** Differs → pushes `auth-model-sync/<short-sha>` and opens a **single-file** PR titled `chore: regenerate auth-model mirror from auth.md@<short-sha>` (body notes the full source SHA). **PR only — never a direct push to v0 main.**

## PART B — `auth-model-freshness.yml` (the GATE)
Trigger: push to `main` changing `auth.md`, a **daily** schedule, and `workflow_dispatch`. Clones the v0 repo and runs `v0/scripts/ci/check-auth-model-synced.sh`, which regenerates from **runtime auth.md** (shared generator) and diffs the **committed** v0 `contracts/auth-model.md` — i.e. it compares the v0 mirror against the runtime **SOURCE**, never a self-copy. **Red on drift.**
- Status-check name: **`Auth Model Mirror Freshness / freshness`**
- Not a blocking check on `auth.md` PRs (the mirror only updates post-merge, which would deadlock); instead it goes red on `main`/daily until the Part A sync PR is merged.

## Secrets the owner must provision (in THIS runtime repo's Actions secrets)
- **`AUTH_MODEL_SYNC_APP_ID`** — the GitHub App ID (`4063106`)
- **`AUTH_MODEL_SYNC_PRIVATE_KEY`** — the GitHub App private key (PEM)

No key is hardcoded; the workflows reference these by name only.

## Where enforcement on the v0 side lands (important — read before requiring a v0 check)
A v0-`main` **branch-protection required status check** that gates `contracts/auth-model.md` per-PR is **not cleanly achievable** under the constraints (no v0-side workflow per Part C; the App has `contents`+`pull-requests` write only — no `checks`/`statuses` write; and the runtime workflow can't observe v0 PR events). GitHub required-status-checks are all-PRs (not path-scoped), so a runtime-posted status would either block every unrelated v0 PR or require a v0 workflow. So the **freshness gate lives runtime-side** (Part B, clobber-proof, name above). Options for a true v0-PR-time gate, for owner decision:
1. add **Commit statuses: write** (or Checks: write) to the App **and** a PR-event bridge, or
2. a path-scoped **CODEOWNERS** review requirement on `contracts/auth-model.md` (native, no workflow, no status check — but it's a review gate, not a freshness check).

## Validation
Both workflow YAMLs parse cleanly (js-yaml): `sync` job; `freshness` job. `git diff --check` clean.

## Dependencies / merge order
Needs runtime fences PR **#451** on `main` (the `mirror:start/end` span) and the v0 scripts (**b8 #43**) on v0 `main`. Until both land, the workflows have nothing to extract / no script to run.

## v0 freshness
- [x] No v0 impact

Reason: CI workflows only (`.github/workflows/`); no contract/API/UI/runtime surface in this repo changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)