### PR TITLE
feat(launchpad): SES redemption invitation email + grants preview (#471)

### DIFF
--- a/apps/launchpad/functions/invitation-bundles/package.json
+++ b/apps/launchpad/functions/invitation-bundles/package.json
@@ -15,6 +15,7 @@
   },
   "devDependencies": {
     "@aws-sdk/client-dynamodb": "^3",
+    "@aws-sdk/client-sesv2": "^3",
     "@aws-sdk/lib-dynamodb": "^3",
     "@types/aws-lambda": "^8",
     "@types/node": "^22",

--- a/apps/launchpad/functions/invitation-bundles/src/email.test.ts
+++ b/apps/launchpad/functions/invitation-bundles/src/email.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { buildRedemptionEmail } from './email';
+
+describe('buildRedemptionEmail (#471 grants preview)', () => {
+  const redeemUrl = 'https://dev.apps.transformotion.com.au/redeem?bundle=abc-123';
+
+  it('renders the account-invite and app-grant preview lines (mirrors the redemption screens)', () => {
+    const { subject, html, text } = buildRedemptionEmail({
+      grants: [
+        { kind: 'account-invite', target: 'Apex Capital' },
+        { kind: 'app-grant', target: 'Stock Analyser' },
+      ],
+      redeemUrl,
+    });
+
+    expect(subject).toMatch(/invited to Transformotion/i);
+
+    // account-invite wording
+    expect(text).toContain('Join Apex Capital');
+    expect(text).toContain('Added to an existing account');
+    expect(html).toContain('Join Apex Capital');
+
+    // app-grant wording
+    expect(text).toContain('Get Stock Analyser access');
+    expect(text).toContain("You'll create your first account on arrival");
+    expect(html).toContain('Get Stock Analyser access');
+
+    // bearer link present in both parts
+    expect(text).toContain(redeemUrl);
+    expect(html).toContain(redeemUrl);
+  });
+
+  it('HTML-escapes user-influenced account names (no injection)', () => {
+    const { html } = buildRedemptionEmail({
+      grants: [{ kind: 'account-invite', target: '<script>x</script> & "co"' }],
+      redeemUrl,
+    });
+    expect(html).not.toContain('<script>x</script>');
+    expect(html).toContain('&lt;script&gt;');
+    expect(html).toContain('&amp;');
+  });
+});

--- a/apps/launchpad/functions/invitation-bundles/src/email.ts
+++ b/apps/launchpad/functions/invitation-bundles/src/email.ts
@@ -1,0 +1,122 @@
+/**
+ * Redemption invitation email (#471) — the grants preview lives HERE.
+ *
+ * The auth-first redemption flow has NO pre-auth in-app preview: the invitee
+ * can't see what they were granted until after they sign in. So the email itself
+ * must carry the grants preview. The wording mirrors the in-app redemption
+ * screens (apps/launchpad/components/launchpad/redemption/screens.tsx):
+ *   - account-invite → "Join <account> — added to an existing account"
+ *   - app-grant      → "Get <app> access — you'll create your first account on arrival"
+ * plus the /redeem?bundle=<id> bearer link.
+ *
+ * Pure rendering — no SES/AWS here, so it is trivially unit-testable.
+ */
+
+/** App slug → display label. Mirrors lib/admin/view-model.ts `appLabelMap`. */
+const APP_LABEL: Record<string, string> = {
+  'stock-analyser': 'Stock Analyser',
+  'budget-tracker': 'Budget Tracker',
+};
+
+export function appLabel(slug: string): string {
+  return APP_LABEL[slug] ?? slug;
+}
+
+/** A grant as the email presents it: a kind plus a human target label. */
+export interface EmailGrant {
+  kind: 'account-invite' | 'app-grant';
+  /** Account name (account-invite) or app label (app-grant). */
+  target: string;
+}
+
+export interface RedemptionEmail {
+  subject: string;
+  html: string;
+  text: string;
+}
+
+/** Escape user-influenced text (account names) before HTML interpolation. */
+function esc(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+/** Headline + subline for one grant, matching the in-app redemption screens. */
+function grantLines(g: EmailGrant): { headline: string; sub: string } {
+  return g.kind === 'account-invite'
+    ? { headline: `Join ${g.target}`, sub: 'Added to an existing account' }
+    : { headline: `Get ${g.target} access`, sub: "You'll create your first account on arrival" };
+}
+
+/**
+ * Render the redemption email (HTML + text) from a bundle's grants and its
+ * bearer redeem link. `grants` must be non-empty (a bundle with no authorized
+ * grants is never persisted, so no email is sent).
+ */
+export function buildRedemptionEmail(input: { grants: EmailGrant[]; redeemUrl: string }): RedemptionEmail {
+  const { grants, redeemUrl } = input;
+
+  const subject = 'You have been invited to Transformotion';
+
+  // ── Plaintext part ──────────────────────────────────────────────────────
+  const textLines = grants.map((g) => {
+    const { headline, sub } = grantLines(g);
+    return `  • ${headline} — ${sub}`;
+  });
+  const text = [
+    'You have been invited to Transformotion.',
+    '',
+    "Here's what you'll get:",
+    ...textLines,
+    '',
+    'Accept your invitation:',
+    redeemUrl,
+    '',
+    'This invitation link is personal to you. If you were not expecting it, you can ignore this email.',
+  ].join('\n');
+
+  // ── HTML part (mirrors the forgot-provider email shell) ─────────────────
+  const grantRows = grants
+    .map((g) => {
+      const { headline, sub } = grantLines(g);
+      return `
+        <tr><td style="padding:0 0 10px">
+          <div style="background:#091523;border:1px solid #1A3550;border-radius:10px;padding:14px 18px">
+            <p style="margin:0 0 2px;font-size:15px;font-weight:600;color:#00C4B3;font-family:sans-serif">${esc(headline)}</p>
+            <p style="margin:0;font-size:13px;color:#7BAAC8;font-family:sans-serif">${esc(sub)}</p>
+          </div>
+        </td></tr>`;
+    })
+    .join('');
+
+  const html = `<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"></head>
+<body style="margin:0;padding:0;background:#0D1B2A">
+<table width="100%" cellpadding="0" cellspacing="0" style="background:#0D1B2A;min-height:100vh">
+  <tr><td align="center" style="padding:48px 16px">
+    <table cellpadding="0" cellspacing="0" style="max-width:480px;width:100%">
+      <tr><td style="padding-bottom:28px;text-align:center">
+        <span style="font-family:'Helvetica Neue',sans-serif;font-size:26px;font-weight:900;letter-spacing:4px;color:#fff">T</span><span style="font-family:'Helvetica Neue',sans-serif;font-size:21px;font-weight:900;letter-spacing:4px;color:#fff">RANSFOR</span><span style="font-family:'Helvetica Neue',sans-serif;font-size:21px;font-weight:900;letter-spacing:4px;color:#00C4B3">M</span><span style="font-family:'Helvetica Neue',sans-serif;font-size:21px;font-weight:900;letter-spacing:4px;color:#E8A838">O</span><span style="font-family:'Helvetica Neue',sans-serif;font-size:21px;font-weight:900;letter-spacing:4px;color:#00C4B3">TION</span>
+      </td></tr>
+      <tr><td style="background:#112538;border:1px solid #1A3550;border-radius:16px;padding:32px">
+        <p style="margin:0 0 6px;font-size:18px;font-weight:700;color:#fff;font-family:sans-serif">You're invited to Transformotion</p>
+        <p style="margin:0 0 22px;font-size:14px;color:#7BAAC8;font-family:sans-serif">Here's what you'll get when you accept:</p>
+        <table width="100%" cellpadding="0" cellspacing="0">${grantRows}
+        </table>
+        <a href="${esc(redeemUrl)}" style="display:inline-block;margin-top:22px;background:#00C4B3;color:#0D1B2A;font-weight:700;font-size:14px;text-decoration:none;padding:12px 28px;border-radius:8px;font-family:sans-serif">Accept invitation &rarr;</a>
+      </td></tr>
+      <tr><td style="padding-top:20px;text-align:center">
+        <p style="margin:0;font-size:12px;color:#7BAAC8;font-family:sans-serif">This link is personal to you. If you weren't expecting it, you can safely ignore this email.</p>
+      </td></tr>
+    </table>
+  </td></tr>
+</table>
+</body></html>`;
+
+  return { subject, html, text };
+}

--- a/apps/launchpad/functions/invitation-bundles/src/index.ts
+++ b/apps/launchpad/functions/invitation-bundles/src/index.ts
@@ -22,6 +22,8 @@ import type {
   InvitationBundle,
   InvitationGrant,
 } from '@transformotion/contracts/launchpad/invitations';
+import { SESv2Client, SendEmailCommand } from '@aws-sdk/client-sesv2';
+import { buildRedemptionEmail, appLabel, type EmailGrant } from './email';
 import { randomUUID } from 'crypto';
 
 // M11 Chunk 3 — invitation-bundle CREATION (POST /api/invitations/bundles).
@@ -45,6 +47,15 @@ export interface BundleCreationDeps {
   ddb: DynamoDBDocumentClient;
   invitationsTable: string;
   accountsTable: string;
+  // ── Redemption-email send seam (4b / #471) — all OPTIONAL ────────────────
+  // When configured, bundle creation also sends the invitee the redemption email
+  // carrying the grants preview + bearer link. Absent (e.g. in unit tests) → the
+  // send is skipped; bundle creation is unaffected either way.
+  ses?: SESv2Client | null;
+  /** Verified SES from-address (stage-derived: noreply-dev@ in dev, noreply@ in prod). */
+  fromEmail?: string;
+  /** App origin for the bearer link, e.g. https://dev.apps.transformotion.com.au. */
+  appUrl?: string;
 }
 
 export function createHandler(deps: BundleCreationDeps) {
@@ -76,6 +87,9 @@ export function createHandler(deps: BundleCreationDeps) {
 
     const decisions: GrantAuthorizationDecision[] = [];
     const authorized: InvitationGrant[] = [];
+    // Parallel preview of the authorized grants for the redemption email (#471):
+    // account-invite → the account name; app-grant → the app label.
+    const emailGrants: EmailGrant[] = [];
 
     for (let index = 0; index < grants.length; index++) {
       const g = grants[index];
@@ -100,7 +114,7 @@ export function createHandler(deps: BundleCreationDeps) {
           continue;
         }
         const acct = await deps.ddb.send(new GetCommand({ TableName: deps.accountsTable, Key: { accountId: g.accountId } }));
-        const account = acct.Item as { appSlug?: string } | undefined;
+        const account = acct.Item as { appSlug?: string; name?: string } | undefined;
         if (!account) {
           decisions.push({ index, allowed: false, reason: 'That account no longer exists.' });
           continue;
@@ -110,10 +124,12 @@ export function createHandler(deps: BundleCreationDeps) {
           continue;
         }
         authorized.push({ grantId: randomUUID(), kind: 'account-invite', appSlug: appSlug as EntitledAppSlug, accountId: g.accountId, role: g.role as AccountRole });
+        emailGrants.push({ kind: 'account-invite', target: account.name ?? 'an existing account' });
         decisions.push({ index, allowed: true, reason: 'Authorized.' });
       } else if (g.kind === 'app-grant') {
         // Roleless, account-less: person + app only.
         authorized.push({ grantId: randomUUID(), kind: 'app-grant', appSlug: appSlug as EntitledAppSlug });
+        emailGrants.push({ kind: 'app-grant', target: appLabel(appSlug) });
         decisions.push({ index, allowed: true, reason: 'Authorized.' });
       } else {
         decisions.push({ index, allowed: false, reason: `Unsupported grant kind '${g.kind ?? ''}'.` });
@@ -146,8 +162,41 @@ export function createHandler(deps: BundleCreationDeps) {
       Item: { invitationId: bundleId, ...bundle },
     }));
 
+    // Send seam (4b / #471): email the invitee the grants preview + bearer link.
+    // The persisted bundle is the source of truth — a failed send NEVER fails
+    // creation (the link still works; resend is a separate concern, not built now).
+    await sendRedemptionEmail(inviteeEmail, bundleId, emailGrants);
+
     const response: CreateInvitationBundleResponse = { bundle, decisions };
     return ok(response);
+  }
+
+  // The redemption-email send seam. No-op unless SES + from-address + app URL are
+  // wired (so unit tests that omit them skip the send). Sandbox SES only delivers
+  // to verified recipients; arbitrary-invitee delivery needs prod access (M17).
+  async function sendRedemptionEmail(toEmail: string, bundleId: string, grants: EmailGrant[]) {
+    if (!deps.ses || !deps.fromEmail || !deps.appUrl || grants.length === 0) return;
+    try {
+      const redeemUrl = `${deps.appUrl.replace(/\/+$/, '')}/redeem?bundle=${encodeURIComponent(bundleId)}`;
+      const { subject, html, text } = buildRedemptionEmail({ grants, redeemUrl });
+      await deps.ses.send(new SendEmailCommand({
+        FromEmailAddress: deps.fromEmail,
+        Destination: { ToAddresses: [toEmail] },
+        Content: {
+          Simple: {
+            Subject: { Data: subject, Charset: 'UTF-8' },
+            Body: {
+              Html: { Data: html, Charset: 'UTF-8' },
+              Text: { Data: text, Charset: 'UTF-8' },
+            },
+          },
+        },
+      }));
+    } catch (err) {
+      // Swallow: the bundle exists and the link works. In sandbox an unverified
+      // recipient throws here — expected until prod SES access (M17).
+      console.error('redemption-email-send-error', { bundleId, name: (err as { name?: string }).name });
+    }
   }
 
   // GET /api/invitations/bundles — list bundles (Redemption Demo inbox / admin
@@ -225,4 +274,9 @@ export const handler = createHandler({
   ddb: DynamoDBDocumentClient.from(new DynamoDBClient({})),
   invitationsTable: process.env.INVITATIONS_TABLE!,
   accountsTable: process.env.ACCOUNTS_TABLE!,
+  // Redemption-email send seam (4b / #471). FROM_EMAIL is stage-derived in the
+  // stack; APP_URL builds the /redeem?bundle=<id> bearer link.
+  ses: new SESv2Client({}),
+  fromEmail: process.env.FROM_EMAIL,
+  appUrl: process.env.APP_URL,
 });

--- a/apps/launchpad/infrastructure/launchpad-control-plane-stack.ts
+++ b/apps/launchpad/infrastructure/launchpad-control-plane-stack.ts
@@ -22,7 +22,6 @@ export interface LaunchpadControlPlaneStackProps extends cdk.StackProps {
   invitationsTableName: string;
   rateLimitsTableName: string;
   appAdminGrantsTableName: string;
-  fromEmail: string;
   appUrl: string;
 }
 
@@ -51,12 +50,19 @@ export class LaunchpadControlPlaneStack extends cdk.Stack {
       invitationsTableName,
       rateLimitsTableName,
       appAdminGrantsTableName,
-      fromEmail,
       appUrl,
     } = props;
     const registry = loadAppRegistry();
     const appSlugs = registry.apps.map(a => a.slug);
     const corsAllowOrigin = appUrl.replace(/\/*$/, '');
+
+    // Stage-derived sender so dev and prod can NEVER be confused (owner
+    // foolproofing): dev → noreply-dev@, prod → noreply@. Derived from the same
+    // `stage` that gates everything else — there is no separate literal to drift.
+    // Both forms are covered by the verified transformotion.com.au SES domain
+    // identity (it covers every @transformotion.com.au address). Prod sends
+    // through prod SES, which is its own setup at M17 (#454).
+    const redemptionFromAddress = `noreply${stage === 'prod' ? '' : `-${stage}`}@transformotion.com.au`;
     const corsAllowHeaders = ['Content-Type', 'Authorization', 'X-Account-Id'];
     const corsAllowMethods = ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'];
 
@@ -128,7 +134,7 @@ export class LaunchpadControlPlaneStack extends cdk.Stack {
       environment: {
         RATE_LIMIT_TABLE: rateLimitTable.tableName,
         USER_POOL_ID: userPoolId,
-        FROM_EMAIL: fromEmail,
+        FROM_EMAIL: redemptionFromAddress,
         APP_URL: appUrl,
       },
       bundling: {
@@ -438,6 +444,10 @@ export class LaunchpadControlPlaneStack extends cdk.Stack {
       environment: {
         INVITATIONS_TABLE: invitationsTable.tableName,
         ACCOUNTS_TABLE: accountsTable.tableName,
+        // Redemption-email send seam (4b / #471): the invitee gets the grants
+        // preview + /redeem?bundle=<id> bearer link on bundle creation.
+        FROM_EMAIL: redemptionFromAddress,
+        APP_URL: appUrl,
       },
       bundling: {
         externalModules: ['@aws-sdk/*'],
@@ -448,6 +458,12 @@ export class LaunchpadControlPlaneStack extends cdk.Stack {
 
     invitationsTable.grantReadWriteData(invitationBundlesFn); // write the bundle
     accountsTable.grantReadData(invitationBundlesFn);          // account-invite: validate account/app
+    // Send the redemption email (4b / #471). SES SendEmail can't be ARN-scoped to
+    // a from-identity without conditions; mirror forgot-provider's grant.
+    invitationBundlesFn.addToRolePolicy(new iam.PolicyStatement({
+      actions: ['ses:SendEmail', 'sesv2:SendEmail'],
+      resources: ['*'],
+    }));
     // No Cognito grant: sender authorization (site-admin / app-admin) reads the
     // token's cognito:groups — no AWS calls. Grants are CONFERRED at redemption (A5).
 

--- a/docs/architecture/inventory.md
+++ b/docs/architecture/inventory.md
@@ -108,6 +108,25 @@ read-only access plus env fallback values; provider secrets and execution remain
 app-owned. The Launchpad Settings UI exposes this provider/model configuration
 to site-admin users only.
 
+### Transactional email (SES)
+
+`launchpad-forgot-provider-{stage}` and `launchpad-invitation-bundles-{stage}`
+send transactional email via SES v2 (`ses:SendEmail`). The redemption invitation
+(`POST /api/invitations/bundles`, M11 4b / #471) carries the grants preview +
+`/redeem?bundle=<id>` bearer link, because the auth-first flow has no pre-auth
+in-app preview; a failed send never fails bundle creation.
+
+- **From-address is stage-derived** in `LaunchpadControlPlaneStack`
+  (`noreply${stage==='prod' ? '' : '-'+stage}@transformotion.com.au`) → dev sends
+  as `noreply-dev@`, prod as `noreply@`. Derived from the stack `stage`, so dev
+  and prod cannot be confused and there is no separate literal to drift.
+- **The SES domain identity `transformotion.com.au` is verified in the dev
+  account but is NOT in CDK/IaC** — it was created out-of-band (EasyDKIM, 3 CNAMEs
+  live; DkimStatus SUCCESS). This is known drift (cf. #263); a deliberate choice
+  to leave it unmanaged rather than risk a conflicting CFN create. Prod SES is a
+  separate setup at M17 (#454). The dev account is in the **SES sandbox**, so
+  sends only reach verified recipients until production access (M17).
+
 ## Stock Analyser
 
 Stock Analyser owns:

--- a/infrastructure/bin/launchpad.ts
+++ b/infrastructure/bin/launchpad.ts
@@ -35,7 +35,6 @@ new LaunchpadControlPlaneStack(app, 'TransformotionDev-LaunchpadControlPlane', {
   invitationsTableName:     devAuth.invitationsTableName,
   rateLimitsTableName:      devAuth.rateLimitsTableName,
   appAdminGrantsTableName:  devAuth.appAdminGrantsTableName,
-  fromEmail:                'noreply@transformotion.com.au',
   appUrl:                   'https://dev.apps.transformotion.com.au',
   description:              'Transformotion Apps - Dev Launchpad control plane',
 });
@@ -62,7 +61,6 @@ new LaunchpadControlPlaneStack(app, 'TransformotionProd-LaunchpadControlPlane', 
   invitationsTableName:     prodAuth.invitationsTableName,
   rateLimitsTableName:      prodAuth.rateLimitsTableName,
   appAdminGrantsTableName:  prodAuth.appAdminGrantsTableName,
-  fromEmail:                'noreply@transformotion.com.au',
   appUrl:                   'https://apps.transformotion.com.au',
   description:              'Transformotion Apps - Prod Launchpad control plane',
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -813,6 +813,9 @@ importers:
       '@aws-sdk/client-dynamodb':
         specifier: ^3
         version: 3.1032.0
+      '@aws-sdk/client-sesv2':
+        specifier: ^3
+        version: 3.1032.0
       '@aws-sdk/lib-dynamodb':
         specifier: ^3
         version: 3.1032.0(@aws-sdk/client-dynamodb@3.1032.0)


### PR DESCRIPTION
Closes #471. M11 4b — SES delivery of the redemption invitation carrying the grants
preview. **Dev sandbox only** (prod SES access is M17/#454).

## ⛔ PR only — owner reviews + gates the deploy
No deploy on my side. Merge → dev deploy via `deploy-launchpad.yml`.

## What this does
On `POST /api/invitations/bundles`, after the bundle persists, the invitee is
emailed the grants preview + `/redeem?bundle=<id>` bearer link. The auth-first flow
has no pre-auth in-app preview, so the email is where the preview lives (#471).

- `email.ts` renders **HTML + text** from the bundle's grants, mirroring the in-app
  redemption screens: account-invite → "Join <account> — added to an existing
  account"; app-grant → "Get <app> access — you'll create your first account on
  arrival". Account names HTML-escaped.
- Send seam: SESv2 `SendEmail` AFTER persist; a failed send is **logged and never
  fails creation** (the link still works; resend is a separate concern, not built).
  IAM `ses:SendEmail` on the bundles Lambda (mirrors forgot-provider).

## Review notes
**(a) SES identity already verified (unmanaged drift).** The dev SES domain
identity `transformotion.com.au` is already verified out-of-band (EasyDKIM, 3
CNAMEs live, DkimStatus SUCCESS) — there is **no DNS for the owner to add**. It is
NOT in CDK/IaC; left unmanaged by choice (adding a CFN identity would collide).
Documented as drift in `inventory.md` (cf. #263).

**(b) Stage-derived from-address.**
`noreply${stage==='prod' ? '' : '-'+stage}@transformotion.com.au` → dev sends as
`noreply-dev@`, prod as `noreply@`. Derived from the stack `stage` (no separate
literal to drift); the literal `fromEmail` prop is retired from props + bin.
Confirmed via `cdk synth` (dev renders `FROM_EMAIL: noreply-dev@…`).

**(c) forgot-provider from-address fix included.** forgot-provider had the SAME
dev/prod-confusion bug (it sent `noreply@` in dev). It now uses the same
stage-derived address. Same bug, same fix — folded in here.

**(d) Sandbox test recipient = `stevemoodie70@gmail.com`** (to be verified in dev
SES before the live test).

## Contract check
No change — pure side-effect of the existing create path; email renders from the
persisted grants (+ the account name already fetched during validation).

## Sandbox reality
Dev SES is in **sandbox** → delivers ONLY to verified recipients. Owner verifies
`stevemoodie70@gmail.com` in dev SES (SES emails a confirm link to that inbox →
owner clicks) before testing. Arbitrary-invitee delivery needs prod access (M17).

## Test plan (after merge + deploy + recipient verified)
1. Create an invitation bundle → redemption email sends to `stevemoodie70@gmail.com`.
2. Confirm it arrived, carries the grants preview correctly, and the "Accept
   invitation" link lands on `/redeem?bundle=<id>`.
3. **Flag INBOX vs SPAM.** DKIM-only is configured today; if it lands in spam,
   **SPF + DMARC are the next DNS step** (additional records on transformotion.com.au).

## Tests
`email.test.ts` (wording faithfulness + HTML-escaping) + existing bundles tests — 9
pass. Function typecheck + `cdk synth` (FROM_EMAIL + ses:SendEmail render) green.

## v0 freshness
- [x] No v0 impact
Reason: backend Lambda send seam + email template + IaC; no UI, contract, mock, or
runtime-shape change. Email wording mirrors the existing in-app redemption screens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)