### PR TITLE
feat(launchpad-dev): persona-switcher runtime — real session-swap behind v0 surface

### DIFF
--- a/apps/launchpad/.env.example
+++ b/apps/launchpad/.env.example
@@ -156,6 +156,18 @@ NEXT_PUBLIC_RUNTIME_PROFILE=mock
 # Valid values: local | dynamo
 # NEXT_PUBLIC_DATA_OVERRIDE=local
 
+# ── Dev tooling ───────────────────────────────────────────────────────────────
+
+# [OPTIONAL] Gate for dev-only surfaces: the Redemption Demo harness and the
+# Persona Switcher (floating dev panel that mints REAL persona sessions via the
+# dev-only POST /api/dev/persona-token endpoint and swaps them into the tab).
+# Defaults ON when unset (safe for local/staging). PRODUCTION MUST SET THIS TO
+# `false` — it removes these surfaces. NOT a security boundary (client flag): the
+# mint endpoint is independently stack-gated + stage-gated + allow-listed and is
+# absent from the prod stack. Orthogonal to NEXT_PUBLIC_AUTH_OVERRIDE (cognito +
+# dev-tools-on is a valid staging combo).
+# NEXT_PUBLIC_DEV_TOOLS=false
+
 # ── Build-injected ────────────────────────────────────────────────────────────
 
 # [BUILD-INJECTED]

--- a/apps/launchpad/app/layout.tsx
+++ b/apps/launchpad/app/layout.tsx
@@ -2,6 +2,8 @@ import type { Metadata, Viewport } from 'next'
 import { Inter, Geist_Mono, Bebas_Neue } from 'next/font/google'
 import { Analytics } from '@vercel/analytics/next'
 import { BUILD_COMMIT_HASH, APP_IDENTITY } from '@/lib/build-info'
