### PR TITLE
M18: correct Launchpad admin visual parity

### DIFF
--- a/apps/launchpad/components/launchpad/admin/admin-shell.tsx
+++ b/apps/launchpad/components/launchpad/admin/admin-shell.tsx
@@ -1,6 +1,8 @@
 'use client'
 
 import type { ReactNode } from 'react'
+import { useEffect, useState } from 'react'
+import { useTheme } from 'next-themes'
 import { usePathname, useRouter } from 'next/navigation'
 import {
   Users,
@@ -149,6 +151,12 @@ export function AdminShell({
   const router = useRouter()
   const pathname = usePathname()
   const viewer = useAdminViewer()
+  const { resolvedTheme } = useTheme()
+  const [mounted, setMounted] = useState(false)
+
+  useEffect(() => setMounted(true), [])
+
+  const isDark = mounted && resolvedTheme === 'dark'
 
   // Pre-resolution / SSR: render a neutral frame, never privileged content.
   if (!viewer) {
@@ -168,11 +176,63 @@ export function AdminShell({
     (canUseInviteSurfaces(viewer) &&
       INVITE_SURFACE_ROUTES.some((route) => pathname.startsWith(route)))
   const navItems = ADMIN_NAV.filter((item) => item.visible(viewer))
+  const railBg = isDark ? 'bg-card border-r border-border' : 'bg-brand-navy'
+  const railMuted = isDark ? 'text-muted-foreground' : 'text-brand-navy-foreground/60'
+  const railPanel = isDark ? 'bg-surface2 ring-border' : 'bg-white/5 ring-white/10'
+  const railIdle = isDark
+    ? 'text-muted-foreground hover:bg-surface2 hover:text-foreground'
+    : 'text-brand-navy-foreground/80 hover:bg-white/10 hover:text-brand-navy-foreground'
 
   return (
-    <div className="min-h-screen bg-background flex flex-col">
+    <div className="min-h-screen bg-background flex">
+      {allowed && (
+        <nav
+          className={cn('hidden md:flex md:w-64 md:shrink-0 md:flex-col', railBg)}
+          aria-label="Admin sections"
+        >
+          <div className="sticky top-0 flex max-h-screen flex-col gap-4 overflow-y-auto p-4">
+            <div className="px-1 pt-1">
+              <BrandLogo
+                surface="navy"
+                className="flex w-full"
+                imgClassName="h-auto w-full max-w-none"
+              />
+            </div>
+
+            <div className={cn('rounded-xl p-3 ring-1', railPanel)}>
+              <p className={cn('mb-2 text-[10px] font-semibold uppercase tracking-wider', railMuted)}>
+                Signed in as
+              </p>
+              <RoleBadges viewer={viewer} />
+            </div>
+
+            <ul className="flex flex-col gap-1">
+              {navItems.map((item) => {
+                const Icon = item.icon
+                const active = pathname === item.href
+                return (
+                  <li key={item.href} className="min-w-0">
+                    <button
+                      onClick={() => router.push(preserveQuery(item.href))}
+                      className={cn(
+                        'flex w-full items-center gap-2 rounded-lg px-3 py-2 text-sm font-medium transition-colors',
+                        active ? 'bg-brand-teal text-brand-teal-foreground' : railIdle,
+                      )}
+                    >
+                      <Icon className="size-4 shrink-0" />
+                      <span className="truncate">{item.label}</span>
+                    </button>
+                  </li>
+                )
+              })}
+            </ul>
+          </div>
+        </nav>
+      )}
+
+      <div className="flex min-w-0 flex-1 flex-col">
       <header className="sticky top-0 z-40 border-b border-border bg-background/95 backdrop-blur-sm">
-        <div className="mx-auto flex max-w-6xl items-center justify-between gap-3 px-4 py-3 md:px-6">
+        <div className="flex items-center justify-between gap-3 px-4 py-3 md:px-6">
           <div className="flex items-center gap-2 min-w-0 sm:gap-3">
             <button
               onClick={() => router.push(preserveQuery('/launchpad'))}
@@ -182,9 +242,6 @@ export function AdminShell({
               <ArrowLeft className="size-4 shrink-0" />
               <span>Launchpad</span>
             </button>
-            <div className="hidden md:flex md:items-center">
-              <BrandLogo surface="page" imgClassName="h-6 w-auto" />
-            </div>
             <span className="rounded-md bg-surface2 px-2 py-1 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
               Admin
             </span>
@@ -225,46 +282,15 @@ export function AdminShell({
           />
         </main>
       ) : (
-        <main className="mx-auto flex w-full max-w-6xl flex-1 flex-col gap-6 px-4 py-6 md:flex-row md:px-6">
-          {/* Sidebar nav */}
-          <nav className="md:w-56 md:shrink-0" aria-label="Admin sections">
-            <div className="mb-4 rounded-xl border border-border bg-card p-3">
-              <p className="mb-2 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
-                Signed in as
-              </p>
-              <RoleBadges viewer={viewer} />
-            </div>
-            <ul className="grid grid-cols-2 gap-2 sm:grid-cols-3 md:flex md:flex-col md:gap-0.5">
-              {navItems.map((item) => {
-                const Icon = item.icon
-                const active = pathname === item.href
-                return (
-                  <li key={item.href} className="min-w-0">
-                    <button
-                      onClick={() => router.push(preserveQuery(item.href))}
-                      className={cn(
-                        'flex w-full items-center gap-2 rounded-lg px-3 py-2 text-sm font-medium transition-colors',
-                        active
-                          ? 'bg-primary/10 text-primary'
-                          : 'text-muted-foreground hover:bg-surface2 hover:text-foreground',
-                      )}
-                    >
-                      <Icon className="size-4 shrink-0" />
-                      <span className="truncate">{item.label}</span>
-                      {!item.ready && (
-                        <span className="ml-auto hidden rounded bg-surface2 px-1.5 py-0.5 text-[9px] uppercase tracking-wider text-muted-foreground md:inline">
-                          Soon
-                        </span>
-                      )}
-                    </button>
-                  </li>
-                )
-              })}
-            </ul>
-          </nav>
+        <main className="flex-1 px-4 py-6 pb-24 md:px-6 md:pb-6">
+          <div className="mb-6 flex flex-wrap items-center gap-2 md:hidden">
+            <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+              Signed in as
+            </span>
+            <RoleBadges viewer={viewer} />
+          </div>
 
-          {/* Content */}
-          <section className="min-w-0 flex-1">
+          <section className="min-w-0">
             <div className="mb-5">
               <h1 className="font-display text-xl font-semibold uppercase tracking-wide text-foreground">{title}</h1>
               <p className="text-xs text-muted-foreground">{subtitle}</p>
@@ -273,6 +299,42 @@ export function AdminShell({
           </section>
         </main>
       )}
+      {allowed && (
+        <nav
+          className={cn(
+            'fixed inset-x-0 bottom-0 z-50 md:hidden',
+            isDark
+              ? 'bg-slate-50 text-brand-navy border-t border-border'
+              : 'bg-brand-navy text-brand-navy-foreground',
+          )}
+          aria-label="Admin sections"
+        >
+          <div className="flex items-stretch justify-around">
+            {navItems.map((item) => {
+              const Icon = item.icon
+              const active = pathname === item.href
+              return (
+                <button
+                  key={item.href}
+                  onClick={() => router.push(preserveQuery(item.href))}
+                  className={cn(
+                    'flex flex-1 flex-col items-center justify-center gap-0.5 py-2.5 transition-colors',
+                    active
+                      ? 'text-brand-teal'
+                      : isDark
+                        ? 'text-brand-navy/60'
+                        : 'text-brand-navy-foreground/70',
+                  )}
+                >
+                  <Icon className="size-5" />
+                  <span className="text-[10px] font-medium leading-tight text-center">{item.label}</span>
+                </button>
+              )
+            })}
+          </div>
+        </nav>
+      )}
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary

Follow-up correction for the #506 Launchpad runtime adoption visual parity failure. This PR only corrects the Launchpad Admin shell to match the approved M18 v0 design-of-record more closely.

- Replaces the prior centered/admin-sidebar runtime layout with the approved full-height desktop rail treatment.
- Uses the prominent real Transformotion logo in the rail.
- Applies light-mode navy rail, dark-mode card/slate rail treatment, teal active item styling, and approved spacing/hierarchy.
- Adds the v0-style mobile bottom admin navigation.
- Preserves existing admin nav items, route targets, authorization checks, viewer logic, and `preserveQuery` navigation behavior.

No Stock Analyser #507 work, Budget Tracker #508 work, Cognito/email changes, routes, auth/session/claim shapes, data/API contracts, persistence behavior, dashboards, deployments, or GitHub issue/project state changes are included.

## Scope notes

This is a separate Launchpad correction PR because #506 had already merged before the owner visual validation failure was identified. It is UI-affecting but limited to `apps/launchpad/components/launchpad/admin/admin-shell.tsx`.

Runtime seam note: local runtime admin users data still depends on the existing control-plane API configuration. In local mock/dev, the admin users screen can show the existing empty state while v0 shows seeded representative users. This PR does not alter API configuration, control-plane data, auth, or contracts.

## v0 freshness

This PR is UI-affecting and is based on the approved `brand-system-foundation` v0 design-of-record:

- https://github.com/stevemoodie/transformotion-apps-b8/commit/6033c3f
- https://github.com/stevemoodie/transformotion-apps-b8/commit/601aac8
- https://github.com/stevemoodie/transformotion-apps-b8/commit/6a2a3399097bd8693bb14853d855a8b3b252ffe9

Runtime implementation preserves existing routes, auth/session/claim shapes, data/API shapes, mocked persistence assumptions, app behavior, and app IA. v0 mock-only seeded data was not ported.

## v0 parity evidence

Artifact root: `C:\Users\steve\OneDrive\Documents\Code Repo\transformotion-apps-m18-parity-artifacts`

| Surface | Viewport | Theme | Route/persona | v0 screenshot | Runtime screenshot | Notes |
| --- | --- | --- | --- | --- | --- | --- |
| Launchpad home | 1366x900 | light default | `/launchpad`, Demo mock persona | `v0-launchpad-home-light-1366.png` | `runtime-launchpad-home-light-1366.png` | Existing merged #506 surface compared; no home changes in this correction. |
| Launchpad home | 1366x900 | dark | `/launchpad`, Demo mock persona | `v0-launchpad-home-dark-1366.png` | `runtime-launchpad-home-dark-1366.png` | Existing merged #506 surface compared; no home changes in this correction. |
| Admin users | 1366x900 | light default | `/launchpad/admin/users`, Demo/site-admin mock persona | `v0-launchpad-admin-users-light-1366.png` | `runtime-launchpad-admin-users-light-1366.png` | Admin shell corrected to full-height navy rail, prominent logo, teal active item, v0 spacing/hierarchy. Runtime data remains existing local empty/API seam. |
| Admin users | 1366x900 | dark | `/launchpad/admin/users`, Demo/site-admin mock persona | `v0-launchpad-admin-users-dark-1366.png` | `runtime-launchpad-admin-users-dark-1366.png` | Dark rail treatment corrected; runtime data seam remains unchanged. |
| Signed out | 1366x900 | light default | `/signed-out` | `v0-signed-out-light-1366.png` | `runtime-signed-out-light-1366.png` | Existing merged #506 surface compared; no signed-out changes in this correction. |
| Signed out | 1366x900 | dark | `/signed-out` | `v0-signed-out-dark-1366.png` | `runtime-signed-out-dark-1366.png` | Existing merged #506 surface compared; no signed-out changes in this correction. |
| Sign in | 1366x900 | light default | `/sign-in` | `v0-sign-in-light-1366.png` | `runtime-sign-in-light-1366.png` | Runtime mock auth redirects/auto-signs into existing sign-in flow; auth behavior unchanged. |
| Sign in | 1366x900 | dark | `/sign-in` | `v0-sign-in-dark-1366.png` | `runtime-sign-in-dark-1366.png` | Runtime mock auth seam remains; no auth behavior changed. |

Remaining acceptable differences:

- Admin users body data differs in local runtime because the control-plane API is not configured for seeded v0-style users; runtime shows the existing empty state. Shell/chrome parity is the correction here.
- `/sign-in` runtime behavior can show the existing mock auth auto-signing/sign-in state rather than the v0 static auth form. This PR does not change auth flow behavior.
- No pixel diff was produced; evidence is side-by-side screenshot artifacts plus computed-style checks.

## Computed typography evidence

Computed evidence files:

- `runtime-launchpad-admin-computed-style-evidence.json`
- `runtime-launchpad-home-computed-style-evidence.json`

Evidence:

- Admin H1 `Users & Access`: `Oswald, "Oswald Fallback", Oswald, sans-serif`.
- Launchpad app tile `Stock Signal Analyser`: `Oswald, "Oswald Fallback", Oswald, sans-serif`.
- Body text: `Inter, "Inter Fallback", Inter, "Inter Fallback", system-ui, sans-serif`.
- Admin nav item `Users & Access`: Inter.
- Logo evidence: `/images/brand/transformotion-logo-transparent.png`, `complete: true`, `naturalWidth: 2272`.

## Browser/manual verification

Local dev server used for parity pass: `http://127.0.0.1:3101/launchpad`.

Verified with headless Chrome DevTools Protocol:

- Launchpad home light and dark screenshots captured.
- Launchpad admin users light and dark screenshots captured after correction.
- `/signed-out` light and dark screenshots captured.
- `/sign-in` light and dark screenshots captured; runtime auth-flow seam documented above.
- Admin navigation placement corrected to v0-style rail on desktop and bottom nav on mobile.
- Theme behavior remains client-side `transformotion-theme`; no backend/user-settings persistence was added.
- No route/auth/session/data/contract/persistence behavior changed.

## Validation

Passed:

- `pnpm install --frozen-lockfile`
- `pnpm sync:v0`
- `pnpm --filter @transformotion/launchpad typecheck`
- `pnpm --filter @transformotion/launchpad lint`
- `pnpm --filter @transformotion/launchpad build`
- `pnpm --filter @transformotion/launchpad test`
- `node scripts/ci/lint-staged-baseline-check.mjs apps/launchpad/components/launchpad/admin/admin-shell.tsx`
- `git diff --check`
- `pnpm check:v0-freshness` with this PR body evidence
- pre-commit staged lint/typecheck hooks

## Commands run

```sh
git fetch origin develop
git worktree add -b codex/m18-launchpad-visual-parity-correction "C:\Users\steve\OneDrive\Documents\Code Repo\transformotion-apps-m18-506-parity" origin/develop
pnpm install --frozen-lockfile
pnpm sync:v0
pnpm --filter @transformotion/launchpad typecheck
pnpm --filter @transformotion/launchpad lint
pnpm --filter @transformotion/launchpad build
pnpm --filter @transformotion/launchpad test
node scripts/ci/lint-staged-baseline-check.mjs apps/launchpad/components/launchpad/admin/admin-shell.tsx
git diff --check
pnpm check:v0-freshness
git commit -m "Correct Launchpad admin visual parity"
git push -u origin codex/m18-launchpad-visual-parity-correction
```

Draft PR only. No deploy performed.