### PR TITLE
fix(launchpad): create launchpad-users row on join so admins can see joiners (#496)

### DIFF
--- a/apps/launchpad/functions/account-provisioning/src/index.test.ts
+++ b/apps/launchpad/functions/account-provisioning/src/index.test.ts
@@ -101,14 +101,27 @@ describe('account-provisioning /auth/setup — m16.1.0 D11 profile bootstrap', (
     });
   });
 
-  it('first login with no Cognito name: falls back to email local part', async () => {
+  it('first login with no Cognito name: OMITS displayName (no email fallback — #494/#496)', async () => {
     const { handler, puts } = makeHandler({ user: undefined }, { cognitoThrows: true });
 
     const res = (await handler(event('/auth/setup', 'user-2', 'carol@example.com'))) as { statusCode: number; body: string };
 
     expect(res.statusCode).toBe(200);
     expect(body(res)).toEqual({ userCreated: true, profileComplete: false });
-    expect(puts[0]).toMatchObject({ displayName: 'carol' });
+    // No given/family from the IdP → the row stores NO displayName, so reads resolve
+    // the name from the token rather than an email-derived value (which would beat it).
+    expect(puts[0]).not.toHaveProperty('displayName');
+    // …but the canonical bootstrap defaults are still written, so the row is a
+    // first-class directory entity identical to the redemption-upsert shape.
+    expect(puts[0]).toMatchObject({
+      userId: 'user-2',
+      email: 'carol@example.com',
+      emailLower: 'carol@example.com',
+      status: 'active',
+      preferences: { notificationsEnabled: false },
+      profileComplete: false,
+      activeAccounts: {},
+    });
   });
 
   it('existing user with an account: { userCreated:false, profileComplete, accountId } and no write', async () => {

--- a/apps/launchpad/functions/account-provisioning/src/index.ts
+++ b/apps/launchpad/functions/account-provisioning/src/index.ts
@@ -37,7 +37,16 @@ interface HandlerDeps {
 export function createHandler(deps: HandlerDeps) {
   const { ddb, cognito, usersTable, accountMembersTable, userPoolId } = deps;
 
-  async function resolveDisplayNameFromCognito(userId: string, email: string): Promise<string> {
+  /**
+   * The user's real name from Cognito (`given_name`/`family_name`), or `undefined`
+   * when the IdP supplied neither (#494/#496). It deliberately does NOT fall back to
+   * the email local part: storing an email-derived displayName at bootstrap would
+   * make `displayName` a non-null email-shaped value that beats the token name in the
+   * display chain — the exact #494 bug. When this returns undefined the row is written
+   * WITHOUT a displayName, so reads resolve the name from the token (or the user sets
+   * one explicitly via PUT /api/user/preferences).
+   */
+  async function resolveDisplayNameFromCognito(userId: string): Promise<string | undefined> {
     try {
       const res = await cognito.send(new AdminGetUserCommand({
         UserPoolId: userPoolId,
@@ -47,10 +56,9 @@ export function createHandler(deps: HandlerDeps) {
       const family = res.UserAttributes?.find(a => a.Name === 'family_name')?.Value?.trim();
       if (given || family) return [given, family].filter(Boolean).join(' ');
     } catch {
-      // Fall through to email fallback
+      // Fall through — no usable name; the row is written without displayName.
     }
-    // Fallback: email local part
-    return email.split('@')[0] ?? email;
+    return undefined;
   }
 
   async function handleSetup(auth: { userId: string; email: string }) {
@@ -61,17 +69,19 @@ export function createHandler(deps: HandlerDeps) {
     const existing = await ddb.send(new GetCommand({ TableName: usersTable, Key: { userId } }));
 
     if (!existing.Item) {
-      // Fetch display name from Cognito given_name/family_name attributes
-      const displayName = await resolveDisplayNameFromCognito(userId, email);
-      const emailLower = email.toLowerCase();
+      // Real name from Cognito if present; otherwise omitted (no email fallback — #494).
+      const displayName = await resolveDisplayNameFromCognito(userId);
 
       await ddb.send(new PutCommand({
         TableName: usersTable,
+        // CANONICAL bootstrap user row (#496). The invitation-redemption upsert
+        // writes the IDENTICAL shape (minus displayName) so a user created via
+        // first-auth vs redemption is indistinguishable — keep the two in lockstep.
         Item: {
           userId,
           email,
-          emailLower,
-          displayName,
+          emailLower: email.toLowerCase(),
+          ...(displayName ? { displayName } : {}),
           status: 'active',
           preferences: { notificationsEnabled: false },
           profileComplete: false,

--- a/apps/launchpad/functions/account-provisioning/vitest.config.ts
+++ b/apps/launchpad/functions/account-provisioning/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    // Local config so these src tests are not silently skipped by the inherited
+    // apps/launchpad/vitest.config.ts (`include: ['lib/**']`). Mirrors the
+    // invitation-redemption function config — without it this suite never ran (#496).
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/apps/launchpad/functions/invitation-redemption/src/index.test.ts
+++ b/apps/launchpad/functions/invitation-redemption/src/index.test.ts
@@ -12,6 +12,7 @@ interface Seed {
 
 function makeHandler(seed: Seed, opts: { stage?: string; cognitoUserId?: string; liveGroups?: string[] } = {}) {
   const memberPuts: Array<Record<string, unknown>> = [];
+  const userPuts: Array<Record<string, unknown>> = [];
   const groupAdds: Array<Record<string, unknown>> = [];
   const statusUpdates: string[] = [];
 
@@ -28,6 +29,18 @@ function makeHandler(seed: Seed, opts: { stage?: string; cognitoUserId?: string;
         if (t === 'members') return { Item: seed.members?.[`${key.accountId}|${key.userId}`] };
       }
       if (name === 'PutCommand' && t === 'members') { memberPuts.push(input.Item ?? {}); return {}; }
+      if (name === 'PutCommand' && t === 'users') {
+        // Mirror DynamoDB's attribute_not_exists conditional Put: an existing row
+        // throws ConditionalCheckFailedException (ensureUserRow swallows it). #496
+        const uid = (input.Item as { userId?: string })?.userId;
+        if (uid && seed.users?.[uid]) {
+          const e = new Error('The conditional request failed') as Error & { name: string };
+          e.name = 'ConditionalCheckFailedException';
+          throw e;
+        }
+        userPuts.push(input.Item ?? {});
+        return {};
+      }
       if (name === 'UpdateCommand' && t === 'invitations') { statusUpdates.push(key.invitationId); return {}; }
       throw new Error(`unexpected ddb command ${name} on ${t}`);
     },
@@ -60,7 +73,7 @@ function makeHandler(seed: Seed, opts: { stage?: string; cognitoUserId?: string;
     }),
   });
 
-  return { handler, memberPuts, groupAdds, statusUpdates };
+  return { handler, memberPuts, userPuts, groupAdds, statusUpdates };
 }
 
 function event(bundleId: string, email = 'invitee@example.com', groups = '') {
@@ -140,6 +153,44 @@ describe('invitation redemption — M11 A5', () => {
     expect(statusUpdates).toEqual(['b-1']);
   });
 
+  it('#496: writes the canonical launchpad-users bootstrap row for the redeemer (no displayName)', async () => {
+    const { handler, userPuts } = makeHandler({
+      bundles: { 'b-1': accountInviteBundle },
+      accounts: { 'acct-1': account1 },
+    });
+
+    await handler(event('b-1', 'invitee@example.com'));
+
+    expect(userPuts).toHaveLength(1);
+    // IDENTICAL bootstrap defaults to account-provisioning /auth/setup, MINUS displayName.
+    expect(userPuts[0]).toMatchObject({
+      userId: 'user-invitee',
+      email: 'invitee@example.com',
+      emailLower: 'invitee@example.com',
+      status: 'active',
+      preferences: { notificationsEnabled: false },
+      profileComplete: false,
+      activeAccounts: {},
+    });
+    expect(userPuts[0]).not.toHaveProperty('displayName');
+  });
+
+  it('#496: user-row upsert is idempotent — an existing row is a no-op, redemption still succeeds', async () => {
+    const { handler, userPuts, memberPuts } = makeHandler({
+      bundles: { 'b-1': accountInviteBundle },
+      accounts: { 'acct-1': account1 },
+      users: { 'user-invitee': { userId: 'user-invitee', email: 'invitee@example.com', status: 'active' } },
+    });
+
+    const res = (await handler(event('b-1'))) as { statusCode: number; body: string };
+
+    // ConditionalCheckFailedException is swallowed → no crash, redemption proceeds.
+    expect(res.statusCode).toBe(200);
+    expect(body(res).results[0]).toMatchObject({ outcome: 'accepted' });
+    expect(userPuts).toHaveLength(0); // attribute_not_exists tripped → nothing written
+    expect(memberPuts).toHaveLength(1); // membership still applied
+  });
+
   it('account-invite: idempotent — already a member yields duplicate, no write', async () => {
     const { handler, memberPuts, groupAdds } = makeHandler({
       bundles: { 'b-1': accountInviteBundle },
@@ -176,10 +227,14 @@ describe('invitation redemption — M11 A5', () => {
     expect(groupAdds).toHaveLength(0);
   });
 
-  it('invitee-only: a caller whose email differs from the bundle is rejected (403)', async () => {
+  it('m16.7.0 link-as-bearer: a caller whose email differs from the bundle still redeems (binds to the caller)', async () => {
+    // The LINK is the bearer (the bundleId is an unguessable UUID); grants bind to the
+    // AUTHENTICATED identity, not bundle.email — the strict same-email 403 was removed in
+    // m16.7.0. (Stale pre-existing test corrected during #496 — it still asserted 403.)
     const { handler } = makeHandler({ bundles: { 'b-2': appGrantBundle } });
-    const res = (await handler(event('b-2', 'someone-else@example.com'))) as { statusCode: number };
-    expect(res.statusCode).toBe(403);
+    const res = (await handler(event('b-2', 'someone-else@example.com'))) as { statusCode: number; body: string };
+    expect(res.statusCode).toBe(200);
+    expect(body(res).userId).toBe('user-invitee'); // bound to the caller's sub, not the invited email
   });
 
   it('missing bundle → 404', async () => {

--- a/apps/launchpad/functions/invitation-redemption/src/index.ts
+++ b/apps/launchpad/functions/invitation-redemption/src/index.ts
@@ -138,6 +138,37 @@ export function createHandler(deps: RedemptionDeps) {
     }
   }
 
+  // #496 — make the redeeming invitee a first-class directory entity. Redemption
+  // historically created groups + memberships but NO launchpad-users row, so a
+  // federated redeemer who never edited a preference was invisible in admin Users &
+  // Access. This is the SAFETY NET for the /auth/setup first-auth bootstrap (B): it
+  // writes the IDENTICAL canonical bootstrap row to account-provisioning, MINUS
+  // displayName (resolved from the token / set explicitly later, per #494). Keep the
+  // shape in lockstep with account-provisioning's handleSetup. Idempotent: an existing
+  // row trips attribute_not_exists and is a no-op.
+  async function ensureUserRow(userId: string, email: string): Promise<void> {
+    const now = new Date().toISOString();
+    try {
+      await deps.ddb.send(new PutCommand({
+        TableName: deps.usersTable,
+        Item: {
+          userId,
+          email,
+          emailLower: email.toLowerCase(),
+          status: 'active',
+          preferences: { notificationsEnabled: false },
+          profileComplete: false,
+          activeAccounts: {},
+          createdAt: now,
+          updatedAt: now,
+        },
+        ConditionExpression: 'attribute_not_exists(userId)',
+      }));
+    } catch (err) {
+      if ((err as { name?: string }).name !== 'ConditionalCheckFailedException') throw err;
+    }
+  }
+
   // Apply a bundle's grants FOR `redeemer`. Shared by the NORMAL (caller redeems
   // their own bundle) and the DEV-ONLY impersonation paths — the per-grant effect
   // is identical; only WHO redeems and which guards run beforehand differ.
@@ -247,6 +278,7 @@ export function createHandler(deps: RedemptionDeps) {
     // (duplicate guards in applyBundle) are UNCHANGED; the strict same-email match
     // was REMOVED to conform to the m16.7.0 redemption-experience contract.
     await assertNotDisabled(auth.userId);
+    await ensureUserRow(auth.userId, auth.email); // #496 — first-class directory entity
     const results = await applyBundle(bundle, bundleId, { userId: auth.userId, email: auth.email, groups: auth.groups });
     return response(bundleId, auth.userId, results);
   }
@@ -288,6 +320,7 @@ export function createHandler(deps: RedemptionDeps) {
       throw badRequest(`No user exists for ${inviteeEmail}; the invitee must have signed in at least once before the demo can impersonate them.`);
     }
     await assertNotDisabled(inviteeUserId);
+    await ensureUserRow(inviteeUserId, inviteeEmail); // #496 — first-class directory entity
     const groups = await liveGroups(inviteeUserId);
     const results = await applyBundle(bundle, bundleId, { userId: inviteeUserId, email: inviteeEmail, groups });
     return response(bundleId, inviteeUserId, results);

--- a/apps/launchpad/stores/auth/use-auth-store.ts
+++ b/apps/launchpad/stores/auth/use-auth-store.ts
@@ -2,6 +2,34 @@ import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
 import type { User } from '@transformotion/auth-client'
 import { authService } from '@/lib/services/auth'
+import { setupAccount } from '@/lib/services/account-onboarding'
+import { getConfig } from '@/lib/config'
+
+/**
+ * Ensure the caller's `launchpad-users` row exists on first authenticated load
+ * (#496). `/auth/setup` is the canonical user-row writer; its client wrapper was
+ * never wired, so federated redeemers (and anyone who joined without later editing
+ * a preference) had no row and were invisible in the admin Users & Access list.
+ *
+ * Fire-and-forget so it never blocks or breaks sign-in, and idempotent
+ * server-side (attribute_not_exists) — a cheap no-op once the row exists. Gated on
+ * a configured control plane so mock/dev doesn't fetch a dead URL. The `.catch`
+ * LOGS rather than silently swallows: a PERSISTENT failure would keep users
+ * invisible in the directory, which must be diagnosable (self-healing on the next
+ * load is fine; a silent permanent failure is not).
+ */
+function bootstrapUserRow(): void {
+  if (!getConfig().controlPlane.apiUrl) return
+  authService
+    .getIdToken()
+    .then((idToken) => (idToken ? setupAccount(idToken) : null))
+    .catch((err) =>
+      console.warn(
+        '[launchpad] /auth/setup bootstrap failed — this user may be missing from the admin Users & Access list until the next load (#496):',
+        err,
+      ),
+    )
+}
 
 interface AuthState {
   user:            User | null
@@ -32,6 +60,7 @@ export const useAuthStore = create<AuthState>()(
           const user = await authService.getCurrentUser()
           if (user) {
             set({ user, isAuthenticated: true, isLoading: false, isInitialized: true, error: null })
+            bootstrapUserRow() // #496 — ensure the launchpad-users row exists (non-blocking)
           } else {
             set({ user: null, isAuthenticated: false, isLoading: false, isInitialized: true })
           }

--- a/docs/architecture/auth.md
+++ b/docs/architecture/auth.md
@@ -441,6 +441,20 @@ The `state` parameter is arbitrary data the app preserves through the auth flow;
 - Enters email + password → Cognito verifies credentials, or
 - Clicks a federated IDP button → redirects to Google / Facebook / Microsoft → returns with user attributes → Cognito creates or updates the federated user record
 
+> **User-record lifecycle (#496).** Step 2 creates/updates the user's **Cognito**
+> record. The control-plane **`launchpad-users-{stage}`** row — the entity the admin
+> Users & Access directory lists (`access-summary` scans this table as its universe) —
+> is created separately, on the **first authenticated app load**: the launchpad calls
+> `POST /auth/setup` (idempotent, `attribute_not_exists`) once the session is
+> established. **Invitation redemption also upserts the row** as a backup, so a
+> redeemer is a first-class directory entity even if the bootstrap is skipped or races.
+> Neither path writes an email-derived `displayName` — it is stored only when the IdP
+> supplies a real given/family name or the user sets one explicitly (see *Display name
+> from claims*), so the directory and greeting resolve the name from the token. Prior
+> to #496 the `/auth/setup` client wiring was absent (dead code), so federated
+> redeemers had groups + memberships but no `launchpad-users` row and were **invisible**
+> in the directory.
+
 **Step 3 — Pre-token Lambda fires.** Cognito invokes the pre-token-generation Lambda synchronously. The Lambda runs the reconciliation and claim-building logic described above and returns the enriched event.
 
 **Step 4 — Cognito issues tokens.** Cognito constructs three JWTs signed with its RSA key:
@@ -878,7 +892,7 @@ Launchpad owns the live onboarding, user profile/preference, account administrat
 
 | Route | Live Lambda | Notes |
 |---|---|---|
-| `POST /auth/setup` | `launchpad-account-provisioning-{stage}` | First-login **profile** bootstrap (D11, contract m16.1.0): ensures the user item exists in `launchpad-users-{stage}`; never auto-creates an account. Returns `AccountSetupResponse { accountId?, userCreated, profileComplete }` — `accountId` omitted unless the user already holds one. |
+| `POST /auth/setup` | `launchpad-account-provisioning-{stage}` | First-login **profile** bootstrap (D11, contract m16.1.0). **Invoked on first authenticated app load** by the launchpad (#496 — the client call was previously unwired); idempotent (`attribute_not_exists`). Ensures the user item exists in `launchpad-users-{stage}` with the canonical bootstrap shape; **omits `displayName` unless the IdP supplies a real given/family name** (#494 — no email fallback); never auto-creates an account. Returns `AccountSetupResponse { accountId?, userCreated, profileComplete }` — `accountId` omitted unless the user already holds one. Invitation redemption upserts the same row as a backup. |
 | `GET /api/user/profile` | `launchpad-user-{stage}` | Reads the caller's profile/preferences from `launchpad-users-{stage}`. |
 | `PUT /api/user/preferences` | `launchpad-user-{stage}` | Merges caller-owned preferences into `launchpad-users-{stage}`. |
 | `POST /accounts` | `launchpad-accounts-{stage}` | M11 A4 — self-service create-first-account. Request `{ name, appSlug }` (m16.6.0: `appSlug` in the body — the multi-app launchpad token can't say which app the user clicked). **Requires the `{appSlug}-app-access` group** (groups-authoritative) + active user — the body says WHICH app, the access group AUTHORIZES it (a caller without it → 403, whatever appSlug is sent; unknown appSlug → 400). Creates the account + **owner** membership; ensures the access group (`AdminAddUserToGroup`, idempotent). No pre-existing membership required. |

--- a/docs/architecture/data.md
+++ b/docs/architecture/data.md
@@ -63,7 +63,7 @@ User profile and preferences keyed by Cognito `sub`.
 | `userId` (PK) | String | Cognito `sub` |
 | `email` | String | User email (original case) |
 | `emailLower` | String | Lowercase email — used by `email-index` GSI for redemption lookup (M16 D4) |
-| `displayName` | String | Human-friendly name. Source of truth; never denormalized onto membership rows (D6). |
+| `displayName` | String (optional) | Human-friendly name. Present only when the IdP supplied a real given/family name **or** the user set one explicitly (#494/#496); **omitted at bootstrap** (no email fallback at write time). Source of truth; never denormalized onto membership rows (D6). |
 | `profileComplete` | Boolean | False until user completes first-time profile setup |
 | `status` | String | `active \| disabled`. Absent means `active` (backwards compatibility). |
 | `preferences` | Map | `{ notificationsEnabled: boolean }` |
@@ -75,8 +75,10 @@ User profile and preferences keyed by Cognito `sub`.
 **Display name fallback chain (M16, applies at read time — never write-time):**
 1. `displayName` (if set and non-empty)
 2. Email local part (`email.split('@')[0]`)
-3. Full email
-This fallback is computed at read time. Do not write a derived display name back to the row.
+
+Computed at read time; **never** the full email (#494) and never written back to the row. The auth client applies the same rule to the token name (`composeDisplayName`), and the launchpad greeting prefers an explicitly-set `displayName` then the token name — so an unset name resolves to the token's given name, not an email-derived value.
+
+**Row population (#496).** A `launchpad-users` row is created by `POST /auth/setup` (`account-provisioning`) on the user's **first authenticated app load**, and upserted as a backup by **invitation redemption** for the redeeming invitee. Both write the **canonical bootstrap shape** — `userId, email, emailLower, status:'active', preferences:{notificationsEnabled:false}, profileComplete:false, activeAccounts:{}, createdAt, updatedAt` — and **omit `displayName`** unless a real name is available (account-provisioning may add it from Cognito `given_name`/`family_name`). Both are idempotent (`attribute_not_exists(userId)`). The row may also be created incidentally by the first `PUT /api/user/preferences` / `PUT /api/user/active-accounts` upsert. The admin Users & Access directory (`access-summary`) treats this table as its authoritative universe, so a missing row makes a user invisible despite holding memberships/groups.
 
 **No display name denormalization (M16 D6 standing rule).** `displayName` lives only on the user item. Member lists, grant rows, access summaries, and discovery results are enriched at read time via `BatchGetItem` on the users table. Do not copy display names onto membership or grant items.
 

--- a/docs/architecture/inventory.md
+++ b/docs/architecture/inventory.md
@@ -61,6 +61,16 @@ those stacks. They are not live ownership surfaces.
   - `launchpad-invitations-{stage}`
   - `launchpad-rate-limits-{stage}`
 
+The `launchpad-users-{stage}` row — the entity the admin **Users & Access**
+directory lists (`access-summary` scans it as the authoritative universe) — is
+created on a user's first authenticated app load via `POST /auth/setup`
+(idempotent), and upserted as a backup by invitation redemption for the redeeming
+invitee (#496). Both write the canonical bootstrap shape and omit `displayName`
+unless a real given/family name is available (#494 — no email fallback). Before
+#496 the `/auth/setup` client call was unwired (dead code), so federated redeemers
+held memberships + groups but had no user row and were invisible in the directory;
+a one-off `scripts/ops/backfill-user-rows-496.mjs` addresses the pre-#496 orphans.
+
 The pre-token trigger emits the `apps` and `accounts` claims consumed by
 Launchpad, Stock Analyser, Budget Tracker, and migration utilities.
 Platform admin status is NOT a claim — it is read from the `site-admin` Cognito

--- a/scripts/ops/backfill-user-rows-496.mjs
+++ b/scripts/ops/backfill-user-rows-496.mjs
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+/**
+ * One-off backfill for #496 — create launchpad-users rows for users who JOINED via
+ * redemption before the user-row creation path was wired, and are therefore invisible
+ * in the admin Users & Access list (which scans launchpad-users as its universe).
+ *
+ * These three users have account memberships + Cognito groups but NO launchpad-users
+ * row, confirmed against dev. They will NOT self-heal (B's first-auth bootstrap only
+ * fires going forward; they'd need to sign in again), so they are backfilled here.
+ *
+ * The written row is the CANONICAL bootstrap shape — IDENTICAL to what
+ * account-provisioning (/auth/setup) and invitation-redemption write — MINUS
+ * displayName (resolved from the token at read time, or set explicitly later; #494).
+ *
+ * SAFETY:
+ *   • DRY-RUN by default — prints exactly what it would write. Pass --execute to write.
+ *   • Each write is conditional (attribute_not_exists(userId)) — an existing row is a
+ *     no-op, never an overwrite.
+ *   • Uses the AWS CLI (no SDK dependency); honours your current AWS credentials/region.
+ *
+ * Usage:
+ *   node scripts/ops/backfill-user-rows-496.mjs                 # dry-run (preview)
+ *   node scripts/ops/backfill-user-rows-496.mjs --execute       # write the rows
+ *   node scripts/ops/backfill-user-rows-496.mjs --table X --region Y --execute
+ */
+
+import { execFileSync } from 'node:child_process';
+
+const args = process.argv.slice(2);
+const execute = args.includes('--execute');
+const table = argValue('--table') ?? 'launchpad-users-dev';
+const region = argValue('--region') ?? 'ap-southeast-2';
+
+function argValue(flag) {
+  const i = args.indexOf(flag);
+  return i >= 0 ? args[i + 1] : undefined;
+}
+
+/** The three confirmed orphans (memberships/groups exist, launchpad-users row absent). */
+const ORPHANS = [
+  { userId: 'a98e7408-8091-70b5-f5d1-1ff97322a911', email: 'stevemoodie70@gmail.com' },          // Google
+  { userId: '293ed468-4091-7006-b2e3-1f88cdc9df73', email: 'stevemoodie@hotmail.com' },           // Microsoft
+  { userId: '093e0458-6051-70c5-39d3-40a8d49d7b7f', email: 'smoke-bt-viewer@transformotion.com.au' }, // native (CI)
+];
+
+/** Canonical bootstrap row (minus displayName) as a DynamoDB attribute-value map. */
+function bootstrapItem({ userId, email }) {
+  const now = new Date().toISOString();
+  return {
+    userId: { S: userId },
+    email: { S: email },
+    emailLower: { S: email.toLowerCase() },
+    status: { S: 'active' },
+    preferences: { M: { notificationsEnabled: { BOOL: false } } },
+    profileComplete: { BOOL: false },
+    activeAccounts: { M: {} },
+    createdAt: { S: now },
+    updatedAt: { S: now },
+  };
+}
+
+console.log(`#496 backfill — table=${table} region=${region} mode=${execute ? 'EXECUTE' : 'DRY-RUN'}`);
+console.log(`Rows to ensure (conditional on attribute_not_exists(userId)):\n`);
+
+let written = 0;
+let skipped = 0;
+
+for (const orphan of ORPHANS) {
+  const item = bootstrapItem(orphan);
+  console.log(`• ${orphan.email}  (${orphan.userId})`);
+  console.log(`    ${JSON.stringify(item)}`);
+
+  if (!execute) continue;
+
+  try {
+    execFileSync(
+      'aws',
+      [
+        'dynamodb', 'put-item',
+        '--table-name', table,
+        '--region', region,
+        '--item', JSON.stringify(item),
+        '--condition-expression', 'attribute_not_exists(userId)',
+      ],
+      { stdio: 'pipe' },
+    );
+    written++;
+    console.log('    → written');
+  } catch (err) {
+    const msg = String(err.stderr ?? err.message ?? err);
+    if (msg.includes('ConditionalCheckFailedException')) {
+      skipped++;
+      console.log('    → already exists, skipped (no-op)');
+    } else {
+      console.error('    → FAILED:', msg);
+      process.exitCode = 1;
+    }
+  }
+}
+
+console.log(
+  execute
+    ? `\nDone. written=${written} skipped(existing)=${skipped} of ${ORPHANS.length}.`
+    : `\nDRY-RUN only — nothing written. Re-run with --execute to apply.`,
+);


### PR DESCRIPTION
Closes #496.

## Problem
Federated redeemers (and anyone who joined without later editing a preference) were **invisible** in the admin **Users & Access** list — they had Cognito groups + account memberships but **no `launchpad-users` row**, and the directory (`access-summary`) scans that table as its authoritative universe. Confirmed orphans on dev: `stevemoodie70@gmail.com` (Google), `stevemoodie@hotmail.com` (Microsoft), `smoke-bt-viewer@…` (native CI).

## Root cause (doubly broken)
- Redemption never wrote a users row (`userCreated:false`).
- The canonical writer `/auth/setup` was **dead code** — its client wrapper `setupAccount()` had zero callers. Rows were only created incidentally via `PUT /preferences` / `PUT /active-accounts` upserts (and seeding), which federated single-account redeemers never trigger.

## Fix (B + A + backfill — launchpad lane only)
- **B (root):** wire `/auth/setup` on first authenticated load via the launchpad auth store `initialize()`. Covers **every** user (native + federated). Fire-and-forget, idempotent server-side (`attribute_not_exists`); the `.catch` **logs** so a persistent failure is diagnosable, not silent.
- **B (#494 consistency — required):** `account-provisioning` no longer writes an **email-derived** `displayName` at bootstrap (only a real Cognito given/family name). Firing `/auth/setup` as-is would have **re-broken #494** by storing an email name that beats the token name.
- **A (safety net):** redemption upserts the **identical** bootstrap row (minus `displayName`) for the redeeming invitee, idempotently — so a redeemer is a first-class directory entity even if B is skipped/races. The two paths write the same shape (locked by tests).
- **Backfill:** `scripts/ops/backfill-user-rows-496.mjs` — **dry-run by default**, `--execute` to write, conditional (`attribute_not_exists`). For the 3 pre-fix orphans. **Owner-run, brought separately** with a preview.

## Incidental (in files I touched)
- Wired `account-provisioning`'s vitest (it had **no local config** → inherited `include: ['lib/**']` → its `src/` tests were silently skipped and never ran in CI). Now runs (6 tests).
- Corrected a **stale** redemption test that still asserted the m16.7.0-removed strict-email `403` (it was already failing on `develop`).

## Tests
- account-provisioning (6) — incl. displayName omitted when no given/family.
- invitation-redemption (13) — incl. ensureUserRow writes the canonical shape + idempotent no-op on existing row.
- Typecheck (launchpad + both functions) green; changed files lint-clean.

## Deploy footprint
B1 (frontend) + B2 + A (Lambdas) = **launchpad lane only**. No SA/BT. Backfill is a manual script run (not a deploy). Both **owner-gated**.

## v0 freshness

- [x] No v0 impact

Reason: Runtime user-lifecycle fix. No contract shape change — the `launchpad-users` bootstrap row is internal control-plane state, and `UserProfile.displayName` is already optional (#494). No frontend/backend data field, payload, WSS, cache, or mock shape changes; the only frontend touch is wiring an existing API call in the auth store.

## Note on the auth.md mirror
This edits `docs/architecture/auth.md`, so on merge the **Auth Model Mirror Sync** will open a fresh `transformotion-apps-b8` PR and the **Auth Model Mirror Freshness** check stays red until that mirror PR is merged (same as #495 → b8 #64).

🤖 Generated with [Claude Code](https://claude.com/claude-code)