### PR TITLE
fix(launchpad-dev): cross-app persona switching — SA/BT carry the persona (#479)

### DIFF
--- a/apps/launchpad/functions/dev-persona-token/src/index.ts
+++ b/apps/launchpad/functions/dev-persona-token/src/index.ts
@@ -27,6 +27,16 @@ const STAGE = process.env.STAGE ?? '';
 const USER_POOL_ID = process.env.USER_POOL_ID ?? '';
 const CLIENT_ID = process.env.LAUNCHPAD_CLIENT_ID ?? '';
 
+// Cross-app personas (#479): a switch must carry into Stock Analyser / Budget
+// Tracker too, each of which authenticates against its OWN app-client in the
+// same pool. We mint a session per app-client so the switcher can swap every
+// app's token store. All three clients have ADMIN_USER_PASSWORD_AUTH enabled.
+const APP_CLIENTS: Array<{ app: string; clientId: string }> = [
+  { app: 'launchpad', clientId: CLIENT_ID },
+  { app: 'stock-analyser', clientId: process.env.STOCK_CLIENT_ID ?? '' },
+  { app: 'budget-tracker', clientId: process.env.BUDGET_CLIENT_ID ?? '' },
+].filter((c) => c.clientId !== '');
+
 const cognito = new CognitoIdentityProviderClient({});
 const secrets = new SecretsManagerClient({});
 
@@ -84,22 +94,29 @@ export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayPr
   if (!password) return resp(500, { error: 'Empty persona password secret.' });
 
   try {
-    const auth = await cognito.send(new AdminInitiateAuthCommand({
-      UserPoolId: USER_POOL_ID,
-      ClientId: CLIENT_ID,
-      AuthFlow: 'ADMIN_USER_PASSWORD_AUTH',
-      AuthParameters: { USERNAME: email, PASSWORD: password },
-    }));
-    const r = auth.AuthenticationResult;
-    if (!r) return resp(502, { error: 'No authentication result (unexpected challenge).' });
-    return resp(200, {
-      personaId,
-      email,
-      idToken: r.IdToken,
-      accessToken: r.AccessToken,
-      refreshToken: r.RefreshToken,
-      expiresIn: r.ExpiresIn,
-    });
+    // Mint one session per app-client so the switcher can swap every app's token
+    // store (cross-app persona, #479). Each client lives in the same pool; the
+    // persona's per-app entitlement still gates what they can do in each app.
+    const sessions = [];
+    for (const { app, clientId } of APP_CLIENTS) {
+      const auth = await cognito.send(new AdminInitiateAuthCommand({
+        UserPoolId: USER_POOL_ID,
+        ClientId: clientId,
+        AuthFlow: 'ADMIN_USER_PASSWORD_AUTH',
+        AuthParameters: { USERNAME: email, PASSWORD: password },
+      }));
+      const r = auth.AuthenticationResult;
+      if (!r) return resp(502, { error: `No authentication result for ${app} (unexpected challenge).` });
+      sessions.push({
+        app,
+        clientId,
+        idToken: r.IdToken,
+        accessToken: r.AccessToken,
+        refreshToken: r.RefreshToken,
+        expiresIn: r.ExpiresIn,
+      });
+    }
+    return resp(200, { personaId, email, sessions });
   } catch (err) {
     return resp(502, { error: `Mint failed: ${(err as { name?: string }).name ?? 'error'}` });
   }

--- a/apps/launchpad/infrastructure/launchpad-control-plane-stack.ts
+++ b/apps/launchpad/infrastructure/launchpad-control-plane-stack.ts
@@ -618,6 +618,11 @@ export class LaunchpadControlPlaneStack extends cdk.Stack {
           STAGE: stage,
           USER_POOL_ID: userPoolId,
           LAUNCHPAD_CLIENT_ID: launchpadAppClientId,
+          // Cross-app persona (#479): mint a session per app-client so a switch
+          // carries into Stock Analyser / Budget Tracker. AdminInitiateAuth is
+          // already pool-scoped in the IAM grant below — covers all three clients.
+          STOCK_CLIENT_ID: stockAnalyserAppClientId,
+          BUDGET_CLIENT_ID: budgetTrackerAppClientId,
         },
         bundling: { externalModules: ['@aws-sdk/*'], minify: true, sourceMap: false, forceDockerBundling: false },
       });

