### PR TITLE
fix(auth): social IdPs on SA + BT app-clients so federated users can enter the apps (#488)

### DIFF
--- a/apps/launchpad/infrastructure/launchpad-auth-stack.ts
+++ b/apps/launchpad/infrastructure/launchpad-auth-stack.ts
@@ -216,8 +216,15 @@ export class LaunchpadAuthStack extends cdk.Stack {
 
     const socialIdps = [googleIdp, facebookIdp, microsoftIdp];
 
-    // Only the Launchpad client offers the social providers in its Hosted-UI
-    // chooser; Stock Analyser and Budget Tracker stay COGNITO-only.
+    // All three app-clients offer the social providers in their Hosted-UI chooser.
+    // This COMPLETES the per-app-auth + platform-SSO model (#488): each app
+    // authenticates via its own client, and the shared Cognito-domain SSO cookie
+    // federates a social-IdP user seamlessly into every app. The earlier
+    // "Launchpad-only social IdPs" (#472) predated real federated users and left
+    // SA/BT unable to admit them — a federated user could sign into the Launchpad
+    // but not enter SA/BT. The IdPs are pool-attached and the Hosted-UI domain is
+    // shared, so this is a client-config change only (no provider-side redirect-URI
+    // change). PROD: the same three-client config must apply at cutover (#454).
     this.launchpadAppClient = this.createAppClient('LaunchpadAppClient', {
       callbackUrls: isProd
         ? [
@@ -257,7 +264,12 @@ export class LaunchpadAuthStack extends cdk.Stack {
       logoutUrls: isProd
         ? ['https://apps.transformotion.com.au/signed-out/']
         : ['https://dev.apps.transformotion.com.au/signed-out/', 'http://localhost:3000/signed-out/'],
-      supportedIdentityProviders: [cognito.UserPoolClientIdentityProvider.COGNITO],
+      supportedIdentityProviders: [
+        cognito.UserPoolClientIdentityProvider.COGNITO,
+        cognito.UserPoolClientIdentityProvider.GOOGLE,
+        cognito.UserPoolClientIdentityProvider.FACEBOOK,
+        cognito.UserPoolClientIdentityProvider.custom('Microsoft'),
+      ],
     });
 
     this.budgetTrackerAppClient = this.createAppClient('BudgetTrackerAppClient', {
@@ -270,8 +282,20 @@ export class LaunchpadAuthStack extends cdk.Stack {
       logoutUrls: isProd
         ? ['https://apps.transformotion.com.au/signed-out/']
         : ['https://dev.apps.transformotion.com.au/signed-out/', 'http://localhost:3002/signed-out/'],
-      supportedIdentityProviders: [cognito.UserPoolClientIdentityProvider.COGNITO],
+      supportedIdentityProviders: [
+        cognito.UserPoolClientIdentityProvider.COGNITO,
+        cognito.UserPoolClientIdentityProvider.GOOGLE,
+        cognito.UserPoolClientIdentityProvider.FACEBOOK,
+        cognito.UserPoolClientIdentityProvider.custom('Microsoft'),
+      ],
     });
+
+    // Every client names the social providers, so CFN must create those providers
+    // before each client (mirrors the Launchpad dependency below).
+    for (const idp of socialIdps) {
+      this.stockAnalyserAppClient.node.addDependency(idp);
+      this.budgetTrackerAppClient.node.addDependency(idp);
+    }
 
     const groups: Array<{ name: string; description: string; precedence: number }> = [
       { name: 'site-admin', description: 'Platform administrator', precedence: 1 },

--- a/docs/architecture/auth.md
+++ b/docs/architecture/auth.md
@@ -6,7 +6,7 @@ The platform uses AWS Cognito as the single source of identity. Authentication i
 
 A pre-token generation Lambda injects structured claims into every issued token. API handlers and the launchpad consume these claims rather than raw group strings. This means authorization logic is centralised in the token, not duplicated across handlers.
 
-Social identity providers (Google, Facebook, Microsoft) are wired at the Cognito layer. Social sign-in happens only at the launchpad; subsequent app access uses the shared Hosted UI domain session cookie.
+Social identity providers (Google, Facebook, Microsoft) are wired at the Cognito layer and offered by ALL three app-clients (launchpad, Stock Analyser, Budget Tracker). Each app authenticates via its own client; the shared Hosted-UI domain SSO cookie then federates a social-IdP user seamlessly from app to app. All clients must offer the social IdPs for that cross-app SSO to work for federated users (#488).
 
 See [cdk.md](./cdk.md) for CDK stack names. See [data.md](./data.md) for account and membership table schemas.
 
@@ -91,10 +91,10 @@ Three distinct Cognito app clients, one per deployable app. All share the same u
 | Client | Callback URLs | Logout URLs | Identity providers | CDK logical ID |
 |---|---|---|---|---|
 | `LaunchpadAppClient` | `{host}/launchpad/callback`, `{host}/sign-in/callback` | `{host}/signed-out/` | Cognito, Google, Facebook, Microsoft where configured | `LaunchpadAppClient` in `LaunchpadAuthStack` |
-| `StockAnalyserAppClient` | `{host}/stock-analyser/callback` | `{host}/signed-out/` | Cognito only | `StockAnalyserAppClient` in `LaunchpadAuthStack` |
-| `BudgetTrackerAppClient` | `{host}/budget-tracker/callback` | `{host}/signed-out/` | Cognito only | `BudgetTrackerAppClient` in `LaunchpadAuthStack` |
+| `StockAnalyserAppClient` | `{host}/stock-analyser/callback` | `{host}/signed-out/` | Cognito, Google, Facebook, Microsoft where configured | `StockAnalyserAppClient` in `LaunchpadAuthStack` |
+| `BudgetTrackerAppClient` | `{host}/budget-tracker/callback` | `{host}/signed-out/` | Cognito, Google, Facebook, Microsoft where configured | `BudgetTrackerAppClient` in `LaunchpadAuthStack` |
 
-Social sign-in is enabled on the launchpad client only. Per-app clients are Cognito-only because social identity sessions established at the launchpad propagate via SSO.
+Social sign-in is enabled on ALL THREE app-clients. The social identity session established at one client propagates to the others via the shared Hosted-UI domain SSO cookie — but each client must list the social IdPs in its `SupportedIdentityProviders`, or the Hosted UI cannot issue that client's tokens for a federated user (#488). The earlier launchpad-only configuration left SA/BT unable to admit federated users.
 
 `LaunchpadAuthStack` creates Launchpad, Stock Analyser, and Budget Tracker app
 clients and emits `LaunchpadAppClientId`, `StockAnalyserAppClientId`, and
@@ -139,8 +139,9 @@ The Hosted UI domain provides the OAuth 2.0 / PKCE flow endpoint for all three a
 
 Google, Facebook, and Microsoft IdPs are registered on the Launchpad-owned pool
 as `CfnUserPoolIdentityProvider` resources in `LaunchpadAuthStack`, and added to
-the `LaunchpadAppClient`'s `SupportedIdentityProviders` (so they appear in the
-Hosted-UI chooser). Stock Analyser and Budget Tracker clients stay COGNITO-only.
+ALL THREE app-clients' `SupportedIdentityProviders` (launchpad, Stock Analyser,
+Budget Tracker) so they appear in each Hosted-UI chooser — required for cross-app
+SSO to work for federated users (#488).
 
 | Provider | `ProviderName` | `ProviderType` | Scopes | Notable detail |
 |---|---|---|---|---|


### PR DESCRIPTION
Closes #488.

## ⛔ OWNER-GATED DEPLOY — live-pool client-config change
Approve after the diff + redirect-URI verification below. Merge → dev deploy
(`deploy-launchpad.yml` updates the `LaunchpadAuth` stack).

## Problem
A social-IdP (Google) user can sign into the Launchpad but not enter Stock Analyser
or Budget Tracker — crossing in hits "Something went wrong" on the Cognito Hosted UI.
SA's/BT's clients listed only `COGNITO`, so the shared Hosted-UI SSO cookie (a Google
session) couldn't be issued SA/BT-client tokens.

## Fix (completes the model — not a re-architecture)
Add Google/Facebook/Microsoft to the SA + BT clients' `SupportedIdentityProviders`,
mirroring the launchpad client (+ IdP construct dependencies). Each app still
authenticates via its own client; the shared SSO cookie now federates a social user
into every app.

## cdk diff (dev LaunchpadAuth) — in-place, minimal
```
[~] AWS::Cognito::UserPoolClient StockAnalyserAppClient
 ├─ [~] SupportedIdentityProviders  COGNITO → COGNITO, Google, Facebook, Microsoft
 └─ [+] DependsOn  [IdpFacebook, IdpGoogle, IdpMicrosoft]
[~] AWS::Cognito::UserPoolClient BudgetTrackerAppClient
 ├─ [~] SupportedIdentityProviders  COGNITO → COGNITO, Google, Facebook, Microsoft
 └─ [+] DependsOn  [IdpFacebook, IdpGoogle, IdpMicrosoft]
```
Both `[~]` (in-place update — **client IDs unchanged → no frontend breakage**); no
other resource touched.

## ★ Pre-deploy verification (CC-flagged "likely" — CONFIRMED)
- **No provider-side change needed.** The pool has ONE Hosted-UI domain
  (`transformotion-launchpad-959516291617-dev`) shared by all three clients →
  `/oauth2/idpresponse` is PER-POOL. Google/Facebook/Microsoft's authorized redirect
  URI already points there (launchpad federation works), so SA/BT using the same
  domain need NO Google/Facebook/Microsoft console change.
- IdPs are **pool-attached** (Google/Facebook/Microsoft on the pool), not per-client.
- SA + BT clients **already include** their own `/stock-analyser/callback` /
  `/budget-tracker/callback` CallbackURLs — unchanged.

## Paired docs (§2.1)
`auth.md` updated: the three client rows + the social-sign-in notes now state all
three clients offer the social IdPs (was "Launchpad only / SA-BT COGNITO-only").

## PROD CUTOVER (#454)
The same three-client config must apply to prod — flagged in the stack comment and
#488. (Today only the dev stack is deployed; prod is unborn.)

## v0 freshness
- [x] No v0 impact
Reason: Cognito app-client IaC config + architecture docs; no UI, contract, mock, or
runtime-shape change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)