### PR TITLE
M18: align Oswald typography usage

### DIFF
--- a/apps/launchpad/components/launchpad/admin/invite-composer-view.tsx
+++ b/apps/launchpad/components/launchpad/admin/invite-composer-view.tsx
@@ -272,7 +272,7 @@ function GrantRow({
   return (
     <Card>
       <div className="mb-3 flex items-center justify-between gap-2">
-        <span className="inline-flex items-center gap-2 text-sm font-semibold text-foreground">
+        <span className="inline-flex items-center gap-2 font-display text-sm font-semibold tracking-wide text-foreground">
           <span className="flex size-6 items-center justify-center rounded-full bg-surface2 text-xs text-muted-foreground">
             {index + 1}
           </span>
@@ -688,7 +688,7 @@ export function InviteComposerView({ viewer }: { viewer: AdminUser }) {
         <Card>
           <div className="mb-3 flex items-center gap-2">
             <Link2 className="size-4 text-primary" />
-            <h3 className="text-sm font-semibold text-foreground">Bundle preview</h3>
+            <h3 className="font-display text-sm font-semibold tracking-wide text-foreground">Bundle preview</h3>
           </div>
 
           <dl className="space-y-1 text-xs">
@@ -747,7 +747,7 @@ export function InviteComposerView({ viewer }: { viewer: AdminUser }) {
         <Card className="bg-surface/40">
           <div className="mb-2 flex items-center gap-2">
             <Mail className="size-4 text-muted-foreground" />
-            <h3 className="text-sm font-semibold text-foreground">Email preview</h3>
+            <h3 className="font-display text-sm font-semibold tracking-wide text-foreground">Email preview</h3>
           </div>
           <div className="rounded-lg border border-border bg-card p-3 text-xs">
             <p className="text-muted-foreground">To: {emailValid ? email : '—'}</p>

--- a/apps/launchpad/components/launchpad/admin/settings-permissions-view.tsx
+++ b/apps/launchpad/components/launchpad/admin/settings-permissions-view.tsx
@@ -116,7 +116,7 @@ function ScopeCard({
         <div className="min-w-0 flex-1">
           <div className="flex items-center justify-between gap-2">
             <div className="min-w-0">
-              <p className="truncate text-sm font-semibold text-foreground">
+              <p className="truncate font-display text-sm font-semibold tracking-wide text-foreground">
                 {meta.label} settings
               </p>
               <p className="truncate text-xs text-muted-foreground">{contextLabel}</p>

--- a/apps/launchpad/components/launchpad/ai-engine-settings.tsx
+++ b/apps/launchpad/components/launchpad/ai-engine-settings.tsx
@@ -195,7 +195,7 @@ export function AiEngineSettings({
       >
         <div className="flex shrink-0 items-center justify-between gap-3 border-b border-border bg-card px-4 py-3">
           <div>
-            <h2 className="text-lg font-semibold text-foreground">AI Engine Settings</h2>
+            <h2 className="font-display text-lg font-semibold tracking-wide text-foreground">AI Engine Settings</h2>
             <p className="text-sm text-muted-foreground">Provider and model controls</p>
           </div>
           <button

--- a/apps/launchpad/components/launchpad/redemption/screens.tsx
+++ b/apps/launchpad/components/launchpad/redemption/screens.tsx
@@ -136,7 +136,7 @@ export function LinkInvalidScreen({ evaluation }: { evaluation: RedemptionLinkIn
     <Card className="overflow-hidden p-0">
       <div className={cn('flex items-center gap-3 border-b px-5 py-4', copy.tone)}>
         <Icon className="size-6 shrink-0" />
-        <p className="text-sm font-semibold">{copy.title}</p>
+        <p className="font-display text-sm font-semibold tracking-wide">{copy.title}</p>
       </div>
       <div className="px-5 py-5">
         <p className="text-sm text-muted-foreground text-pretty">{copy.body}</p>
@@ -164,7 +164,7 @@ export function EmailMismatchScreen({
       <div className="flex items-center gap-3 border-b border-primary/30 bg-primary/10 px-5 py-4 text-primary">
         <ShieldAlert className="size-6 shrink-0" />
         <div>
-          <p className="text-sm font-semibold">This invitation was addressed to a different email</p>
+          <p className="font-display text-sm font-semibold tracking-wide">This invitation was addressed to a different email</p>
           <p className="text-xs opacity-90">You can still accept it with the account you&apos;re signed in as.</p>
         </div>
       </div>
@@ -215,7 +215,7 @@ export function NeedsVerificationScreen({
     <Card className="overflow-hidden p-0">
       <div className="flex items-center gap-3 border-b border-signal-gold/30 bg-signal-gold/10 px-5 py-4 text-signal-gold">
         <ShieldAlert className="size-6 shrink-0" />
-        <p className="text-sm font-semibold">Verify your email to continue</p>
+        <p className="font-display text-sm font-semibold tracking-wide">Verify your email to continue</p>
       </div>
       <div className="px-5 py-5">
         <IdentityChip identity={evaluation.identity} />
@@ -315,7 +315,7 @@ export function AppliedScreen({
       <div className={cn('flex items-center gap-3 border-b px-5 py-4', banner.tone)}>
         <BannerIcon className="size-6 shrink-0" />
         <div>
-          <p className="text-sm font-semibold">{headline}</p>
+          <p className="font-display text-sm font-semibold tracking-wide">{headline}</p>
           <p className="text-xs opacity-90">
             {added} of {total} {total === 1 ? 'item' : 'items'} added for {evaluation.identity.email}
           </p>

--- a/apps/stock-analyser/components/stock-analyser/tabs/etfs-tab.tsx
+++ b/apps/stock-analyser/components/stock-analyser/tabs/etfs-tab.tsx
@@ -160,8 +160,8 @@ Provide 6 ETFs. Return ONLY valid JSON.`,
                 {/* Header: Ticker + Signal */}
                 <div className="flex items-start justify-between">
                   <div className="flex-1">
-                    <h4 className="text-sm font-semibold text-foreground">{etf.ticker}</h4>
-                    <p className="text-xs text-muted-foreground leading-tight mt-0.5">{etf.name}</p>
+                    <h4 className="font-display text-sm font-semibold tracking-wide text-foreground">{etf.ticker}</h4>
+                    <p className="mt-0.5 font-display text-xs font-medium leading-tight tracking-wide text-muted-foreground">{etf.name}</p>
                     <p className="text-[11px] text-muted-foreground mt-1">{etf.category}</p>
                   </div>
                   <span className={cn(

--- a/apps/stock-analyser/components/stock-analyser/tabs/market-analysis-tab.tsx
+++ b/apps/stock-analyser/components/stock-analyser/tabs/market-analysis-tab.tsx
@@ -306,7 +306,7 @@ IMPORTANT: Your entire response must be a single valid JSON object. Begin your r
               return (
                 <div key={indicator.label} className="flex-shrink-0 w-[200px] md:w-auto p-4 bg-card border border-border rounded-xl space-y-2">
                   <span className="text-[10px] uppercase tracking-wider text-muted-foreground">{indicator.label}</span>
-                  <h4 className="text-sm font-semibold text-foreground">{indicator.title}</h4>
+                  <h4 className="font-display text-sm font-semibold tracking-wide text-foreground">{indicator.title}</h4>
                   
                   {/* Description - conditionally visible or expandable */}
                   {(textVisible || expandedCards.has(cardKey)) && (
@@ -394,7 +394,7 @@ IMPORTANT: Your entire response must be a single valid JSON object. Begin your r
                     <div className="space-y-3">
                       {/* Header: Sector name + Signal badge */}
                       <div className="flex items-center justify-between">
-                        <h4 className="text-sm font-semibold text-foreground">{sector.sector}</h4>
+                        <h4 className="font-display text-sm font-semibold tracking-wide text-foreground">{sector.sector}</h4>
                         <span className={cn(
                           "px-2 py-0.5 rounded text-[10px] font-semibold uppercase",
                           sector.signal === "ENTER" ? "bg-signal-green text-white" :
@@ -471,7 +471,7 @@ IMPORTANT: Your entire response must be a single valid JSON object. Begin your r
             <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
               {/* Enter / Overweight */}
               <Card className="border-l-2 border-l-signal-green">
-                <h4 className="text-sm font-semibold text-signal-green mb-3">Enter / Overweight</h4>
+                <h4 className="mb-3 font-display text-sm font-semibold tracking-wide text-signal-green">Enter / Overweight</h4>
                 <div className="space-y-3">
                   {result.actionSummary.enter.map((item, i) => (
                     <div key={item.sector} className="flex gap-3">
@@ -489,7 +489,7 @@ IMPORTANT: Your entire response must be a single valid JSON object. Begin your r
 
               {/* Exit / Reduce */}
               <Card className="border-l-2 border-l-signal-red">
-                <h4 className="text-sm font-semibold text-signal-red mb-3">Exit / Reduce</h4>
+                <h4 className="mb-3 font-display text-sm font-semibold tracking-wide text-signal-red">Exit / Reduce</h4>
                 <div className="space-y-3">
                   {result.actionSummary.exit.map((item, i) => (
                     <div key={item.sector} className="flex gap-3">

--- a/apps/stock-analyser/components/stock-analyser/tabs/metals-tab.tsx
+++ b/apps/stock-analyser/components/stock-analyser/tabs/metals-tab.tsx
@@ -224,7 +224,7 @@ Return ONLY valid JSON.`,
                   {/* Header: Name + Signal */}
                   <div className="flex items-start justify-between">
                     <div>
-                      <h3 className="text-base font-semibold text-foreground">{metal.name}</h3>
+                      <h3 className="font-display text-base font-semibold tracking-wide text-foreground">{metal.name}</h3>
                       <p className="text-xs text-muted-foreground">{metal.symbol}</p>
                     </div>
                     <TrendBadge trend={metal.signal} />

--- a/apps/stock-analyser/components/stock-analyser/tabs/portfolio-tab.tsx
+++ b/apps/stock-analyser/components/stock-analyser/tabs/portfolio-tab.tsx
@@ -351,7 +351,7 @@ export function PortfolioTab() {
                 <div className="flex items-start justify-between">
                   <div>
                     <div className="flex items-center gap-2 flex-wrap">
-                      <h3 className="text-base font-semibold text-foreground">{holding.ticker}</h3>
+                      <h3 className="font-display text-base font-semibold tracking-wide text-foreground">{holding.ticker}</h3>
                       {a?.company && <span className="text-sm text-muted-foreground">{a.company}</span>}
                       {a?.sector  && <span className="text-xs text-muted-foreground">{a.sector}</span>}
                     </div>

--- a/apps/stock-analyser/components/stock-analyser/tabs/recommendations-tab.tsx
+++ b/apps/stock-analyser/components/stock-analyser/tabs/recommendations-tab.tsx
@@ -322,7 +322,7 @@ Return 6 stocks. Return ONLY valid JSON.`,
                   {/* Header: Ticker + Signal badge */}
                   <div className="flex items-start justify-between">
                     <div className="flex-1">
-                      <h4 className="text-sm font-semibold text-foreground">{stock.ticker}</h4>
+                      <h4 className="font-display text-sm font-semibold tracking-wide text-foreground">{stock.ticker}</h4>
                       <p className="text-xs text-muted-foreground leading-tight mt-0.5">{stock.company}</p>
                       <p className="text-[11px] text-muted-foreground mt-1">{stock.sector} · {stock.subcategory}</p>
                     </div>

--- a/apps/stock-analyser/components/stock-analyser/tabs/settings-tab.tsx
+++ b/apps/stock-analyser/components/stock-analyser/tabs/settings-tab.tsx
@@ -64,7 +64,7 @@ function AnalysisTextCard() {
           <FileText className="size-5 text-primary" />
         </div>
         <div>
-          <h3 className="text-sm font-semibold text-foreground">Analysis text</h3>
+          <h3 className="font-display text-sm font-semibold tracking-wide text-foreground">Analysis text</h3>
           <p className="text-xs text-muted-foreground leading-relaxed">
             Show explanatory analysis text alongside signals and verdicts. This is saved as a user preference for the active account.
           </p>
@@ -167,7 +167,7 @@ function AiEngineCard() {
           <Cpu className="size-5 text-primary" />
         </div>
         <div>
-          <h3 className="text-sm font-semibold text-foreground">AI Engine</h3>
+          <h3 className="font-display text-sm font-semibold tracking-wide text-foreground">AI Engine</h3>
           <p className="text-xs text-muted-foreground leading-relaxed">
             Choose the provider and model Stock Analyser uses for AI analysis. Leaving the override unset inherits the Launchpad platform default.
           </p>

--- a/apps/stock-analyser/components/stock-analyser/tabs/watchlist-tab.tsx
+++ b/apps/stock-analyser/components/stock-analyser/tabs/watchlist-tab.tsx
@@ -215,7 +215,7 @@ export function WatchlistTab() {
                 {/* Header row */}
                 <div className="flex items-start justify-between gap-3">
                   <div className="flex items-center gap-2 flex-wrap">
-                    <span className="font-bold text-foreground">{entry.ticker}</span>
+                    <span className="font-display font-bold tracking-wide text-foreground">{entry.ticker}</span>
                     <span className="text-sm text-muted-foreground">{company}</span>
                     {analysis?.sector && (
                       <span className="text-[11px] px-1.5 py-0.5 rounded border border-border text-muted-foreground">{analysis.sector}</span>


### PR DESCRIPTION
## Summary

Applies the approved M18 Oswald display font treatment to the remaining runtime text elements identified by the owner.

- Stock Analyser: result headings/titles in Market, Recommendations, ETF, Metals, Portfolio, Watchlist, and Settings.
- Launchpad: AI Engine Settings modal heading, Invite User grant/preview headings, Settings Permissions scope headings, and live runtime redemption headings.
- Budget Tracker: no file changes; the listed Import CSV, New Rule, and AI Suggestions headings were already using `font-display` from the Budget adoption PR.
- Auth/signed-out: `/sign-in` hero and `/signed-out` CTA were already using `font-display`; runtime does not currently include a separate forgot-provider modal or mock signup/review redemption screens because Cognito Hosted UI and auto-apply redemption are the live runtime path.

## Scope

Typography-only UI parity follow-up. No route, auth/session/claim, API, data contract, persistence, navigation, deployment, or backend behavior changed.

## v0 freshness

Approved source of truth: transformotion-apps-b8 commit https://github.com/transformotion/transformotion-apps-b8/commit/6a2a3399097bd8693bb14853d855a8b3b252ffe9 on branch `brand-system-foundation`, including the approved typography refinements for M18.

This PR is non-contract UI typography parity only. It applies Oswald display classes to the runtime headings/titles listed by the owner and does not change routes, auth/session/claim shapes, APIs, data contracts, persistence, navigation, or runtime behavior.

## Validation

Passed:

- `pnpm install --frozen-lockfile`
- `$env:V0_REPO_PATH='C:\Users\steve\OneDrive\Documents\Code Repo\transformotion-apps-b8-brand-system-foundation'; pnpm sync:v0`
- `git diff --check`
- changed-file lint baseline check
- `pnpm --filter @transformotion/stock-analyser typecheck`
- `pnpm --filter @transformotion/launchpad typecheck`
- `pnpm --filter @transformotion/stock-analyser build`
- `pnpm --filter @transformotion/launchpad build`
- `pnpm check:v0-freshness` with explicit changed-file list and this PR body's v0 freshness section
- pre-commit staged lint/typecheck hooks

## Deployment

Not deployed by this PR. Dev deploy validation can run after merge if triggered by the app deploy workflows.