### PR TITLE
feat(auth): project control-plane displayName as the token name (#501)

### DIFF
--- a/apps/launchpad/functions/pre-token-generation/src/index.test.ts
+++ b/apps/launchpad/functions/pre-token-generation/src/index.test.ts
@@ -102,4 +102,18 @@ describe('membershipUserId — table key is the sub, not the Username (#486)', (
   it('falls back to userName when sub is somehow absent (defensive)', () => {
     expect(membershipUserId({ userName: 'u-1', request: { userAttributes: {} } })).toBe('u-1');
   });
+
+  it('#501: the display_name projection reads launchpad-users by this SAME sub key', () => {
+    // The pre-token trigger reads the control-plane displayName via
+    // fetchDisplayName(membershipUserId(event)) — the same sub-keyed id as the
+    // membership query. So a FEDERATED user's projected name comes from THEIR row
+    // (keyed on the sub written at #496), not the provider-shaped Username. Guarding
+    // this here keeps the #486 federated-keying guarantee covering #501 too.
+    const federated = {
+      userName: 'Microsoft_AAAAAAAAAAAAAAAAAAAAACkKgT1UYwsZ9B8QTHWoWIk',
+      request: { userAttributes: { sub: '293ed468-4091-7006-b2e3-1f88cdc9df73', email: 'x@y.com' } },
+    };
+    expect(membershipUserId(federated)).toBe('293ed468-4091-7006-b2e3-1f88cdc9df73');
+    expect(membershipUserId(federated)).not.toBe(federated.userName);
+  });
 });

--- a/apps/launchpad/functions/pre-token-generation/src/index.ts
+++ b/apps/launchpad/functions/pre-token-generation/src/index.ts
@@ -4,13 +4,14 @@ import {
   CognitoIdentityProviderClient,
 } from '@aws-sdk/client-cognito-identity-provider';
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
-import { BatchGetCommand, DynamoDBDocumentClient, QueryCommand } from '@aws-sdk/lib-dynamodb';
+import { BatchGetCommand, DynamoDBDocumentClient, GetCommand, QueryCommand } from '@aws-sdk/lib-dynamodb';
 
 const cognito = new CognitoIdentityProviderClient({});
 const ddb = DynamoDBDocumentClient.from(new DynamoDBClient({}));
 
 const ACCOUNT_MEMBERS_TABLE = process.env.ACCOUNT_MEMBERS_TABLE!;
 const ACCOUNTS_TABLE = process.env.ACCOUNTS_TABLE!;
+const USERS_TABLE = process.env.USERS_TABLE!;
 
 interface AppEntry {
   slug: string;
@@ -50,6 +51,31 @@ export function membershipUserId(
 interface AccountRow {
   accountId: string;
   appSlug: string;
+}
+
+/**
+ * The user's EXPLICITLY-set control-plane display name, or `undefined` (#501).
+ *
+ * Projected into the token's `display_name` claim so a name set on the Profile screen
+ * is the source of truth shown across every app (all read `user.name` from the token
+ * via `composeDisplayName`). Keyed on the `sub` (`userId`) — correct for native AND
+ * federated users (the row is written keyed on the sub; #496). When absent, no claim
+ * is added and the auth client falls back to the IdP name (#494 chain) — so this
+ * never overrides a user who has not set a name. Read failures fail OPEN (no claim).
+ */
+async function fetchDisplayName(userId: string): Promise<string | undefined> {
+  try {
+    const res = await ddb.send(new GetCommand({
+      TableName: USERS_TABLE,
+      Key: { userId },
+      ProjectionExpression: 'displayName',
+    }));
+    const displayName = (res.Item?.['displayName'] as string | undefined)?.trim();
+    return displayName || undefined;
+  } catch (err) {
+    console.error('[launchpad-pre-token] displayName read failed (omitting claim):', err);
+    return undefined;
+  }
 }
 
 async function queryMemberships(userId: string): Promise<MembershipRow[]> {
@@ -209,7 +235,10 @@ export const handler = async (
 
     console.log('[launchpad-pre-token] username:', cognitoUsername, 'sub:', subject, 'groups:', currentGroups.join(','));
 
-    const memberships = await queryMemberships(subject);
+    const [memberships, displayName] = await Promise.all([
+      queryMemberships(subject),
+      fetchDisplayName(subject), // #501 — the control-plane display name, projected below
+    ]);
 
     // Resolve appSlug for legacy membership rows that predate D3 denormalization
     const missingAppSlugIds = memberships
@@ -237,6 +266,9 @@ export const handler = async (
     const claims: Record<string, string> = {
       apps: JSON.stringify(buildAppsList(reconciledGroups)),
       accounts: JSON.stringify(accountsByApp),
+      // #501 — project the control-plane display name as the authoritative token name.
+      // Omitted when unset, so the auth client falls back to the IdP name (#494 chain).
+      ...(displayName ? { display_name: displayName } : {}),
     };
 
     console.log('[launchpad-pre-token] claims apps:', claims['apps']);

--- a/apps/launchpad/infrastructure/launchpad-auth-stack.ts
+++ b/apps/launchpad/infrastructure/launchpad-auth-stack.ts
@@ -444,6 +444,7 @@ export class LaunchpadAuthStack extends cdk.Stack {
       environment: {
         ACCOUNT_MEMBERS_TABLE: this.accountMembersTable.tableName,
         ACCOUNTS_TABLE: this.accountsTable.tableName,
+        USERS_TABLE: this.usersTable.tableName,
         APP_REGISTRY: appRegistryJson,
       },
       bundling: {
@@ -456,6 +457,9 @@ export class LaunchpadAuthStack extends cdk.Stack {
 
     this.accountMembersTable.grantReadData(preTokenFn);
     this.accountsTable.grantReadData(preTokenFn);
+    // #501 — project the control-plane display name into the token's `display_name`
+    // claim so a name set in Profile shows across every app. Read-only on the users table.
+    this.usersTable.grantReadData(preTokenFn);
     // M11 groups-authoritative: the pre-token trigger no longer reads the
     // app-admin-grants table — app-admin status travels in `cognito:groups`
     // (`{app}-app-admin`), not the struck `app_admin` claim. The grants table

--- a/docs/architecture/auth.md
+++ b/docs/architecture/auth.md
@@ -80,7 +80,7 @@ claims. There is no `site_admin` claim and no `app_admin` claim.)
 
 | Trigger | Function | Purpose |
 |---|---|---|
-| Pre-token generation | `launchpad-pre-token-generation-{stage}` | Injects `apps`, `accounts` custom claims - see below |
+| Pre-token generation | `launchpad-pre-token-generation-{stage}` | Injects `apps`, `accounts`, and `display_name` (#501) custom claims - see below |
 
 ---
 
@@ -189,19 +189,27 @@ correct first name. The `ProviderName` values are deliberately
 (`apps/launchpad/lib/redemption/seam.ts`) resolves the `identities` claim to the
 contract `IdpProvider`.
 
-**Display name from claims (#494).** The auth client composes `User.name` from the
-ID-token claims as `given + family → OIDC name claim → given alone → email LOCAL
-part` — **never the full email** (`composeDisplayName`,
+**Display name from claims (#494/#501).** The auth client composes `User.name` from the
+ID-token claims as `control-plane displayName → given + family → OIDC name claim →
+given alone → email LOCAL part` — **never the full email** (`composeDisplayName`,
 `packages/auth-client/src/display.ts`). The earlier composition fell back to the
 full email, which the app sidebars then rendered whole (they take
 `name.split(' ')[0]`, and an email has no space). Apps derive the first name and
-initials via the shared `userFirstName`/`userInitials` helpers. The Launchpad home
-view additionally prefers an **explicitly user-set** control-plane `displayName`:
-the `user` Lambda (`GET /api/user/profile`) now omits `displayName` unless the user
-set one (the contract field is optional), so an unset name falls through to the
-token name rather than the email-derived value. A name set via
-`PUT /api/user/preferences` is still stored and wins. Per-app duplication of the
-first-name/initials derivation is unified under #491.
+initials via the shared `userFirstName`/`userInitials` helpers.
+
+**Name projection (#501).** The user's explicitly-set name lives in the control plane
+(`launchpad-users.displayName`, edited via the Profile screen). The
+**pre-token-generation trigger projects it into the token's `display_name` claim** (read
+keyed on the `sub`, so it is correct for native *and* federated users), and
+`composeDisplayName` prefers it. This makes the control-plane displayName the single
+source of truth: the name a user sets in Profile appears in **every** app (all read
+`user.name` from the token), and it survives re-federation (projected fresh each token,
+never stored on the Cognito user). When no displayName is set the claim is omitted and the
+chain is exactly the #494 order — nothing changes for users who have not set a name.
+Cross-app it is **eventually consistent**: an app reflects a changed name on its next
+token refresh (Amplify caches ~1h); the launchpad (same session) updates immediately on
+save (#500). Per-app duplication of the first-name/initials derivation is unified under
+#491.
 
 `LaunchpadAuthStack` creates Launchpad-owned secret paths under
 `/launchpad/{stage}/cognito/*`; each IdP reads its client-id/secret from these via

--- a/docs/architecture/cdk.md
+++ b/docs/architecture/cdk.md
@@ -154,7 +154,7 @@ Launchpad control-plane and auth-domain variables:
 
 | Variable | Lambda | Value |
 |---|---|---|
-| `USERS_TABLE` | `launchpad-user-{stage}` | `launchpad-users-{stage}` |
+| `USERS_TABLE` | `launchpad-user-{stage}`, `launchpad-account-provisioning-{stage}`, `launchpad-invitation-redemption-{stage}`, `launchpad-pre-token-generation-{stage}` (#501, read-only) | `launchpad-users-{stage}` |
 | `ACCOUNTS_TABLE` | Launchpad account-provisioning, accounts, invitations, pre-token generation | `launchpad-accounts-{stage}` |
 | `ACCOUNT_MEMBERS_TABLE` | Launchpad account-provisioning, accounts, pre-token generation | `launchpad-account-members-{stage}` |
 | `INVITATIONS_TABLE` | `launchpad-invitations-{stage}` | `launchpad-invitations-{stage}` |

--- a/docs/architecture/data.md
+++ b/docs/architecture/data.md
@@ -63,7 +63,7 @@ User profile and preferences keyed by Cognito `sub`.
 | `userId` (PK) | String | Cognito `sub` |
 | `email` | String | User email (original case) |
 | `emailLower` | String | Lowercase email — used by `email-index` GSI for redemption lookup (M16 D4) |
-| `displayName` | String (optional) | Human-friendly name. Present only when the IdP supplied a real given/family name **or** the user set one explicitly (#494/#496); **omitted at bootstrap** (no email fallback at write time). Source of truth; never denormalized onto membership rows (D6). |
+| `displayName` | String (optional) | Human-friendly name. Present only when the IdP supplied a real given/family name **or** the user set one explicitly (#494/#496); **omitted at bootstrap** (no email fallback at write time). **Source of truth for the user's name — the pre-token-generation trigger projects it into the token's `display_name` claim (#501), keyed on the `sub`, so the name a user sets in Profile shows across every app.** Never denormalized onto membership rows (D6). |
 | `profileComplete` | Boolean | False until user completes first-time profile setup |
 | `status` | String | `active \| disabled`. Absent means `active` (backwards compatibility). |
 | `preferences` | Map | `{ notificationsEnabled: boolean }` |

--- a/docs/architecture/inventory.md
+++ b/docs/architecture/inventory.md
@@ -72,7 +72,10 @@ held memberships + groups but had no user row and were invisible in the director
 a one-off `scripts/ops/backfill-user-rows-496.mjs` addresses the pre-#496 orphans.
 
 The pre-token trigger emits the `apps` and `accounts` claims consumed by
-Launchpad, Stock Analyser, Budget Tracker, and migration utilities.
+Launchpad, Stock Analyser, Budget Tracker, and migration utilities. It also
+projects the control-plane `launchpad-users.displayName` into the `display_name`
+claim (#501), so the name a user sets in Profile is the source of truth shown
+across every app (the auth client's `composeDisplayName` prefers it).
 Platform admin status is NOT a claim — it is read from the `site-admin` Cognito
 group (`cognito:groups`); the `site_admin` claim was removed in M16 Phase 6
 (v0 contract `m16.2.0` / D11).

--- a/packages/auth-client/src/cognito-auth.ts
+++ b/packages/auth-client/src/cognito-auth.ts
@@ -51,6 +51,10 @@ export class CognitoAuthService implements AuthService {
       // the next-best full name so federated users without given/family still show a
       // real name (and a correct first name once split) rather than the email.
       const nameClaim  = (claims['name'] as string | undefined)?.trim() || undefined
+      // The user's EXPLICITLY-set display name, projected from the control-plane
+      // `launchpad-users.displayName` into this token claim by the pre-token trigger
+      // (#501). Authoritative — the name set in Profile shows in every app.
+      const displayName = (claims['display_name'] as string | undefined)?.trim() || undefined
       // M16 Phase 6 (D11): platform admin status comes from the `site-admin`
       // Cognito group. The earlier `site_admin` token claim was an unintended
       // projection of the same group and has been removed — the frontend now
@@ -66,8 +70,8 @@ export class CognitoAuthService implements AuthService {
       // M11 groups-authoritative: apps the user may ENTER come from the
       // `{app}-app-access` groups (the launchpad gate keys on this, not membership).
       const appAccess  = deriveAppAccess(groups as CognitoGroup[])
-      // Name source order (#494) — NEVER the full email; see composeDisplayName.
-      const name       = composeDisplayName({ givenName, familyName, nameClaim, email })
+      // Name source order (#494/#501) — NEVER the full email; see composeDisplayName.
+      const name       = composeDisplayName({ displayName, givenName, familyName, nameClaim, email })
       return { id: cognitoUser.userId, email, name, metadata: { siteAdmin, appAdmin, appAccess } }
     } catch {
       return null

--- a/packages/auth-client/src/display.test.ts
+++ b/packages/auth-client/src/display.test.ts
@@ -36,6 +36,27 @@ describe('composeDisplayName — token claims → User.name (#494)', () => {
   })
 })
 
+describe('composeDisplayName — control-plane displayName projection (#501)', () => {
+  it('the projected displayName WINS over given+family (the name set in Profile)', () => {
+    expect(
+      composeDisplayName({ displayName: 'Hotty Mail', givenName: 'Steve', familyName: 'Moodie', email: 'x@y.com' }),
+    ).toBe('Hotty Mail')
+  })
+
+  it('wins over the OIDC `name` claim too (federated user who set a name)', () => {
+    expect(
+      composeDisplayName({ displayName: 'Hotty Mail', nameClaim: 'Steve Moodie', email: 'stevemoodie@hotmail.com' }),
+    ).toBe('Hotty Mail')
+  })
+
+  it('absent/whitespace displayName → the #494 chain is UNCHANGED', () => {
+    // The whole point: not setting a name leaves every other user exactly as before.
+    expect(composeDisplayName({ givenName: 'Steve', familyName: 'Moodie', email: 'x@y.com' })).toBe('Steve Moodie')
+    expect(composeDisplayName({ displayName: '   ', nameClaim: 'Steve Moodie', email: 'x@y.com' })).toBe('Steve Moodie')
+    expect(composeDisplayName({ displayName: undefined, email: 'stevemoodie70@gmail.com' })).toBe('stevemoodie70')
+  })
+})
+
 describe('userFirstName / userInitials (#494)', () => {
   it('first name is the first whitespace token', () => {
     expect(userFirstName({ name: 'Steve Moodie' })).toBe('Steve')

--- a/packages/auth-client/src/display.ts
+++ b/packages/auth-client/src/display.ts
@@ -14,22 +14,31 @@
 type NamedUser = { name?: string | null }
 
 /**
- * Compose the `User.name` from ID-token claims (#494). The result is NEVER the full
- * email — a sidebar that renders `name.split(' ')[0]` on a full address showed the
+ * Compose the `User.name` from ID-token claims (#494, #501). The result is NEVER the
+ * full email — a sidebar that renders `name.split(' ')[0]` on a full address showed the
  * whole email; the email LOCAL part is the only email-derived fallback. Order:
  *
- *   given + family → OIDC `name` claim → given alone → email local part → email
+ *   control-plane displayName → given + family → OIDC `name` claim → given alone
+ *     → email local part → email
  *
- * The `name` claim sits above `given` alone because IdPs that map only `name`
- * (Microsoft, Facebook before #494's mapping change) still yield a real full name,
- * and splitting it gives a correct first name.
+ * `displayName` is the user's EXPLICITLY-set name, projected into the token's
+ * `display_name` claim by the pre-token-generation trigger from the control-plane
+ * `launchpad-users.displayName` (#501). It is the source of truth and wins, so the
+ * name a user sets in Profile appears in EVERY app (all read `user.name` from the
+ * token). When it is absent the rest of the chain is exactly the #494 order — so
+ * nothing changes for users who have not set a displayName. The `name` claim sits
+ * above `given` alone because IdPs that map only `name` (Microsoft, Facebook before
+ * #494's mapping change) still yield a real full name, split to a correct first name.
  */
 export function composeDisplayName(claims: {
+  displayName?: string | null
   givenName?: string | null
   familyName?: string | null
   nameClaim?: string | null
   email?: string | null
 }): string {
+  const displayName = claims.displayName?.trim() || undefined
+  if (displayName) return displayName // control-plane source of truth (#501)
   const given = claims.givenName?.trim() || undefined
   const family = claims.familyName?.trim() || undefined
   const nameClaim = claims.nameClaim?.trim() || undefined


### PR DESCRIPTION
Closes #501.

## Problem
A user's edited **display name** lives only in the control plane (`launchpad-users.displayName`, edited in Profile), but **Stock Analyser / Budget Tracker render the token `given_name`** (`user.name` = `composeDisplayName`). The two were disconnected — the name you set in Profile never reached SA/BT.

## Fix — approach A (pre-token projection)
The **pre-token-generation trigger projects the control-plane displayName into the token's `display_name` claim**; `composeDisplayName` prefers it. The control-plane displayName becomes the single source of truth: the name set in Profile shows in **every** app (all read `user.name` from the token), and survives re-federation (projected fresh each token, never stored on the Cognito user — it also obsoletes any directly-set `given_name` sentinel).

### Load-bearing care (this is the pre-token trigger — #486/#473 lived here)
- **#494 precedence preserved.** New order: `displayName → given+family → name-claim → given → email LOCAL part`. The chain below the new top entry is **unchanged** — nothing changes for users who haven't set a displayName (claim omitted ⟹ exact #494 behaviour). Covered by tests.
- **Native + federated.** The displayName is read keyed on the **sub** (`membershipUserId`) — the same #486 federated-keying path that the membership query uses — so a federated user's projected name comes from their own row, not the provider-shaped Username. Read failures **fail open** (no claim). Added a federated-shaped test.
- No app code changed — apps keep reading `user.name`.

## Caveat (documented, by design)
Cross-app it is **eventually consistent**: an app reflects a changed name on its **next token refresh** (Amplify caches ~1h). The launchpad updates immediately on save (#500). We deliberately do **not** force-refresh every app load just for names (perf cost).

## Changes
- `composeDisplayName` (`packages/auth-client`): new top-priority `displayName` source + tests.
- `cognito-auth`: reads the `display_name` claim → `user.name`.
- Pre-token trigger: `fetchDisplayName(sub)` → projects `display_name` claim (omitted when unset) + federated test.
- CDK (`launchpad-auth-stack`): `USERS_TABLE` env + **read-only** grant on the users table to the pre-token Lambda.
- Docs (§2.1): auth.md (name projection + pre-token claims), data.md, inventory.md, cdk.md.

## Deploy footprint — 3 lanes
auth-client change → **launchpad + stock-analyser + budget-tracker**; the pre-token + CDK change rides the **launchpad** lane (LaunchpadAuth stack — the pre-token Lambda + its new grant).

## Validation
auth-client tests (32) · pre-token tests (10) · typecheck (3 apps + auth-client + pre-token + root `infrastructure/`) · lint — all green. Behavioural verify on dev after deploy: set a name in Profile, confirm LP (instant via #500) + SA/BT (after token refresh) show it; native + federated.

## v0 freshness

- [x] No v0 impact

Reason: Runtime token-projection mechanism. No contract/mock/UI shape change — apps consume `user.name` (unchanged); the `display_name` claim is an internal token projection read only by the shared auth client. This makes the REAL runtime match v0's existing mock semantic (where the control-plane displayName already drives the name everywhere).

## Note on the auth.md mirror
This edits `docs/architecture/auth.md`; on merge the Auth Model Mirror Sync runs (the #494/#496 edits in this same section were outside the mirrored block → "nothing to open"; expect the same here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)