### PR TITLE
fix(ci): sync v0 contracts in migration-utilities deploy before CDK bundling

### DIFF
--- a/.github/workflows/deploy-migration-utilities.yml
+++ b/.github/workflows/deploy-migration-utilities.yml
@@ -52,6 +52,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Clone v0 repo
+        env:
+          V0_REPO_READ_TOKEN: ${{ secrets.V0_REPO_READ_TOKEN }}
+        run: git clone --depth 1 "https://x-access-token:${V0_REPO_READ_TOKEN}@github.com/transformotion/transformotion-apps-b8.git" "$RUNNER_TEMP/transformotion-apps-b8"
+
       - uses: actions/setup-node@v4
         with:
           node-version: '22'
@@ -62,6 +67,20 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+
+      # The migration-utilities CDK app bundles Lambdas that import shared
+      # packages (@transformotion/lambda-middleware → @transformotion/contracts),
+      # which re-export the gitignored, sync-only v0-reference contracts. Without
+      # this sync, esbuild cannot resolve v0-reference and bundling fails (#460).
+      - name: Sync v0 contracts
+        env:
+          V0_REPO_PATH: ${{ runner.temp }}/transformotion-apps-b8
+        run: pnpm sync:v0
+
+      - name: Verify v0 contracts byte identity
+        env:
+          V0_REPO_PATH: ${{ runner.temp }}/transformotion-apps-b8
+        run: pnpm check:v0-contracts
 
       - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@v4
@@ -81,6 +100,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Clone v0 repo
+        env:
+          V0_REPO_READ_TOKEN: ${{ secrets.V0_REPO_READ_TOKEN }}
+        run: git clone --depth 1 "https://x-access-token:${V0_REPO_READ_TOKEN}@github.com/transformotion/transformotion-apps-b8.git" "$RUNNER_TEMP/transformotion-apps-b8"
+
       - uses: actions/setup-node@v4
         with:
           node-version: '22'
@@ -91,6 +115,18 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+
+      # See dev job: shared-package Lambdas re-export the sync-only v0-reference
+      # contracts, so esbuild bundling needs `pnpm sync:v0` first (#460).
+      - name: Sync v0 contracts
+        env:
+          V0_REPO_PATH: ${{ runner.temp }}/transformotion-apps-b8
+        run: pnpm sync:v0
+
+      - name: Verify v0 contracts byte identity
+        env:
+          V0_REPO_PATH: ${{ runner.temp }}/transformotion-apps-b8
+        run: pnpm check:v0-contracts
 
       - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@v4


### PR DESCRIPTION
## What

Adds the v0 contracts sync to **both jobs** (dev + prod) of `deploy-migration-utilities.yml`, mirroring the launchpad / stock-analyser / budget-tracker lanes: Clone v0 repo (`V0_REPO_READ_TOKEN`) → `pnpm sync:v0` → `pnpm check:v0-contracts`, before the CDK deploy step.

## Why

The migration-utilities CDK app bundles Lambdas that import shared packages (`@transformotion/lambda-middleware` → `@transformotion/contracts`), which re-export the gitignored, **sync-only** `v0-reference` contracts. With no sync step, esbuild can't resolve `v0-reference/contracts/_shared/auth` and the CDK bundle fails:

```
FailedToBundleAsset … BudgetTrackerTransactionsMigrateFn …
packages/contracts/src/_shared/auth.ts:1:14: Could not resolve '../../../../v0-reference/contracts/_shared/auth'
```

migration-utilities was the only app-deploy lane missing this step. It was latent until a **runtime** (value) import on that path landed in lambda-middleware (M11 A3, #459) — prior imports were `import type` (erased at compile), so esbuild never needed `v0-reference` for migration Lambdas.

No live/AWS damage occurred — the original failure was at esbuild bundling during `cdk deploy` synth, before any CloudFormation change.

Failed run: https://github.com/transformotion/transformotion-apps/actions/runs/27596856260

Fixes #460.

## v0 freshness

- [x] No v0 impact

Reason: CI workflow change only (adds the standard v0 sync steps already used by the other deploy lanes). No UI, contract, or runtime code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)