### PR TITLE
fix(launchpad): reflect a saved profile name without a reload

### DIFF
--- a/apps/launchpad/components/launchpad/launchpad.tsx
+++ b/apps/launchpad/components/launchpad/launchpad.tsx
@@ -484,6 +484,9 @@ export function Launchpad({
   const [profileMenuOpen, setProfileMenuOpen] = useState(false)
   const [userProfileOpen, setUserProfileOpen] = useState(false)
   const [settingsOpen, setSettingsOpen] = useState(false)
+  // Optimistic display-name after a profile save, so the greeting/menu update WITHOUT a
+  // reload (the live profile read is keyed on identity and won't refetch on a mutation).
+  const [displayNameOverride, setDisplayNameOverride] = useState<string | null>(null)
   // Create-first-account flow: the app whose modal is open, plus an OPTIMISTIC set
   // of slugs just created (so the tile flips to normal-open immediately — the next
   // token refresh confirms it via the accounts claim).
@@ -506,7 +509,7 @@ export function Launchpad({
   // name (`authUser.name`), which the auth client guarantees is a real name or the
   // email local part — never the full address.
   const displayName = resolveDisplayName({
-    displayName: data.profile?.displayName,
+    displayName: displayNameOverride ?? data.profile?.displayName,
     cognitoName: authUser?.name,
     email,
   })
@@ -619,6 +622,12 @@ export function Launchpad({
                 initialNotificationsEnabled={data.profile?.preferences?.notificationsEnabled ?? false}
                 heading={displayName}
                 description="Update how your name appears and whether we send you notifications."
+                onSaved={(profile) => {
+                  // Instant: the greeting/menu reflect the new name immediately.
+                  setDisplayNameOverride(profile.displayName ?? null)
+                  // Reconcile: re-read the live profile so state matches the server.
+                  data.refresh()
+                }}
               />
               <YourAccountsAccess summary={selfAccess.summary} loading={selfAccess.loading} />
             </div>

--- a/apps/launchpad/hooks/use-launchpad-data.ts
+++ b/apps/launchpad/hooks/use-launchpad-data.ts
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import type { User } from '@transformotion/auth-client'
 import { authService } from '@/lib/services/auth'
 import { getConfig } from '@/lib/config'
@@ -24,9 +24,14 @@ export interface LaunchpadData {
   accountNames: Record<string, string>
   /** True when the live read failed and entitlement came from a claims fallback. */
   degraded: boolean
+  /** Re-run the live profile/entitlement read (e.g. after the user edits their profile). */
+  refresh: () => void
 }
 
-const EMPTY: LaunchpadData = {
+/** Internal state — the data without the `refresh` action (which the hook supplies). */
+type LaunchpadDataState = Omit<LaunchpadData, 'refresh'>
+
+const EMPTY: LaunchpadDataState = {
   loading: false,
   profile: null,
   entitledSlugs: new Set(),
@@ -45,7 +50,11 @@ const EMPTY: LaunchpadData = {
  * claims-based entitlement probe — never crashes, never blank-crashes a tile.
  */
 export function useLaunchpadData(user: User | null): LaunchpadData {
-  const [state, setState] = useState<LaunchpadData>({ ...EMPTY, loading: true })
+  const [state, setState] = useState<LaunchpadDataState>({ ...EMPTY, loading: true })
+  // Bumped to force a re-read (e.g. after the user saves their profile) — the live
+  // read is otherwise keyed on the stable identity and won't refetch on a mutation.
+  const [refreshNonce, setRefreshNonce] = useState(0)
+  const refresh = useCallback(() => setRefreshNonce((n) => n + 1), [])
 
   useEffect(() => {
     let cancelled = false
@@ -138,12 +147,13 @@ export function useLaunchpadData(user: User | null): LaunchpadData {
     return () => {
       cancelled = true
     }
-    // Re-run only when the authenticated identity changes, not on every store
-    // update (the persisted user object changes identity on each set()).
+    // Re-run when the authenticated identity changes, or when `refresh()` is called
+    // (e.g. after a profile save) — NOT on every store update (the persisted user
+    // object changes identity on each set()).
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [user?.id])
+  }, [user?.id, refreshNonce])
 
-  return state
+  return { ...state, refresh }
 }
 
 /**


### PR DESCRIPTION
Fixes testing issue #1: after saving the display name in the Profile dialog, the launchpad greeting/menu kept showing the old name until a manual page refresh.

## Cause
`useLaunchpadData` is keyed on the stable identity (`user.id`) and does not refetch on a mutation, so a profile save didn't update the rendered name.

## Fix (launchpad-only)
- `useLaunchpadData` now exposes `refresh()` (a nonce bump that re-runs the live profile/entitlement read).
- On `ProfileForm` save, the launchpad **optimistically** applies the returned `displayName` (instant greeting/menu update) **and** calls `data.refresh()` to reconcile with the server.

No contract change; no cross-app change. (SA/BT showing the token name rather than the edited displayName is a separate architecture seam — tracked under approach A / its own PR.)

## v0 freshness

- [x] No v0 impact

Reason: Runtime-only behaviour fix (refetch-after-save) on the launchpad home view. No contract, data, API, WSS, cache, or mock shape change; reproduces the expected v0 behaviour of a save taking effect immediately.

## Validation
Typecheck ✓ · lint ✓ (changed files clean). Behavioural verify on dev after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)