### PR TITLE
fix(redemption): federated invitees get their grants — pre-token keys by sub (#486) + force refresh after apply (#485)

### DIFF
--- a/apps/launchpad/functions/pre-token-generation/src/index.test.ts
+++ b/apps/launchpad/functions/pre-token-generation/src/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { planReconcile } from './index';
+import { planReconcile, membershipUserId } from './index';
 
 // ---------------------------------------------------------------------------
 // Pre-token reconcile is ADD-ONLY (one-directional invariant, #473).
@@ -72,5 +72,34 @@ describe('planReconcile — add-only app-access invariant (#473)', () => {
     const result = plan(['site-admin', 'stock-app-access', 'budget-app-access'], {});
     expect(result.toAdd).toEqual([]);
     expect(result.resultingGroups).toEqual(['site-admin', 'stock-app-access', 'budget-app-access']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Membership-table key resolution (#486). The membership table is keyed on the
+// Cognito `sub`. The trigger MUST key its membership query on the sub, NOT
+// `event.userName` — which is provider-shaped for federated users and diverges
+// from the sub, silently returning no rows. The prior tests never caught this
+// because they only exercised planReconcile with native-shaped ids (userName==sub).
+// ---------------------------------------------------------------------------
+describe('membershipUserId — table key is the sub, not the Username (#486)', () => {
+  it('returns the SUB for a FEDERATED user (Username Google_… diverges from sub)', () => {
+    const event = {
+      userName: 'Google_111439223304386966737',
+      request: { userAttributes: { sub: '492ed4a8-0061-7018-5fc3-0dc6d59c80f4', email: 'x@y.com' } },
+    };
+    // The bug was keying on userName here → the BT membership (row keyed on the
+    // sub) was never found → accounts claim empty for every federated invitee.
+    expect(membershipUserId(event)).toBe('492ed4a8-0061-7018-5fc3-0dc6d59c80f4');
+    expect(membershipUserId(event)).not.toBe(event.userName);
+  });
+
+  it('returns the sub for a native user (Username == sub — unchanged behaviour)', () => {
+    const sub = 'c98e14a8-50f1-70a6-d099-7eb0cab0cacf';
+    expect(membershipUserId({ userName: sub, request: { userAttributes: { sub } } })).toBe(sub);
+  });
+
+  it('falls back to userName when sub is somehow absent (defensive)', () => {
+    expect(membershipUserId({ userName: 'u-1', request: { userAttributes: {} } })).toBe('u-1');
   });
 });

--- a/apps/launchpad/functions/pre-token-generation/src/index.ts
+++ b/apps/launchpad/functions/pre-token-generation/src/index.ts
@@ -28,6 +28,25 @@ interface MembershipRow {
   appSlug?: string;
 }
 
+/**
+ * The stable user id for control-plane TABLE keys (account-members, users): the
+ * Cognito `sub`. This is what `@transformotion/lambda-middleware` derives
+ * (`claims['sub']`) and what the redemption handler writes, so the membership
+ * table is keyed on the sub.
+ *
+ * It is NOT `event.userName`: for FEDERATED users (Google/Facebook/Microsoft) the
+ * Cognito Username is provider-shaped (e.g. `Google_…`) and DIVERGES from the sub,
+ * so keying a table query on userName silently returns no rows — federated
+ * account-invitees would never get their memberships in the token (#486). Native
+ * users have Username == sub (email-alias pool), which is why this stayed hidden
+ * until the first social-IdP redemption. Cognito GROUP ops still use the Username.
+ */
+export function membershipUserId(
+  event: { userName: string; request: { userAttributes?: Record<string, string> } },
+): string {
+  return event.request.userAttributes?.['sub'] ?? event.userName;
+}
+
 interface AccountRow {
   accountId: string;
   appSlug: string;
@@ -178,13 +197,19 @@ export const handler = async (
   event: PreTokenGenerationTriggerEvent,
 ): Promise<PreTokenGenerationTriggerEvent> => {
   try {
-    const userId = event.userName;
+    // Cognito Username — used for GROUP ops (AdminAddUserToGroup). For federated
+    // users this is provider-shaped (e.g. Google_…).
+    const cognitoUsername = event.userName;
+    // Stable id for control-plane TABLE keys — the sub (#486). Diverges from the
+    // Username for federated users; keying table queries on the Username silently
+    // misses every row.
+    const subject = membershipUserId(event);
     const userPoolId = event.userPoolId;
     const currentGroups = event.request.groupConfiguration.groupsToOverride ?? [];
 
-    console.log('[launchpad-pre-token] userId:', userId, 'groups:', currentGroups.join(','));
+    console.log('[launchpad-pre-token] username:', cognitoUsername, 'sub:', subject, 'groups:', currentGroups.join(','));
 
-    const memberships = await queryMemberships(userId);
+    const memberships = await queryMemberships(subject);
 
     // Resolve appSlug for legacy membership rows that predate D3 denormalization
     const missingAppSlugIds = memberships
@@ -194,8 +219,10 @@ export const handler = async (
 
     const accountsByApp = groupByApp(memberships, appSlugByAccount);
 
+    // Group ops key on the Cognito Username (NOT the sub) — for federated users
+    // AdminAddUserToGroup needs the provider-shaped Username.
     const reconciledGroups = await reconcileInvariant(
-      userId,
+      cognitoUsername,
       userPoolId,
       currentGroups,
       accountsByApp,

--- a/apps/launchpad/lib/redemption/machine.ts
+++ b/apps/launchpad/lib/redemption/machine.ts
@@ -28,6 +28,7 @@ import {
 } from '@transformotion/contracts/launchpad/redemption'
 import type { GrantRedemptionResult, InvitationBundle } from '@transformotion/contracts/launchpad/invitations'
 import { getControlPlaneClient } from '@/lib/services/control-plane-client'
+import { authService } from '@/lib/services/auth'
 
 const APP_LABELS: Record<string, string> = {
   'stock-analyser': 'Stock Analyser',
@@ -147,6 +148,15 @@ export async function applyRedemption(
 ): Promise<RedemptionEvaluation> {
   try {
     const response = await getControlPlaneClient().redeemBundle(bundleId)
+
+    // Redemption just added the invitee's Cognito access groups + account
+    // memberships SERVER-SIDE. The current token predates them (it was minted at
+    // sign-in), so force a fresh token NOW — the pre-token trigger re-issues the
+    // `apps`/`accounts` claims on refresh — BEFORE the Launchpad hand-off. Without
+    // this the invitee lands on the Launchpad with apps=[] (#485). Best-effort: a
+    // failed refresh degrades to a manual refresh / re-login, not a hard failure.
+    await authService.refreshTokens().catch(() => {})
+
     const results = response.results
     return {
       status: 'applied',


### PR DESCRIPTION
Closes #486. Closes #485. Both surfaced by the first social-IdP (Google) redemption.

## ⛔ PR only — owner deploys + re-tests (dev)

## B — pre-token membership keying (#486, load-bearing)
The pre-token trigger queried the membership table by `event.userName`, but the
table is keyed on the **`sub`** (what `@transformotion/lambda-middleware` derives —
`claims['sub']` — and what the redemption handler writes). NATIVE users have
Username == sub (email-alias pool) so it worked; FEDERATED Usernames are
provider-shaped (`Google_…`) and **diverge from the sub** → the query matched
nothing → empty `accounts` claim and the membership ⟹ access reconcile saw no
memberships. This broke account-invites for **all** federated/social-IdP invitees.

Fix: `membershipUserId(event)` keys table queries on
`event.request.userAttributes.sub`; Cognito **group** ops keep `event.userName`
(correct there). Added a **federated-shaped (userName != sub) test** — the exact gap
that hid this (prior tests only used native-shaped ids).

## A — token staleness (#485)
The invitee's token was minted at sign-in, before redemption added the groups +
memberships, and nothing forced a refresh → they landed with `apps=[]`. Fix:
`applyRedemption` now forces `authService.refreshTokens()` after redeem succeeds,
before the Launchpad hand-off, so the pre-token trigger re-issues the apps/accounts
claims. Best-effort (a failed refresh degrades to a manual refresh/re-login).

## Audit (siblings of B)
Pre-token was the **only** `userName==sub` assumption. All REST handlers derive
`userId` from `claims['sub']` via lambda-middleware; the redemption handler writes
membership/users rows keyed on the sub; `account-members` PK is `(accountId,
userId=sub)`. No other place breaks for federated identities.

## Trace that drove this (bundle e0bb2b06, sub 492ed4a8…)
Redeem ran + succeeded (bundle → accepted); backend had both groups + the BT
membership; the owner's token showed `apps=[]` → token-staleness (A), and the
`accounts` claim would have stayed empty even after refresh → keying (B).

## Test artifacts reset (done, dev) — clean slate for the re-test
- Bundle `e0bb2b06-d794-431c-9a28-e99b2fb62bf6` → **pending** (was accepted).
- Deleted Cognito user `stevemoodie70@gmail.com` (`Google_111439223304386966737`,
  sub `492ed4a8…`) — re-confirmed the username mapped to that exact sub first.
- Deleted the orphaned BT membership row (acct-bt-steve-liz / 492ed4a8) left by the
  deleted user.
- Untouched: the `Steve & Liz Household` account itself, the Steve persona/inviter,
  everything else.

## Re-test (validates BOTH fixes)
Fresh incognito → open the `/redeem?bundle=e0bb2b06…` link → authenticate via Google
as `stevemoodie70@gmail.com` → expect: lands on `/redeem` → auto-applies → forced
refresh → the new token carries app-access AND account memberships → Launchpad shows
**Stock Analyser** (create-first-account; app-grant, no account) AND **Budget
Tracker joined to Steve & Liz Household** (account-invite).

## Checks
pre-token 9 tests (3 new federated) · launchpad 43 tests · typecheck · lint ·
static-export build — all green.

## v0 freshness
- [x] No v0 impact
Reason: backend pre-token trigger keying + a token-refresh call in the redemption
machine; no UI surface, contract, mock, or runtime-shape change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)