### PR TITLE
fix(launchpad-auth): pre-token reconcile ADD-ONLY — durable "access, no accounts" (#473)

### DIFF
--- a/apps/launchpad/functions/pre-token-generation/package.json
+++ b/apps/launchpad/functions/pre-token-generation/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "build": "tsc --noEmit",
     "typecheck": "tsc --noEmit",
-    "lint": "echo \"lint: launchpad-pre-token-generation\""
+    "lint": "echo \"lint: launchpad-pre-token-generation\"",
+    "test": "vitest run"
   },
   "dependencies": {},
   "devDependencies": {
@@ -15,6 +16,7 @@
     "@aws-sdk/lib-dynamodb": "^3",
     "@types/aws-lambda": "^8",
     "@types/node": "^22",
-    "typescript": "*"
+    "typescript": "*",
+    "vitest": "^1"
   }
 }

--- a/apps/launchpad/functions/pre-token-generation/src/index.test.ts
+++ b/apps/launchpad/functions/pre-token-generation/src/index.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import { planReconcile } from './index';
+
+// ---------------------------------------------------------------------------
+// Pre-token reconcile is ADD-ONLY (one-directional invariant, #473).
+//
+// The load-bearing case is the one the prior tests never exercised: a user who
+// holds {app}-app-access with ZERO accounts (the "access, no accounts" state,
+// e.g. a fresh app-grant invitee) must RETAIN the access group through a token
+// refresh. The former remove-on-zero branch stripped it on refresh, locking the
+// invitee out of the create-first-account flow.
+// ---------------------------------------------------------------------------
+
+const APP_SLUGS = ['stock-analyser', 'budget-tracker'];
+const ACCESS_GROUP: Record<string, string> = {
+  'stock-analyser': 'stock-app-access',
+  'budget-tracker': 'budget-app-access',
+};
+
+type Accounts = Record<string, Array<{ accountId: string; role: string }>>;
+const plan = (groups: string[], accounts: Accounts) =>
+  planReconcile(groups, accounts, APP_SLUGS, ACCESS_GROUP);
+
+describe('planReconcile — add-only app-access invariant (#473)', () => {
+  it('RETAINS app-access at zero accounts (access, no accounts survives a refresh)', () => {
+    // App-grant invitee: holds the access group, owns no accounts. On the next
+    // token issuance the group must NOT be stripped.
+    const result = plan(['stock-app-access'], {});
+    expect(result.resultingGroups).toContain('stock-app-access');
+    expect(result.toAdd).toEqual([]); // nothing added, nothing removed
+  });
+
+  it('is stable across repeated refreshes (idempotent — never drifts to stripping)', () => {
+    let groups = ['stock-app-access'];
+    for (let refresh = 0; refresh < 3; refresh++) {
+      const result = plan(groups, {}); // still zero accounts each refresh
+      expect(result.resultingGroups).toContain('stock-app-access');
+      groups = result.resultingGroups;
+    }
+    expect(groups).toEqual(['stock-app-access']);
+  });
+
+  it('ADDS app-access when the user has >=1 account but lacks the group (membership ⟹ access)', () => {
+    const result = plan([], { 'stock-analyser': [{ accountId: 'acct-1', role: 'owner' }] });
+    expect(result.toAdd).toEqual(['stock-app-access']);
+    expect(result.resultingGroups).toContain('stock-app-access');
+  });
+
+  it('does not double-add when the user already holds the group and has accounts', () => {
+    const result = plan(['stock-app-access'], {
+      'stock-analyser': [{ accountId: 'acct-1', role: 'owner' }],
+    });
+    expect(result.toAdd).toEqual([]);
+    expect(result.resultingGroups).toEqual(['stock-app-access']);
+  });
+
+  it('reconciles each app independently and preserves unrelated groups', () => {
+    // Holds SA access with no SA accounts (retain), has a BT account but lacks BT
+    // access (add), and carries site-admin (preserved untouched).
+    const result = plan(['site-admin', 'stock-app-access'], {
+      'budget-tracker': [{ accountId: 'acct-bt', role: 'manager' }],
+    });
+    expect(result.toAdd).toEqual(['budget-app-access']);
+    expect(result.resultingGroups).toEqual(
+      expect.arrayContaining(['site-admin', 'stock-app-access', 'budget-app-access']),
+    );
+  });
+
+  it('never emits a remove: a site-admin holding access with zero accounts keeps it', () => {
+    // D11 removed the site-admin exemption, but with the remove branch gone there
+    // is nothing to be exempt from — no group is ever stripped here.
+    const result = plan(['site-admin', 'stock-app-access', 'budget-app-access'], {});
+    expect(result.toAdd).toEqual([]);
+    expect(result.resultingGroups).toEqual(['site-admin', 'stock-app-access', 'budget-app-access']);
+  });
+});

