### PR TITLE
fix(auth): federated cross-app SSO via provider hint (#490)

### DIFF
--- a/apps/budget-tracker/components/budget-tracker/budget-tracker-app.tsx
+++ b/apps/budget-tracker/components/budget-tracker/budget-tracker-app.tsx
@@ -10,6 +10,7 @@ import { RulesTab } from "./tabs/rules-tab"
 import { ReviewTab } from "./tabs/review-tab"
 import { SettingsTab } from "./tabs/settings-tab"
 import { useBudgetStore } from "@/stores/budget-tracker/use-budget-store"
+import { idpHintToProvider } from "@transformotion/auth-client"
 import { useAuthStore } from "@/stores/auth/use-auth-store"
 import { authService } from "@/lib/services/auth"
 import { AccountGate } from "@/components/providers/account-gate"
@@ -117,7 +118,16 @@ export function BudgetTrackerApp({
 
   useEffect(() => {
     if (authIsInitialized && !isAuthenticated) {
-      authService.signInWithRedirect()
+      // Cross-app SSO hint (#490): the launchpad appends ?idp=<provider> when it
+      // launches this app for a FEDERATED user. Passing it as the Hosted-UI
+      // `provider` re-federates silently instead of showing the chooser. A native
+      // user arrives with no hint → undefined → normal silent local-session SSO.
+      // Unknown hint → undefined → chooser (fail-open).
+      const hint = typeof window !== 'undefined'
+        ? new URLSearchParams(window.location.search).get('idp')
+        : null
+      const provider = idpHintToProvider(hint)
+      authService.signInWithRedirect(provider ? { provider } : undefined)
     }
   }, [isAuthenticated, authIsInitialized])
 

--- a/apps/launchpad/app/page.tsx
+++ b/apps/launchpad/app/page.tsx
@@ -2,11 +2,33 @@
 
 import { useEffect } from 'react'
 import { useRouter } from 'next/navigation'
+import { providerHintFromIdToken } from '@transformotion/auth-client'
 import { Launchpad } from '@/components/launchpad/launchpad'
 import { useAuthStore } from '@/stores/auth/use-auth-store'
+import { authService } from '@/lib/services/auth'
 import { getConfig } from '@/lib/config'
 
 const STOCK_ANALYSER_URL = process.env.NEXT_PUBLIC_STOCK_URL ?? 'http://localhost:3000/stock-analyser/'
+
+/**
+ * Append the federated-IdP hint (`?idp=google|facebook|microsoft`) when launching
+ * another app, so that app can re-federate silently instead of showing the Cognito
+ * chooser (#490). A NATIVE user has no `identities` claim → no hint → the app keeps
+ * its silent local-session SSO. Fail-open: if the token can't be read, just launch
+ * without a hint (today's behaviour).
+ */
+async function appUrlWithIdpHint(baseUrl: string): Promise<string> {
+  const idToken = await authService.getIdToken().catch(() => null)
+  const hint = providerHintFromIdToken(idToken)
+  if (!hint) return baseUrl
+  try {
+    const url = new URL(baseUrl)
+    url.searchParams.set('idp', hint)
+    return url.toString()
+  } catch {
+    return baseUrl
+  }
+}
 
 export default function Page() {
   const router = useRouter()
@@ -40,8 +62,8 @@ export default function Page() {
   return (
     <Launchpad
       user={user}
-      onLaunchApp={() => { window.location.href = STOCK_ANALYSER_URL }}
-      onLaunchBudgetTracker={() => { window.location.assign(getConfig().apps.budgetTrackerUrl) }}
+      onLaunchApp={async () => { window.location.href = await appUrlWithIdpHint(STOCK_ANALYSER_URL) }}
+      onLaunchBudgetTracker={async () => { window.location.assign(await appUrlWithIdpHint(getConfig().apps.budgetTrackerUrl)) }}
       onSignOut={handleSignOut}
     />
   )

--- a/apps/stock-analyser/components/providers/auth-guard.tsx
+++ b/apps/stock-analyser/components/providers/auth-guard.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useEffect } from 'react'
+import { idpHintToProvider } from '@transformotion/auth-client'
 import { useAuthStore } from '@/stores/auth/use-auth-store'
 import { authService } from '@/lib/services/auth'
 
@@ -14,7 +15,16 @@ export function AuthGuard({ children }: { children: React.ReactNode }) {
 
   useEffect(() => {
     if (isInitialized && !isAuthenticated) {
-      authService.signInWithRedirect()
+      // Cross-app SSO hint (#490): the launchpad appends ?idp=<provider> when it
+      // launches this app for a FEDERATED user. Passing it as the Hosted-UI
+      // `provider` re-federates silently (identity_provider=<X>) instead of showing
+      // the chooser. A native user arrives with no hint → undefined → normal silent
+      // local-session SSO. Unknown hint → undefined → chooser (fail-open).
+      const hint = typeof window !== 'undefined'
+        ? new URLSearchParams(window.location.search).get('idp')
+        : null
+      const provider = idpHintToProvider(hint)
+      authService.signInWithRedirect(provider ? { provider } : undefined)
     }
   }, [isAuthenticated, isInitialized])
 

--- a/docs/architecture/auth.md
+++ b/docs/architecture/auth.md
@@ -6,7 +6,7 @@ The platform uses AWS Cognito as the single source of identity. Authentication i
 
 A pre-token generation Lambda injects structured claims into every issued token. API handlers and the launchpad consume these claims rather than raw group strings. This means authorization logic is centralised in the token, not duplicated across handlers.
 
-Social identity providers (Google, Facebook, Microsoft) are wired at the Cognito layer and offered by ALL three app-clients (launchpad, Stock Analyser, Budget Tracker). Each app authenticates via its own client; the shared Hosted-UI domain SSO cookie then federates a social-IdP user seamlessly from app to app. All clients must offer the social IdPs for that cross-app SSO to work for federated users (#488).
+Social identity providers (Google, Facebook, Microsoft) are wired at the Cognito layer and offered by ALL three app-clients (launchpad, Stock Analyser, Budget Tracker). Each app authenticates via its own client. Native users cross between apps silently via the reusable Cognito session; federated users need a per-app re-federation, which the Launchpad triggers by passing a provider hint (#490). See [App clients](#app-clients) → "Federated cross-app SSO".
 
 See [cdk.md](./cdk.md) for CDK stack names. See [data.md](./data.md) for account and membership table schemas.
 
@@ -86,7 +86,7 @@ claims. There is no `site_admin` claim and no `app_admin` claim.)
 
 ## App clients
 
-Three distinct Cognito app clients, one per deployable app. All share the same user pool; SSO works via the shared Hosted UI domain session cookie.
+Three distinct Cognito app clients, one per deployable app. All share the same user pool. Cross-app SSO differs by sign-in type: a **native** (Cognito directory) user has a reusable Hosted-UI session, so crossing from one app-client to another issues tokens silently. A **federated** (Google/Facebook/Microsoft) user does NOT — Cognito's login-session cookie is keyed to the (client, provider) it was set with, and a different app-client's `/authorize` shows the chooser unless the request names the IdP (`identity_provider=<X>`, which "redirects silently to your IdP"). See [Federated cross-app SSO](#federated-cross-app-sso-provider-hint) (#490).
 
 | Client | Callback URLs | Logout URLs | Identity providers | CDK logical ID |
 |---|---|---|---|---|
@@ -94,7 +94,35 @@ Three distinct Cognito app clients, one per deployable app. All share the same u
 | `StockAnalyserAppClient` | `{host}/stock-analyser/callback` | `{host}/signed-out/` | Cognito, Google, Facebook, Microsoft where configured | `StockAnalyserAppClient` in `LaunchpadAuthStack` |
 | `BudgetTrackerAppClient` | `{host}/budget-tracker/callback` | `{host}/signed-out/` | Cognito, Google, Facebook, Microsoft where configured | `BudgetTrackerAppClient` in `LaunchpadAuthStack` |
 
-Social sign-in is enabled on ALL THREE app-clients. The social identity session established at one client propagates to the others via the shared Hosted-UI domain SSO cookie — but each client must list the social IdPs in its `SupportedIdentityProviders`, or the Hosted UI cannot issue that client's tokens for a federated user (#488). The earlier launchpad-only configuration left SA/BT unable to admit federated users.
+Social sign-in is enabled on ALL THREE app-clients (#488): each client must list the
+social IdPs in its `SupportedIdentityProviders`, or the Hosted UI cannot issue that
+client's tokens for a federated user at all (the earlier launchpad-only config left
+SA/BT unable to admit federated users). Listing the IdPs is necessary but **not
+sufficient** for *silent* cross-app entry — see below.
+
+### Federated cross-app SSO (provider hint)
+
+For a **native** user, crossing Launchpad → app SSOs silently: the user pool holds a
+reusable Cognito session and the app's `/authorize` mints tokens directly, no IdP hop.
+
+For a **federated** user there is no reusable local session — the authentication is the
+IdP federation. Cognito's login-session cookie is scoped to the (client, provider) it
+was set with, so a *different* app-client's `/authorize` does not reuse it, and because
+the app's `signInWithRedirect` names no IdP, Cognito falls back to the managed-login
+chooser (per the [AWS docs](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pools-identity-federation.html):
+"if you provide an `identity_provider` parameter… it redirects silently to your IdP…
+otherwise, it redirects to the managed login Login endpoint").
+
+So the Launchpad passes a **provider hint** on cross-app launch (#490): it reads which
+IdP the user federated with from the idToken `identities` claim and appends
+`?idp=<google|facebook|microsoft>` to the app URL. The app maps the hint to the Amplify
+`signInWithRedirect` provider (`identity_provider=<X>`) and re-federates silently — the
+IdP already has a session, so there is no prompt. The mapping is shared in
+`@transformotion/auth-client` (`providerHintFromIdToken`, `idpHintToProvider`) so all
+three apps agree. **Native users carry no hint** (no `identities` claim) and keep their
+silent local-session SSO; an unknown/absent hint maps to no provider and falls back to
+the chooser (fail-open). Microsoft is a **custom** OIDC provider, so the hint maps to
+`{ custom: 'Microsoft' }` (a bare string would not emit `identity_provider=Microsoft`).
 
 `LaunchpadAuthStack` creates Launchpad, Stock Analyser, and Budget Tracker app
 clients and emits `LaunchpadAppClientId`, `StockAnalyserAppClientId`, and

--- a/packages/auth-client/src/cognito-auth.ts
+++ b/packages/auth-client/src/cognito-auth.ts
@@ -11,7 +11,7 @@ import {
 } from 'aws-amplify/auth'
 import { parseCognitoGroups } from '@transformotion/contracts/cognito-groups'
 import { deriveAppAdmin, deriveAppAccess, type CognitoGroup } from '@transformotion/contracts/_shared/auth'
-import type { AuthService, AuthSession, AuthTokens, User, Account, SignInCredentials, SignUpCredentials } from './index'
+import type { AuthService, AuthSession, AuthTokens, User, Account, SignInCredentials, SignUpCredentials, FederatedProvider } from './index'
 
 export class CognitoAuthService implements AuthService {
   constructor(private readonly appSlug?: string) {
@@ -141,7 +141,9 @@ export class CognitoAuthService implements AuthService {
     await amplifySignOut({ global: true })
   }
 
-  async signInWithRedirect(options?: { provider?: string }): Promise<void> {
+  async signInWithRedirect(options?: { provider?: FederatedProvider }): Promise<void> {
+    // `provider` (built-in string OR `{ custom }`) becomes `identity_provider=<X>` on
+    // /authorize → Cognito redirects silently to that IdP, skipping the chooser (#490).
     const args = options?.provider ? { provider: options.provider as never } : {}
     try {
       await amplifySignInWithRedirect(args)

--- a/packages/auth-client/src/idp-hint.test.ts
+++ b/packages/auth-client/src/idp-hint.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest'
+import { idpHintToProvider, providerHintFromIdToken } from './index'
+
+/** Minimal unsigned JWT carrying the given claims (browser-style base64url). */
+function jwt(claims: Record<string, unknown>): string {
+  const part = (o: unknown) => Buffer.from(JSON.stringify(o)).toString('base64url')
+  return `${part({ alg: 'none' })}.${part(claims)}.sig`
+}
+
+describe('idpHintToProvider — hint → Amplify provider (#490)', () => {
+  it('maps the built-in social providers to bare strings', () => {
+    expect(idpHintToProvider('google')).toBe('Google')
+    expect(idpHintToProvider('facebook')).toBe('Facebook')
+  })
+
+  it('maps Microsoft to the CUSTOM provider shape (the load-bearing catch)', () => {
+    // A bare string 'Microsoft' would NOT produce identity_provider=Microsoft on
+    // /authorize — Microsoft is a custom OIDC provider, so it must be {custom}.
+    expect(idpHintToProvider('microsoft')).toEqual({ custom: 'Microsoft' })
+  })
+
+  it('is case-insensitive', () => {
+    expect(idpHintToProvider('GOOGLE')).toBe('Google')
+    expect(idpHintToProvider('Microsoft')).toEqual({ custom: 'Microsoft' })
+  })
+
+  it('fails OPEN for unknown/absent hints → undefined (→ chooser, today behaviour)', () => {
+    expect(idpHintToProvider('xyz')).toBeUndefined()
+    expect(idpHintToProvider('')).toBeUndefined()
+    expect(idpHintToProvider(null)).toBeUndefined()
+    expect(idpHintToProvider(undefined)).toBeUndefined()
+  })
+})
+
+describe('providerHintFromIdToken — idToken → hint (#490)', () => {
+  it('returns the IdP for a federated user (identities claim)', () => {
+    expect(providerHintFromIdToken(jwt({ identities: [{ providerName: 'Google' }] }))).toBe('google')
+    expect(providerHintFromIdToken(jwt({ identities: [{ providerName: 'Facebook' }] }))).toBe('facebook')
+    expect(providerHintFromIdToken(jwt({ identities: [{ providerName: 'Microsoft' }] }))).toBe('microsoft')
+  })
+
+  it('handles the identities claim arriving as a JSON STRING (Cognito variant)', () => {
+    expect(providerHintFromIdToken(jwt({ identities: JSON.stringify([{ providerName: 'Google' }]) }))).toBe('google')
+  })
+
+  it('returns NULL for a NATIVE user (no identities claim) → no hint, native untouched', () => {
+    expect(providerHintFromIdToken(jwt({ email: 'a@b.com', 'cognito:username': 'abc' }))).toBeNull()
+  })
+
+  it('returns null for missing/garbage tokens (defensive)', () => {
+    expect(providerHintFromIdToken(null)).toBeNull()
+    expect(providerHintFromIdToken(undefined)).toBeNull()
+    expect(providerHintFromIdToken('not.a.jwt')).toBeNull()
+  })
+
+  it('round-trips: a federated idToken → hint → provider', () => {
+    const hint = providerHintFromIdToken(jwt({ identities: [{ providerName: 'Microsoft' }] }))
+    expect(idpHintToProvider(hint)).toEqual({ custom: 'Microsoft' })
+  })
+})

--- a/packages/auth-client/src/index.ts
+++ b/packages/auth-client/src/index.ts
@@ -59,6 +59,18 @@ export interface SignUpCredentials {
   name:     string
 }
 
+/**
+ * A federated IdP to send the Hosted UI straight to (skips the chooser) — Amplify's
+ * `signInWithRedirect` `provider`. Built-in social providers are bare strings; a
+ * CUSTOM OIDC/SAML provider (e.g. Microsoft, registered as a custom provider named
+ * "Microsoft") must use the `{ custom }` form, or Amplify won't emit
+ * `identity_provider=<name>` on `/authorize` (#490).
+ */
+export type FederatedProvider = 'Google' | 'Facebook' | 'Amazon' | 'Apple' | { custom: string }
+
+/** Cross-app SSO hint: which IdP a user federated with (lowercase). */
+export type IdpHint = 'google' | 'facebook' | 'microsoft'
+
 export interface AuthService {
   /**
    * Stable session identity from the cached ID-token claims — the read-once
@@ -73,7 +85,7 @@ export interface AuthService {
   signIn(credentials: SignInCredentials):  Promise<AuthSession>
   signUp(credentials: SignUpCredentials):  Promise<AuthSession>
   signOut():         Promise<void>
-  signInWithRedirect(options?: { provider?: string }): Promise<void>
+  signInWithRedirect(options?: { provider?: FederatedProvider }): Promise<void>
   getAccessToken():  Promise<string | null>
   getIdToken():      Promise<string | null>
   refreshTokens():   Promise<AuthTokens>
@@ -102,4 +114,76 @@ export function createAuthService(
     return new CognitoAuthService(appSlug)
   }
   return createMockAuthService()
+}
+
+// ---------------------------------------------------------------------------
+// Federated cross-app SSO hint (#490)
+// ---------------------------------------------------------------------------
+// Native (Cognito directory) users have a reusable Hosted-UI session, so crossing
+// from one app-client to another SSOs silently. Federated users do NOT — Cognito
+// shows the chooser unless `/authorize` names the IdP (`identity_provider=<X>`,
+// which "redirects silently to your IdP"). The launchpad reads which IdP the user
+// federated with and passes it to each app, which re-federates silently. These
+// helpers are shared so launchpad + Stock Analyser + Budget Tracker map identically
+// (no cross-app imports). Unknown/native → no hint → the chooser (today's behaviour).
+
+/** Decode a JWT payload (browser-safe base64url). Returns {} on any failure. */
+function decodeJwtPayload(token: string): Record<string, unknown> {
+  try {
+    const part = token.split('.')[1]
+    if (!part) return {}
+    const b64 = part.replace(/-/g, '+').replace(/_/g, '/')
+    const json = decodeURIComponent(
+      atob(b64)
+        .split('')
+        .map((c) => '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2))
+        .join(''),
+    )
+    return JSON.parse(json) as Record<string, unknown>
+  } catch {
+    return {}
+  }
+}
+
+/**
+ * The IdP a user federated with, derived from the idToken `identities` claim — or
+ * `null` for a NATIVE (Cognito directory) user, who has no `identities` claim. A
+ * native user therefore gets NO hint and keeps silent local-session SSO untouched.
+ */
+export function providerHintFromIdToken(idToken: string | null | undefined): IdpHint | null {
+  if (!idToken) return null
+  const raw = decodeJwtPayload(idToken)['identities']
+  let providerName = ''
+  try {
+    const identities = typeof raw === 'string' ? JSON.parse(raw) : raw
+    if (Array.isArray(identities) && identities[0] && typeof identities[0] === 'object') {
+      providerName = String((identities[0] as { providerName?: string }).providerName ?? '')
+    }
+  } catch {
+    /* native — no identities */
+  }
+  const p = providerName.toLowerCase()
+  if (p.includes('google')) return 'google'
+  if (p.includes('facebook')) return 'facebook'
+  if (p.includes('microsoft') || p.includes('azure')) return 'microsoft'
+  return null
+}
+
+/**
+ * Map a cross-app `?idp=` hint to the Amplify `provider` that sends Cognito straight
+ * to that IdP. Unknown/absent → `undefined` (fall back to the chooser — fail-open).
+ * Microsoft is a CUSTOM provider, so it uses `{ custom: 'Microsoft' }` (the Cognito
+ * provider name) — a bare string would NOT produce `identity_provider=Microsoft`.
+ */
+export function idpHintToProvider(hint: string | null | undefined): FederatedProvider | undefined {
+  switch ((hint ?? '').toLowerCase()) {
+    case 'google':
+      return 'Google'
+    case 'facebook':
+      return 'Facebook'
+    case 'microsoft':
+      return { custom: 'Microsoft' }
+    default:
+      return undefined
+  }
 }

--- a/packages/auth-client/src/mock-auth.ts
+++ b/packages/auth-client/src/mock-auth.ts
@@ -1,4 +1,4 @@
-import type { AuthService, User, Account, AuthSession, AuthTokens, SignInCredentials, SignUpCredentials } from './index'
+import type { AuthService, User, Account, AuthSession, AuthTokens, SignInCredentials, SignUpCredentials, FederatedProvider } from './index'
 
 const STORAGE_KEY = 'transformotion-auth-session'
 
@@ -109,7 +109,7 @@ export class MockAuthService implements AuthService {
     this.notifyListeners()
   }
 
-  async signInWithRedirect(_options?: { provider?: string }): Promise<void> {
+  async signInWithRedirect(_options?: { provider?: FederatedProvider }): Promise<void> {
     // Mirrors Cognito's full-page-navigation UX: seed session then reload so
     // the calling page (sign-in) re-mounts as authenticated.
     this.session = {


### PR DESCRIPTION
Closes #490.

## ⛔ OWNER-GATED — multi-app change, THREE deploy lanes
Merging triggers `deploy-launchpad.yml`, `deploy-stock-analyser.yml`, AND
`deploy-budget-tracker.yml` (each app changed + the shared auth-client). I'll watch all
three. Approve the merge when ready.

## Problem
Federated (Google/Facebook/Microsoft) users bounced to the Cognito Hosted-UI chooser
when crossing Launchpad → an app; native users crossed silently. Cognito's login-session
cookie is keyed to (client, provider) — a different app-client's `/authorize` shows the
chooser unless it names the IdP (`identity_provider=<X>` "redirects silently to your
IdP"). Native users have a reusable local session, so no IdP hop. (#488 added the IdPs to
SA/BT clients — necessary but not sufficient for *silent* entry.)

## Fix — Option A, IdP-agnostic provider hint
- **auth-client**: `providerHintFromIdToken` (idToken `identities` → google|facebook|
  microsoft, or **null for native**) + `idpHintToProvider` (hint → Amplify provider).
  **Microsoft is a CUSTOM provider → `{ custom: 'Microsoft' }`** (a bare string would NOT
  emit `identity_provider=Microsoft` — the load-bearing correctness catch).
  `signInWithRedirect` widened to the custom-provider shape. Shared so all three apps map
  identically (no cross-app imports).
- **launchpad**: appends `?idp=<provider>` on SA/BT launch, from the current user's
  idToken. Native users (no `identities`) get no hint.
- **SA** (`auth-guard.tsx`) + **BT** (`budget-tracker-app.tsx`): read `?idp` → pass
  provider → silent re-federation. Unknown/absent hint → undefined → chooser (fail-open).
- **auth.md**: corrected the false "federates seamlessly via the cookie" claim; documents
  the provider-hint and why native differs from federated.

## Confirmations (your four)
1. **Microsoft**: maps to `{ custom: 'Microsoft' }` (unit-tested). The Cognito provider
   name is "Microsoft", so `identity_provider=Microsoft` on /authorize → silent
   re-federate. (E2E Microsoft is owner-verified in the re-test.)
2. **Native safety, deploy-order-independent**: native idToken has no `identities` claim
   → launchpad emits NO hint → app does normal silent local-session SSO. Unit-tested
   (`providerHintFromIdToken(native) === null`). Never gets a hint regardless of order.
3. **auth.md** now states the accurate provider-hint mechanism + native (reusable local
   session) vs federated (re-federation per client).
4. **Three deploys** watched on merge; I'll confirm each app picked up the shared
   auth-client change.

## Fail-safe / deploy-order independence
At every intermediate deploy state the worst case is "chooser still shows" (= today),
never a new breakage: LP-emits-before-apps-read → app ignores the hint → chooser;
apps-read-before-LP-emits → no hint → chooser. Native untouched throughout.

## Out of scope (filed separately)
Auth-integration debt — SA/BT/LP have 3 divergent auth bootstraps, so this landed 3×.
Tracked in **#491** (unify behind a shared guard/bootstrap); NOT refactored here.

## Checks
auth-client 18 (9 new) · launchpad 43 · SA 31 · BT 5 · typecheck (all workspaces) · lint
baseline (no new violations) · 3 static-export builds — all green.

## v0 freshness
- [x] No v0 impact
Reason: runtime auth integration (cross-app sign-in mechanic) + a doc correction; no UI
surface, contract, claim, mock, or runtime-shape change. v0 mocks auth in isolation and
never models real cross-client Cognito SSO.

🤖 Generated with [Claude Code](https://claude.com/claude-code)