### PR TITLE
feat(m11-chunk3-pr1): groups-authoritative launchpad gate + create-first-account tile

### DIFF
--- a/apps/launchpad/components/launchpad/launchpad.tsx
+++ b/apps/launchpad/components/launchpad/launchpad.tsx
@@ -5,7 +5,7 @@ import { cn } from '@/lib/utils'
 import { Wordmark } from '@/components/brand/wordmark'
 import { AiEngineSettings } from '@/components/launchpad/ai-engine-settings'
 import { AccountMembersModal, useCanManageMembers } from '@/components/launchpad/account-members'
-import { TrendingUp, Wallet, Layers, LogOut, Settings, User as UserIcon, Users, Inbox } from 'lucide-react'
+import { TrendingUp, Wallet, Layers, LogOut, Settings, User as UserIcon, Users, Inbox, Plus, Sparkles, X } from 'lucide-react'
 import type { User } from '@transformotion/auth-client'
 import {
   LAUNCHPAD_APPS,
@@ -14,8 +14,11 @@ import {
   resolveDisplayName,
   firstNameOf,
   type AppTile as AppTileModel,
+  type ViewerEntitlement,
 } from '@/lib/entitlement'
 import { useLaunchpadData } from '@/hooks/use-launchpad-data'
+import { authService } from '@/lib/services/auth'
+import { createAccount } from '@/lib/services/account-admin'
 
 const APP_ICONS: Record<string, React.ComponentType<{ className?: string }>> = {
   'stock-analyser': TrendingUp,
@@ -103,12 +106,54 @@ function AppTile({
   app,
   index,
   onLaunch,
+  onCreateAccount,
 }: {
   app: AppTileModel
   index: number
   onLaunch?: () => void
+  onCreateAccount?: () => void
 }) {
   const Icon = APP_ICONS[app.slug] ?? Layers
+
+  // DISTINCT STATE (M11): the viewer holds the access group but has no account
+  // yet — render an actionable "create your first account" card (v0 #49 design),
+  // set apart from the normal "open" tile with a primary-accent treatment.
+  if (app.needsFirstAccount) {
+    return (
+      <div
+        className={cn(
+          'relative overflow-hidden p-6 rounded-2xl border text-left flex flex-col',
+          'border-primary/40 bg-primary/5 ring-1 ring-primary/10',
+          'animate-in fade-in slide-in-from-bottom-4',
+        )}
+        style={{ animationDelay: `${index * 100}ms` }}
+      >
+        <div className={cn('absolute inset-0 bg-gradient-to-br opacity-40', app.bgGradient)} />
+        <div className="relative flex flex-col flex-1">
+          <div className="flex items-start justify-between gap-2 mb-4">
+            <div className="size-14 rounded-xl flex items-center justify-center bg-surface2">
+              <Icon className={cn('size-7', app.color)} />
+            </div>
+            <span className="inline-flex items-center gap-1 rounded-full bg-primary/15 px-2.5 py-1 text-xs font-medium text-primary">
+              <Sparkles className="size-3" aria-hidden="true" />
+              Access granted
+            </span>
+          </div>
+          <h3 className="text-lg font-semibold text-foreground mb-1">{app.name}</h3>
+          <p className="text-sm leading-relaxed text-muted-foreground">
+            You have access — create your first account to get started.
+          </p>
+          <button
+            onClick={onCreateAccount}
+            className="mt-4 inline-flex items-center justify-center gap-2 rounded-lg bg-primary px-4 py-2.5 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 active:scale-[0.98] self-start"
+          >
+            <Plus className="size-4" aria-hidden="true" />
+            Create account
+          </button>
+        </div>
+      </div>
+    )
+  }
 
   return (
     <button
@@ -188,9 +233,11 @@ function AppGridSkeleton() {
 function AppGrid({
   tiles,
   getLaunchHandler,
+  onCreateAccount,
 }: {
   tiles: AppTileModel[]
   getLaunchHandler: (slug: string) => (() => void) | undefined
+  onCreateAccount: (slug: string) => void
 }) {
   const visible = tiles.filter((t) => t.visible)
   if (visible.length === 0) return <EmptyApps />
@@ -198,9 +245,99 @@ function AppGrid({
   return (
     <div className="grid gap-4 md:gap-6 sm:grid-cols-2 lg:grid-cols-3">
       {visible.map((app, index) => (
-        <AppTile key={app.slug} app={app} index={index} onLaunch={getLaunchHandler(app.slug)} />
+        <AppTile
+          key={app.slug}
+          app={app}
+          index={index}
+          onLaunch={getLaunchHandler(app.slug)}
+          onCreateAccount={() => onCreateAccount(app.slug)}
+        />
       ))}
     </div>
+  )
+}
+
+/** Create-first-account modal (v0 #49). Owner-on-create; calls the real POST /accounts. */
+function CreateAccountModal({
+  app,
+  busy,
+  error,
+  onSubmit,
+  onClose,
+}: {
+  app: AppTileModel
+  busy: boolean
+  error: string | null
+  onSubmit: (name: string) => void
+  onClose: () => void
+}) {
+  const [name, setName] = useState('')
+  const Icon = APP_ICONS[app.slug] ?? Layers
+  const canSubmit = name.trim().length > 0 && !busy
+  const submit = () => { if (canSubmit) onSubmit(name.trim()) }
+
+  return (
+    <>
+      <div className="fixed inset-0 bg-black/50 z-50" onClick={busy ? undefined : onClose} />
+      <div className="fixed left-1/2 top-1/2 z-50 w-[min(28rem,calc(100vw-2rem))] -translate-x-1/2 -translate-y-1/2 rounded-2xl border border-border bg-card shadow-2xl">
+        <div className="flex items-center justify-between gap-3 border-b border-border px-4 py-3">
+          <div className="flex items-center gap-3">
+            <div className="size-10 rounded-lg flex items-center justify-center bg-surface2">
+              <Icon className={cn('size-5', app.color)} />
+            </div>
+            <div>
+              <h2 className="text-sm font-semibold text-foreground">Create your {app.name} account</h2>
+              <p className="text-xs text-muted-foreground">You&apos;ll be the owner of this account</p>
+            </div>
+          </div>
+          <button
+            onClick={onClose}
+            disabled={busy}
+            className="size-8 rounded-lg flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-surface2 disabled:opacity-50"
+            aria-label="Close"
+          >
+            <X className="size-4" />
+          </button>
+        </div>
+
+        <div className="p-4">
+          <label htmlFor="new-account-name" className="block text-xs font-medium text-muted-foreground mb-1.5">
+            Account name
+          </label>
+          <input
+            id="new-account-name"
+            autoFocus
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            onKeyDown={(e) => { if (e.key === 'Enter') submit() }}
+            placeholder={`e.g. ${app.name} workspace`}
+            className="w-full h-10 rounded-lg border border-border bg-background px-3 text-sm text-foreground placeholder:text-muted-foreground/70 focus:outline-none focus:ring-2 focus:ring-primary/40"
+          />
+          <p className="mt-2 text-xs text-muted-foreground leading-relaxed">
+            This creates your first {app.name} account and makes you its owner. You can rename or add more later.
+          </p>
+          {error ? <p className="mt-2 text-xs text-signal-red">{error}</p> : null}
+
+          <div className="mt-4 flex items-center justify-end gap-2">
+            <button
+              onClick={onClose}
+              disabled={busy}
+              className="rounded-lg px-3 py-2 text-sm font-medium text-muted-foreground hover:bg-surface2 transition-colors disabled:opacity-50"
+            >
+              Cancel
+            </button>
+            <button
+              onClick={submit}
+              disabled={!canSubmit}
+              className="inline-flex items-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              <Plus className="size-4" aria-hidden="true" />
+              {busy ? 'Creating…' : 'Create account'}
+            </button>
+          </div>
+        </div>
+      </div>
+    </>
   )
 }
 
@@ -335,6 +472,13 @@ export function Launchpad({
   const [profileMenuOpen, setProfileMenuOpen] = useState(false)
   const [settingsOpen, setSettingsOpen] = useState(false)
   const [membersOpen, setMembersOpen] = useState(false)
+  // Create-first-account flow: the app whose modal is open, plus an OPTIMISTIC set
+  // of slugs just created (so the tile flips to normal-open immediately — the next
+  // token refresh confirms it via the accounts claim).
+  const [createAccountSlug, setCreateAccountSlug] = useState<string | null>(null)
+  const [createdSlugs, setCreatedSlugs] = useState<ReadonlySet<string>>(new Set())
+  const [creating, setCreating] = useState(false)
+  const [createError, setCreateError] = useState<string | null>(null)
 
   // Admin/control-plane surfaces gate on the site-admin Cognito group (via
   // metadata.siteAdmin), NOT app membership (D11; no site_admin claim).
@@ -355,8 +499,19 @@ export function Launchpad({
     email,
   })
 
-  // Tiles derive from entitlement (memberships per app), not a hard-coded list.
-  const tiles = deriveAppTiles(LAUNCHPAD_APPS, data.entitledSlugs)
+  // Tile visibility is GROUPS-AUTHORITATIVE (M11): the access/admin GROUPS from the
+  // token (metadata.appAccess / appAdmin / siteAdmin) decide what's visible — NOT
+  // membership. `accounted` (apps with >=1 account, from active-accounts) only
+  // distinguishes the create-first-account state from the normal-open state.
+  const meta = authUser?.metadata as { appAccess?: string[]; appAdmin?: string[] } | undefined
+  const viewer: ViewerEntitlement = {
+    siteAdmin: isSiteAdmin,
+    appAdmin: new Set(meta?.appAdmin ?? []),
+    appAccess: new Set(meta?.appAccess ?? []),
+    accounted: new Set([...data.entitledSlugs, ...createdSlugs]),
+  }
+  const tiles = deriveAppTiles(LAUNCHPAD_APPS, viewer)
+  const createAccountTile = createAccountSlug ? tiles.find((t) => t.slug === createAccountSlug) ?? null : null
 
   const accounts: AccountRow[] = data.selections.map((s) => ({
     appSlug: s.appSlug,
@@ -371,6 +526,30 @@ export function Launchpad({
     return undefined
   }
 
+  // Create the viewer's FIRST account in an app they already hold access to. Calls
+  // the real POST /accounts (A4) with { name, appSlug }; authorization is the
+  // caller's {appSlug}-app-access group. On success: optimistically mark the app
+  // accounted (tile flips to normal-open) and refresh the token so the new account
+  // + membership land in the next token's claims.
+  const handleCreateAccount = async (name: string) => {
+    if (!createAccountSlug) return
+    setCreating(true)
+    setCreateError(null)
+    try {
+      const idToken = await authService.getIdToken()
+      if (!idToken) throw new Error('Not signed in')
+      await createAccount(idToken, createAccountSlug, name)
+      setCreatedSlugs((prev) => new Set(prev).add(createAccountSlug))
+      setCreateAccountSlug(null)
+      authService.refreshTokens().catch(() => { /* next natural load reconciles */ })
+    } catch (err) {
+      console.error('[launchpad] create account failed:', err)
+      setCreateError('Could not create the account. Please try again.')
+    } finally {
+      setCreating(false)
+    }
+  }
+
   return (
     <div className="min-h-screen bg-background flex flex-col">
       <Header displayName={displayName} onOpenProfile={() => setProfileMenuOpen(true)} />
@@ -381,7 +560,11 @@ export function Launchpad({
           {data.loading ? (
             <AppGridSkeleton />
           ) : hasVisibleApps(tiles) ? (
-            <AppGrid tiles={tiles} getLaunchHandler={getLaunchHandler} />
+            <AppGrid
+              tiles={tiles}
+              getLaunchHandler={getLaunchHandler}
+              onCreateAccount={(slug) => { setCreateError(null); setCreateAccountSlug(slug) }}
+            />
           ) : (
             <EmptyApps />
           )}
@@ -398,6 +581,16 @@ export function Launchpad({
         onOpenSettings={isSiteAdmin ? () => setSettingsOpen(true) : undefined}
         onOpenMembers={canManageMembers ? () => setMembersOpen(true) : undefined}
       />
+
+      {createAccountTile && (
+        <CreateAccountModal
+          app={createAccountTile}
+          busy={creating}
+          error={createError}
+          onSubmit={handleCreateAccount}
+          onClose={() => { if (!creating) { setCreateAccountSlug(null); setCreateError(null) } }}
+        />
+      )}
 
       <AiEngineSettings isOpen={settingsOpen && isSiteAdmin} onClose={() => setSettingsOpen(false)} />
 

--- a/apps/launchpad/lib/entitlement.test.ts
+++ b/apps/launchpad/lib/entitlement.test.ts
@@ -9,8 +9,15 @@ import {
   fallbackWarnings,
 } from './entitlement';
 
-const visibleSlugs = (entitled: string[]) =>
-  deriveAppTiles(LAUNCHPAD_APPS, new Set(entitled))
+/** A viewer who holds the access group AND an account for each `slugs` app. */
+const accessed = (slugs: string[]) => ({
+  siteAdmin: false,
+  appAdmin: new Set<string>(),
+  appAccess: new Set(slugs),
+  accounted: new Set(slugs),
+});
+const visibleSlugs = (slugs: string[]) =>
+  deriveAppTiles(LAUNCHPAD_APPS, accessed(slugs))
     .filter((t) => t.visible)
     .map((t) => t.slug);
 
@@ -23,22 +30,21 @@ describe('entitledSlugsFromSelections', () => {
     expect([...set].sort()).toEqual(['budget-tracker', 'stock-analyser']);
   });
 
-  it('returns an empty set for no selections (zero-membership user)', () => {
+  it('returns an empty set for no selections (zero-account user)', () => {
     expect(entitledSlugsFromSelections([]).size).toBe(0);
   });
 });
 
-describe('deriveAppTiles — three-state model (D11)', () => {
-  it('shows a deployed app ONLY when the user is entitled', () => {
+describe('deriveAppTiles — groups-authoritative gate (M11)', () => {
+  it('shows a deployed app ONLY when the viewer holds the access group', () => {
     expect(visibleSlugs(['stock-analyser'])).toEqual(['stock-analyser']);
   });
 
-  it('hides a deployed app when the user has no membership', () => {
-    // entitled to BT only → SA hidden, BT shown
+  it('hides a deployed app the viewer has no access group for', () => {
     expect(visibleSlugs(['budget-tracker'])).toEqual(['budget-tracker']);
   });
 
-  it('shows multiple entitled apps in registry order', () => {
+  it('shows multiple accessed apps in registry order', () => {
     expect(visibleSlugs(['budget-tracker', 'stock-analyser'])).toEqual([
       'stock-analyser',
       'budget-tracker',
@@ -46,22 +52,48 @@ describe('deriveAppTiles — three-state model (D11)', () => {
   });
 
   it('never shows the not-deployed marketing app (coming-soon stays hidden)', () => {
-    // even if a stray entitlement slug matched it, it is not entitlement-gated
     expect(visibleSlugs(['transformation-framework'])).toEqual([]);
   });
 
-  it('shows nothing for a zero-membership user (empty state)', () => {
-    const tiles = deriveAppTiles(LAUNCHPAD_APPS, new Set());
+  it('shows nothing for a viewer with no access groups (empty state)', () => {
+    const tiles = deriveAppTiles(LAUNCHPAD_APPS, accessed([]));
     expect(hasVisibleApps(tiles)).toBe(false);
     expect(visibleSlugs([])).toEqual([]);
   });
 
-  it('marks visible gated tiles launchable and tolerates unknown slugs', () => {
-    const tiles = deriveAppTiles(LAUNCHPAD_APPS, new Set(['stock-analyser', 'made-up-app']));
-    const sa = tiles.find((t) => t.slug === 'stock-analyser')!;
-    expect(sa.visible).toBe(true);
-    expect(sa.launchable).toBe(true);
-    expect(hasVisibleApps(tiles)).toBe(true);
+  it('access-group + an account → visible, launchable, NOT create-first-account', () => {
+    const sa = deriveAppTiles(LAUNCHPAD_APPS, accessed(['stock-analyser'])).find((t) => t.slug === 'stock-analyser')!;
+    expect(sa).toMatchObject({ visible: true, launchable: true, needsFirstAccount: false });
+  });
+
+  it('access-group + ZERO accounts → visible, needsFirstAccount, NOT launchable (the app-grant persona)', () => {
+    const viewer = { siteAdmin: false, appAdmin: new Set<string>(), appAccess: new Set(['stock-analyser']), accounted: new Set<string>() };
+    const sa = deriveAppTiles(LAUNCHPAD_APPS, viewer).find((t) => t.slug === 'stock-analyser')!;
+    expect(sa).toMatchObject({ visible: true, needsFirstAccount: true, launchable: false });
+  });
+
+  it('per-app mix: accounted SA beside access-no-account BT, independently', () => {
+    const viewer = { siteAdmin: false, appAdmin: new Set<string>(), appAccess: new Set(['stock-analyser', 'budget-tracker']), accounted: new Set(['stock-analyser']) };
+    const tiles = deriveAppTiles(LAUNCHPAD_APPS, viewer);
+    expect(tiles.find((t) => t.slug === 'stock-analyser')).toMatchObject({ launchable: true, needsFirstAccount: false });
+    expect(tiles.find((t) => t.slug === 'budget-tracker')).toMatchObject({ launchable: false, needsFirstAccount: true });
+  });
+
+  it('site-admin sees a deployed app even without the access group (normal launch tile, not create)', () => {
+    const viewer = { siteAdmin: true, appAdmin: new Set<string>(), appAccess: new Set<string>(), accounted: new Set<string>() };
+    const sa = deriveAppTiles(LAUNCHPAD_APPS, viewer).find((t) => t.slug === 'stock-analyser')!;
+    expect(sa).toMatchObject({ visible: true, launchable: true, needsFirstAccount: false });
+  });
+
+  it('app-admin (no access group) sees the app as a normal tile, not create-first-account', () => {
+    const viewer = { siteAdmin: false, appAdmin: new Set(['budget-tracker']), appAccess: new Set<string>(), accounted: new Set<string>() };
+    const bt = deriveAppTiles(LAUNCHPAD_APPS, viewer).find((t) => t.slug === 'budget-tracker')!;
+    expect(bt).toMatchObject({ visible: true, launchable: true, needsFirstAccount: false });
+  });
+
+  it('tolerates unknown slugs in the access set', () => {
+    const viewer = { siteAdmin: false, appAdmin: new Set<string>(), appAccess: new Set(['stock-analyser', 'made-up']), accounted: new Set(['stock-analyser']) };
+    expect(hasVisibleApps(deriveAppTiles(LAUNCHPAD_APPS, viewer))).toBe(true);
   });
 });
 

--- a/apps/launchpad/lib/entitlement.ts
+++ b/apps/launchpad/lib/entitlement.ts
@@ -1,13 +1,15 @@
 /**
- * Pure entitlement + display helpers for the Launchpad home view (M16 Phase 3).
+ * Pure entitlement + display helpers for the Launchpad home view.
  *
- * Tiles derive from the user's per-app membership (the access projection), NOT
- * from a hard-coded list (ADR D11). Admin/control-plane surfaces gate on the
- * site-admin Cognito group / `app_admin` claim elsewhere — never on app
- * membership (the `site_admin` claim was removed in M16 Phase 6).
+ * Tile visibility is GROUPS-AUTHORITATIVE (M11): a tile shows when the viewer
+ * holds the app's `{app}-app-access` Cognito group (or is site-admin / app-admin
+ * for it) — NOT when they hold a membership. A viewer who holds the access group
+ * with ZERO accounts (the "access, no accounts" state produced by an app-grant
+ * invitation) sees a distinct "create your first account" tile. Each app's tile
+ * reflects its own state independently.
  *
  * Everything here is pure and framework-free so it can be unit-tested without a
- * DOM; the React component maps slugs to icons/launch handlers.
+ * DOM; the React component maps slugs to icons/launch/create handlers.
  */
 
 /** Static catalogue of apps the Launchpad knows how to present. */
@@ -30,12 +32,29 @@ export interface LaunchpadAppDef {
 
 /** One resolved tile for the current user. */
 export interface AppTile extends LaunchpadAppDef {
-  /** User holds at least one membership in this app. */
-  entitled: boolean;
-  /** Should the tile render at all. */
+  /** Should the tile render at all (viewer can see this app). */
   visible: boolean;
-  /** Tile is clickable (deployed AND entitled). */
+  /** Tile is a normal launch tile (deployed, visible, and the viewer has an account). */
   launchable: boolean;
+  /**
+   * Viewer holds the `{app}-app-access` group but has ZERO accounts in this app
+   * — the "access, no accounts" state. The tile renders a create-first-account
+   * CTA instead of a launch action. Site-admins / app-admins WITHOUT the access
+   * group are NOT first-account candidates (they see the app via their role).
+   */
+  needsFirstAccount: boolean;
+}
+
+/** The viewer's group-authoritative access, as the launchpad gate keys on it. */
+export interface ViewerEntitlement {
+  /** site-admin sees every deployed app. */
+  siteAdmin: boolean;
+  /** Apps the viewer admins (`{app}-app-admin` groups). */
+  appAdmin: ReadonlySet<string>;
+  /** Apps the viewer may ENTER (`{app}-app-access` groups) — the tile-visibility key. */
+  appAccess: ReadonlySet<string>;
+  /** Apps the viewer holds >=1 account in (active-account selections / accounts claim). */
+  accounted: ReadonlySet<string>;
 }
 
 /**
@@ -86,25 +105,29 @@ export function entitledSlugsFromSelections<T extends { appSlug: string }>(
 }
 
 /**
- * Resolve which tiles render for a user, given their entitled app slugs.
+ * Resolve which tiles render for a viewer, group-authoritatively (M11).
  *
- * Three-state model (D11):
- *  - entitlement-gated + deployed + entitled  → visible, launchable
- *  - entitlement-gated + deployed + NOT entitled → hidden (no membership, no tile)
- *  - not entitlement-gated (coming-soon/future) → hidden by default
+ *  - not entitlement-gated (coming-soon) OR not deployed → hidden.
+ *  - gated + deployed + (site-admin OR app-admin OR holds the access group) → visible.
+ *      · holds the access group but NO account → `needsFirstAccount` (create CTA).
+ *      · otherwise → `launchable` (normal open tile).
+ *  - gated + deployed + none of the above → hidden.
  *
- * Backfill tolerant: an unknown/empty entitlement set simply yields no visible
- * gated tiles (the empty state), never an error.
+ * Tolerant of unknown slugs and empty sets — simply yields no visible gated
+ * tiles (the empty state), never an error.
  */
 export function deriveAppTiles(
   apps: readonly LaunchpadAppDef[],
-  entitledSlugs: ReadonlySet<string>,
+  viewer: ViewerEntitlement,
 ): AppTile[] {
   return apps.map((app) => {
-    const entitled = entitledSlugs.has(app.slug);
-    const visible = app.entitlementGated ? app.deployed && entitled : false;
-    const launchable = visible && app.deployed && entitled;
-    return { ...app, entitled, visible, launchable };
+    if (!app.entitlementGated || !app.deployed) {
+      return { ...app, visible: false, launchable: false, needsFirstAccount: false };
+    }
+    const canSee = viewer.siteAdmin || viewer.appAdmin.has(app.slug) || viewer.appAccess.has(app.slug);
+    const needsFirstAccount = viewer.appAccess.has(app.slug) && !viewer.accounted.has(app.slug);
+    const launchable = canSee && !needsFirstAccount;
+    return { ...app, visible: canSee, launchable, needsFirstAccount };
   });
 }
 

--- a/apps/launchpad/lib/services/account-admin/index.ts
+++ b/apps/launchpad/lib/services/account-admin/index.ts
@@ -3,6 +3,7 @@ import { controlPlaneUrl } from '@/lib/services/control-plane';
 export interface AccountSummary {
   accountId: string;
   name: string;
+  appSlug?: string;
   ownerId?: string;
   createdAt?: string;
   updatedAt?: string;
@@ -48,15 +49,26 @@ async function request<T>(
   return response.json() as Promise<T>;
 }
 
-export function createAccount(
+/**
+ * M11 A4 / m16.6.0 — create the caller's first account in `appSlug`. POST /accounts
+ * is `withAuthOnly` (no account context), so it carries NO `X-Account-Id`; the
+ * target app travels in the body. Authorization is the caller's `{appSlug}-app-access`
+ * group (the access group authorizes; the body only says which app).
+ */
+export async function createAccount(
   idToken: string,
-  activeAccountId: string,
+  appSlug: string,
   name: string,
 ): Promise<{ account: AccountSummary }> {
-  return request(idToken, activeAccountId, '/accounts', {
+  const response = await fetch(controlPlaneUrl('/accounts'), {
     method: 'POST',
-    body: JSON.stringify({ name }),
+    headers: { Authorization: `Bearer ${idToken}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name, appSlug }),
   });
+  if (!response.ok) {
+    throw new Error(`POST /accounts failed: ${response.status}`);
+  }
+  return response.json() as Promise<{ account: AccountSummary }>;
 }
 
 export function getAccount(

--- a/docs/architecture/auth.md
+++ b/docs/architecture/auth.md
@@ -340,7 +340,7 @@ accounts:   Record<appSlug, Array<{accountId, role}>>          — per-app lean 
 
 Plus the standard Cognito claims (`sub`, `email`, `cognito:groups`, token lifetime fields). `custom:accounts` is inert (see Custom attributes above).
 
-**Launchpad renders tiles from the user's per-app membership** (the access projection, read at runtime via `GET /api/user/active-accounts`), not by inspecting the `apps` claim directly — see [Three-state tile model](#three-state-tile-model) (M16 Phase 3, D11).
+**Launchpad renders tiles GROUPS-AUTHORITATIVELY** (M11): a tile shows when the user holds the app's `{app}-app-access` Cognito group (or is site-admin / app-admin for it), NOT from membership. A holder of the access group with **zero** accounts (the "access, no accounts" state) sees a *create-first-account* tile; membership only distinguishes that state from the normal-open tile — see [Three-state tile model](#three-state-tile-model).
 **API handlers enforce per-account authorization by inspecting `accounts`.**
 
 <!-- mirror:end -->
@@ -396,19 +396,19 @@ The Hosted UI session cookie is what enables SSO across the three app clients �
 
 ## Three-state tile model
 
-> **M16 Phase 3 (D11) — revised.** Tiles now derive from the user's **account membership** (the access projection), read at runtime via the active-account read API (`GET /api/user/active-accounts`): the set of apps in which the user holds at least one account is the entitlement set. The previous rule — *"tiles from the `apps` claim plus a hardcoded deployed list"* — is **Stale-by-decision**. The `apps` claim survives as a coarse projection, but Launchpad reads entitlement from membership, and **admin/control-plane surfaces gate on the `site-admin` Cognito group / `{app}-app-admin` group, never on app membership.**
+> **M11 — groups-authoritative.** Tile VISIBILITY derives from the `{app}-app-access` Cognito group (`cognito:groups`, surfaced client-side as `User.metadata.appAccess`), plus site-admin / `{app}-app-admin`. NOT from membership. Membership (apps with ≥1 account, read via `GET /api/user/active-accounts`) only distinguishes the *create-first-account* state from the normal-open state. The earlier "tiles from membership" and "tiles from the `apps` claim + hardcoded list" rules are both **Stale-by-decision**. **Admin/control-plane surfaces gate on the `site-admin` / `{app}-app-admin` groups, never on app membership.**
 
-The launchpad resolves each app tile from two conditions — entitlement (membership) and deployment:
+The launchpad resolves each app tile group-authoritatively (gated, deployed apps):
 
-| User holds a membership in the app | App is deployed | Tile state |
+| Viewer (for the app) | Has ≥1 account | Tile state |
 |---|---|---|
-| Yes | Yes | Active — clickable, launches the app |
-| Yes | No | Visible, greyed out, "Coming Soon" label |
-| No | Any | Not rendered |
+| Holds the access group | Yes | Active — clickable, launches the app |
+| Holds the access group | No | **Create-first-account** — "Access granted, create your first account" CTA → `POST /accounts` (A4) |
+| site-admin / app-admin only (no access group) | Any | Active — normal launch tile (not create-first-account) |
+| None of the above | Any | Not rendered |
+| Any of the above, app NOT deployed | Any | Not rendered |
 
-A user with **zero** memberships sees an explicit empty state ("No apps yet — access arrives by invitation") — by design a real first-login state, never a blank page or an error. Backfill tolerance: missing or legacy entitlement data resolves to "not entitled" (no tile), never a crash.
-
-App deployment state is statically known to the launchpad (a catalogue of app slugs each carrying a `deployed` flag). Membership controls **visibility**; deployment controls **interactivity**. Not-deployed catalogue entries (coming-soon/marketing) stay hidden by default, preserving the pre-M16 deployed/coming-soon handling. Admin surfaces (e.g. AI runtime settings, and a future Users & Access view) are shown from the `site-admin` Cognito group / `{app}-app-admin` group independently of any app tile.
+Each app's tile reflects its OWN state independently (a viewer can have an account in one app beside an access-no-account tile in another). A viewer with **no** access groups (and not admin) sees the explicit empty state ("No apps yet — access arrives by invitation"). Backfill tolerant: missing/legacy data resolves to "not visible", never a crash. Coming-soon/not-deployed catalogue entries stay hidden. Admin surfaces (AI runtime settings, Users & Access) show from the `site-admin` / `{app}-app-admin` groups independently of any tile.
 
 ---
 

--- a/packages/auth-client/src/cognito-auth.ts
+++ b/packages/auth-client/src/cognito-auth.ts
@@ -10,7 +10,7 @@ import {
   fetchAuthSession,
 } from 'aws-amplify/auth'
 import { parseCognitoGroups } from '@transformotion/contracts/cognito-groups'
-import { deriveAppAdmin, type CognitoGroup } from '@transformotion/contracts/_shared/auth'
+import { deriveAppAdmin, deriveAppAccess, type CognitoGroup } from '@transformotion/contracts/_shared/auth'
 import type { AuthService, AuthSession, AuthTokens, User, Account, SignInCredentials, SignUpCredentials } from './index'
 
 export class CognitoAuthService implements AuthService {
@@ -57,10 +57,13 @@ export class CognitoAuthService implements AuthService {
       // `siteAdmin`. The former table-derived `app_admin` token claim was struck
       // (it duplicated group state); the group in the token is the sole signal.
       const appAdmin   = deriveAppAdmin(groups as CognitoGroup[])
+      // M11 groups-authoritative: apps the user may ENTER come from the
+      // `{app}-app-access` groups (the launchpad gate keys on this, not membership).
+      const appAccess  = deriveAppAccess(groups as CognitoGroup[])
       const name       = (givenName && familyName)
         ? `${givenName} ${familyName}`
         : (givenName ?? email)
-      return { id: cognitoUser.userId, email, name, metadata: { siteAdmin, appAdmin } }
+      return { id: cognitoUser.userId, email, name, metadata: { siteAdmin, appAdmin, appAccess } }
     } catch {
       return null
     }

--- a/packages/auth-client/src/index.ts
+++ b/packages/auth-client/src/index.ts
@@ -13,7 +13,11 @@ export interface User {
    *  - `appAdmin: string[]` — app slugs derived from the `{app}-app-admin` Cognito
    *    groups (`cognito:groups`). The `app_admin` token claim was struck (M11);
    *    the groups are the sole source, mirroring `siteAdmin`.
-   * UI gates admin surfaces on these.
+   *  - `appAccess: string[]` — app slugs the user may ENTER, derived from the
+   *    `{app}-app-access` Cognito groups (`cognito:groups`). Groups-authoritative
+   *    (M11): the launchpad gate keys on this, NOT membership — a user holding the
+   *    access group with zero accounts is the valid "access, no accounts" state.
+   * UI gates admin surfaces on siteAdmin/appAdmin, and the app tiles on appAccess.
    */
   metadata?: Record<string, unknown>
 }

--- a/packages/auth-client/src/mock-auth.ts
+++ b/packages/auth-client/src/mock-auth.ts
@@ -8,10 +8,11 @@ const MOCK_USER: User = {
   name: 'Demo User',
   avatarUrl: undefined,
   // Mirrors the Cognito provider's metadata shape: `siteAdmin` from the
-  // `site-admin` Cognito group, `appAdmin` derived from the `{app}-app-admin`
-  // groups (M11 groups-authoritative — the `app_admin` claim was struck). The
-  // mock user is a site-admin in no app-admin group, so `appAdmin` is empty.
-  metadata: { siteAdmin: true, appAdmin: [] as string[] },
+  // `site-admin` Cognito group, `appAdmin`/`appAccess` derived from the
+  // `{app}-app-admin`/`{app}-app-access` groups (M11 groups-authoritative — the
+  // `app_admin` claim was struck). The mock user is a site-admin in no app group,
+  // so both are empty (the launchpad shows all tiles via the site-admin path).
+  metadata: { siteAdmin: true, appAdmin: [] as string[], appAccess: [] as string[] },
 }
 
 const MOCK_ACCOUNTS: Account[] = [


### PR DESCRIPTION
## What (Chunk 3, PR 1 of 3)

Port the v0 **#49** launchpad gate + create-first-account surface into the live app, wired to the real backend. Tile visibility is now **groups-authoritative** (`cognito:groups`), not membership.

## Changes

- **auth-client**: expose `User.metadata.appAccess` (`deriveAppAccess` from the token groups), mirroring `siteAdmin`/`appAdmin`. The gate keys on this.
- **lib/entitlement**: `deriveAppTiles(apps, ViewerEntitlement)` resolves each tile group-authoritatively:
  - access group + an account → **launchable** (normal open)
  - access group + **zero** accounts → **needsFirstAccount** (create CTA) — the app-grant "access, no accounts" persona
  - site-admin / app-admin without the access group → visible normal tile (not create)
  - else → hidden. Per-app independent.
- **launchpad.tsx**: create-first-account tile + `CreateAccountModal` (v0 #49 design). "Create account" calls the **real** `POST /accounts` (A4) via `account-admin.createAccount(idToken, appSlug, name)` → `{ name, appSlug }` (m16.6.0), no `X-Account-Id`. On success: optimistic flip to normal-open + background token refresh.

## Tests

entitlement **25** (group-based visibility; create-first-account state; per-app mix; site-admin/app-admin normal tile; tolerant); auth-client **9** (`appAccess` derivation). Typecheck clean.

## §2.1 docs

`auth.md` — tile model + gate description rewritten group-authoritative (membership → access group; create-first-account state documented).

## v0 freshness

Reproduces the v0-prototyped create-first-account surface (the design-of-record). Provenance: https://github.com/transformotion/transformotion-apps-b8/commit/4ac2173 ("Launchpad: create-first-account state for app-access-no-accounts users"). The live app has its own parallel implementation; this PR ports that v0 design wired to the real Cognito `{app}-app-access` groups + `POST /accounts` (A4). No `packages/contracts/` change; v0-reference synced at v0 `main` (m16.6.0).