--- a/apps/launchpad/functions/pre-token-generation/src/index.ts
+++ b/apps/launchpad/functions/pre-token-generation/src/index.ts
@@ -1,7 +1,6 @@
 import type { PreTokenGenerationTriggerEvent } from 'aws-lambda';
 import {
   AdminAddUserToGroupCommand,
-  AdminRemoveUserFromGroupCommand,
   CognitoIdentityProviderClient,
 } from '@aws-sdk/client-cognito-identity-provider';
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
@@ -91,49 +90,76 @@ function groupByApp(
   return result;
 }
 
+/** The reconcile decision: the group list to claim on, and the access groups to add. */
+export interface ReconcilePlan {
+  /** Groups after the add-only reconcile (drives the apps claim). */
+  resultingGroups: string[];
+  /** Access groups to AdminAddUserToGroup (a user holds ≥1 account but lacks the group). */
+  toAdd: string[];
+}
+
+/**
+ * Pure, ADD-ONLY reconcile of the app-access invariant.
+ *
+ * The app-access invariant is ONE-DIRECTIONAL (auth.md §"App-access is
+ * independently held"): membership ⟹ app-access, but app-access ⇏ membership.
+ * So this only ADDs the access group for a user who holds ≥1 account for the app
+ * and lacks it. It MUST NEVER strip the access group when the user has zero
+ * accounts — "access, no accounts" is a VALID designed state (the app-grant
+ * landing that drives create-first-account), and it must SURVIVE every token
+ * refresh. App-access is removed ONLY by explicit grant-removal / app-removal
+ * cascade operations, never by this reconcile.
+ *
+ * #473: the former `else if (!hasAccounts && inGroup)` remove-on-zero branch
+ * enforced a bidirectional ⇔ and stripped app-access on the next token refresh,
+ * locking real app-grant invitees out of the create-first-account flow.
+ */
+export function planReconcile(
+  currentGroups: string[],
+  accountsByApp: Record<string, Array<{ accountId: string; role: string }>>,
+  appSlugs: string[],
+  accessGroupOf: Record<string, string>,
+): ReconcilePlan {
+  const resultingGroups = [...currentGroups];
+  const toAdd: string[] = [];
+
+  for (const slug of appSlugs) {
+    const accessGroup = accessGroupOf[slug];
+    const hasAccounts = (accountsByApp[slug]?.length ?? 0) > 0;
+    const inGroup = resultingGroups.includes(accessGroup);
+
+    if (hasAccounts && !inGroup) {
+      toAdd.push(accessGroup);
+      resultingGroups.push(accessGroup);
+    }
+    // No removal branch — the invariant is one-directional (see doc above, #473).
+  }
+
+  return { resultingGroups, toAdd };
+}
+
 async function reconcileInvariant(
   userId: string,
   userPoolId: string,
   currentGroups: string[],
   accountsByApp: Record<string, Array<{ accountId: string; role: string }>>,
 ): Promise<string[]> {
-  const groups = [...currentGroups];
+  const { resultingGroups, toAdd } = planReconcile(currentGroups, accountsByApp, APP_SLUGS, ACCESS_GROUP);
+  const groups = [...resultingGroups];
 
-  for (const slug of APP_SLUGS) {
-    const accessGroup = ACCESS_GROUP[slug];
-    const hasAccounts = (accountsByApp[slug]?.length ?? 0) > 0;
-    const inGroup = groups.includes(accessGroup);
-
-    // D11 item 1 (Phase 5): the site-admin override is REMOVED — the invariant
-    // (group membership ⇔ ≥1 account for the app) applies uniformly. A site-admin
-    // with no accounts for an app is removed from its access group like anyone
-    // else; site-admin's supervisory power rides the site-admin Cognito group
-    // (read from cognito:groups), not app-access groups.
-    if (hasAccounts && !inGroup) {
-      console.log(`[launchpad-pre-token] reconcile: adding ${userId} to ${accessGroup}`);
-      try {
-        await cognito.send(new AdminAddUserToGroupCommand({
-          UserPoolId: userPoolId,
-          Username: userId,
-          GroupName: accessGroup,
-        }));
-        groups.push(accessGroup);
-      } catch (err) {
-        console.error(`[launchpad-pre-token] reconcile: failed to add ${userId} to ${accessGroup}:`, err);
-      }
-    } else if (!hasAccounts && inGroup) {
-      console.log(`[launchpad-pre-token] reconcile: removing ${userId} from ${accessGroup}`);
-      try {
-        await cognito.send(new AdminRemoveUserFromGroupCommand({
-          UserPoolId: userPoolId,
-          Username: userId,
-          GroupName: accessGroup,
-        }));
-        const idx = groups.indexOf(accessGroup);
-        if (idx !== -1) groups.splice(idx, 1);
-      } catch (err) {
-        console.error(`[launchpad-pre-token] reconcile: failed to remove ${userId} from ${accessGroup}:`, err);
-      }
+  for (const accessGroup of toAdd) {
+    console.log(`[launchpad-pre-token] reconcile: adding ${userId} to ${accessGroup}`);
+    try {
+      await cognito.send(new AdminAddUserToGroupCommand({
+        UserPoolId: userPoolId,
+        Username: userId,
+        GroupName: accessGroup,
+      }));
+    } catch (err) {
+      console.error(`[launchpad-pre-token] reconcile: failed to add ${userId} to ${accessGroup}:`, err);
+      // The add failed — do not claim a group the user is not actually in.
+      const idx = groups.indexOf(accessGroup);
+      if (idx !== -1) groups.splice(idx, 1);
     }
   }
 

--- a/apps/launchpad/functions/pre-token-generation/vitest.config.ts
+++ b/apps/launchpad/functions/pre-token-generation/vitest.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    // Without a local config this package inherits apps/launchpad/vitest.config.ts
+    // (`include: ['lib/**']`), which silently skips these co-located src tests.
+    include: ['src/**/*.test.ts'],
+    // The handler module parses these at load (JSON.parse(APP_REGISTRY), table
+    // names). planReconcile takes its slugs/groups as params, but importing the
+    // module still evaluates the top-level consts — so they must be present.
+    env: {
+      ACCOUNT_MEMBERS_TABLE: 'members-test',
+      ACCOUNTS_TABLE: 'accounts-test',
+      APP_REGISTRY: JSON.stringify({
+        apps: [
+          { slug: 'stock-analyser', cognitoGroup: 'stock-app-access' },
+          { slug: 'budget-tracker', cognitoGroup: 'budget-app-access' },
+        ],
+      }),
+    },
+  },
+});

