### PR TITLE
feat(launchpad): wire the live Profile screen (v0-prototyped)

### DIFF
--- a/apps/launchpad/components/launchpad/launchpad.tsx
+++ b/apps/launchpad/components/launchpad/launchpad.tsx
@@ -17,8 +17,11 @@ import {
   type ViewerEntitlement,
 } from '@/lib/entitlement'
 import { useLaunchpadData } from '@/hooks/use-launchpad-data'
+import { useSelfAccess } from '@/hooks/use-self-access'
 import { authService } from '@/lib/services/auth'
 import { createAccount } from '@/lib/services/account-admin'
+import { ProfileForm } from '@/components/launchpad/profile-form'
+import { YourAccountsAccess } from '@/components/launchpad/your-accounts-access'
 
 const APP_ICONS: Record<string, React.ComponentType<{ className?: string }>> = {
   'stock-analyser': TrendingUp,
@@ -350,6 +353,7 @@ function ProfileMenu({
   onLogout,
   onOpenSettings,
   onOpenAdmin,
+  onOpenUserProfile,
 }: {
   displayName: string
   email: string
@@ -359,6 +363,7 @@ function ProfileMenu({
   onLogout: () => void
   onOpenSettings?: () => void
   onOpenAdmin?: () => void
+  onOpenUserProfile: () => void
 }) {
   if (!isOpen) return null
 
@@ -398,7 +403,13 @@ function ProfileMenu({
         )}
 
         <div className="py-2">
-          <button className="w-full flex items-center gap-3 px-4 py-2.5 text-sm text-foreground hover:bg-surface2 transition-colors">
+          <button
+            onClick={() => {
+              onClose()
+              onOpenUserProfile()
+            }}
+            className="w-full flex items-center gap-3 px-4 py-2.5 text-sm text-foreground hover:bg-surface2 transition-colors"
+          >
             <UserIcon className="size-4 text-muted-foreground" />
             Profile
           </button>
@@ -471,6 +482,7 @@ export function Launchpad({
 }) {
   const router = useRouter()
   const [profileMenuOpen, setProfileMenuOpen] = useState(false)
+  const [userProfileOpen, setUserProfileOpen] = useState(false)
   const [settingsOpen, setSettingsOpen] = useState(false)
   // Create-first-account flow: the app whose modal is open, plus an OPTIMISTIC set
   // of slugs just created (so the tile flips to normal-open immediately — the next
@@ -485,6 +497,7 @@ export function Launchpad({
   const isSiteAdmin = authUser?.metadata?.siteAdmin === true
 
   const data = useLaunchpadData(authUser)
+  const selfAccess = useSelfAccess(authUser)
 
   const email = authUser?.email ?? ''
   // Canonical chain (#423/#494): EXPLICIT profile displayName → Cognito name → email
@@ -579,7 +592,39 @@ export function Launchpad({
         onLogout={onSignOut || (() => {})}
         onOpenSettings={isSiteAdmin ? () => setSettingsOpen(true) : undefined}
         onOpenAdmin={isSiteAdmin ? () => router.push('/launchpad/admin/users') : undefined}
+        onOpenUserProfile={() => setUserProfileOpen(true)}
       />
+
+      {userProfileOpen && authUser && (
+        <>
+          <div className="fixed inset-0 bg-black/50 z-50" onClick={() => setUserProfileOpen(false)} />
+          <div className="fixed left-1/2 top-1/2 z-50 w-[calc(100vw-2rem)] max-w-md -translate-x-1/2 -translate-y-1/2 overflow-hidden rounded-xl border border-border bg-card shadow-2xl">
+            <div className="flex items-center justify-between gap-3 border-b border-border px-4 py-3">
+              <div>
+                <h2 className="text-sm font-semibold text-foreground">Your profile</h2>
+                <p className="text-xs text-muted-foreground">Shown across all Transformotion apps</p>
+              </div>
+              <button
+                onClick={() => setUserProfileOpen(false)}
+                className="size-8 rounded-lg flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-surface2"
+                aria-label="Close profile"
+              >
+                <X className="size-4" />
+              </button>
+            </div>
+            <div className="max-h-[calc(100vh-8rem)] overflow-y-auto p-4 flex flex-col gap-4">
+              <ProfileForm
+                email={email}
+                initialDisplayName={displayName}
+                initialNotificationsEnabled={data.profile?.preferences?.notificationsEnabled ?? false}
+                heading={displayName}
+                description="Update how your name appears and whether we send you notifications."
+              />
+              <YourAccountsAccess summary={selfAccess.summary} loading={selfAccess.loading} />
+            </div>
+          </div>
+        </>
+      )}
 
       {createAccountTile && (
         <CreateAccountModal

--- a/apps/launchpad/components/launchpad/profile-form.tsx
+++ b/apps/launchpad/components/launchpad/profile-form.tsx
@@ -1,0 +1,167 @@
+'use client'
+
+import { useState } from 'react'
+import { Bell, BellOff, Check, UserRound } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { authService } from '@/lib/services/auth'
+import { saveUserProfile, type UserProfile } from '@/lib/services/user-profile'
+
+/**
+ * Profile setup/edit form, backed by the live control-plane.
+ *
+ * Ported verbatim from the v0 prototype (`components/launchpad/profile-form.tsx`);
+ * only the data layer changes. Display name and the notifications preference are
+ * saved TOGETHER via the contracted `UpdateUserPreferencesRequest` (m16.8.0 typed
+ * `displayName` + `notificationsEnabled`) → PUT /api/user/preferences.
+ *
+ * The display name field is seeded with the correctly-RESOLVED current name
+ * (#494 precedence: explicit displayName → token given_name → email local part),
+ * computed by the caller via the same chain the launchpad greeting uses.
+ *
+ * Notifications: CONTRACT-BACKED and persists a real preference. Nothing consumes
+ * `notificationsEnabled` yet (no delivery system) — that is a future seam; the
+ * toggle correctly persists the preference today.
+ */
+export function ProfileForm({
+  email,
+  initialDisplayName,
+  initialNotificationsEnabled,
+  heading,
+  description,
+  submitLabel = 'Save profile',
+  onSaved,
+}: {
+  email: string
+  initialDisplayName: string
+  initialNotificationsEnabled: boolean
+  heading: string
+  description: string
+  submitLabel?: string
+  onSaved?: (profile: UserProfile) => void
+}) {
+  const [displayName, setDisplayName] = useState(initialDisplayName)
+  const [notificationsEnabled, setNotificationsEnabled] = useState(initialNotificationsEnabled)
+  const [error, setError] = useState<string | null>(null)
+  const [saving, setSaving] = useState(false)
+  const [saved, setSaved] = useState(false)
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setError(null)
+    const name = displayName.trim()
+    if (!name) {
+      setError('Display name is required.')
+      return
+    }
+    setSaving(true)
+    try {
+      const idToken = await authService.getIdToken()
+      if (!idToken) throw new Error('Not signed in')
+      // displayName + notificationsEnabled save together (contracted request).
+      const profile = await saveUserProfile(idToken, { displayName: name, notificationsEnabled })
+      setSaved(true)
+      onSaved?.(profile)
+    } catch (err) {
+      console.error('[launchpad] profile save failed:', err)
+      setError('Could not save your profile. Please try again.')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  if (saved) {
+    return (
+      <div className="flex items-start gap-3 rounded-lg border border-primary/30 bg-primary/5 p-4">
+        <div className="flex size-8 shrink-0 items-center justify-center rounded-full bg-primary/15">
+          <Check className="size-4 text-primary" />
+        </div>
+        <div>
+          <p className="text-sm font-semibold text-foreground">Profile saved</p>
+          <p className="mt-0.5 text-sm text-muted-foreground">
+            You&apos;re all set, {displayName.trim()}. Your name and preferences now apply across
+            every Transformotion app.
+          </p>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="rounded-lg border border-border bg-surface/40 p-4">
+      <div className="flex items-start gap-3">
+        <div className="flex size-8 shrink-0 items-center justify-center rounded-full bg-primary/15">
+          <UserRound className="size-4 text-primary" />
+        </div>
+        <div className="min-w-0">
+          <h4 className="text-sm font-semibold text-foreground">{heading}</h4>
+          <p className="mt-0.5 text-sm text-pretty text-muted-foreground">{description}</p>
+        </div>
+      </div>
+
+      <div className="mt-4 flex flex-col gap-4">
+        <label className="flex flex-col gap-1.5">
+          <span className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+            Display name
+          </span>
+          <input
+            type="text"
+            value={displayName}
+            onChange={(e) => setDisplayName(e.target.value)}
+            placeholder="How should we address you?"
+            required
+            className="h-10 rounded-lg border border-border bg-background px-3 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/40"
+          />
+          <span className="text-xs text-muted-foreground">
+            Signed in as <span className="font-medium text-foreground">{email}</span>
+          </span>
+        </label>
+
+        <button
+          type="button"
+          role="switch"
+          aria-checked={notificationsEnabled}
+          onClick={() => setNotificationsEnabled((v) => !v)}
+          className="flex items-center justify-between gap-3 rounded-lg border border-border bg-background px-3 py-2.5 text-left transition-colors hover:border-primary/30"
+        >
+          <span className="flex items-center gap-2.5">
+            {notificationsEnabled ? (
+              <Bell className="size-4 text-primary" />
+            ) : (
+              <BellOff className="size-4 text-muted-foreground" />
+            )}
+            <span>
+              <span className="block text-sm font-medium text-foreground">Notifications</span>
+              <span className="block text-xs text-muted-foreground">
+                Account activity and invitation updates
+              </span>
+            </span>
+          </span>
+          <span
+            className={cn(
+              'relative h-5 w-9 shrink-0 rounded-full transition-colors',
+              notificationsEnabled ? 'bg-primary' : 'bg-surface2',
+            )}
+          >
+            <span
+              className={cn(
+                'absolute top-0.5 size-4 rounded-full bg-background shadow transition-all',
+                notificationsEnabled ? 'left-[18px]' : 'left-0.5',
+              )}
+            />
+          </span>
+        </button>
+
+        {error && <p className="text-sm text-signal-red">{error}</p>}
+
+        <button
+          type="submit"
+          disabled={saving}
+          className="inline-flex h-10 items-center justify-center gap-2 rounded-lg bg-primary px-4 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:opacity-60"
+        >
+          <Check className="size-4" />
+          {saving ? 'Saving…' : submitLabel}
+        </button>
+      </div>
+    </form>
+  )
+}

--- a/apps/launchpad/components/launchpad/your-accounts-access.tsx
+++ b/apps/launchpad/components/launchpad/your-accounts-access.tsx
@@ -1,0 +1,139 @@
+'use client'
+
+import { Info, LayoutGrid, Shield, ShieldCheck } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import type { UserAccessSummary } from '@transformotion/contracts/launchpad/invitations'
+import type { AccountRole } from '@transformotion/contracts/_shared/auth'
+import { LAUNCHPAD_APPS } from '@/lib/entitlement'
+
+/**
+ * Read-only, self-service view of the SIGNED-IN user's own platform access:
+ * which apps they can enter, which accounts they belong to, and their role in
+ * each. This is the self version of the admin user-detail access panel — same
+ * canonical read model (`UserAccessSummary`), same visual language, but with NO
+ * supervisory actions.
+ *
+ * Ported verbatim from the v0 prototype (`components/launchpad/your-accounts-access.tsx`),
+ * with two data-layer changes only: the summary is derived from the live token
+ * (`useSelfAccess`) instead of the mock store, and the "Pending invitations" sub-list
+ * is OMITTED — its self-pending-bundle read has no contract yet and is the same
+ * capability as #482 (see the PR disposition list). Everything else is unchanged.
+ */
+
+function appLabel(slug: string): string {
+  return LAUNCHPAD_APPS.find((a) => a.slug === slug)?.name ?? slug
+}
+
+const ROLE_STYLES: Record<AccountRole, string> = {
+  owner: 'bg-primary/15 text-primary',
+  manager: 'bg-signal-green/15 text-signal-green',
+  member: 'bg-surface2 text-foreground',
+  viewer: 'bg-surface2 text-muted-foreground',
+}
+
+function RoleChip({ role }: { role: AccountRole }) {
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider',
+        ROLE_STYLES[role],
+      )}
+    >
+      {role}
+    </span>
+  )
+}
+
+export function YourAccountsAccess({
+  summary,
+  loading,
+}: {
+  summary: UserAccessSummary | null
+  loading: boolean
+}) {
+  const siteAdmin = summary?.siteAdmin ?? false
+
+  return (
+    <section
+      aria-label="Your apps and accounts"
+      className="rounded-lg border border-border bg-surface/40 p-4"
+    >
+      <div className="flex items-start gap-3">
+        <div className="flex size-8 shrink-0 items-center justify-center rounded-full bg-primary/15">
+          <LayoutGrid className="size-4 text-primary" />
+        </div>
+        <div className="min-w-0">
+          <h4 className="text-sm font-semibold text-foreground">Your apps &amp; accounts</h4>
+          <p className="mt-0.5 text-sm text-pretty text-muted-foreground">
+            The apps you can access and the accounts you belong to, with your role in each.
+          </p>
+        </div>
+      </div>
+
+      {siteAdmin && (
+        <div className="mt-3 flex items-center gap-2 rounded-lg border border-primary/30 bg-primary/5 px-3 py-2">
+          <ShieldCheck className="size-4 shrink-0 text-primary" />
+          <p className="text-xs text-foreground">
+            You&apos;re a <span className="font-medium">site admin</span> with platform-wide
+            supervisory access.
+          </p>
+        </div>
+      )}
+
+      <div className="mt-4 flex flex-col gap-3">
+        {loading ? (
+          <div className="rounded-lg border border-dashed border-border bg-background/40 px-3 py-6 text-center">
+            <p className="text-sm text-muted-foreground">Loading your access…</p>
+          </div>
+        ) : !summary || summary.appAccess.length === 0 ? (
+          <div className="rounded-lg border border-dashed border-border bg-background/40 px-3 py-6 text-center">
+            <p className="text-sm font-medium text-foreground">No app access yet</p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              When you&apos;re invited to an app or account, it will appear here.
+            </p>
+          </div>
+        ) : (
+          summary.appAccess.map((app) => (
+            <div key={app.appSlug} className="rounded-lg border border-border bg-background/50 p-3">
+              <div className="mb-2 flex items-center justify-between gap-2">
+                <span className="text-sm font-medium text-foreground">{appLabel(app.appSlug)}</span>
+                {app.appAdmin && (
+                  <span className="inline-flex items-center gap-1 rounded-full bg-signal-gold/15 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-signal-gold">
+                    <Shield className="size-3" />
+                    app-admin
+                  </span>
+                )}
+              </div>
+              {app.accounts.length === 0 ? (
+                <p className="text-xs text-muted-foreground">
+                  {app.appAdmin
+                    ? 'App-level administration only (no account membership).'
+                    : 'Access granted — create your first account to get started.'}
+                </p>
+              ) : (
+                <ul className="flex flex-col gap-1.5">
+                  {app.accounts.map((account) => (
+                    <li key={account.accountId} className="flex items-center gap-2">
+                      <span className="truncate text-sm text-foreground">{account.accountName}</span>
+                      <span className="ml-auto">
+                        <RoleChip role={account.role} />
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          ))
+        )}
+      </div>
+
+      <div className="mt-4 flex items-start gap-2 rounded-lg border border-border bg-background/40 p-3">
+        <Info className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+        <p className="text-xs text-muted-foreground">
+          This is a read-only summary of your access. To invite people or manage members, open the
+          relevant app or ask a site admin.
+        </p>
+      </div>
+    </section>
+  )
+}

--- a/apps/launchpad/hooks/use-self-access.ts
+++ b/apps/launchpad/hooks/use-self-access.ts
@@ -1,0 +1,109 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import type { User } from '@transformotion/auth-client'
+import type {
+  UserAccessSummary,
+  UserAppAccess,
+  UserAccountAccess,
+} from '@transformotion/contracts/launchpad/invitations'
+import type { AccountRole, EntitledAppSlug, UserStatus } from '@transformotion/contracts/_shared/auth'
+import { authService } from '@/lib/services/auth'
+import { getConfig } from '@/lib/config'
+import { getAccount } from '@/lib/services/account-admin'
+import { LAUNCHPAD_APPS } from '@/lib/entitlement'
+
+const GATED_SLUGS = LAUNCHPAD_APPS.filter((a) => a.entitlementGated).map((a) => a.slug)
+
+export interface SelfAccess {
+  loading: boolean
+  /** The signed-in user's own cross-app access, or null while loading / when signed out. */
+  summary: UserAccessSummary | null
+}
+
+/**
+ * The signed-in user's OWN cross-app access (#- Profile "Your apps & accounts").
+ *
+ * This is the self version of the admin Users & Access detail read: same canonical
+ * `UserAccessSummary` shape, but derived CLIENT-SIDE from the caller's own token —
+ * the `{app}-app-access` / `{app}-app-admin` / `site-admin` groups (which apps they
+ * can enter and admin) plus the `accounts` claim (their accounts + role per app),
+ * with account NAMES resolved via the control plane. No supervisory actions, no
+ * site-admin gate — a user reads only their own access.
+ *
+ * `pendingInvites` is always 0 here: the "your pending invitations" sub-list needs a
+ * self-pending-bundle read keyed on the authed identity, which has no contract yet and
+ * is the same capability as #482 (on-sign-in reconciliation). It will be wired here
+ * once #482's read is defined in v0 and implemented. See the disposition list.
+ */
+export function useSelfAccess(user: User | null): SelfAccess {
+  const [state, setState] = useState<SelfAccess>({ loading: true, summary: null })
+
+  useEffect(() => {
+    let cancelled = false
+
+    async function load() {
+      if (!user) {
+        if (!cancelled) setState({ loading: false, summary: null })
+        return
+      }
+
+      const meta = user.metadata as
+        | { siteAdmin?: boolean; appAdmin?: string[]; appAccess?: string[] }
+        | undefined
+      const siteAdmin = meta?.siteAdmin === true
+      const appAdminSet = new Set(meta?.appAdmin ?? [])
+      const appAccessSet = new Set(meta?.appAccess ?? [])
+
+      const idToken = await authService.getIdToken().catch(() => null)
+      const apiConfigured = Boolean(getConfig().controlPlane.apiUrl && idToken)
+
+      // Apps the viewer can SEE: holds the access group OR admins the app (groups-authoritative).
+      const slugs = GATED_SLUGS.filter((s) => appAccessSet.has(s) || appAdminSet.has(s))
+
+      const appAccess: UserAppAccess[] = await Promise.all(
+        slugs.map(async (slug) => {
+          const memberships = await authService.getAccountsForApp(slug).catch(() => [])
+          const accounts: UserAccountAccess[] = await Promise.all(
+            memberships.map(async (m) => {
+              let accountName = m.accountId
+              if (apiConfigured) {
+                try {
+                  const res = await getAccount(idToken!, m.accountId, m.accountId)
+                  accountName = res.account?.name ?? m.accountId
+                } catch {
+                  /* name unresolved — fall back to the id, never blocks the row */
+                }
+              }
+              return { accountId: m.accountId, accountName, role: m.role as AccountRole }
+            }),
+          )
+          return { appSlug: slug as EntitledAppSlug, appAdmin: appAdminSet.has(slug), accounts }
+        }),
+      )
+
+      const summary: UserAccessSummary = {
+        userId: user.id,
+        email: user.email,
+        status: 'active' as UserStatus,
+        siteAdmin,
+        appAccess,
+        pendingInvites: 0,
+      }
+
+      if (!cancelled) setState({ loading: false, summary })
+    }
+
+    load().catch(() => {
+      if (!cancelled) setState({ loading: false, summary: null })
+    })
+
+    return () => {
+      cancelled = true
+    }
+    // Re-derive only when the authenticated identity changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [user?.id])
+
+  return state
+}

--- a/apps/launchpad/lib/services/user-profile/index.ts
+++ b/apps/launchpad/lib/services/user-profile/index.ts
@@ -1,9 +1,37 @@
 import type { UserProfile, UserPreferences } from '@transformotion/contracts/_shared/auth';
+import type { UpdateUserPreferencesRequest } from '@transformotion/contracts/launchpad/api';
 import { controlPlaneUrl } from '@/lib/services/control-plane';
 
 // Canonical shapes (contract m16.1.0). UserProfile carries the M16 fields:
 // userId, email, displayName, status, preferences, profileComplete, updatedAt.
-export type { UserProfile, UserPreferences };
+export type { UserProfile, UserPreferences, UpdateUserPreferencesRequest };
+
+/**
+ * Save the caller's own profile via the contracted `UpdateUserPreferencesRequest`
+ * (m16.8.0 typed `displayName` + `notificationsEnabled`) → PUT /api/user/preferences.
+ * The Profile surface saves display name and the notifications preference TOGETHER in
+ * one request; the handler returns the updated `UserProfile`. `displayName` is now a
+ * typed field on the request (previously sent untyped — see `updateDisplayName`).
+ */
+export async function saveUserProfile(
+  idToken: string,
+  req: UpdateUserPreferencesRequest,
+): Promise<UserProfile> {
+  const response = await fetch(controlPlaneUrl('/api/user/preferences'), {
+    method: 'PUT',
+    headers: {
+      Authorization: `Bearer ${idToken}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(req),
+  });
+
+  if (!response.ok) {
+    throw new Error(`PUT /api/user/preferences (profile) failed: ${response.status}`);
+  }
+
+  return response.json() as Promise<UserProfile>;
+}
 
 export async function getUserProfile(idToken: string): Promise<UserProfile> {
   const response = await fetch(controlPlaneUrl('/api/user/profile'), {


### PR DESCRIPTION
Wires the **Profile screen** into the live launchpad, reproducing the v0-prototyped surface verbatim (markup/copy/controls); only the data layer changes. Opened from the profile menu's "Profile" action.

## v0 provenance
Ported from `transformotion-apps-b8` main (`ad243c6`): `components/launchpad/profile-form.tsx` + the new `components/launchpad/your-accounts-access.tsx` (b8 #65 "add 'Your apps & accounts'"), saved via the typed `UpdateUserPreferencesRequest.displayName` (b8 #66, m16.8.0). My local b8 clone was stale on first read (dd34783) — refreshed to main + re-ran `pnpm sync:v0` (no runtime-contract delta) before porting.

## Disposition list (every control — §8.A self-check)
| # | Control | Disposition | Reason |
|---|---|---|---|
| 1 | Display name (editable) | **KEEP** | Seeded with the #494-resolved current name; saved via contracted `UpdateUserPreferencesRequest` → PUT /api/user/preferences |
| 2 | Notifications toggle | **KEEP** | Contract-backed (`UpdateUserPreferencesRequest.notificationsEnabled`); persists; saved together with displayName. Delivery is a future seam — toggle only persists today |
| 3 | Your apps & accounts (apps, accounts, roles, app-admin chips) | **KEEP** | `UserAccessSummary` derived client-side from the token (groups + accounts claim → names + roles), `useSelfAccess` |
| 4 | Access-no-accounts hint ("create your first account") | **KEEP** | Reproduced verbatim |
| 5 | Site-admin callout | **KEEP** | Gated on the real `metadata.siteAdmin` group |
| 6 | "No app access yet" empty / "Profile saved" success / read-only info footer | **KEEP** | Presentational, verbatim |
| 7 | Loading state + submit `disabled:opacity-60` | **ADD** | The real save is async; v0's mock is synchronous |
| 8 | **Pending invitations sub-list** | **CUT** | Real v0 element, but its self-pending-bundle read (pending bundles for the authed identity) has **no contract** and is the **same capability as #482** (on-sign-in reconciliation). Noted on #482 as a second consumer; define the read in v0 first, then wire here. Not invented as a one-off endpoint |

## Visual diff vs v0 (normalized markup diff)
- **ProfileForm:** identical except `{email}` prop (vs `{user.email}`) and the added `disabled:opacity-60` on submit.
- **YourAccountsAccess:** identical except the data-layer (`summary`/`loading` props vs mock `getUserAccess`/`userIsSiteAdmin`), `appLabel(app.appSlug)` (runtime `UserAppAccess` has no `appLabel`; derived from the app catalogue), the added loading state, and the pending-invites block removed (the CUT above).

## Contract check
`notificationsEnabled` is on the synced profile-update path (`UpdateUserPreferencesRequest`, m16.8.0 also typed `displayName`). Gate passes; toggle stays. Both fields save together in one PUT. (There is no `UpdateProfileRequest` type — the contracted request is `UpdateUserPreferencesRequest`.)

## Validation
Typecheck ✓ · lint ✓ (changed files clean) · `next build` static export ✓. Behavioural in-browser verify pending on dev after deploy (no automated render). No new endpoints; consumes existing routes.

## v0 freshness
v0 source: https://github.com/transformotion/transformotion-apps-b8/pull/65 (Profile "Your apps & accounts") + https://github.com/transformotion/transformotion-apps-b8/pull/66 (typed `displayName`, m16.8.0). Reproduced from b8 main `ad243c6`. No contract authored here (consumed via `pnpm sync:v0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)