### PR TITLE
feat(m11-a1): add {app}-app-admin Cognito groups (stock/budget)

### DIFF
--- a/apps/launchpad/infrastructure/launchpad-auth-stack.ts
+++ b/apps/launchpad/infrastructure/launchpad-auth-stack.ts
@@ -186,11 +186,25 @@ export class LaunchpadAuthStack extends cdk.Stack {
 
     const groups: Array<{ name: string; description: string; precedence: number }> = [
       { name: 'site-admin', description: 'Platform administrator', precedence: 1 },
-      ...registry.apps.map((app, idx) => ({
-        name: app.cognitoGroup,
-        description: app.groupDescription,
-        precedence: 50 + idx * 10,
-      })),
+      ...registry.apps.flatMap((app, idx) => {
+        const base = 50 + idx * 10;
+        return [
+          // {app}-app-access — registry-driven; already deployed.
+          {
+            name: app.cognitoGroup,
+            description: app.groupDescription,
+            precedence: base,
+          },
+          // {app}-app-admin — M11 A1: the groups-authoritative app-admin signal.
+          // Derived from the access group's shared prefix so the names track
+          // (contract appAdminGroup() = `${prefix}-admin`); see auth.md.
+          {
+            name: app.cognitoGroup.replace(/-access$/, '-admin'),
+            description: `User administers ${app.displayName}`,
+            precedence: base + 5,
+          },
+        ];
+      }),
       { name: 'admin', description: 'Legacy platform administrators - full access to all apps', precedence: 2 },
       { name: 'stock-app', description: 'Legacy Stock Signal Analyser access', precedence: 10 },
       { name: 'budget-app', description: 'Legacy Budget Tracker access', precedence: 20 },

--- a/docs/architecture/inventory.md
+++ b/docs/architecture/inventory.md
@@ -49,7 +49,8 @@ those stacks. They are not live ownership surfaces.
 - Cognito User Pool: `launchpad-auth-{stage}`
 - Hosted UI domain
 - Launchpad, Stock Analyser, and Budget Tracker app clients
-- Cognito groups: `site-admin`, `stock-app-access`, `budget-app-access`
+- Cognito groups: `site-admin`, `stock-app-access`, `stock-app-admin`,
+  `budget-app-access`, `budget-app-admin`
 - Social IdP configuration and secret placeholders
 - Hosted UI customization
 - Pre-token trigger: `launchpad-pre-token-generation-{stage}`
@@ -65,6 +66,12 @@ consumed by Launchpad, Stock Analyser, Budget Tracker, and migration utilities.
 Platform admin status is NOT a claim — it is read from the `site-admin` Cognito
 group (`cognito:groups`); the `site_admin` claim was removed in M16 Phase 6
 (v0 contract `m16.2.0` / D11).
+
+The `{app}-app-admin` groups (`stock-app-admin`, `budget-app-admin`) were
+deployed in M11 step A1 as the groups-authoritative app-admin foundation. They
+are additive and not yet consumed: the live app-admin signal remains the
+`app_admin` claim emitted by the pre-token trigger from the app-admin grants
+table, pending the A2 strike that moves authority to the group.
 
 ## Launchpad Control Plane
 


### PR DESCRIPTION
## What

M11 backend **step A1** — create the groups-authoritative app-admin foundation. Adds the `{app}-app-admin` Cognito groups (`stock-app-admin`, `budget-app-admin`) to `TransformotionDev-LaunchpadAuth`, alongside the existing `{app}-app-access` groups.

The registry-driven group map now emits both groups per app via `flatMap`, deriving the admin name from the access group's shared prefix (`-access` → `-admin`). This matches the contract's `appAdminGroup()` (= `${prefix}-admin`) exactly.

| group | precedence | status |
|---|---|---|
| `stock-app-access` | 50 | unchanged |
| `stock-app-admin` | 55 | **new** |
| `budget-app-access` | 60 | unchanged |
| `budget-app-admin` | 65 | **new** |

## Why this PR exists

The admin groups were **already deployed to dev** from local IaC during A1. That left the live pool *ahead* of `develop` — a `deploy-launchpad.yml` run from `develop` (which lacked this edit) would compute a diff that **removes** both admin groups, reverting the change. This PR lands the IaC on `develop` so the live state is durable.

## Scope / risk

- Additive only: no user is in the new groups yet.
- Not yet consumed: the live app-admin signal remains the `app_admin` claim emitted by the pre-token trigger from the app-admin grants table, **pending the A2 strike** that moves authority to the group. The pre-token Lambda is untouched here.
- `cdk diff` against dev showed exactly two additions (`Group-stock-app-admin`, `Group-budget-app-admin`), no modifications/deletions. Verified post-deploy via `aws cognito-idp list-groups`: access groups byte-unchanged, no other group touched.

## §2.1 doc pairing

`docs/architecture/inventory.md` — group enumeration updated to list both admin groups, with a note that they are foundation-only pending A2. cdk.md describes groups only at resource-type granularity ("groups") with no enumeration and its `app_admin` claim note stays accurate (claim still emitted), so no cdk.md change is required.

## v0 freshness

- [x] No v0 impact

Reason: CDK infrastructure (Cognito groups) + an architecture doc only. No UI-affecting paths (app/, components/, UI lib/stores/hooks/services) and no contract paths (`packages/contracts/`, `v0-reference/contracts/`) are touched. Group-name strings already match the existing v0 contract `appAccessGroup()`/`appAdminGroup()` — no contract change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)