### PR TITLE
fix(auth): Microsoft OIDC issuer → consumers tenant (personal accounts) — fixes 'Bad id_token issuer'

### DIFF
--- a/apps/launchpad/infrastructure/launchpad-auth-stack.ts
+++ b/apps/launchpad/infrastructure/launchpad-auth-stack.ts
@@ -201,10 +201,17 @@ export class LaunchpadAuthStack extends cdk.Stack {
         client_id: secretRef('MicrosoftClientIdSecretName'),
         client_secret: secretRef('MicrosoftClientSecretSecretName'),
         attributes_request_method: 'GET',
-        // Multi-tenant + personal-account issuer; Cognito discovers endpoints
-        // from its .well-known/openid-configuration. Owner: narrow to a tenant
-        // (…/{tenantId}/v2.0) or /organizations if the Azure app requires it.
-        oidc_issuer: 'https://login.microsoftonline.com/common/v2.0',
+        // The CONSUMERS (personal Microsoft account — hotmail/outlook/live) tenant.
+        // Cognito EXACT-MATCHES the id_token `iss` against the discovery doc's
+        // `issuer`. The `/common` endpoint's discovery `issuer` is the placeholder
+        // `…/{tenantid}/v2.0`, which never appears in a real token — a personal
+        // account's token is issued by this consumers tenant
+        // (9188040d-6c67-4c5b-b112-36a304b66dad), so `/common` was rejected as
+        // "Bad id_token issuer". This tenant's discovery `issuer` equals the token
+        // `iss` verbatim, so validation passes. NOTE: this admits PERSONAL accounts
+        // only; work/school (Azure AD org) accounts carry their org tenant issuer
+        // and would need a separate provider / tenant decision.
+        oidc_issuer: 'https://login.microsoftonline.com/9188040d-6c67-4c5b-b112-36a304b66dad/v2.0',
         authorize_scopes: 'openid email profile',
       },
       attributeMapping: {

--- a/docs/architecture/auth.md
+++ b/docs/architecture/auth.md
@@ -175,7 +175,7 @@ SSO to work for federated users (#488).
 |---|---|---|---|---|
 | Google | `Google` | `Google` | `openid email profile` | — |
 | Facebook | `Facebook` | `Facebook` | `public_profile,email` | `api_version` `v17.0`; no reliable `email_verified` |
-| Microsoft | `Microsoft` | `OIDC` | `openid email profile` | `oidc_issuer` `https://login.microsoftonline.com/common/v2.0` (multi-tenant; narrow to `/{tenantId}/v2.0` if the Azure app is single-tenant) |
+| Microsoft | `Microsoft` | `OIDC` | `openid email profile` | `oidc_issuer` `https://login.microsoftonline.com/9188040d-6c67-4c5b-b112-36a304b66dad/v2.0` — the **consumers** tenant (PERSONAL Microsoft accounts only). Cognito exact-matches the token `iss`; `/common`'s discovery `issuer` is the `…/{tenantid}/v2.0` placeholder, so it was rejected as "Bad id_token issuer". Work/school accounts carry their org tenant issuer and would need a separate provider/tenant. The Azure app registration must also list the pool's `…/oauth2/idpresponse` as a redirect URI (provider-side). |
 
 Attribute mappings send `email`→`email`, `name`→`name`, and `email_verified`→
 `email_verified` (Google/Microsoft; Facebook omits `email_verified`); Google also


### PR DESCRIPTION
## ⛔ OWNER-GATED — live-pool IdP config change (deploy-launchpad updates LaunchpadAuth)

## Problem
A personal Microsoft (hotmail) sign-in completed at Microsoft but failed at the Cognito
callback: `error=invalid_request, "Bad id_token issuer
https://login.microsoftonline.com/9188040d-6c67-4c5b-b112-36a304b66dad/v2.0"`.

Cognito exact-matches the id_token `iss` against the OIDC provider's discovery `issuer`.
The provider was configured with `…/common/v2.0`, whose discovery `issuer` is the
placeholder `…/{tenantid}/v2.0` (never in a real token). A personal account's token is
issued by the **consumers tenant** `9188040d-6c67-4c5b-b112-36a304b66dad`, so Cognito
rejected it.

## Fix (verified)
Set `oidc_issuer` to the consumers tenant. Confirmed against Microsoft's discovery doc:
`https://login.microsoftonline.com/9188040d-…/v2.0/.well-known/openid-configuration`
returns `"issuer": "https://login.microsoftonline.com/9188040d-…/v2.0"` — equal to the
token `iss` → validation passes.

```
cdk diff (dev LaunchpadAuth):
[~] IdpMicrosoft.ProviderDetails.oidc_issuer:
    [-] https://login.microsoftonline.com/common/v2.0
    [+] https://login.microsoftonline.com/9188040d-6c67-4c5b-b112-36a304b66dad/v2.0
```
In-place; no other resource touched.

## ★ Decision (scope of Microsoft account types)
This admits **PERSONAL** Microsoft accounts (hotmail/outlook/live) — the target for the
family platform and what you're testing. **Work/school (Azure AD org) accounts** carry
their own org tenant issuer and would NOT validate against this issuer; supporting both
is a Cognito limitation (one OIDC provider validates one issuer) and would need a
separate provider/tenant. Confirm personal-only is the intended scope (recommended).

## Provider-side (already done by owner)
The Azure app registration (client `51ae7bdc-…`) now lists the pool's
`…/oauth2/idpresponse` as a redirect URI — that was the first error you fixed. This PR
is the second, Cognito-side half.

## PROD cutover (#454)
Prod's Microsoft provider needs the same consumers issuer, and the prod pool's
`idpresponse` must be added to the Azure app's redirect URIs.

## v0 freshness
- [x] No v0 impact
Reason: Cognito IdP config (oidc_issuer) + architecture doc; no UI, contract, mock, or
runtime-shape change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)