### PR TITLE
ci(verify-deploy): make the SA smoke a true signal — require a real membership (#470)

### DIFF
--- a/scripts/ci/verify-deploy.sh
+++ b/scripts/ci/verify-deploy.sh
@@ -270,9 +270,12 @@ const payload = token.split('.')[1] ?? '';
 try {
   const claims = JSON.parse(Buffer.from(payload, 'base64url').toString('utf8'));
   const accounts = claims.accounts ? JSON.parse(claims.accounts) : {};
-  const accountId = accounts?.[app]?.[0]?.accountId
-    ?? (claims.site_admin === 'true' ? claims.sub : '')
-    ?? '';
+  // Account-scoped routes require a REAL account membership: there is no
+  // site-admin data bypass (D9), so X-Account-Id MUST come from the caller's
+  // own `accounts` claim. The former `site_admin` fallback was removed — the
+  // `site_admin` token claim was struck in m16.2.0, and even if present, using
+  // `sub` as X-Account-Id would be denied by `requireAccountData`. (#470)
+  const accountId = accounts?.[app]?.[0]?.accountId ?? '';
   process.stdout.write(accountId);
 } catch {
   process.stdout.write('');
@@ -284,9 +287,10 @@ NODE
 
 FAIL: could not derive X-Account-Id for app '$EXPECTED_APP' from the smoke-test token.
 
-The authenticated smoke check calls an account-scoped API route. The CI user
-must have either an accounts claim containing an account for '$EXPECTED_APP',
-or the site_admin claim.
+The authenticated smoke check calls an account-scoped API route, which requires a
+real account membership (there is no site-admin data bypass — D9). The CI user
+must hold an account for '$EXPECTED_APP' (its 'accounts' claim must contain one).
+Provision a smoke account + membership for the CI user in that app.
 
 EOF
       exit 1


### PR DESCRIPTION
Part of the #470 fix (the CI-only piece; the substantive fix was a live-data change, see below).

## What #470 actually was
The SA deploy smoke ([5/5], account-scoped `/portfolio`) derives `X-Account-Id` from the token's `accounts` claim for `stock-analyser`. The CI smoke user's only SA-candidate account was **`03d2eb72` ("Cutover Smoke")** — the **#146 legacy account missing `appSlug`**. The pre-token trigger drops appSlug-less accounts (D9 fail-closed), so the CI user's token had no `stock-analyser` entry → couldn't derive `X-Account-Id` → **red on every deploy**. BT passed because its account resolves `appSlug=budget-tracker`.

## This PR (CI hygiene)
`verify-deploy.sh` had a dead/wrong derivation fallback: `claims.site_admin === 'true' ? claims.sub`. The `site_admin` claim was struck in **m16.2.0** (never fires), and even if it did, `sub`-as-`X-Account-Id` would be **denied by `requireAccountData`** (no site-admin data bypass, D9). Removed it; an account-scoped smoke requires a real membership. Failure message clarified accordingly.

## Substantive fix (applied as live data, owner-approved)
Repurposed the clean-orphan account `03d2eb72` (one member = the CI user, zero app data, zero refs) → set `appSlug=stock-analyser` on the account + membership rows, renamed to "CI Smoke - Stock Analyser". This **resolves #146's residual row** AND gives the CI user a real SA account. **Verified TRUE green** by re-running the SA deploy:
```
[5/5] Token acquired → Derived X-Account-Id for stock-analyser → /portfolio → HTTP 200
```
A genuine SA failure (API/route/auth down) still reds — it actually exercises the route.

## Durability note (seed)
No recurring seed provisions the CI smoke account — it was a one-off m9-386 cutover artifact. `seed-dev-personas.mjs` is the **v0 persona set** (wrong home for a CI fixture), and `seed-auth-domain-dev.mjs` is a **live-copy reseed** (copies the now-corrected account as-is). So the live fix is durable via the documented reseed; no seed code change is required. (A dedicated `seed-ci-smoke` could be added for from-scratch-rebuild reproducibility if desired — flagged for owner.)

## v0 freshness

- [x] No v0 impact

Reason: CI-only change to a post-deploy verification script (`scripts/ci/verify-deploy.sh`). No app code, contract, data shape, or UI change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)