### PR TITLE
fix(ci): key auth-mirror workflows to develop (not the stale main)

### DIFF
--- a/.github/workflows/auth-model-freshness.yml
+++ b/.github/workflows/auth-model-freshness.yml
@@ -10,20 +10,22 @@ name: Auth Model Mirror Freshness
 # runtime auth.md via the shared generator and diffs the committed v0 file, so
 # the source side and the v0 side agree by construction.
 #
-# Status-check name (require this on RUNTIME main branch protection):
-#   Auth Model Mirror Freshness / freshness
+# Status-check name: Auth Model Mirror Freshness / freshness
+# Used as a MONITOR, not a required branch-protection check (it does not run on
+# pull_request, so requiring it would block every PR). The red signal + the Part
+# A auto-PR are the enforcement loop.
 #
-# Triggers: after auth.md lands on main (so a stale mirror shows red until the
-# Part A sync PR is merged), plus a daily drift sweep and manual dispatch. It is
-# deliberately NOT a blocking check on auth.md PRs (the mirror updates only after
-# merge, which would otherwise deadlock).
+# Triggers: after auth.md lands on develop (the active branch; main is a stale
+# mirror), so a stale v0 mirror shows red until the Part A sync PR is merged;
+# plus a daily drift sweep and manual dispatch. Deliberately NOT a blocking check
+# on auth.md PRs (the mirror updates only after merge, which would deadlock).
 #
 # Required Actions secrets (same App as Part A; read access is sufficient here):
 #   AUTH_MODEL_SYNC_APP_ID, AUTH_MODEL_SYNC_PRIVATE_KEY
 
 on:
   push:
-    branches: [main]
+    branches: [develop, main]
     paths:
       - docs/architecture/auth.md
   schedule:
@@ -38,10 +40,14 @@ jobs:
     name: freshness
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout runtime (auth.md source)
+      - name: Checkout runtime (auth.md source — develop is the source of truth)
         uses: actions/checkout@v4
         with:
           path: runtime
+          # Pin to develop (the active branch). schedule / workflow_dispatch
+          # otherwise check out the default branch (main), which is a stale
+          # mirror with no mirror:start/end fences -> the check would go red.
+          ref: develop
 
       - name: Mint GitHub App token (read the v0 repo)
         id: app-token

--- a/.github/workflows/auth-model-sync.yml
+++ b/.github/workflows/auth-model-sync.yml
@@ -1,6 +1,7 @@
 name: Auth Model Mirror Sync
 
-# PART A — when the canonical auth.md changes on main, regenerate the v0 mirror
+# PART A — when the canonical auth.md changes on develop (the repo's active
+# branch; the default branch `main` is a stale mirror), regenerate the v0 mirror
 # (contracts/auth-model.md in transformotion-apps-b8) and open a PR there.
 #
 # Direction: runtime owns auth.md and syncs DOWN to v0. The runtime repo is
@@ -16,7 +17,7 @@ name: Auth Model Mirror Sync
 
 on:
   push:
-    branches: [main]
+    branches: [develop, main]
     paths:
       - docs/architecture/auth.md
   workflow_dispatch:
@@ -29,10 +30,14 @@ jobs:
     name: sync
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout runtime (auth.md source)
+      - name: Checkout runtime (auth.md source — develop is the source of truth)
         uses: actions/checkout@v4
         with:
           path: runtime
+          # Pin to develop: it is the active branch. The default branch (main)
+          # is a stale mirror, so without this, workflow_dispatch (and any main
+          # push) would read a fenceless auth.md. develop is the canonical source.
+          ref: develop
 
       - name: Mint GitHub App token (scoped to the v0 repo)
         id: app-token


### PR DESCRIPTION
Fixes what surfaced from your question: the auth-mirror workflows were keyed to `main`, but this repo runs on **develop** (`main` is ~440 commits / ~2 months behind, all deploys run from develop, no live prod). As merged, the workflows were **inert** — nothing pushes to main. This repoints them, **with no develop→main promotion needed**.

## Two `main`-assumptions found & fixed (answers audit (b))
1. **push trigger** `branches: [main] → [develop, main]` (matches `deploy-*.yml`) — so they fire on auth.md changes on develop.
2. **runtime checkout pin `ref: develop`** — the repo **default branch is `main`** (stale, no `mirror:start/end` fences). Without a pin, the freshness check's `schedule`/`workflow_dispatch` runs would check out `main`, find no fences, and go **red**. Pinning to develop makes every event compare/generate from the canonical source.

Also: corrected the stale "on main" comments; dropped the "require on branch protection" note from the freshness header (it's a monitor, per your decision).

## Audit (b) result — is anything else mis-keyed to main? NO.
Everything else targets the correct branch:
- the v0 clone uses v0's **default branch (main)** — correct, v0's active branch *is* main;
- the sync PR is opened with `--base main` into the **v0** repo — correct;
- the freshness check reads the v0 mirror from **v0 main** (where #43 placed it) — correct.
The only mis-keyed thing was these two runtime workflows, and both `main`-assumptions in them are fixed here.

## Validation
Both YAMLs parse (js-yaml): `push branches: [develop, main]`, `checkout ref: develop`. `git diff --check` clean. No `pull_request` trigger added (no deadlock).

## After merge — (a) freshness first-run check
`merging this changes .github/ only` (not auth.md), so it won't auto-trigger freshness. I'll run it manually once it's on develop:
`gh workflow run auth-model-freshness.yml --ref develop` → watch → report green/red. With `ref: develop` it reads develop's fenced auth.md vs the v0 main mirror (#43) — expected green.

## v0 freshness
- [x] No v0 impact

Reason: CI workflow trigger/checkout fix only; no contract/API/UI/runtime surface changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)