--- a/docs/architecture/auth.md
+++ b/docs/architecture/auth.md
@@ -305,7 +305,7 @@ Because groups are authoritative, granting and removing app-access or app-admin 
 
 **On failure:** Return the event unchanged. Cognito issues tokens without custom claims. Consumers (launchpad, API handlers) fail closed — empty or missing `apps`/`accounts` means the user has no access.
 
-**Latency budget:** One DynamoDB query per token issuance plus zero-to-two `AdminAddUserToGroup` / `AdminRemoveUserFromGroup` calls in the reconciliation step. Invoked only on sign-in and token refresh (roughly every hour per active user, not every API call). Cost and latency are negligible at family-platform scale.
+**Latency budget:** One DynamoDB query per token issuance plus zero-to-N `AdminAddUserToGroup` calls in the reconciliation step (**add-only** — the reconcile never removes a group; #473). Invoked only on sign-in and token refresh (roughly every hour per active user, not every API call). Cost and latency are negligible at family-platform scale.
 
 ---
 
@@ -722,7 +722,7 @@ Steps (fail-closed ordering):
 3. Delete the row in `launchpad-account-members-{stage}` for `(accountId, userId)` — the authoritative control-plane removal. From this instant the removed user's app-data **writes** fail closed via the live row-check (D8), and their next token refresh drops the account.
 4. Call `AdminUserGlobalSignOut` on the target — invalidates refresh tokens immediately. A sign-out failure is **surfaced as 502, never a silent success**; the row-delete is idempotent on retry. (No `custom:accounts` write — D11.)
 
-After this: the target's existing access token remains valid until expiry (≤1h), but writes already fail closed. On next refresh the pre-token Lambda issues a token without the account; if it was the user's last account in an app, the invariant reconciliation removes them from that app's `-access` group.
+After this: the target's existing access token remains valid until expiry (≤1h), but writes already fail closed. On next refresh the pre-token Lambda issues a token without the account. If it was the user's last account in an app, the access group is **retained** — the reconcile is one-directional (membership ⟹ app-access, never the reverse, see Pre-token generation Lambda above), so the user lands in the valid "access, no accounts" state (a create-first-account tile), **not** removed from the app. Dropping app-access entirely is only the explicit app-removal cascade (§ below), never the pre-token reconcile (#473).
 
 ### Scenario B: Disabling a user
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -856,6 +856,9 @@ importers:
       typescript:
         specifier: '*'
         version: 5.7.3
+      vitest:
+        specifier: ^1
+        version: 1.6.1(@types/node@22.19.17)(jsdom@29.1.1)(lightningcss@1.32.0)
 
   apps/launchpad/functions/user:
     dependencies:


### PR DESCRIPTION
Closes #473.

## Problem
The pre-token generation Lambda stripped `{app}-app-access` whenever a user held
the group with **zero** accounts for that app — a bidirectional equivalence
(`app-access ⇔ ≥1 account`) that contradicts the **one-directional** invariant
(`membership ⟹ app-access`, `access ⇏ membership`; `auth.md` L229/L321/L323) and
**breaks M11's create-first-account flow**: an app-grant invitee reaches the
"access, no accounts" state, then loses the access group on the next token refresh
(≤1h) and is locked out of the app and the flow. Affects every real app-grant
invitee. Full diagnosis + git archaeology in #473.

## Fix
- Delete the `else if (!hasAccounts && inGroup)` remove-on-zero branch — the
  reconcile is now **ADD-ONLY** (adds the access group for a user with ≥1 account
  who lacks it; never removes). Access removal stays solely with the explicit
  grant-removal / app-removal cascade ops (`auth.md` L323).
- Drop the now-unused `AdminRemoveUserFromGroupCommand` import.
- Extract the decision into a pure exported `planReconcile()` so the behavior is
  unit-testable; `reconcileInvariant` is a thin side-effecting wrapper that
  preserves the failed-add semantics (a failed `AdminAddUserToGroup` is not
  claimed).

## Verification (the gap that hid this)
New `src/index.test.ts` (6 tests, all green) exercises the case prior tests never
did — **across a token refresh**:
- a user holding `{app}-app-access` with **zero** accounts **RETAINS** it (single
  refresh + repeated refreshes / idempotent);
- `membership ⟹ access` still adds; no double-add; per-app independence;
  site-admin groups preserved; no remove ever emitted.

## Paired docs (§2.1)
`auth.md`: latency-budget line (add-only; no remove call) and the account-removal
step (last account lost ⟹ access **retained** as "access, no accounts", not
stripped) corrected to match the canonical Pre-token §323 statement.

## Deploy
Pre-token trigger ships in the `LaunchpadAuth` stack via `deploy-launchpad.yml`.
Behavioral Lambda fix — it *stops* a destructive action (no new resource, no new
permission). **Owner-gated**: diff below; deploy on approval.

## v0 freshness
No v0 impact — backend Lambda behavior + architecture docs only; no UI/contract
change.