### PR TITLE
fix(auth): show the user's first name, never the email (#494)

### DIFF
--- a/apps/budget-tracker/components/budget-tracker/app-shell.tsx
+++ b/apps/budget-tracker/components/budget-tracker/app-shell.tsx
@@ -21,6 +21,7 @@ import {
 import { ConfirmationModal } from "@transformotion/ui-primitives"
 import { useBudgetStore, type BudgetTabId } from "@/stores/budget-tracker/use-budget-store"
 import { useAuthStore } from "@/stores/auth/use-auth-store"
+import { userFirstName, userInitials } from "@transformotion/auth-client"
 import { useActiveAccountStore } from "@/stores/active-account/use-active-account-store"
 
 // Account switcher backed by the control-plane active-account store (D7).
@@ -111,8 +112,8 @@ export function BudgetUserHeader({
   const [profileMenuOpen, setProfileMenuOpen] = useState(false)
   const [signOutConfirm, setSignOutConfirm] = useState(false)
 
-  const initials = (user?.name ?? '').split(' ').map(n => n[0]).join('')
-  const firstName = (user?.name ?? '').split(' ')[0]
+  const initials = userInitials(user)   // first name from given_name, never the email (#494)
+  const firstName = userFirstName(user)
 
   function handleSignOut() {
     onSignOut?.()
@@ -231,8 +232,8 @@ export function BudgetDesktopSidebar({
   const [accountMenuOpen, setAccountMenuOpen] = useState(false)
   const [signOutConfirm, setSignOutConfirm] = useState(false)
 
-  const initials = (user?.name ?? '').split(' ').map(n => n[0]).join('')
-  const firstName = (user?.name ?? '').split(' ')[0]
+  const initials = userInitials(user)   // first name from given_name, never the email (#494)
+  const firstName = userFirstName(user)
 
   function handleSignOut() {
     onSignOut?.()

--- a/apps/launchpad/components/launchpad/launchpad.tsx
+++ b/apps/launchpad/components/launchpad/launchpad.tsx
@@ -487,9 +487,11 @@ export function Launchpad({
   const data = useLaunchpadData(authUser)
 
   const email = authUser?.email ?? ''
-  // Canonical chain (#423): profile displayName → Cognito name → email local part.
-  // authUser.name can be the raw email (no given/family name) — passed as cognitoName
-  // so resolveDisplayName skips it rather than rendering the full address.
+  // Canonical chain (#423/#494): EXPLICIT profile displayName → Cognito name → email
+  // local part. The user Lambda now omits displayName unless the user explicitly set
+  // one (#494), so a federated user with no stored name falls through to the token
+  // name (`authUser.name`), which the auth client guarantees is a real name or the
+  // email local part — never the full address.
   const displayName = resolveDisplayName({
     displayName: data.profile?.displayName,
     cognitoName: authUser?.name,

--- a/apps/launchpad/functions/user/src/index.test.ts
+++ b/apps/launchpad/functions/user/src/index.test.ts
@@ -113,7 +113,7 @@ function body(res: { body: string }) {
 // Test area 3: Display name fallback chain
 // ---------------------------------------------------------------------------
 
-describe('resolveDisplayName', () => {
+describe('resolveDisplayName (#494: explicit-name-or-undefined)', () => {
   it('returns displayName when set and non-empty', () => {
     expect(resolveDisplayName({ displayName: 'Alice', email: 'alice@example.com' })).toBe('Alice');
   });
@@ -122,16 +122,12 @@ describe('resolveDisplayName', () => {
     expect(resolveDisplayName({ displayName: '  Bob  ', email: 'bob@example.com' })).toBe('Bob');
   });
 
-  it('falls back to email local part when displayName is absent', () => {
-    expect(resolveDisplayName({ email: 'carol@example.com' })).toBe('carol');
+  it('returns undefined (NOT the email) when displayName is absent — client falls to the token name', () => {
+    expect(resolveDisplayName({ email: 'carol@example.com' })).toBeUndefined();
   });
 
-  it('falls back to email local part when displayName is whitespace-only', () => {
-    expect(resolveDisplayName({ displayName: '   ', email: 'dave@example.com' })).toBe('dave');
-  });
-
-  it('falls back to full email when local part is empty', () => {
-    expect(resolveDisplayName({ email: '@example.com' })).toBe('@example.com');
+  it('returns undefined when displayName is whitespace-only', () => {
+    expect(resolveDisplayName({ displayName: '   ', email: 'dave@example.com' })).toBeUndefined();
   });
 });
 
@@ -384,13 +380,13 @@ describe('GET /api/user/profile field completeness', () => {
     const parsed = body(res);
     expect(parsed.userId).toBe('new-user');
     expect(parsed.email).toBe('new@example.com');
-    expect(parsed.displayName).toBe('new'); // email local part fallback
+    expect(parsed.displayName).toBeUndefined(); // #494: omitted when unset, not the email
     expect(parsed.status).toBe('active');
     expect(parsed.profileComplete).toBe(false);
     expect(parsed.preferences).toEqual({ notificationsEnabled: false });
   });
 
-  it('uses email local part when displayName is absent from user item', async () => {
+  it('omits displayName when absent from the user item (#494) — never the email', async () => {
     const handler = makeHandler({
       users: {
         'user-2': { userId: 'user-2', email: 'carol@example.com', status: 'active' },
@@ -402,6 +398,6 @@ describe('GET /api/user/profile field completeness', () => {
     })) as { statusCode: number; body: string };
 
     expect(res.statusCode).toBe(200);
-    expect(body(res).displayName).toBe('carol');
+    expect(body(res)).not.toHaveProperty('displayName');
   });
 });

--- a/apps/launchpad/functions/user/src/index.ts
+++ b/apps/launchpad/functions/user/src/index.ts
@@ -47,11 +47,20 @@ interface AccountRow {
   createdAt?: string;
 }
 
-/** Compute display name per fallback chain: displayName → email local part → email. */
-export function resolveDisplayName(item: { displayName?: string; email: string }): string {
-  if (item.displayName?.trim()) return item.displayName.trim();
-  const localPart = item.email.split('@')[0];
-  return localPart || item.email;
+/**
+ * The user's EXPLICITLY-set display name, or `undefined` when they have not set
+ * one (#494).
+ *
+ * Previously this fell back to the email local part so the field was always a
+ * string — but that email-derived value then beat the token's real name in the
+ * client's display chain (a federated user with `given_name:"Steve"` showed
+ * "stevemoodie70"). The contract field is optional (`UserProfile.displayName?`),
+ * so omitting it when unset is contract-compatible and lets the client fall
+ * through to the token name. A name the user set via `PUT /api/user/preferences`
+ * is still stored and returned, so the name-edit feature is unaffected.
+ */
+export function resolveDisplayName(item: { displayName?: string; email: string }): string | undefined {
+  return item.displayName?.trim() || undefined;
 }
 
 /**

--- a/apps/launchpad/infrastructure/launchpad-auth-stack.ts
+++ b/apps/launchpad/infrastructure/launchpad-auth-stack.ts
@@ -187,9 +187,13 @@ export class LaunchpadAuthStack extends cdk.Stack {
       },
       // Facebook does not return a reliable email_verified; Option D defaults
       // requireVerifiedEmail=false, so email + name are sufficient.
+      // given/family come from Facebook's `first_name`/`last_name` fields (not OIDC
+      // `given_name`/`family_name`) so the apps can show a true first name (#494).
       attributeMapping: {
         email: 'email',
         name: 'name',
+        given_name: 'first_name',
+        family_name: 'last_name',
       },
     });
 
@@ -214,10 +218,17 @@ export class LaunchpadAuthStack extends cdk.Stack {
         oidc_issuer: 'https://login.microsoftonline.com/9188040d-6c67-4c5b-b112-36a304b66dad/v2.0',
         authorize_scopes: 'openid email profile',
       },
+      // Microsoft v2.0 id_tokens carry OIDC `given_name`/`family_name` (the `profile`
+      // scope) — map them so the apps can show a true first name rather than the full
+      // `name` (#494). Mappings apply at each federation, so already-provisioned MS
+      // users populate these on their next sign-in; until then the auth client's
+      // `name`-claim fallback already yields a correct first name.
       attributeMapping: {
         email: 'email',
         email_verified: 'email_verified',
         name: 'name',
+        given_name: 'given_name',
+        family_name: 'family_name',
       },
     });
 

--- a/apps/launchpad/lib/entitlement.ts
+++ b/apps/launchpad/lib/entitlement.ts
@@ -138,13 +138,14 @@ export function hasVisibleApps(tiles: readonly AppTile[]): boolean {
 
 /**
  * Canonical display-name fallback chain (M16 D6):
- *   profile displayName → Cognito name → email local part → full email.
+ *   EXPLICIT profile displayName → Cognito name → email local part.
  *
- * The Cognito-provided name is only honoured when it is a real name: the auth
- * client falls back to the raw email when the user has no given/family name, so
- * a `cognitoName` equal to the email is skipped (otherwise the greeting shows
- * the full address instead of the local part — issue #423). The full email is a
- * last resort only when there is no usable local part.
+ * `displayName` is now only present when the user explicitly set one (#494): the
+ * user Lambda omits it otherwise, so an unset name no longer beats the token name.
+ * The auth client guarantees `cognitoName` (the token name) is a real name or the
+ * email local part — never the full address — so the `cognito !== email` guard is
+ * defensive belt-and-suspenders. The full email is returned only if there is no
+ * usable local part (a malformed address).
  */
 export function resolveDisplayName(input: {
   displayName?: string | null;

--- a/apps/stock-analyser/components/stock-analyser/app-shell.tsx
+++ b/apps/stock-analyser/components/stock-analyser/app-shell.tsx
@@ -23,6 +23,7 @@ import {
   FileText,
 } from "lucide-react"
 import { ConfirmationModal } from "@transformotion/ui-primitives"
+import { userFirstName, userInitials } from "@transformotion/auth-client"
 import { useActiveAccountStore } from "@/stores/active-account/use-active-account-store"
 
 // ============================================================================
@@ -379,8 +380,8 @@ export function UserHeader() {
   const [signOutConfirm, setSignOutConfirm] = useState(false)
   
   const activeAccount = user.accounts.find(a => a.id === user.activeAccountId)
-  const initials = user.name.split(' ').map(n => n[0]).join('')
-  const firstName = user.name.split(' ')[0]
+  const initials = userInitials(user)   // first name from given_name, never the email (#494)
+  const firstName = userFirstName(user)
 
   return (
     <div className="flex items-center justify-between py-3 px-4 bg-card border-b border-border md:hidden">
@@ -504,8 +505,8 @@ export function DesktopSidebar() {
   const [signOutConfirm, setSignOutConfirm] = useState(false)
   
   const activeAccount = user.accounts.find(a => a.id === user.activeAccountId)
-  const initials = user.name.split(' ').map(n => n[0]).join('')
-  const firstName = user.name.split(' ')[0]
+  const initials = userInitials(user)   // first name from given_name, never the email (#494)
+  const firstName = userFirstName(user)
 
   return (
     <aside className="hidden md:flex flex-col w-56 h-screen bg-card border-r border-border fixed left-0 top-0">

--- a/docs/architecture/auth.md
+++ b/docs/architecture/auth.md
@@ -178,11 +178,30 @@ SSO to work for federated users (#488).
 | Microsoft | `Microsoft` | `OIDC` | `openid email profile` | `oidc_issuer` `https://login.microsoftonline.com/9188040d-6c67-4c5b-b112-36a304b66dad/v2.0` — the **consumers** tenant (PERSONAL Microsoft accounts only). Cognito exact-matches the token `iss`; `/common`'s discovery `issuer` is the `…/{tenantid}/v2.0` placeholder, so it was rejected as "Bad id_token issuer". Work/school accounts carry their org tenant issuer and would need a separate provider/tenant. The Azure app registration must also list the pool's `…/oauth2/idpresponse` as a redirect URI (provider-side). |
 
 Attribute mappings send `email`→`email`, `name`→`name`, and `email_verified`→
-`email_verified` (Google/Microsoft; Facebook omits `email_verified`); Google also
-maps `given_name`/`family_name`. The `ProviderName` values are deliberately
+`email_verified` (Google/Microsoft; Facebook omits `email_verified`). All three
+providers map `given_name`/`family_name` (#494): Google and Microsoft from the
+OIDC `given_name`/`family_name` claims, Facebook from its `first_name`/`last_name`
+fields. This lets the apps show a true first name. Mappings apply at each
+federation, so an already-provisioned user populates given/family on their next
+sign-in; until then the auth client's `name`-claim fallback (below) still yields a
+correct first name. The `ProviderName` values are deliberately
 `Google`/`Facebook`/`Microsoft` so the redemption seam's `providerFromClaims()`
 (`apps/launchpad/lib/redemption/seam.ts`) resolves the `identities` claim to the
 contract `IdpProvider`.
+
+**Display name from claims (#494).** The auth client composes `User.name` from the
+ID-token claims as `given + family → OIDC name claim → given alone → email LOCAL
+part` — **never the full email** (`composeDisplayName`,
+`packages/auth-client/src/display.ts`). The earlier composition fell back to the
+full email, which the app sidebars then rendered whole (they take
+`name.split(' ')[0]`, and an email has no space). Apps derive the first name and
+initials via the shared `userFirstName`/`userInitials` helpers. The Launchpad home
+view additionally prefers an **explicitly user-set** control-plane `displayName`:
+the `user` Lambda (`GET /api/user/profile`) now omits `displayName` unless the user
+set one (the contract field is optional), so an unset name falls through to the
+token name rather than the email-derived value. A name set via
+`PUT /api/user/preferences` is still stored and wins. Per-app duplication of the
+first-name/initials derivation is unified under #491.
 
 `LaunchpadAuthStack` creates Launchpad-owned secret paths under
 `/launchpad/{stage}/cognito/*`; each IdP reads its client-id/secret from these via

--- a/packages/auth-client/src/cognito-auth.ts
+++ b/packages/auth-client/src/cognito-auth.ts
@@ -11,6 +11,7 @@ import {
 } from 'aws-amplify/auth'
 import { parseCognitoGroups } from '@transformotion/contracts/cognito-groups'
 import { deriveAppAdmin, deriveAppAccess, type CognitoGroup } from '@transformotion/contracts/_shared/auth'
+import { composeDisplayName } from './display'
 import type { AuthService, AuthSession, AuthTokens, User, Account, SignInCredentials, SignUpCredentials, FederatedProvider } from './index'
 
 export class CognitoAuthService implements AuthService {
@@ -43,8 +44,13 @@ export class CognitoAuthService implements AuthService {
       if (!session.tokens?.idToken) return null
       const claims     = session.tokens.idToken.payload
       const email      = claims['email'] as string
-      const givenName  = claims['given_name'] as string | undefined
-      const familyName = claims['family_name'] as string | undefined
+      const givenName  = (claims['given_name'] as string | undefined)?.trim() || undefined
+      const familyName = (claims['family_name'] as string | undefined)?.trim() || undefined
+      // The OIDC `name` claim — a full display name some IdPs send when they do NOT
+      // also map given/family (Microsoft + Facebook map only `name`; #494). Used as
+      // the next-best full name so federated users without given/family still show a
+      // real name (and a correct first name once split) rather than the email.
+      const nameClaim  = (claims['name'] as string | undefined)?.trim() || undefined
       // M16 Phase 6 (D11): platform admin status comes from the `site-admin`
       // Cognito group. The earlier `site_admin` token claim was an unintended
       // projection of the same group and has been removed — the frontend now
@@ -60,9 +66,8 @@ export class CognitoAuthService implements AuthService {
       // M11 groups-authoritative: apps the user may ENTER come from the
       // `{app}-app-access` groups (the launchpad gate keys on this, not membership).
       const appAccess  = deriveAppAccess(groups as CognitoGroup[])
-      const name       = (givenName && familyName)
-        ? `${givenName} ${familyName}`
-        : (givenName ?? email)
+      // Name source order (#494) — NEVER the full email; see composeDisplayName.
+      const name       = composeDisplayName({ givenName, familyName, nameClaim, email })
       return { id: cognitoUser.userId, email, name, metadata: { siteAdmin, appAdmin, appAccess } }
     } catch {
       return null

--- a/packages/auth-client/src/display.test.ts
+++ b/packages/auth-client/src/display.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest'
+import { composeDisplayName, userFirstName, userInitials } from './index'
+
+describe('composeDisplayName — token claims → User.name (#494)', () => {
+  it('prefers given + family (a Google / native user)', () => {
+    expect(composeDisplayName({ givenName: 'Steve', familyName: 'Moodie', email: 'x@y.com' }))
+      .toBe('Steve Moodie')
+  })
+
+  it('uses the OIDC `name` claim when given/family are absent (Microsoft / Facebook before mapping)', () => {
+    // The load-bearing case: MS/FB mapped only `name`. Without this the result was
+    // the full email; here it is a real name that splits to "Steve".
+    expect(composeDisplayName({ nameClaim: 'Steve Moodie', email: 'stevemoodie@hotmail.com' }))
+      .toBe('Steve Moodie')
+  })
+
+  it('uses given alone when there is no family and no name claim', () => {
+    expect(composeDisplayName({ givenName: 'Steve', email: 'steve@y.com' })).toBe('Steve')
+  })
+
+  it('falls back to the email LOCAL part — NEVER the full email — when no name is present', () => {
+    expect(composeDisplayName({ email: 'stevemoodie70@gmail.com' })).toBe('stevemoodie70')
+  })
+
+  it('ignores whitespace-only claims', () => {
+    expect(composeDisplayName({ givenName: '  ', nameClaim: '  ', email: 'carol@example.com' }))
+      .toBe('carol')
+  })
+
+  it('returns the email only when there is no usable local part (malformed)', () => {
+    expect(composeDisplayName({ email: '@example.com' })).toBe('@example.com')
+  })
+
+  it('returns empty string defensively when nothing is available', () => {
+    expect(composeDisplayName({})).toBe('')
+  })
+})
+
+describe('userFirstName / userInitials (#494)', () => {
+  it('first name is the first whitespace token', () => {
+    expect(userFirstName({ name: 'Steve Moodie' })).toBe('Steve')
+    expect(userFirstName({ name: 'Steve' })).toBe('Steve')
+  })
+
+  it('first name of an email-local-part fallback is the local part (never a full email)', () => {
+    expect(userFirstName({ name: 'stevemoodie70' })).toBe('stevemoodie70')
+  })
+
+  it('is null/undefined safe', () => {
+    expect(userFirstName(null)).toBe('')
+    expect(userFirstName(undefined)).toBe('')
+    expect(userFirstName({ name: '' })).toBe('')
+  })
+
+  it('initials are up to two UPPERCASE letters', () => {
+    expect(userInitials({ name: 'Steve Moodie' })).toBe('SM')
+    expect(userInitials({ name: 'Steve Andrew Moodie' })).toBe('SA')
+    expect(userInitials({ name: 'stevemoodie70' })).toBe('S')
+    expect(userInitials(null)).toBe('')
+  })
+})

--- a/packages/auth-client/src/display.ts
+++ b/packages/auth-client/src/display.ts
@@ -1,0 +1,55 @@
+/**
+ * Shared name-display helpers (#494).
+ *
+ * The three apps each re-derived a first name / initials from `user.name` inline
+ * (`user.name.split(' ')[0]`), which on a name that had collapsed to the full
+ * email rendered the whole address in the sidebar. The auth client now guarantees
+ * `user.name` is a real name or the email LOCAL part (never the full email — see
+ * `CognitoAuthService.getCurrentUser`), so the first whitespace token is always a
+ * safe first name. These helpers centralise that derivation so every surface reads
+ * identically. (Full auth-bootstrap unification across the apps is tracked in #491.)
+ */
+
+/** Anything carrying a display `name` — the auth `User` and the app view-models all satisfy this. */
+type NamedUser = { name?: string | null }
+
+/**
+ * Compose the `User.name` from ID-token claims (#494). The result is NEVER the full
+ * email — a sidebar that renders `name.split(' ')[0]` on a full address showed the
+ * whole email; the email LOCAL part is the only email-derived fallback. Order:
+ *
+ *   given + family → OIDC `name` claim → given alone → email local part → email
+ *
+ * The `name` claim sits above `given` alone because IdPs that map only `name`
+ * (Microsoft, Facebook before #494's mapping change) still yield a real full name,
+ * and splitting it gives a correct first name.
+ */
+export function composeDisplayName(claims: {
+  givenName?: string | null
+  familyName?: string | null
+  nameClaim?: string | null
+  email?: string | null
+}): string {
+  const given = claims.givenName?.trim() || undefined
+  const family = claims.familyName?.trim() || undefined
+  const nameClaim = claims.nameClaim?.trim() || undefined
+  const email = claims.email?.trim() || undefined
+  const localPart = email ? email.split('@')[0] || undefined : undefined
+  if (given && family) return `${given} ${family}`
+  return nameClaim ?? given ?? localPart ?? email ?? ''
+}
+
+/**
+ * First name for greetings and sidebars. Safe to split because `user.name` is
+ * never the full email (#494): it is a real name or the email local part.
+ */
+export function userFirstName(user: NamedUser | null | undefined): string {
+  const name = (user?.name ?? '').trim()
+  return name.split(/\s+/)[0] || name
+}
+
+/** Up to two UPPERCASE initials from the display name (e.g. "Steve Moodie" → "SM"). */
+export function userInitials(user: NamedUser | null | undefined): string {
+  const parts = (user?.name ?? '').trim().split(/\s+/).filter(Boolean)
+  return parts.slice(0, 2).map((p) => p[0]!.toUpperCase()).join('')
+}

--- a/packages/auth-client/src/index.ts
+++ b/packages/auth-client/src/index.ts
@@ -105,6 +105,7 @@ export interface AuthService {
 
 export { MockAuthService, createMockAuthService } from './mock-auth'
 export { CognitoAuthService } from './cognito-auth'
+export { userFirstName, userInitials, composeDisplayName } from './display'
 
 export function createAuthService(
   appSlug?: string,


### PR DESCRIPTION
Closes #494.

## Problem
Across all three apps the current user's name rendered from the **email**, not the token's `given_name`. With `given_name:"Steve"`, `family_name:"Moodie"`:
- **Launchpad** greeting showed `stevemoodie70` (email local-part).
- **Budget Tracker** sidebar showed `stevemoodie@hotma…` (the **full email**).
- **Stock Analyser** same as BT.

v0 shows the first name ("Good afternoon, **Steve**"); this brings the runtime in line.

## Root cause (3 layers)
1. `@transformotion/auth-client` `getCurrentUser` composed `user.name` as `"given family" → given → FULL email`. The sidebars take `name.split(' ')[0]`, which on an email (no space) returns the whole address.
2. **Microsoft + Facebook** IdP `attributeMapping` mapped only `name` (no given/family), so those users had no `given_name`.
3. Launchpad `resolveDisplayName` preferred the control-plane `profile.displayName`, which the user Lambda derived from the **email** when unset.

## Fix (layered; no auth-bootstrap refactor — that stays with #491)
- **A.** New pure `composeDisplayName` (auth-client): `given+family → OIDC name claim → given alone → email LOCAL part`. **Never the full email.** Flows to all three apps (they hydrate `user` straight from `getCurrentUser`).
- **B.** Add `given_name`/`family_name` to the **Microsoft** (OIDC `given_name`/`family_name`) and **Facebook** (`first_name`/`last_name`) attribute mappings. Mappings apply at each federation, so already-provisioned MS/FB users populate them on next sign-in; until then A's `name`-claim fallback already yields a correct first name.
- **C.** `user` Lambda `getProfile`/`putPreferences` **omit `displayName` unless explicitly set** (the contract field is already optional — `UserProfile.displayName?`), so an unset name falls through to the token name. A name set via `PUT /api/user/preferences` is still stored and **wins** (name-edit unaffected).
- **D.** Shared `userFirstName`/`userInitials` helpers in auth-client; LP/BT/SA display sites read them.

### Cascade check (C)
The only consumer of the Lambda's `profile.displayName` is `use-launchpad-data` → `resolveDisplayName`, which already tolerates `undefined`. The persona/admin surfaces read `user.name` (A-fixed) or a dev-session value, not the Lambda field. No undefined-cascade.

## Tests
- auth-client: `composeDisplayName` source-order + email-local-part-never-full-email; `userFirstName`/`userInitials` (29 pass).
- user Lambda: `resolveDisplayName` returns `undefined` when unset; `GET /profile` **omits** `displayName` when unset; explicit name still returned (19 pass).
- Typecheck: auth-client, all 3 apps, user Lambda, **and root `infrastructure/`** (auth stack) all clean. Lint: changed files clean (remaining app lint errors are pre-existing baseline in untouched files).

## Deploy footprint — 3 lanes
auth-client change triggers **launchpad + stock-analyser + budget-tracker**; the IdP `attributeMapping` change rides the **launchpad** lane (LaunchpadAuth stack).

## v0 freshness

- [x] No v0 impact

Reason: Runtime bug fix that reproduces the EXISTING v0 prototype behaviour — v0 already greets with the first name ("Good afternoon, Steve") — and changes no contract shape. `UserProfile.displayName` is already optional; this PR only stops the server synthesising an email-derived value when none is set, and adds IdP attribute mappings + auth-client name composition. No frontend/backend data field, payload, WSS, cache, or mock shape changes.

## Manual re-test when deployed
- Google user → "Steve" in LP greeting + BT + SA.
- **Microsoft** user (hotmail) → first name (not full email) in all three — the key check (IdP-mapping path).
- Native user → "Steve".

🤖 Generated with [Claude Code](https://claude.com/claude-code)