+import { PersonaSwitcher } from '@/components/launchpad/dev/persona-switcher'
+import { devToolsEnabled } from '@/lib/dev-tools'
 import './globals.css'
 
 const inter = Inter({
@@ -45,6 +47,9 @@ export default function RootLayout({
     >
       <body className="font-sans antialiased min-h-screen bg-background text-foreground">
         {children}
+        {/* Dev-only persona switcher (gated mount + the component self-gates via
+            devToolsEnabled()). Absent from production builds. */}
+        {devToolsEnabled() && <PersonaSwitcher />}
         {process.env.NODE_ENV === 'production' && <Analytics />}
       </body>
     </html>

--- a/apps/launchpad/components/launchpad/dev/persona-switcher.tsx
+++ b/apps/launchpad/components/launchpad/dev/persona-switcher.tsx
@@ -1,0 +1,313 @@
+/**
+ * Dev Persona Switcher — Live Persona Session Control (dev-only)
+ * =============================================================
+ * RUNTIME of v0's prototyped surface (transformotion-apps-b8
+ * components/launchpad/dev/persona-switcher.tsx @ 0fbc9e3). The SURFACE is ported
+ * verbatim; the only thing that changed is the data/auth layer behind the seam.
+ *
+ * Picking a persona mints a REAL session (dev-only POST /api/dev/persona-token)
+ * and swaps it into THIS tab (same-tab replace, via the Amplify token store) —
+ * the app genuinely authenticates you AS the persona until you switch back. The
+ * tester's ORIGINAL session is preserved across persona hops, so "switch back"
+ * returns to the original tester (e.g. Steve), not the previous hop.
+ *
+ * Disabled personas (Leo) are NOT mintable and are shown non-switchable. Gated by
+ * `devToolsEnabled()` — same as the Redemption Demo — so it never ships to prod.
+ *
+ * Differences from the mock prototype (data layer only): the name edit persists
+ * live (PUT /api/user/preferences displayName); the mock-only "reset backend to
+ * seed" control is dropped (no live equivalent).
+ */
+
+"use client"
+
+import { useEffect, useState } from "react"
+import {
+  UserCog,
+  LogOut,
+  ShieldCheck,
+  ShieldAlert,
+  Ban,
+  Check,
+  X,
+  Pencil,
+  Eye,
+  Undo2,
+  Zap,
+} from "lucide-react"
+import { cn } from "@/lib/utils"
+import { authService } from "@/lib/services/auth"
+import { updateDisplayName } from "@/lib/services/user-profile"
+import { listPersonas } from "@/lib/dev/persona-catalog"
+import { startImpersonation, stopImpersonation } from "@/lib/dev/persona-impersonation"
+import { usePersonaSession, useImpersonator } from "@/hooks/use-persona-switcher"
+import { devToolsEnabled } from "@/lib/dev-tools"
+
+export function PersonaSwitcher() {
+  const session = usePersonaSession()
+  const impersonator = useImpersonator()
+  const personas = listPersonas()
+  const [open, setOpen] = useState(false)
+  const [editingName, setEditingName] = useState(false)
+  const [draftName, setDraftName] = useState("")
+  const [switchError, setSwitchError] = useState<string | null>(null)
+  // Static-export SSR guard: render nothing until mounted so the first client
+  // render matches the prerendered HTML (the auth store rehydrates a persisted
+  // user on the client only — without this the FAB label hydration-mismatches).
+  const [mounted, setMounted] = useState(false)
+  useEffect(() => setMounted(true), [])
+
+  const isImpersonating = impersonator !== null
+
+  async function handleSwitch(personaId: string) {
+    setSwitchError(null)
+    const result = await startImpersonation(personaId)
+    // On success the tab reloads as the persona; only surface failures here.
+    if (!result.ok) {
+      setSwitchError(result.error)
+    }
+  }
+
+  function handleSwitchBack() {
+    setSwitchError(null)
+    stopImpersonation()
+  }
+
+  function startEditName() {
+    setDraftName(session?.displayName ?? "")
+    setEditingName(true)
+  }
+  async function saveName() {
+    const idToken = await authService.getIdToken().catch(() => null)
+    if (idToken) {
+      try {
+        await updateDisplayName(idToken, draftName)
+      } catch {
+        /* best-effort; the live read on next load reflects the persisted name */
+      }
+    }
+    setEditingName(false)
+  }
+
+  // Dev/test-harness gate. Placed after all hooks (rules-of-hooks safe); the
+  // flag is module-stable so this is consistent across renders. Disabled in
+  // production builds (NEXT_PUBLIC_DEV_TOOLS=false) — the switcher disappears
+  // from every screen it is mounted on at once.
+  if (!devToolsEnabled() || !mounted) return null
+
+  return (
+    <div className="fixed bottom-4 right-4 z-[100] font-sans">
+      {open ? (
+        <div className="flex max-h-[calc(100vh-2rem)] w-80 flex-col overflow-hidden rounded-xl border border-border bg-surface shadow-2xl">
+          {/* Header — stays pinned so the close (X) is always reachable */}
+          <div className="flex shrink-0 items-center justify-between border-b border-border bg-surface2/60 px-4 py-3">
+            <div className="flex items-center gap-2">
+              <UserCog className="size-4 text-primary" />
+              <span className="text-xs font-semibold uppercase tracking-wider text-foreground">
+                Persona switcher (dev)
+              </span>
+            </div>
+            <button
+              onClick={() => setOpen(false)}
+              className="rounded-md p-1 text-muted-foreground hover:bg-surface hover:text-foreground"
+              aria-label="Close persona switcher"
+            >
+              <X className="size-4" />
+            </button>
+          </div>
+
+          {/* Honesty note — this is a REAL minted session, not a pretend flip */}
+          <div className="flex shrink-0 items-start gap-1.5 border-b border-border bg-surface2/30 px-4 py-2">
+            <Zap className="mt-0.5 size-3 shrink-0 text-signal-amber" />
+            <p className="text-[10px] leading-relaxed text-muted-foreground">
+              Switching mints a <span className="font-semibold text-foreground">real session</span> for
+              the persona and replaces yours in this tab. The app truly sees you as them until you switch
+              back.
+            </p>
+          </div>
+
+          {/* Active impersonation banner — always visible while viewing-as */}
+          {isImpersonating && (
+            <div className="shrink-0 border-b border-signal-amber/40 bg-signal-amber/10 px-4 py-2.5">
+              <div className="flex items-center gap-1.5">
+                <Eye className="size-3.5 text-signal-amber" />
+                <p className="text-[11px] font-semibold text-foreground">
+                  Viewing as {session?.label}
+                </p>
+              </div>
+              <p className="mt-0.5 text-[10px] text-muted-foreground">
+                Your session: {impersonator?.label}
+              </p>
+              <button
+                onClick={handleSwitchBack}
+                className="mt-2 inline-flex w-full items-center justify-center gap-1.5 rounded-md bg-signal-amber px-2 py-1.5 text-[11px] font-semibold text-background hover:bg-signal-amber/90"
+              >
+                <Undo2 className="size-3.5" />
+                Switch back to {impersonator?.label}
+              </button>
+            </div>
+          )}
+
+          {/* Current session */}
+          <div className="shrink-0 border-b border-border px-4 py-3">
+            {session ? (
+              <>
+                <p className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+                  {isImpersonating ? "Acting as" : "Signed in as"}
+                </p>
+                {editingName ? (
+                  <div className="mt-1.5 flex items-center gap-1.5">
+                    <input
+                      value={draftName}
+                      onChange={(e) => setDraftName(e.target.value)}
+                      placeholder="Display name"
+                      className="min-w-0 flex-1 rounded-md border border-border bg-background px-2 py-1 text-sm text-foreground outline-none focus:border-primary"
+                      autoFocus
+                    />
+                    <button
+                      onClick={saveName}
+                      className="rounded-md bg-primary p-1.5 text-primary-foreground hover:bg-primary/90"
+                      aria-label="Save display name"
+                    >
+                      <Check className="size-3.5" />
+                    </button>
+                    <button
+                      onClick={() => setEditingName(false)}
+                      className="rounded-md border border-border p-1.5 text-muted-foreground hover:bg-surface2"
+                      aria-label="Cancel"
+                    >
+                      <X className="size-3.5" />
+                    </button>
+                  </div>
+                ) : (
+                  <div className="mt-1 flex items-center gap-2">
+                    <span className="text-sm font-semibold text-foreground">{session.label}</span>
+                    <button
+                      onClick={startEditName}
+                      className="rounded p-0.5 text-muted-foreground hover:text-foreground"
+                      aria-label="Edit display name"
+                    >
+                      <Pencil className="size-3" />
+                    </button>
+                    {session.siteAdmin && (
+                      <span className="ml-auto inline-flex items-center gap-1 rounded-full bg-primary/15 px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wider text-primary">
+                        <ShieldCheck className="size-2.5" />
+                        site-admin
+                      </span>
+                    )}
+                  </div>
+                )}
+                <p className="mt-0.5 truncate text-xs text-muted-foreground">{session.email}</p>
+                {session.appAdmin.length > 0 && (
+                  <p className="mt-1 text-[11px] text-muted-foreground">
+                    App-admin: {session.appAdmin.join(", ")}
+                  </p>
+                )}
+                {!isImpersonating && (
+                  <button
+                    onClick={() => authService.signOut()}
+                    className="mt-2.5 inline-flex w-full items-center justify-center gap-1.5 rounded-md border border-border px-2 py-1.5 text-xs font-medium text-foreground hover:bg-surface2"
+                  >
+                    <LogOut className="size-3.5" />
+                    Sign out
+                  </button>
+                )}
+              </>
+            ) : (
+              <p className="py-1 text-sm text-muted-foreground">Signed out. Pick a persona below.</p>
+            )}
+          </div>
+
+          {/* Persona list — the only scrolling region; subtle themed scrollbar */}
+          <div className="scrollbar-subtle min-h-0 max-h-72 flex-1 overflow-y-auto px-2 py-2">
+            <p className="px-2 pb-1 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+              Switch to persona
+            </p>
+            {switchError && (
+              <p className="mx-2 mb-1.5 flex items-center gap-1 rounded-md bg-signal-red/10 px-2 py-1 text-[11px] text-signal-red">
+                <ShieldAlert className="size-3" />
+                {switchError}
+              </p>
+            )}
+            <ul className="space-y-1">
+              {personas.map((p) => {
+                const active = session?.email?.toLowerCase() === p.email.toLowerCase()
+                const disabled = p.status === "disabled"
+                return (
+                  <li key={p.id}>
+                    <button
+                      onClick={() => !disabled && handleSwitch(p.id)}
+                      disabled={disabled}
+                      aria-disabled={disabled}
+                      title={
+                        disabled
+                          ? "Disabled personas are not mintable — cannot impersonate"
+                          : undefined
+                      }
+                      className={cn(
+                        "w-full rounded-lg border px-2.5 py-2 text-left transition-colors",
+                        disabled
+                          ? "cursor-not-allowed border-transparent opacity-60"
+                          : active
+                            ? "border-primary bg-primary/10"
+                            : "border-transparent hover:border-border hover:bg-surface2",
+                      )}
+                    >
+                      <div className="flex items-center gap-2">
+                        <span
+                          className={cn(
+                            "truncate text-sm font-medium",
+                            disabled ? "text-muted-foreground" : "text-foreground",
+                          )}
+                        >
+                          {p.label}
+                        </span>
+                        {active && !disabled && (
+                          <span className="inline-flex items-center gap-1 rounded-full bg-primary/15 px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wider text-primary">
+                            <Eye className="size-2.5" />
+                            current
+                          </span>
+                        )}
+                        {disabled && (
+                          <span className="ml-auto inline-flex items-center gap-1 rounded-full bg-signal-red/15 px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wider text-signal-red">
+                            <Ban className="size-2.5" />
+                            disabled
+                          </span>
+                        )}
+                        {p.siteAdmin && !disabled && (
+                          <ShieldCheck className="ml-auto size-3 text-primary" />
+                        )}
+                      </div>
+                      <p className="mt-0.5 line-clamp-1 text-[11px] text-muted-foreground">{p.blurb}</p>
+                    </button>
+                  </li>
+                )
+              })}
+            </ul>
+          </div>
+        </div>
+      ) : (
+        <button
+          onClick={() => setOpen(true)}
+          className={cn(
+            "inline-flex items-center gap-2 rounded-full border px-3 py-2 text-xs font-semibold shadow-lg",
+            isImpersonating
+              ? "border-signal-amber/50 bg-signal-amber/15 text-foreground hover:bg-signal-amber/25"
+              : "border-border bg-surface text-foreground hover:bg-surface2",
+          )}
+        >
+          {isImpersonating ? (
+            <Eye className="size-4 text-signal-amber" />
+          ) : (
+            <UserCog className="size-4 text-primary" />
+          )}
+          {isImpersonating
+            ? `Viewing as ${session?.label}`
+            : session
+              ? session.label
+              : "Signed out"}
+        </button>
+      )}
+    </div>
+  )
+}

--- a/apps/launchpad/hooks/use-persona-switcher.ts
+++ b/apps/launchpad/hooks/use-persona-switcher.ts
@@ -1,0 +1,63 @@
+'use client'
+
+/**
+ * Hooks for the dev persona switcher — the runtime equivalents of v0's
+ * `useControlPlaneSession()` + `useImpersonator()` (transformotion-apps-b8
+ * use-control-plane-store @ 0fbc9e3). The SURFACE is unchanged; only the data
+ * source moves: the session is derived from the live auth store, and the
+ * impersonator from the parked-session snapshot in localStorage.
+ */
+
+import { useEffect, useMemo, useState } from 'react'
+import { useAuthStore } from '@/stores/auth/use-auth-store'
+import { appLabel } from '@/lib/dev/persona-catalog'
+import { getImpersonator, type ImpersonatorIdentity } from '@/lib/dev/persona-impersonation'
+
+/** Session view-model the switcher surface renders (v0 `MockSession` parity). */
+export interface PersonaSessionVM {
+  /** Cognito sub (the live identity). */
+  userId: string
+  label: string
+  displayName: string
+  email: string
+  siteAdmin: boolean
+  /** App-admin app labels (e.g. "Stock Analyser"), for the chip line. */
+  appAdmin: string[]
+}
+
+/**
+ * The current authenticated session as a switcher view-model, or null when
+ * signed out. Derived from the live auth store (NOT a mock store) — while
+ * impersonating, the store already holds the persona, so this reflects them.
+ */
+export function usePersonaSession(): PersonaSessionVM | null {
+  const user = useAuthStore((s) => s.user)
+  return useMemo(() => {
+    if (!user) return null
+    const meta = (user.metadata ?? {}) as {
+      siteAdmin?: boolean
+      appAdmin?: string[]
+    }
+    return {
+      userId: user.id,
+      label: user.name,
+      displayName: user.name,
+      email: user.email,
+      siteAdmin: Boolean(meta.siteAdmin),
+      appAdmin: (meta.appAdmin ?? []).map(appLabel),
+    }
+  }, [user])
+}
+
+/**
+ * The tester's OWN session while impersonating (null when acting as themselves).
+ * Read client-side after mount (the value only changes via a reload-triggering
+ * start/stop, so a one-shot read is correct and avoids an SSR hydration gap).
+ */
+export function useImpersonator(): ImpersonatorIdentity | null {
+  const [impersonator, setImpersonator] = useState<ImpersonatorIdentity | null>(null)
+  useEffect(() => {
+    setImpersonator(getImpersonator())
+  }, [])
+  return impersonator
+}

--- a/apps/launchpad/lib/dev/persona-catalog.ts
+++ b/apps/launchpad/lib/dev/persona-catalog.ts
@@ -1,0 +1,116 @@
+/**
+ * Persona catalog — the runtime `listPersonas()` for the dev persona switcher.
+ *
+ * Mirrors the B1 seed-of-record (scripts/migrations/launchpad/seed-dev-personas.mjs,
+ * itself the v0 seed @ transformotion-apps-b8 dd34783). These 8 personas are the
+ * users B1 provisions into the live dev LaunchpadAuth pool; switching to one mints
+ * its REAL session via the B2 endpoint. `leo` is `disabled` (non-mintable — the
+ * B2 allow-list excludes it) and is shown non-switchable.
+ *
+ * Blurbs are derived with the SAME entitlement-shape logic as v0's
+ * `describePersona` (groups-authoritative: app-admin > app-access > membership),
+ * so the surface reads identically — the catalog is the only thing that changed.
+ *
+ * This is dev-tooling data, intentionally NOT sourced from the contracts package:
+ * it is a fixed fixture of the seed, decoupled from runtime auth shapes.
+ */
+
+export type PersonaStatus = 'active' | 'disabled'
+
+export interface Persona {
+  /** Stable persona id — matches the B2 mint allow-list key (e.g. `priya`). */
+  id: string
+  /** Cognito sign-in email — the cross-walk to the live minted session. */
+  email: string
+  /** Display label for the row + FAB. */
+  label: string
+  /** Entitlement-shape one-liner (v0 `describePersona` parity). */
+  blurb: string
+  status: PersonaStatus
+  siteAdmin: boolean
+  /** App slugs this persona is app-admin for (display + parity). */
+  appAdmin: string[]
+}
+
+const APP_LABEL: Record<string, string> = {
+  'stock-analyser': 'Stock Analyser',
+  'budget-tracker': 'Budget Tracker',
+}
+
+type Seed = {
+  id: string
+  email: string
+  label: string
+  status: PersonaStatus
+  /** Cognito groups the persona holds (seed-of-record). */
+  groups: string[]
+  /** Distinct account memberships (count drives the blurb). */
+  accountCount: number
+}
+
+// Seed-of-record (B1). Order matches the seed/v0 list.
+const SEED: Seed[] = [
+  { id: 'steve',  email: 'steve@example.com',        label: 'Steve Moodie', status: 'active',   groups: ['site-admin', 'stock-app-access', 'budget-app-access'],   accountCount: 4 },
+  { id: 'ava',    email: 'ava.chen@example.com',     label: 'Ava Chen',     status: 'active',   groups: ['stock-app-access', 'stock-app-admin', 'budget-app-access'], accountCount: 3 },
+  { id: 'noah',   email: 'noah.patel@example.com',   label: 'Noah Patel',   status: 'active',   groups: ['stock-app-access', 'budget-app-access'],                accountCount: 2 },
+  { id: 'mara',   email: 'mara.silva@example.com',   label: 'Mara Silva',   status: 'active',   groups: ['budget-app-access', 'budget-app-admin'],                accountCount: 2 },
+  { id: 'leo',    email: 'leo.kim@example.com',      label: 'Leo Kim',      status: 'disabled', groups: ['stock-app-access'],                                     accountCount: 1 },
+  { id: 'priya',  email: 'priya.nair@example.com',   label: 'Priya Nair',   status: 'active',   groups: ['stock-app-access'],                                     accountCount: 0 },
+  { id: 'marcus', email: 'marcus.webb@example.com',  label: 'Marcus Webb',  status: 'active',   groups: ['stock-app-access', 'stock-app-admin'],                  accountCount: 0 },
+  { id: 'jordan', email: 'jordan.diaz@example.com',  label: 'Jordan Diaz',  status: 'active',   groups: [],                                                       accountCount: 0 },
+]
+
+export function appLabel(slug: string): string {
+  return APP_LABEL[slug] ?? slug
+}
+
+function accessSlugs(groups: string[]): string[] {
+  return Object.keys(APP_LABEL).filter((slug) => groups.includes(`${slug.split('-')[0]}-app-access`))
+}
+
+function adminSlugs(groups: string[]): string[] {
+  return Object.keys(APP_LABEL).filter((slug) => groups.includes(`${slug.split('-')[0]}-app-admin`))
+}
+
+function accountPhrase(n: number): string {
+  if (n === 0) return 'no account'
+  return `${n} account${n === 1 ? '' : 's'}`
+}
+
+/**
+ * Entitlement-shape blurb — verbatim parity with v0 `describePersona`:
+ * disabled → site-admin → app-admin > app-access > bare membership > none.
+ */
+function describePersona(s: Seed): string {
+  if (s.status === 'disabled') return 'Disabled user — sign-in is blocked'
+  if (s.groups.includes('site-admin')) return 'Site-admin — full platform supervisory access'
+  const admin = adminSlugs(s.groups).map(appLabel)
+  const access = accessSlugs(s.groups).map(appLabel)
+  const phrase = accountPhrase(s.accountCount)
+  if (admin.length > 0) return `${admin.join(' + ')} app-admin · ${phrase}`
+  if (access.length > 0) return `${access.join(' + ')} access · ${phrase}`
+  if (s.accountCount > 0) return `Member of ${phrase}`
+  return 'No app access'
+}
+
+const CATALOG: Persona[] = SEED.map((s) => ({
+  id: s.id,
+  email: s.email,
+  label: s.label,
+  blurb: describePersona(s),
+  status: s.status,
+  siteAdmin: s.groups.includes('site-admin'),
+  appAdmin: adminSlugs(s.groups),
+}))
+
+/** The mintable + non-mintable persona set, in seed order. */
+export function listPersonas(): Persona[] {
+  return CATALOG
+}
+
+/** Lookup by Cognito email (the live-session cross-walk). */
+export function personaByEmail(email: string | undefined): Persona | undefined {
+  if (!email) return undefined
+  const lower = email.toLowerCase()
+  return CATALOG.find((p) => p.email.toLowerCase() === lower)
+}

--- a/apps/launchpad/lib/dev/persona-impersonation.test.ts
+++ b/apps/launchpad/lib/dev/persona-impersonation.test.ts
@@ -1,0 +1,121 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// The seam reads NEXT_PUBLIC_COGNITO_CLIENT_ID (Amplify key prefix) and routes
+// the mint through the control-plane URL — set both before importing anything
+// that resolves config.
+const CLIENT_ID = 'testclient'
+process.env.NEXT_PUBLIC_COGNITO_CLIENT_ID = CLIENT_ID
+process.env.NEXT_PUBLIC_LAUNCHPAD_CONTROL_PLANE_API_URL = 'https://cp.example.test/dev/'
+
+import {
+  startImpersonation,
+  stopImpersonation,
+  getImpersonator,
+  isImpersonating,
+} from './persona-impersonation'
+
+const PREFIX = `CognitoIdentityServiceProvider.${CLIENT_ID}`
+
+/** Minimal unsigned JWT with the given claims (browser-style base64url). */
+function jwt(claims: Record<string, unknown>): string {
+  const part = (o: unknown) => Buffer.from(JSON.stringify(o)).toString('base64url')
+  return `${part({ alg: 'none' })}.${part(claims)}.sig`
+}
+
+function seedTesterSession(): void {
+  localStorage.clear()
+  localStorage.setItem(`${PREFIX}.LastAuthUser`, 'steve-sub')
+  localStorage.setItem(
+    `${PREFIX}.steve-sub.idToken`,
+    jwt({ email: 'steve@example.com', given_name: 'Steve', family_name: 'Moodie' }),
+  )
+  localStorage.setItem(`${PREFIX}.steve-sub.accessToken`, jwt({ username: 'steve-sub', sub: 'steve-sub' }))
+  localStorage.setItem(`${PREFIX}.steve-sub.refreshToken`, 'r-steve')
+  localStorage.setItem(`${PREFIX}.steve-sub.clockDrift`, '0')
+}
+
+function mintFor(sub: string, email: string, given: string, family: string) {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => ({
+      idToken: jwt({ email, given_name: given, family_name: family }),
+      accessToken: jwt({ username: sub, sub }),
+      refreshToken: `r-${sub}`,
+    }),
+  }
+}
+
+function lastAuthUser(): string | null {
+  return localStorage.getItem(`${PREFIX}.LastAuthUser`)
+}
+
+beforeEach(() => {
+  // Fresh in-memory localStorage backed by a Map.
+  const store = new Map<string, string>()
+  const mock = {
+    getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+    setItem: (k: string, v: string) => void store.set(k, String(v)),
+    removeItem: (k: string) => void store.delete(k),
+    clear: () => store.clear(),
+    key: (i: number) => Array.from(store.keys())[i] ?? null,
+    get length() {
+      return store.size
+    },
+  }
+  vi.stubGlobal('localStorage', mock)
+  // window.location.reload is a no-op in the test; localStorage persists across a
+  // real reload, so the post-reload state IS the mutated store — this models it.
+  vi.stubGlobal('window', { location: { reload: vi.fn() } })
+  seedTesterSession()
+})
+
+describe('persona impersonation seam', () => {
+  it('preserves the ORIGINAL tester across persona hops (Steve→Priya→Marcus→back→Steve)', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => mintFor('priya-sub', 'priya.nair@example.com', 'Priya', 'Nair')),
+    )
+
+    // Hop 1: Steve → Priya. Snapshot captures Steve; the live session is Priya.
+    const r1 = await startImpersonation('priya')
+    expect(r1).toEqual({ ok: true })
+    expect(lastAuthUser()).toBe('priya-sub')
+    expect(isImpersonating()).toBe(true)
+    expect(getImpersonator()?.email).toBe('steve@example.com')
+    expect(getImpersonator()?.label).toBe('Steve Moodie')
+
+    // Hop 2: Priya → Marcus WITHOUT switching back. Snapshot must NOT be
+    // overwritten — switch-back still returns to the original (Steve).
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => mintFor('marcus-sub', 'marcus.webb@example.com', 'Marcus', 'Webb')),
+    )
+    const r2 = await startImpersonation('marcus')
+    expect(r2).toEqual({ ok: true })
+    expect(lastAuthUser()).toBe('marcus-sub')
+    expect(getImpersonator()?.email).toBe('steve@example.com') // still STEVE, not Priya
+
+    // Switch back → restores the ORIGINAL tester, not the previous hop.
+    stopImpersonation()
+    expect(isImpersonating()).toBe(false)
+    expect(getImpersonator()).toBeNull()
+    expect(lastAuthUser()).toBe('steve-sub')
+    expect(localStorage.getItem(`${PREFIX}.steve-sub.refreshToken`)).toBe('r-steve')
+  })
+
+  it('rejects a disabled/unknown persona (403) without mutating the session', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: false, status: 403, json: async () => ({}) })))
+    const r = await startImpersonation('leo')
+    expect(r.ok).toBe(false)
+    if (!r.ok) expect(r.error).toMatch(/disabled/i)
+    expect(isImpersonating()).toBe(false)
+    expect(lastAuthUser()).toBe('steve-sub') // untouched
+  })
+
+  it('stopImpersonation is a no-op when not impersonating', () => {
+    expect(isImpersonating()).toBe(false)
+    stopImpersonation()
+    expect(lastAuthUser()).toBe('steve-sub')
+  })
+})

