### PR TITLE
fix(launchpad-dev): CORS header on dev-persona-token response (#477)

### DIFF
--- a/apps/launchpad/functions/dev-persona-token/src/index.ts
+++ b/apps/launchpad/functions/dev-persona-token/src/index.ts
@@ -41,8 +41,24 @@ const PERSONA_EMAIL: Record<string, string> = {
   jordan: 'jordan.diaz@example.com',
 };
 
+// CORS: this is a Lambda-proxy integration, so the API Gateway
+// `defaultCorsPreflightOptions` only covers the OPTIONS preflight — the actual
+// response must carry `Access-Control-Allow-Origin` itself or the browser blocks
+// the body (a 200 reads as a CORS failure, surfacing as the seam's "could not
+// reach" error). Mirror @transformotion/lambda-middleware's CORS_HEADERS (the
+// shared wildcard the other control-plane handlers use) so the in-browser mint
+// works. #477.
+const CORS_HEADERS = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'Content-Type,Authorization,X-Account-Id',
+};
+
 function resp(statusCode: number, body: unknown): APIGatewayProxyResult {
-  return { statusCode, headers: { 'content-type': 'application/json' }, body: JSON.stringify(body) };
+  return {
+    statusCode,
+    headers: { 'content-type': 'application/json', ...CORS_HEADERS },
+    body: JSON.stringify(body),
+  };
 }
 
 export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {


### PR DESCRIPTION
Closes #477.

## Problem
The Persona Switcher (#476) failed in-browser with **"Could not reach the persona
mint endpoint."** Network showed `POST /api/dev/persona-token` → **200 OK with the
token body**, flagged red: a CORS block. The response lacked
`Access-Control-Allow-Origin`, so the browser blocked the body and `fetch()` rejected.

## Cause
`defaultCorsPreflightOptions` handles only the OPTIONS preflight; for Lambda-proxy
integrations the actual response must carry the CORS header itself. Sibling handlers
get it from `@transformotion/lambda-middleware` (`Access-Control-Allow-Origin: *`);
the hand-rolled `dev-persona-token` `resp()` set only `content-type`. Server-side
`curl` ignores CORS — which is why it verified green at the API level but failed in
the browser.

## Fix
Add the shared CORS headers to every `dev-persona-token` response. One file, dev-only,
additive — no pool/contract change. Function typecheck ✓.

## Verification after deploy
Re-test in the browser on dev: open the switcher → click Priya → app becomes her
create-first-account view → hop to Marcus without switching back → switch back →
return to yourself → Leo non-switchable → banner visible.

## v0 freshness
- [x] No v0 impact
Reason: backend-only dev Lambda CORS header (`apps/launchpad/functions/**`); no UI,
contract, mock, or runtime-shape change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)