### PR TITLE
fix(stock-analyser): show the real user's name in the sidebar, not a placeholder (#501)

### DIFF
--- a/apps/stock-analyser/components/stock-analyser/app-shell.tsx
+++ b/apps/stock-analyser/components/stock-analyser/app-shell.tsx
@@ -25,6 +25,7 @@ import {
 import { ConfirmationModal } from "@transformotion/ui-primitives"
 import { userFirstName, userInitials } from "@transformotion/auth-client"
 import { useActiveAccountStore } from "@/stores/active-account/use-active-account-store"
+import { useAuthStore, selectUser } from "@/stores/auth/use-auth-store"
 
 // ============================================================================
 // TYPES
@@ -166,6 +167,10 @@ export function NavigationProvider({
   // and active selection come from the store, not hard-coded placeholders.
   const storeAccounts = useActiveAccountStore(s => s.accounts)
   const storeActiveId = useActiveAccountStore(s => s.activeAccountId)
+  // The authenticated identity — its `name` is the auth client's resolved display
+  // name (control-plane displayName projected into the token, #501/#494), so the
+  // sidebar shows the user's real/chosen name instead of the DEFAULT_USER placeholder.
+  const authUser = useAuthStore(selectUser)
   const storeSwitchTo = useActiveAccountStore(s => s.switchTo)
 
   const navigateTo = useCallback((tab: TabId) => {
@@ -303,10 +308,14 @@ export function NavigationProvider({
     return state.tabCache[tab] ?? null
   }, [state.tabCache])
 
-  // Override the placeholder user accounts with the live control-plane set.
-  // (Display name/email enrichment is a follow-up; the selector shows account ids.)
+  // Override the placeholder user with the live identity + control-plane account set.
+  // name/email come from the authenticated user (auth client's resolved display name
+  // — control-plane displayName via the token, #501); DEFAULT_USER is only a
+  // pre-hydration fallback. accounts/activeAccountId come from the active-account store.
   const user: User = {
     ...state.user,
+    name: authUser?.name ?? state.user.name,
+    email: authUser?.email ?? state.user.email,
     accounts: storeAccounts.map(a => ({ id: a.accountId, name: a.name ?? a.accountId, type: 'Personal' as const })),
     activeAccountId: storeActiveId ?? '',
   }


### PR DESCRIPTION
Completes #501 for **Stock Analyser**. After #502 (pre-token `display_name` projection), Budget Tracker correctly showed the user's chosen name but **SA still showed "Steve"** — even though the token carried `display_name: "Hotty Male"` and SA's deployed bundle has the #502 auth-client.

## Root cause (verified on dev)
- The token is correct (`display_name` present on every app-client token).
- SA's deployed bundle **does** contain the #502 auth-client (confirmed by grepping the live JS — earlier "missing" was my own basePath grep error).
- But SA's `NavigationProvider` built its `user` from the hardcoded **`DEFAULT_USER`** (`name: "Steve Moodie"`, `email: steve@example.com`) and only overrode `accounts`/`activeAccountId` — **`name`/`email` were never wired to the authenticated user** (a flagged "Display name/email enrichment is a follow-up"). So the sidebar always rendered "Steve", and **neither #494 nor #501 ever reached it**. Budget Tracker reads the real `useAuthStore` user directly, which is why BT showed the projected name and SA didn't. Classic #491-class per-app divergence.

## Fix (SA lane only)
Source the navigation `user.name`/`user.email` from the auth store's user (`useAuthStore(selectUser)`) — whose `name` is the auth client's resolved display name (the control-plane displayName projected into the token, #501). `DEFAULT_USER` remains only a pre-hydration fallback. `accounts`/`activeAccountId` unchanged.

## Validation
Typecheck ✓ · lint ✓ (app-shell clean; remaining SA lint errors are pre-existing baseline in tab files). Behavioural verify on dev after deploy: federated (Microsoft) + native users see their resolved name in the SA sidebar.

## v0 freshness

- [x] No v0 impact

Reason: Runtime-only data-source fix — the SA sidebar now reads the authenticated user's resolved name instead of a placeholder constant. No contract, data, API, WSS, cache, or mock shape change; no UI/layout change. Brings SA in line with the v0 intent (the signed-in user's name in the sidebar).

🤖 Generated with [Claude Code](https://claude.com/claude-code)