--- a/apps/launchpad/lib/dev/persona-impersonation.ts
+++ b/apps/launchpad/lib/dev/persona-impersonation.ts
@@ -1,0 +1,231 @@
+'use client'
+
+/**
+ * Dev persona impersonation seam — the LIVE "switch to persona" implementation
+ * behind v0's prototyped surface (transformotion-apps-b8
+ * components/launchpad/data/auth-service.ts @ 0fbc9e3:
+ * startImpersonation / stopImpersonation / getImpersonator).
+ *
+ * v0 mocked the swap by flipping a mock store's `currentUserId`. The runtime does
+ * the REAL thing: it mints a genuine Cognito session for the persona (the B2
+ * dev-only POST /api/dev/persona-token endpoint) and SWAPS it into this tab by
+ * replacing the Amplify token store in localStorage, then reloads so every
+ * surface (launchpad tiles, admin views, every `authService.getIdToken()` API
+ * call) re-reads auth and genuinely authenticates AS the persona. Same-tab
+ * replace (v0 decision 2a).
+ *
+ * HOP-PRESERVE (behavioral conformance): the tester's ORIGINAL session is
+ * snapshotted on the FIRST impersonation only and never overwritten on later
+ * hops, so Steve → Priya → Ava → "switch back" returns to STEVE, not Priya.
+ * `stopImpersonation` restores that first snapshot.
+ *
+ * SECURITY: dev-tool only. This is NOT a security boundary — it can only obtain
+ * a persona session because the B2 endpoint exists (dev-only, stack-gated +
+ * runtime-stage-gated + allow-listed) and mints from seeded persona passwords.
+ * In prod the endpoint does not exist, so a swap cannot be minted.
+ */
+
+import { controlPlaneUrl } from '@/lib/services/control-plane'
+
+/** localStorage key holding the tester's parked session during impersonation. */
+const SNAPSHOT_KEY = 'launchpad.persona-switcher.impersonator.v1'
+
+/** The tester's own identity, decoded for the banner ("you are Y"). */
+export interface ImpersonatorIdentity {
+  email: string
+  label: string
+}
+
+interface Snapshot {
+  /** The tester's original Amplify token-store entries (verbatim key→value). */
+  amplifyKeys: Record<string, string>
+  /** The tester's decoded identity (for the banner). */
+  identity: ImpersonatorIdentity
+}
+
+interface MintResult {
+  idToken: string
+  accessToken: string
+  refreshToken: string
+}
+
+export type ImpersonationOutcome = { ok: true } | { ok: false; error: string }
+
+function hasWindow(): boolean {
+  return typeof window !== 'undefined'
+}
+
+function cognitoClientId(): string {
+  // Same client id the CognitoAuthService configures Amplify with.
+  return process.env.NEXT_PUBLIC_COGNITO_CLIENT_ID ?? ''
+}
+
+/** Prefix of every Amplify v6 Cognito token-store key for this app client. */
+function amplifyPrefix(): string {
+  return `CognitoIdentityServiceProvider.${cognitoClientId()}`
+}
+
+/** Decode a JWT payload (browser-safe base64url). Returns {} on any failure. */
+function decodeJwt(token: string): Record<string, unknown> {
+  try {
+    const part = token.split('.')[1]
+    const b64 = part.replace(/-/g, '+').replace(/_/g, '/')
+    const json = decodeURIComponent(
+      atob(b64)
+        .split('')
+        .map((c) => '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2))
+        .join(''),
+    )
+    return JSON.parse(json) as Record<string, unknown>
+  } catch {
+    return {}
+  }
+}
+
+/** Read all Amplify token-store entries for this client (the live session). */
+function readAmplifyKeys(): Record<string, string> {
+  const prefix = amplifyPrefix()
+  const out: Record<string, string> = {}
+  for (let i = 0; i < localStorage.length; i++) {
+    const k = localStorage.key(i)
+    if (k && k.startsWith(prefix)) {
+      const v = localStorage.getItem(k)
+      if (v !== null) out[k] = v
+    }
+  }
+  return out
+}
+
+/** Remove all Amplify token-store entries for this client. */
+function clearAmplifyKeys(): void {
+  const prefix = amplifyPrefix()
+  Object.keys(localStorage)
+    .filter((k) => k.startsWith(prefix))
+    .forEach((k) => localStorage.removeItem(k))
+}
+
+/** Write a verbatim Amplify key set back into the token store. */
+function writeAmplifyKeys(keys: Record<string, string>): void {
+  for (const [k, v] of Object.entries(keys)) localStorage.setItem(k, v)
+}
+
+/** Identity from a minted/stored idToken, for the parked-session banner. */
+function identityFromIdToken(idToken: string): ImpersonatorIdentity {
+  const claims = decodeJwt(idToken)
+  const email = (claims['email'] as string) ?? ''
+  const given = claims['given_name'] as string | undefined
+  const family = claims['family_name'] as string | undefined
+  const label = given && family ? `${given} ${family}` : (given ?? email)
+  return { email, label }
+}
+
+/**
+ * Replace the Amplify token store with a minted persona session. Cognito (this
+ * pool) uses an email alias, so the access token's `username` equals the sub;
+ * Amplify keys are namespaced by that username with `LastAuthUser` pointing at it.
+ */
+function writePersonaSession(mint: MintResult): void {
+  const access = decodeJwt(mint.accessToken)
+  const username =
+    (access['username'] as string) ??
+    (access['sub'] as string) ??
+    (decodeJwt(mint.idToken)['cognito:username'] as string) ??
+    (decodeJwt(mint.idToken)['sub'] as string) ??
+    ''
+  const prefix = amplifyPrefix()
+  const base = `${prefix}.${username}`
+  clearAmplifyKeys()
+  localStorage.setItem(`${prefix}.LastAuthUser`, username)
+  localStorage.setItem(`${base}.idToken`, mint.idToken)
+  localStorage.setItem(`${base}.accessToken`, mint.accessToken)
+  localStorage.setItem(`${base}.refreshToken`, mint.refreshToken)
+  localStorage.setItem(`${base}.clockDrift`, '0')
+}
+
+function readSnapshot(): Snapshot | null {
+  try {
+    const raw = localStorage.getItem(SNAPSHOT_KEY)
+    if (!raw) return null
+    return JSON.parse(raw) as Snapshot
+  } catch {
+    return null
+  }
+}
+
+/** Are we currently viewing-as a persona (a parked tester session exists)? */
+export function isImpersonating(): boolean {
+  if (!hasWindow()) return false
+  return localStorage.getItem(SNAPSHOT_KEY) !== null
+}
+
+/**
+ * The tester's OWN identity while impersonating (who "switch back" returns to),
+ * or null when acting as themselves. Drives the "you are Y" banner.
+ */
+export function getImpersonator(): ImpersonatorIdentity | null {
+  if (!hasWindow()) return null
+  return readSnapshot()?.identity ?? null
+}
+
+/**
+ * Begin impersonating a persona: mint a real session and swap it into this tab.
+ * The tester's original session is captured on the FIRST hop only (preserved
+ * across consecutive persona hops). Reloads on success. Disabled personas are
+ * rejected (the server also refuses them).
+ */
+export async function startImpersonation(personaId: string): Promise<ImpersonationOutcome> {
+  if (!hasWindow()) return { ok: false, error: 'Unavailable.' }
+
+  let mint: MintResult
+  try {
+    const res = await fetch(controlPlaneUrl('/api/dev/persona-token'), {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ personaId }),
+    })
+    if (!res.ok) {
+      // 403 → disabled/unknown persona; 404 → endpoint not in this env (prod).
+      const msg =
+        res.status === 403
+          ? 'That persona is disabled and cannot be minted a session.'
+          : res.status === 404
+            ? 'Persona mint endpoint is not available in this environment.'
+            : `Mint failed (${res.status}).`
+      return { ok: false, error: msg }
+    }
+    const body = (await res.json()) as Partial<MintResult>
+    if (!body.idToken || !body.accessToken || !body.refreshToken) {
+      return { ok: false, error: 'Mint returned an incomplete session.' }
+    }
+    mint = { idToken: body.idToken, accessToken: body.accessToken, refreshToken: body.refreshToken }
+  } catch {
+    return { ok: false, error: 'Could not reach the persona mint endpoint.' }
+  }
+
+  // Capture the tester's ORIGINAL session ONCE — never overwrite across hops.
+  if (!isImpersonating()) {
+    const amplifyKeys = readAmplifyKeys()
+    const idTokenEntry = Object.entries(amplifyKeys).find(([k]) => k.endsWith('.idToken'))
+    const identity = idTokenEntry ? identityFromIdToken(idTokenEntry[1]) : { email: '', label: 'your session' }
+    const snapshot: Snapshot = { amplifyKeys, identity }
+    localStorage.setItem(SNAPSHOT_KEY, JSON.stringify(snapshot))
+  }
+
+  writePersonaSession(mint)
+  window.location.reload()
+  return { ok: true }
+}
+
+/**
+ * Stop impersonating and restore the tester's OWN session (the first snapshot).
+ * No-op when not impersonating. Reloads so the app re-reads the restored session.
+ */
+export function stopImpersonation(): void {
+  if (!hasWindow()) return
+  const snapshot = readSnapshot()
+  if (!snapshot) return
+  clearAmplifyKeys()
+  writeAmplifyKeys(snapshot.amplifyKeys)
+  localStorage.removeItem(SNAPSHOT_KEY)
+  window.location.reload()
+}