--- a/apps/launchpad/lib/dev/persona-impersonation.test.ts
+++ b/apps/launchpad/lib/dev/persona-impersonation.test.ts
@@ -1,10 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-// The seam reads NEXT_PUBLIC_COGNITO_CLIENT_ID (Amplify key prefix) and routes
-// the mint through the control-plane URL — set both before importing anything
-// that resolves config.
-const CLIENT_ID = 'testclient'
-process.env.NEXT_PUBLIC_COGNITO_CLIENT_ID = CLIENT_ID
+// The seam routes the mint through the control-plane URL — set it before
+// importing anything that resolves config. (Client ids now come from the mint
+// response per app-client, not from env — cross-app, #479.)
 process.env.NEXT_PUBLIC_LAUNCHPAD_CONTROL_PLANE_API_URL = 'https://cp.example.test/dev/'
 
 import {
@@ -14,7 +12,11 @@ import {
   isImpersonating,
 } from './persona-impersonation'
 
-const PREFIX = `CognitoIdentityServiceProvider.${CLIENT_ID}`
+// Three app-clients in the one pool (Launchpad, Stock Analyser, Budget Tracker).
+const LP = 'lpclient'
+const SA = 'saclient'
+const BT = 'btclient'
+const prefix = (clientId: string) => `CognitoIdentityServiceProvider.${clientId}`
 
 /** Minimal unsigned JWT with the given claims (browser-style base64url). */
 function jwt(claims: Record<string, unknown>): string {
@@ -22,36 +24,39 @@ function jwt(claims: Record<string, unknown>): string {
   return `${part({ alg: 'none' })}.${part(claims)}.sig`
 }
 
-function seedTesterSession(): void {
-  localStorage.clear()
-  localStorage.setItem(`${PREFIX}.LastAuthUser`, 'steve-sub')
-  localStorage.setItem(
-    `${PREFIX}.steve-sub.idToken`,
-    jwt({ email: 'steve@example.com', given_name: 'Steve', family_name: 'Moodie' }),
-  )
-  localStorage.setItem(`${PREFIX}.steve-sub.accessToken`, jwt({ username: 'steve-sub', sub: 'steve-sub' }))
-  localStorage.setItem(`${PREFIX}.steve-sub.refreshToken`, 'r-steve')
-  localStorage.setItem(`${PREFIX}.steve-sub.clockDrift`, '0')
+/** Seed a tester session for one app-client namespace. */
+function seedSession(clientId: string, sub: string, email: string, given: string, family: string): void {
+  const base = `${prefix(clientId)}.${sub}`
+  localStorage.setItem(`${prefix(clientId)}.LastAuthUser`, sub)
+  localStorage.setItem(`${base}.idToken`, jwt({ email, given_name: given, family_name: family }))
+  localStorage.setItem(`${base}.accessToken`, jwt({ username: sub, sub }))
+  localStorage.setItem(`${base}.refreshToken`, `r-${sub}`)
+  localStorage.setItem(`${base}.clockDrift`, '0')
 }
 
-function mintFor(sub: string, email: string, given: string, family: string) {
+/** A B2 mint response: one session per app-client for the persona. */
+function mintResponse(sub: string, email: string, given: string, family: string) {
+  const session = (app: string, clientId: string) => ({
+    app,
+    clientId,
+    idToken: jwt({ email, given_name: given, family_name: family }),
+    accessToken: jwt({ username: sub, sub }),
+    refreshToken: `r-${sub}`,
+  })
   return {
     ok: true,
     status: 200,
     json: async () => ({
-      idToken: jwt({ email, given_name: given, family_name: family }),
-      accessToken: jwt({ username: sub, sub }),
-      refreshToken: `r-${sub}`,
+      personaId: email.split('.')[0],
+      email,
+      sessions: [session('launchpad', LP), session('stock-analyser', SA), session('budget-tracker', BT)],
     }),
   }
 }
 
-function lastAuthUser(): string | null {
-  return localStorage.getItem(`${PREFIX}.LastAuthUser`)
-}
+const lastUser = (clientId: string) => localStorage.getItem(`${prefix(clientId)}.LastAuthUser`)
 
 beforeEach(() => {
-  // Fresh in-memory localStorage backed by a Map.
   const store = new Map<string, string>()
   const mock = {
     getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
@@ -64,58 +69,59 @@ beforeEach(() => {
     },
   }
   vi.stubGlobal('localStorage', mock)
-  // window.location.reload is a no-op in the test; localStorage persists across a
-  // real reload, so the post-reload state IS the mutated store — this models it.
   vi.stubGlobal('window', { location: { reload: vi.fn() } })
-  seedTesterSession()
+  // Tester (Steve) is signed into Launchpad AND Stock Analyser; has never opened
+  // Budget Tracker (its namespace is empty).
+  seedSession(LP, 'steve-sub', 'steve@example.com', 'Steve', 'Moodie')
+  seedSession(SA, 'steve-sub', 'steve@example.com', 'Steve', 'Moodie')
 })
 
-describe('persona impersonation seam', () => {
-  it('preserves the ORIGINAL tester across persona hops (Steve→Priya→Marcus→back→Steve)', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn(async () => mintFor('priya-sub', 'priya.nair@example.com', 'Priya', 'Nair')),
-    )
+describe('cross-app persona impersonation seam (#479)', () => {
+  it('swaps EVERY app-client namespace and preserves the original tester across hops', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => mintResponse('priya-sub', 'priya.nair@example.com', 'Priya', 'Nair')))
 
-    // Hop 1: Steve → Priya. Snapshot captures Steve; the live session is Priya.
+    // Hop 1: Steve → Priya. All three app-clients now hold Priya (so SA/BT also
+    // see her on navigation), and the tester (Steve) is parked.
     const r1 = await startImpersonation('priya')
     expect(r1).toEqual({ ok: true })
-    expect(lastAuthUser()).toBe('priya-sub')
+    expect(lastUser(LP)).toBe('priya-sub')
+    expect(lastUser(SA)).toBe('priya-sub') // ← the cross-app fix: SA is Priya, not Steve
+    expect(lastUser(BT)).toBe('priya-sub')
     expect(isImpersonating()).toBe(true)
     expect(getImpersonator()?.email).toBe('steve@example.com')
-    expect(getImpersonator()?.label).toBe('Steve Moodie')
 
-    // Hop 2: Priya → Marcus WITHOUT switching back. Snapshot must NOT be
-    // overwritten — switch-back still returns to the original (Steve).
-    vi.stubGlobal(
-      'fetch',
-      vi.fn(async () => mintFor('marcus-sub', 'marcus.webb@example.com', 'Marcus', 'Webb')),
-    )
+    // Hop 2: Priya → Marcus WITHOUT switching back — snapshot must NOT be overwritten.
+    vi.stubGlobal('fetch', vi.fn(async () => mintResponse('marcus-sub', 'marcus.webb@example.com', 'Marcus', 'Webb')))
     const r2 = await startImpersonation('marcus')
     expect(r2).toEqual({ ok: true })
-    expect(lastAuthUser()).toBe('marcus-sub')
+    expect(lastUser(LP)).toBe('marcus-sub')
+    expect(lastUser(SA)).toBe('marcus-sub')
     expect(getImpersonator()?.email).toBe('steve@example.com') // still STEVE, not Priya
 
-    // Switch back → restores the ORIGINAL tester, not the previous hop.
+    // Switch back → restores the ORIGINAL tester across the apps he had, and the
+    // app he never opened (BT) goes back to empty (no stale persona session).
     stopImpersonation()
     expect(isImpersonating()).toBe(false)
     expect(getImpersonator()).toBeNull()
-    expect(lastAuthUser()).toBe('steve-sub')
-    expect(localStorage.getItem(`${PREFIX}.steve-sub.refreshToken`)).toBe('r-steve')
+    expect(lastUser(LP)).toBe('steve-sub')
+    expect(lastUser(SA)).toBe('steve-sub')
+    expect(lastUser(BT)).toBeNull() // never seeded → cleared, not left as Marcus
+    expect(localStorage.getItem(`${prefix(LP)}.steve-sub.refreshToken`)).toBe('r-steve-sub')
   })
 
-  it('rejects a disabled/unknown persona (403) without mutating the session', async () => {
+  it('rejects a disabled/unknown persona (403) without mutating any session', async () => {
     vi.stubGlobal('fetch', vi.fn(async () => ({ ok: false, status: 403, json: async () => ({}) })))
     const r = await startImpersonation('leo')
     expect(r.ok).toBe(false)
     if (!r.ok) expect(r.error).toMatch(/disabled/i)
     expect(isImpersonating()).toBe(false)
-    expect(lastAuthUser()).toBe('steve-sub') // untouched
+    expect(lastUser(LP)).toBe('steve-sub')
+    expect(lastUser(SA)).toBe('steve-sub')
   })
 
   it('stopImpersonation is a no-op when not impersonating', () => {
     expect(isImpersonating()).toBe(false)
     stopImpersonation()
-    expect(lastAuthUser()).toBe('steve-sub')
+    expect(lastUser(LP)).toBe('steve-sub')
   })
 })

--- a/apps/launchpad/lib/dev/persona-impersonation.ts
+++ b/apps/launchpad/lib/dev/persona-impersonation.ts
@@ -43,7 +43,10 @@ interface Snapshot {
   identity: ImpersonatorIdentity
 }
 
-interface MintResult {
+/** One minted app-client session from the B2 endpoint (cross-app, #479). */
+interface MintSession {
+  app: string
+  clientId: string
   idToken: string
   accessToken: string
   refreshToken: string
@@ -51,18 +54,14 @@ interface MintResult {
 
 export type ImpersonationOutcome = { ok: true } | { ok: false; error: string }
 
+// Root of EVERY Amplify v6 Cognito token-store key, across all app-clients
+// (Launchpad, Stock Analyser, Budget Tracker) — they share this origin's
+// localStorage, namespaced per clientId. Cross-app impersonation (#479) swaps
+// and snapshots ALL of them, so a persona carries into SA/BT, not just LP.
+const COGNITO_ROOT = 'CognitoIdentityServiceProvider.'
+
 function hasWindow(): boolean {
   return typeof window !== 'undefined'
-}
-
-function cognitoClientId(): string {
-  // Same client id the CognitoAuthService configures Amplify with.
-  return process.env.NEXT_PUBLIC_COGNITO_CLIENT_ID ?? ''
-}
-
-/** Prefix of every Amplify v6 Cognito token-store key for this app client. */
-function amplifyPrefix(): string {
-  return `CognitoIdentityServiceProvider.${cognitoClientId()}`
 }
 
 /** Decode a JWT payload (browser-safe base64url). Returns {} on any failure. */
@@ -82,13 +81,12 @@ function decodeJwt(token: string): Record<string, unknown> {
   }
 }
 
-/** Read all Amplify token-store entries for this client (the live session). */
+/** Read ALL Amplify token-store entries across every app-client (the live sessions). */
 function readAmplifyKeys(): Record<string, string> {
-  const prefix = amplifyPrefix()
   const out: Record<string, string> = {}
   for (let i = 0; i < localStorage.length; i++) {
     const k = localStorage.key(i)
-    if (k && k.startsWith(prefix)) {
+    if (k && k.startsWith(COGNITO_ROOT)) {
       const v = localStorage.getItem(k)
       if (v !== null) out[k] = v
     }
@@ -96,12 +94,16 @@ function readAmplifyKeys(): Record<string, string> {
   return out
 }
 
-/** Remove all Amplify token-store entries for this client. */
+/** Remove ALL Amplify token-store entries across every app-client. */
 function clearAmplifyKeys(): void {
-  const prefix = amplifyPrefix()
-  Object.keys(localStorage)
-    .filter((k) => k.startsWith(prefix))
-    .forEach((k) => localStorage.removeItem(k))
+  // Collect first (removing during the index walk would shift indices). Uses the
+  // canonical indexed Storage API, matching readAmplifyKeys.
+  const toRemove: string[] = []
+  for (let i = 0; i < localStorage.length; i++) {
+    const k = localStorage.key(i)
+    if (k && k.startsWith(COGNITO_ROOT)) toRemove.push(k)
+  }
+  toRemove.forEach((k) => localStorage.removeItem(k))
 }
 
 /** Write a verbatim Amplify key set back into the token store. */
@@ -120,33 +122,45 @@ function identityFromIdToken(idToken: string): ImpersonatorIdentity {
 }
 
 /**
- * Replace the Amplify token store with a minted persona session. Cognito (this
- * pool) uses an email alias, so the access token's `username` equals the sub;
- * Amplify keys are namespaced by that username with `LastAuthUser` pointing at it.
+ * Write one minted app-client session into its Amplify token-store namespace.
+ * Cognito (this pool) uses an email alias, so the access token's `username`
+ * equals the sub; Amplify keys are namespaced by clientId then username, with
+ * `LastAuthUser` pointing at it.
+ *
+ * ⚠ COUPLING: this writes Amplify v6's localStorage token-store format directly
+ * (`CognitoIdentityServiceProvider.<clientId>.<user>.{idToken,accessToken,
+ * refreshToken,clockDrift}` + `.LastAuthUser`) so the swap is a CONSISTENT
+ * same-tab replace — every surface that reads Amplify (not just authService)
+ * sees the persona. It BREAKS if Amplify changes this storage format on upgrade;
+ * if so, update the key shape HERE. Dev-only — blast radius is the persona
+ * switcher only, never prod or real auth.
  */
-function writePersonaSession(mint: MintResult): void {
-  const access = decodeJwt(mint.accessToken)
+function writeSession(session: MintSession): void {
+  const access = decodeJwt(session.accessToken)
   const username =
     (access['username'] as string) ??
     (access['sub'] as string) ??
-    (decodeJwt(mint.idToken)['cognito:username'] as string) ??
-    (decodeJwt(mint.idToken)['sub'] as string) ??
+    (decodeJwt(session.idToken)['cognito:username'] as string) ??
+    (decodeJwt(session.idToken)['sub'] as string) ??
     ''
-  const prefix = amplifyPrefix()
+  const prefix = `${COGNITO_ROOT}${session.clientId}`
   const base = `${prefix}.${username}`
-  // ⚠ COUPLING: this writes Amplify v6's localStorage token-store format directly
-  // (`CognitoIdentityServiceProvider.<clientId>.<user>.{idToken,accessToken,
-  // refreshToken,clockDrift}` + `.LastAuthUser`) so the swap is a CONSISTENT
-  // same-tab replace — every surface that reads Amplify (not just authService)
-  // sees the persona. It BREAKS if Amplify changes this storage format on upgrade;
-  // if so, update the key shape HERE. Dev-only — blast radius is the persona
-  // switcher only, never prod or real auth.
-  clearAmplifyKeys()
   localStorage.setItem(`${prefix}.LastAuthUser`, username)
-  localStorage.setItem(`${base}.idToken`, mint.idToken)
-  localStorage.setItem(`${base}.accessToken`, mint.accessToken)
-  localStorage.setItem(`${base}.refreshToken`, mint.refreshToken)
+  localStorage.setItem(`${base}.idToken`, session.idToken)
+  localStorage.setItem(`${base}.accessToken`, session.accessToken)
+  localStorage.setItem(`${base}.refreshToken`, session.refreshToken)
   localStorage.setItem(`${base}.clockDrift`, '0')
+}
+
+/**
+ * Replace EVERY app-client's token store with the minted persona sessions, so
+ * the persona is active in Launchpad AND Stock Analyser / Budget Tracker on the
+ * next navigation (#479). Clears all namespaces first (the snapshot already holds
+ * the tester's originals) so no stale tester session lingers in any app.
+ */
+function writePersonaSessions(sessions: MintSession[]): void {
+  clearAmplifyKeys()
+  for (const session of sessions) writeSession(session)
 }
 
 function readSnapshot(): Snapshot | null {
@@ -183,7 +197,7 @@ export function getImpersonator(): ImpersonatorIdentity | null {
 export async function startImpersonation(personaId: string): Promise<ImpersonationOutcome> {
   if (!hasWindow()) return { ok: false, error: 'Unavailable.' }
 
-  let mint: MintResult
+  let sessions: MintSession[]
   try {
     const res = await fetch(controlPlaneUrl('/api/dev/persona-token'), {
       method: 'POST',
@@ -200,16 +214,19 @@ export async function startImpersonation(personaId: string): Promise<Impersonati
             : `Mint failed (${res.status}).`
       return { ok: false, error: msg }
     }
-    const body = (await res.json()) as Partial<MintResult>
-    if (!body.idToken || !body.accessToken || !body.refreshToken) {
-      return { ok: false, error: 'Mint returned an incomplete session.' }
+    const body = (await res.json()) as { sessions?: MintSession[] }
+    sessions = (body.sessions ?? []).filter(
+      (s) => s && s.clientId && s.idToken && s.accessToken && s.refreshToken,
+    )
+    if (sessions.length === 0) {
+      return { ok: false, error: 'Mint returned no usable sessions.' }
     }
-    mint = { idToken: body.idToken, accessToken: body.accessToken, refreshToken: body.refreshToken }
   } catch {
     return { ok: false, error: 'Could not reach the persona mint endpoint.' }
   }
 
-  // Capture the tester's ORIGINAL session ONCE — never overwrite across hops.
+  // Capture the tester's ORIGINAL sessions (all app-clients) ONCE — never
+  // overwrite across hops, so "switch back" returns to the FIRST tester.
   if (!isImpersonating()) {
     const amplifyKeys = readAmplifyKeys()
     const idTokenEntry = Object.entries(amplifyKeys).find(([k]) => k.endsWith('.idToken'))
@@ -218,7 +235,7 @@ export async function startImpersonation(personaId: string): Promise<Impersonati
     localStorage.setItem(SNAPSHOT_KEY, JSON.stringify(snapshot))
   }
 
-  writePersonaSession(mint)
+  writePersonaSessions(sessions)
   window.location.reload()
   return { ok: true }
 }


### PR DESCRIPTION
Closes #479.

## Problem
Switching to a persona in Launchpad then clicking into Stock Analyser / Budget
Tracker landed as the **real tester** (Steve), not the persona. The switcher
swapped only the Launchpad app-client token store; SA/BT are separate app-clients
with their own token-store namespaces, which still held the tester's session.

## Fix
- **B2 mint** (`/api/dev/persona-token`) now mints **one session per app-client**
  (Launchpad, Stock Analyser, Budget Tracker — one pool, all `adminUserPassword`
  enabled) and returns a `sessions[]` array with the `clientId` per app. The stack
  threads the SA/BT client ids (already in props) into the Lambda env;
  `AdminInitiateAuth` IAM is already pool-scoped, covering all three.
- **Switcher seam** writes EVERY app-client's token-store namespace and
  snapshots/restores ALL of them, so the persona carries into SA/BT and
  switch-back restores the original tester everywhere (an app the tester never
  opened goes back to empty, not left as the persona).
- `clearAmplifyKeys` switched to the canonical indexed Storage API (matches
  `readAmplifyKeys`) — robust across namespaces and testable.

Persona entitlement stays per-app (Marcus has SA access but not BT → BT shows
no-access, correct).

## Tests
Cross-app hop-preserve: Steve→Priya→Marcus→back asserts the **SA + BT** namespaces
swap and restore (not just LP); plus 403-disabled is non-mutating. 40 pass;
typecheck, lint, static-export build green.

## Scope
Dev-only (the mint endpoint is stage-gated + absent from prod). Additive — no
pool/contract change; the SA/BT app-clients already exist.

## Verification after deploy
On dev: impersonate Marcus → click into Stock Analyser → confirm you are Marcus
(not Steve) → switch back in LP → confirm SA returns to the tester.

## v0 freshness
- [x] No v0 impact
Reason: dev-only persona harness (Lambda + IaC env + dev seam in `lib/dev/`); no
UI surface, contract, mock, or runtime-shape change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)