### PR TITLE
fix(redemption): callback navigates exactly once — stop dropping the bundle (#483)

### DIFF
--- a/apps/launchpad/app/launchpad/callback/page.tsx
+++ b/apps/launchpad/app/launchpad/callback/page.tsx
@@ -3,25 +3,7 @@
 import { useEffect, useState } from 'react'
 import { Hub } from 'aws-amplify/utils'
 import { authService } from '@/lib/services/auth'
-import { REDEEM_RETURN_KEY } from '@/lib/redemption/seam'
-
-/**
- * Where to go after a successful callback. A redemption sign-in (A4) stashes the
- * bundleId so the reused callback returns to /redeem?bundle=<id> instead of `/`
- * (consumed once). Everything else lands on the Launchpad home.
- */
-function postCallbackTarget(): string {
-  try {
-    const bundleId = sessionStorage.getItem(REDEEM_RETURN_KEY)
-    if (bundleId) {
-      sessionStorage.removeItem(REDEEM_RETURN_KEY)
-      return `/redeem?bundle=${encodeURIComponent(bundleId)}`
-    }
-  } catch {
-    /* no sessionStorage — fall through to home */
-  }
-  return '/'
-}
+import { takeRedeemReturnTarget } from '@/lib/redemption/seam'
 
 function sanitizeAmplifyOAuthState() {
   const keysToFix: string[] = []
@@ -38,10 +20,23 @@ export default function CallbackPage() {
   const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
+    // OAuth completion can surface via TWO triggers — the Hub 'signInWithRedirect'
+    // event AND the getCurrentUser() fallback (for when the Hub event fired before
+    // this listener attached). Navigate EXACTLY ONCE: takePostCallbackTarget()
+    // destructively consumes the redeem-return key, so a double-invoke would let
+    // the second read see an empty key and override the redemption return with `/`.
+    // The guard makes the post-callback navigation idempotent. (#483)
+    let navigated = false
+    const go = () => {
+      if (navigated) return
+      navigated = true
+      sanitizeAmplifyOAuthState()
+      window.location.replace(takeRedeemReturnTarget())
+    }
+
     const unsubscribe = Hub.listen('auth', ({ payload }) => {
       if (payload.event === 'signInWithRedirect') {
-        sanitizeAmplifyOAuthState()
-        window.location.replace(postCallbackTarget())
+        go()
       }
       if (payload.event === 'signInWithRedirect_failure') {
         setError('Sign in failed. Please try again.')
@@ -49,9 +44,9 @@ export default function CallbackPage() {
     })
 
     // If the Hub event already fired before the listener was set up, check
-    // whether Amplify already has an authenticated user.
+    // whether Amplify already has an authenticated user — same single navigation.
     authService.getCurrentUser().then((user) => {
-      if (user) window.location.replace(postCallbackTarget())
+      if (user) go()
     }).catch(() => {})
 
     return unsubscribe

--- a/apps/launchpad/lib/redemption/seam.test.ts
+++ b/apps/launchpad/lib/redemption/seam.test.ts
@@ -1,0 +1,37 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { REDEEM_RETURN_KEY, takeRedeemReturnTarget } from './seam'
+
+// seam.ts reads window.sessionStorage — shim a Map-backed one (node env).
+beforeEach(() => {
+  const store = new Map<string, string>()
+  const sessionStorage = {
+    getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+    setItem: (k: string, v: string) => void store.set(k, String(v)),
+    removeItem: (k: string) => void store.delete(k),
+  }
+  vi.stubGlobal('window', { sessionStorage })
+})
+
+describe('takeRedeemReturnTarget (#483 — destructive, call-once)', () => {
+  it('returns the redeem target AND consumes the key (so a second read cannot reuse it)', () => {
+    window.sessionStorage.setItem(REDEEM_RETURN_KEY, 'e0bb2b06-d794-431c-9a28-e99b2fb62bf6')
+
+    // First call (the single guarded navigation) → redeem target, key cleared.
+    expect(takeRedeemReturnTarget()).toBe('/redeem?bundle=e0bb2b06-d794-431c-9a28-e99b2fb62bf6')
+    expect(window.sessionStorage.getItem(REDEEM_RETURN_KEY)).toBeNull()
+
+    // ★ The bug: a SECOND read (the un-guarded double-trigger) now sees an empty
+    // key and returns `/`. The callback's navigatedRef guard prevents this second
+    // call from happening at all; this asserts WHY the guard is required.
+    expect(takeRedeemReturnTarget()).toBe('/')
+  })
+
+  it('returns `/` for a normal (non-redemption) sign-in with no stashed bundle', () => {
+    expect(takeRedeemReturnTarget()).toBe('/')
+  })
+
+  it('url-encodes the bundle id', () => {
+    window.sessionStorage.setItem(REDEEM_RETURN_KEY, 'a b/c&d')
+    expect(takeRedeemReturnTarget()).toBe('/redeem?bundle=a%20b%2Fc%26d')
+  })
+})

--- a/apps/launchpad/lib/redemption/seam.ts
+++ b/apps/launchpad/lib/redemption/seam.ts
@@ -21,6 +21,28 @@ import type { AuthenticatedIdentity, IdpProvider } from '@transformotion/contrac
 /** Key the callback reads to know it should return to a redemption, not `/`. */
 export const REDEEM_RETURN_KEY = 'launchpad.redeem-return.v1'
 
+/**
+ * Consume the stashed redeem-return after the Hosted-UI round-trip: returns
+ * `/redeem?bundle=<id>` when a redemption sign-in is in flight (clearing the key
+ * so it is used once), else `/` (normal sign-in → Launchpad home).
+ *
+ * ⚠ DESTRUCTIVE — it removeItem's the key, so it must be invoked exactly once per
+ * callback. The callback guards its two completion triggers (Hub event +
+ * getCurrentUser fallback) so the key cannot be double-consumed (#483).
+ */
+export function takeRedeemReturnTarget(): string {
+  try {
+    const bundleId = window.sessionStorage.getItem(REDEEM_RETURN_KEY)
+    if (bundleId) {
+      window.sessionStorage.removeItem(REDEEM_RETURN_KEY)
+      return `/redeem?bundle=${encodeURIComponent(bundleId)}`
+    }
+  } catch {
+    /* no sessionStorage — fall through to home */
+  }
+  return '/'
+}
+
 /** Decode a JWT payload (no verification — claims are read for display only). */
 function parseJwtPayload(token: string): Record<string, unknown> {
   try {


### PR DESCRIPTION
Closes #483.

## Problem
A perfect invitee entering through the email link — `/redeem?bundle=<id>` → Hosted
UI → authenticate → `/launchpad/callback` — landed on the bare Launchpad with zero
grants. Redemption **never ran** (the main path, not the #482 safety-net).

## Root cause — destructive double-trigger in the callback
The callback chose its destination via a **destructive read** of the redeem-return
`sessionStorage` key, called from **both** completion triggers with no guard:
`Hub('signInWithRedirect')` AND the `getCurrentUser()` fallback. The first call
returned `/redeem` and **removed** the key; the second read the now-empty key and
returned `/`; the second `window.location.replace` won → the redemption return was
overridden to the home and the bundle dropped. (Normal sign-in has no key, so both
return `/` and the defect is invisible there — it is redemption-specific.)

## Fix — navigate exactly once
A `navigated` guard makes the post-callback navigation idempotent, so the key is
consumed once and a redemption return reliably lands on `/redeem`. The destructive
read is centralised in the seam as `takeRedeemReturnTarget()` and **unit-tested**
for its call-once semantics (the 2nd read returning `/` is exactly the bug the guard
prevents). 43 launchpad tests pass; typecheck, lint, static-export build green.

## Stash side — verified, no bug found
Traced the needs-auth auto-redirect path: `beginRedemptionSignIn` does
`sessionStorage.setItem(REDEEM_RETURN_KEY, bundleId)` **synchronously before**
`signInWithRedirect`, with the bundleId read from the **query param**
(`useSearchParams().get('bundle')`). So the stash fires; the owner's "no key
pre-redirect" is explained by the callback consuming/racing it. **Falsifiable:** if
a post-fix re-test still lands on `/`, that proves a stash-side bug to chase with the
breakpoint (no speculative change made to an untested OAuth path).

## Test artifacts reset (done, dev)
- Deleted the Cognito user `stevemoodie70@gmail.com`
  (`Google_111439223304386966737`, sub `c94e3418-6041-7011-c8e8-c7989e0a6da5`).
  Confirmed exactly that user; the Steve persona/inviter (`steve@example.com`,
  sub `c98e14a8…`) is a distinct user and was untouched.
- `launchpad-users-dev[c94e3418…]` = no item; account-members for the sub = [] (no
  residue, as the trace said).
- Bundle `e0bb2b06-d794-431c-9a28-e99b2fb62bf6` left **pending / reusable** for the
  re-test.

## Next (owner)
Deploy to dev, then re-test the link end-to-end (open the email's /redeem link in a
fresh incognito, authenticate via Google as the invited email → should land on
`/redeem` and auto-apply → Budget Tracker membership + Stock Analyser access).

## v0 freshness
- [x] No v0 impact
Reason: backend-of-the-frontend navigation/bugfix in the redemption callback + seam
helper; no UI surface, contract, mock, or runtime-shape change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)