--- a/apps/launchpad/lib/dev/persona-impersonation.ts
+++ b/apps/launchpad/lib/dev/persona-impersonation.ts
@@ -134,6 +134,13 @@ function writePersonaSession(mint: MintResult): void {
     ''
   const prefix = amplifyPrefix()
   const base = `${prefix}.${username}`
+  // ⚠ COUPLING: this writes Amplify v6's localStorage token-store format directly
+  // (`CognitoIdentityServiceProvider.<clientId>.<user>.{idToken,accessToken,
+  // refreshToken,clockDrift}` + `.LastAuthUser`) so the swap is a CONSISTENT
+  // same-tab replace — every surface that reads Amplify (not just authService)
+  // sees the persona. It BREAKS if Amplify changes this storage format on upgrade;
+  // if so, update the key shape HERE. Dev-only — blast radius is the persona
+  // switcher only, never prod or real auth.
   clearAmplifyKeys()
   localStorage.setItem(`${prefix}.LastAuthUser`, username)
   localStorage.setItem(`${base}.idToken`, mint.idToken)

--- a/apps/launchpad/lib/services/user-profile/index.ts
+++ b/apps/launchpad/lib/services/user-profile/index.ts
@@ -19,6 +19,27 @@ export async function getUserProfile(idToken: string): Promise<UserProfile> {
   return response.json() as Promise<UserProfile>;
 }
 
+/**
+ * Update the caller's own profile display name via the existing
+ * PUT /api/user/preferences capability (the handler accepts a top-level
+ * `displayName`). Runtime-only client call to an existing server route — no
+ * contract change. Used by the dev persona switcher's inline name edit.
+ */
+export async function updateDisplayName(idToken: string, displayName: string): Promise<void> {
+  const response = await fetch(controlPlaneUrl('/api/user/preferences'), {
+    method: 'PUT',
+    headers: {
+      Authorization: `Bearer ${idToken}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ displayName }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`PUT /api/user/preferences (displayName) failed: ${response.status}`);
+  }
+}
+
 export async function updateUserPreferences(
   idToken: string,
   preferences: Partial<UserPreferences>,


### PR DESCRIPTION
## Summary
Runtime build of the **dev persona switcher**: ports v0's prototyped SURFACE
verbatim and reimplements the impersonation seam against **real auth**. Switching
to a persona mints a **real Cognito session** (the B2 dev-only mint endpoint,
#475) and swaps it into the tab — the app genuinely authenticates AS the persona
until you switch back. Dev-only, additive.

## ⛔ Review gate
**Do not merge/deploy yet** — opening this so the **session-swap approach** can be
reviewed first (per the ask). No pool/IaC/contract change; merge → dev deploy via
`deploy-launchpad.yml`.

## The seam swap (the substance) — `lib/dev/persona-impersonation.ts`
1. **startImpersonation(personaId)** → `POST /api/dev/persona-token` → minted
   `{ idToken, accessToken, refreshToken }` → **inject into the Amplify token
   store** (localStorage `CognitoIdentityServiceProvider.<clientId>.<user>.*` +
   `LastAuthUser`) → `window.location.reload()`. True **same-tab replace** (v0
   decision 2a): every surface and every `authService.getIdToken()` API call
   re-reads auth as the persona.
2. **stopImpersonation()** → restore the tester's own session and reload.
3. **getImpersonator()** → decode the parked session for the banner.

### Behavioral conformance — hop-preserve
The tester's original Amplify session is snapshotted on the **first** impersonation
**only** and never overwritten on later hops. `Steve → Priya → Marcus → switch
back` returns to **Steve**, not Marcus. Locked by a unit test
(`persona-impersonation.test.ts`): Steve→Priya→Marcus→back asserts `LastAuthUser`
and the decoded impersonator identity stay Steve across the hop, and restore to
Steve on stop. Also: a 403 (disabled persona, e.g. Leo) returns `ok:false` and
**does not mutate** the stored session.

## Surface — `components/launchpad/dev/persona-switcher.tsx`
Ported verbatim from b8 `0fbc9e3`: honesty note, amber "Viewing as X / your
session: Y" banner + switch-back, entitlement-shape blurbs, **Leo disabled +
non-switchable**, "current" chip, FAB turns amber while impersonating. Only the
data/auth layer changed:
- session view-model from the live `useAuthStore` (not a mock store);
- personas from a static catalog (`lib/dev/persona-catalog.ts`) mirroring the B1
  seed-of-record (8 personas; Leo `disabled`); active-match by Cognito email;
- **name edit wired LIVE** → `PUT /api/user/preferences` `displayName` (existing
  server capability; runtime-only client method — no contract change);
- mock-only **"reset backend to seed" dropped** (no live equivalent).

(Owner-selected dispositions for the two mock-only controls.)

## Gating (three-fold, floating-surface form)
`NEXT_PUBLIC_DEV_TOOLS` — **gated mount** in `app/layout.tsx` **+** the component
self-gates (`devToolsEnabled()` early-return null). Plus a static-export mount
guard to avoid a hydration mismatch. Absent from prod builds. The mint endpoint
is independently stack/stage/allow-list gated and absent from the prod stack.

## Files
- `lib/dev/persona-impersonation.ts` (+ `.test.ts`) — seam: Amplify token I/O, mint, hop-preserve
- `lib/dev/persona-catalog.ts` — static 8-persona catalog + `describePersona` blurb parity
- `hooks/use-persona-switcher.ts` — `usePersonaSession` + `useImpersonator`
- `components/launchpad/dev/persona-switcher.tsx` — surface (verbatim)
- `app/layout.tsx` — gated mount
- `lib/services/user-profile/index.ts` — `updateDisplayName` (existing endpoint)
- `.env.example` — documents the `NEXT_PUBLIC_DEV_TOOLS` prod gate (pre-existing doc gap)

## Checks
`typecheck` ✓ · `lint` ✓ · `test` ✓ (40, incl. 3 new seam tests) · static-export `build` ✓

## Verification (behavioral, in-browser — runs after deploy/local-against-dev)
Impersonate **Priya** → launchpad shows her access-no-accounts *create-first-
account* state → switch to **Marcus** without switching back → confirm Marcus →
switch back → confirm return to **yourself** (the original tester). Confirm **Leo**
non-switchable and the impersonation banner visible throughout. I'll drive this
via `/verify` once it's deployed to dev or runnable locally against the live pool.

## v0 freshness
Runtime reimplementation of a v0-prototyped surface. Ported from the v0
design-of-record commit:
https://github.com/transformotion/transformotion-apps-b8/commit/0fbc9e31442546104cecca13e48e64a392b32bec
(branch `v0/stevemoodie70-6804-a8387d72` — the impersonation seam on the mock
store). Runtime reimplements that seam behind the same surface; no new
UI/contract/mock shape is introduced here (consumes the already-shipped B2 mint
endpoint and the existing `displayName` capability on PUT /api/user/preferences).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
