### PR TITLE
fix(stock-analyser): source price/change from market data, not the AI (#468)

### DIFF
--- a/apps/stock-analyser/components/stock-analyser/tabs/analyser-tab.tsx
+++ b/apps/stock-analyser/components/stock-analyser/tabs/analyser-tab.tsx
@@ -30,6 +30,7 @@ import { cn } from "@/lib/utils"
 import { useClaude } from "@/lib/hooks"
 import { useCycleData } from "@/lib/hooks/use-cycle-data"
 import { useOhlcvData } from "@/lib/hooks/use-ohlcv-data"
+import { latestPriceFromOhlcv } from "@/lib/market-data"
 import type { OhlcvRange } from "@transformotion/api-client"
 import { PriceChart } from "@/components/price-chart/price-chart"
 
@@ -44,8 +45,10 @@ interface AnalysisResult {
   ticker: string
   company: string
   sector: string
-  price: number
-  change: number
+  // Sourced from real market data (OHLCV), not the AI — nullable when no live
+  // quote is available. The AI's own price/change are not trusted.
+  price: number | null
+  change: number | null
   verdict: Verdict
   cyclePosition: number
   cycleStage: CycleStage
@@ -159,6 +162,10 @@ Return ONLY valid JSON.`,
 
   const onWatchlist = result ? isOnWatchlist(result.ticker) : false
 
+  // Real current price/change from market data (the OHLCV chart's latest close),
+  // NOT the AI — which has no live prices. Null until OHLCV loads / if it fails.
+  const livePrice = latestPriceFromOhlcv(ohlcvData)
+
   return (
     <div className="p-4 space-y-4">
       {/* Back link if came from another tab */}
@@ -271,8 +278,19 @@ Return ONLY valid JSON.`,
               <div>
                 <h2 className="text-2xl font-bold text-foreground">{result.company}</h2>
                 <div className="flex items-baseline gap-3 mt-2">
-                  <span className="text-3xl font-bold text-foreground">A${result.price.toFixed(3)}</span>
-                  <span className="text-sm font-semibold text-signal-green">+{result.change.toFixed(2)}%</span>
+                  <span className="text-3xl font-bold text-foreground">
+                    {livePrice.price !== null ? `A$${livePrice.price.toFixed(3)}` : "—"}
+                  </span>
+                  {livePrice.change !== null && (
+                    <span
+                      className={cn(
+                        "text-sm font-semibold",
+                        livePrice.change >= 0 ? "text-signal-green" : "text-signal-red",
+                      )}
+                    >
+                      {livePrice.change >= 0 ? "+" : ""}{livePrice.change.toFixed(2)}%
+                    </span>
+                  )}
                 </div>
               </div>
               <VerdictBadge verdict={result.verdict} size="md" />

--- a/apps/stock-analyser/components/stock-analyser/tabs/portfolio-tab.tsx
+++ b/apps/stock-analyser/components/stock-analyser/tabs/portfolio-tab.tsx
@@ -356,7 +356,7 @@ export function PortfolioTab() {
                       <>
                         <VerdictBadge verdict={a.verdict as Verdict} size="sm" />
                         <p className="text-xl font-bold text-foreground mt-1">
-                          A${a.price.toFixed(2)}
+                          {a.price !== null ? `A$${a.price.toFixed(2)}` : "—"}
                         </p>
                         {pl !== null && (
                           <p className={cn("text-xs font-semibold", pl >= 0 ? "text-signal-green" : "text-signal-red")}>

--- a/apps/stock-analyser/lib/market-data.ts
+++ b/apps/stock-analyser/lib/market-data.ts
@@ -1,0 +1,19 @@
+import type { OhlcvDataResponse } from '@transformotion/api-client'
+
+/**
+ * Current price + daily change %, derived from a REAL OHLCV series (latest and
+ * previous close). Price comes from market data — never from the AI, which has
+ * no real-time prices and returns null/unreliable values in `live`. Returns
+ * nulls when the series is unavailable so callers degrade gracefully.
+ */
+export function latestPriceFromOhlcv(
+  ohlcv: OhlcvDataResponse | null | undefined,
+): { price: number | null; change: number | null } {
+  const closes = ohlcv?.closes
+  if (!closes || closes.length === 0) return { price: null, change: null }
+  const price = closes[closes.length - 1] ?? null
+  const prev = closes.length >= 2 ? (closes[closes.length - 2] ?? null) : null
+  const change =
+    price !== null && prev !== null && prev !== 0 ? ((price - prev) / prev) * 100 : null
+  return { price, change }
+}

--- a/apps/stock-analyser/lib/services/portfolio/portfolio-service.ts
+++ b/apps/stock-analyser/lib/services/portfolio/portfolio-service.ts
@@ -9,7 +9,30 @@ import { getStockAnalyserClient } from '@/lib/api'
 import { getConfig } from '@/lib/config'
 import { dynamoCache } from '@/lib/services/cache/dynamo-ttl-cache'
 import { callClaudeAPI } from '@/lib/hooks/use-claude'
+import { getMockOhlcvData } from '@/lib/services/ai/fixtures/ohlcv-data'
+import { latestPriceFromOhlcv } from '@/lib/market-data'
 import type { PortfolioHolding, StockAnalysisResult } from './types'
+
+/**
+ * Overlay the REAL current price/change (from market data / OHLCV) onto an
+ * analysis. The AI cannot supply live prices, so its `price`/`change` are
+ * discarded here and replaced with the latest close. Best-effort: a failed
+ * quote leaves them null (the UI degrades gracefully).
+ */
+async function overlayLivePrice(
+  ticker: string,
+  analysis: StockAnalysisResult,
+): Promise<StockAnalysisResult> {
+  try {
+    const ohlcv = getConfig().ai.provider === 'mock'
+      ? getMockOhlcvData(ticker, '1mo', '1d')
+      : await getStockAnalyserClient().getOhlcvData(ticker, '1mo', '1d')
+    const { price, change } = latestPriceFromOhlcv(ohlcv)
+    return { ...analysis, price, change }
+  } catch {
+    return { ...analysis, price: null, change: null }
+  }
+}
 
 // ── Mock holdings ─────────────────────────────────────────────────────────────
 
@@ -91,9 +114,9 @@ export const portfolioService = {
       }))
     )
 
-    // 2. Deliver cache hits immediately
+    // 2. Deliver cache hits — overlaying the real (market-data) price/change.
     for (const { ticker, cached } of cacheChecks) {
-      if (cached) onResult(ticker, cached)
+      if (cached) onResult(ticker, await overlayLivePrice(ticker, cached))
     }
 
     // 3. Call Claude sequentially for cache misses
@@ -109,7 +132,7 @@ export const portfolioService = {
         dynamoCache.set(`ANALYSIS#${ticker}`, result).catch(err =>
           console.warn('[portfolio] cache write failed for', ticker, err)
         )
-        onResult(ticker, result)
+        onResult(ticker, await overlayLivePrice(ticker, result))
       } catch (err) {
         if (signal?.aborted) break
         console.warn('[portfolio] enrichment failed for', ticker, err)

--- a/apps/stock-analyser/lib/services/portfolio/types.ts
+++ b/apps/stock-analyser/lib/services/portfolio/types.ts
@@ -1,13 +1,18 @@
 export type { PortfolioHolding } from '@transformotion/contracts/stock-analyser/types'
 import type { PortfolioHolding } from '@transformotion/contracts/stock-analyser/types'
 
-/** Shape returned by the Claude stock analysis prompt (shared with Analyser tab). */
+/**
+ * Shape returned by the Claude stock analysis prompt (shared with Analyser tab).
+ * `price`/`change` are NULLABLE: they are sourced from real market data (OHLCV),
+ * not the AI — and may be null when a live quote is unavailable. The AI's own
+ * price/change (it has no real-time data) are NOT trusted.
+ */
 export interface StockAnalysisResult {
   ticker:        string
   company:       string
   sector:        string
-  price:         number
-  change:        number
+  price:         number | null
+  change:        number | null
   verdict:       'BUY' | 'SELL' | 'HOLD' | 'NEUTRAL'
   cyclePosition: number
   cycleStage:    'early' | 'mid' | 'late' | 'peak'


### PR DESCRIPTION
Fixes #468.

## Summary
The Analyser tab and Portfolio page crashed in `live` with `Cannot read properties of null (reading 'toFixed')` for **every** ticker (CBA.AX, SPACEX), in **both** Fast and Live modes. `price`/`change` were sourced from the Claude analysis — but an LLM has no real-time prices, so it returns `null` in live (mock fixtures hardcode them, which hid it). The unguarded `.toFixed()` then threw.

## Fix (runtime-only; LOCAL types, no v0 contract)
- `lib/market-data.ts` — `latestPriceFromOhlcv()` derives current price + daily change from the real OHLCV series (latest/prev close).
- `StockAnalysisResult.price`/`change` → `number | null` (type honesty).
- `portfolio-service.enrichHoldings` — overlays the **real** market price onto every holding; the AI's price is discarded.
- `analyser-tab` — header price/change sourced from the OHLCV the tab already fetches; guarded; correct +/− sign and green/red colour.
- `portfolio-tab` — null-guarded price render.

Real prices in both modes; degrades to `—` when a quote is briefly unavailable.

## Verification
- `tsc --noEmit` ✓
- `next build` ✓ (static export, all routes)
- No new lint violations (3 flagged errors are pre-existing baseline debt, untouched).

## Scope — does NOT touch the in-flight M11 work
- Stock Analyser only: 5 files under `apps/stock-analyser/`. This branch is off `develop`; the M11/Launchpad rebuild lives on a separate branch and is not in this diff.
- Separate deploy lane (`deploy-stock-analyser.yml`).

## v0 freshness
- [x] No v0 impact
- Reason: Runtime-only data-sourcing + robustness fix. The affected `AnalysisResult` / `StockAnalysisResult` are LOCAL app types (not in `v0-reference/contracts/stock-analyser/`), and v0 runs on mock data where price is always populated — so v0 cannot exhibit this bug and its mock path is unaffected. No layout change; the header still shows price + change%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)