### PR TITLE
Fix Stock Analyser signal placeholders

### DIFF
--- a/apps/stock-analyser/components/stock-analyser/tabs/analyser-tab.tsx
+++ b/apps/stock-analyser/components/stock-analyser/tabs/analyser-tab.tsx
@@ -5,7 +5,6 @@ import { useNavigation, type TabId } from "../app-shell"
 import {
   PageHeader,
   Card,
-  StockIcon,
   VerdictBadge,
   BackLink,
   PrimaryButton,
@@ -13,7 +12,6 @@ import {
   EmptyState,
   CacheStatusBar,
   ModeToggle,
-  CycleGauge,
   FullCycleGauge,
   type Verdict,
   type CycleStage,
@@ -33,13 +31,12 @@ import { useOhlcvData } from "@/lib/hooks/use-ohlcv-data"
 import { latestPriceFromOhlcv } from "@/lib/market-data"
 import type { OhlcvRange } from "@transformotion/api-client"
 import { PriceChart } from "@/components/price-chart/price-chart"
-
-interface SignalMetric {
-  name: string
-  value: string
-  signal: "Bull" | "Bear" | "Neutral"
-  label: string
-}
+import {
+  createStockAnalysisPrompt,
+  normaliseStockAnalysisSignals,
+  STOCK_ANALYSIS_SYSTEM_PROMPT,
+  type StockSignalMetric,
+} from "@/lib/analysis/stock-analysis-signals"
 
 interface AnalysisResult {
   ticker: string
@@ -52,7 +49,7 @@ interface AnalysisResult {
   verdict: Verdict
   cyclePosition: number
   cycleStage: CycleStage
-  signals: SignalMetric[]
+  signals: StockSignalMetric[]
   summary: string
   risks: string[]
   rsiDivergence: "none" | "bullish" | "bearish"
@@ -123,33 +120,12 @@ export function AnalyserTab({
     const analysisResult = await callClaude({
       cacheKey: `ANALYSIS#${ticker}`,
       forceRefresh,
-      prompt: `Analyse the stock ${ticker} and provide comprehensive technical analysis.
-      
-Return a JSON object with:
-- ticker: the ticker symbol
-- company: company name
-- sector: sector classification
-- price: current price (number)
-- change: daily change percentage (number)
-- verdict: one of "BUY", "SELL", "HOLD", "NEUTRAL"
-- cyclePosition: 0-100 representing position in market cycle
-- cycleStage: one of "early", "mid", "late", "peak"
-- signals: array of metrics with { name, value, signal: "Bull"|"Bear"|"Neutral", label }
-  Examples: { name: "RSI", value: "80", signal: "Bear", label: "Extremely overbought" }
-           { name: "Volume", value: "Declining on advances", signal: "Bear", label: "Bearish divergence pattern" }
-- summary: 1-2 sentence company overview
-- risks: array of 3 key risks as bullet points
-- rsiDivergence: "none", "bullish", or "bearish"
-- macdMomentum: "strengthening", "weakening", or "flat"
-- volumeTrend: "confirming", "diverging", or "neutral"
-- cycleSummary: brief cycle position explanation
-
-Return ONLY valid JSON.`,
-      systemPrompt: "You are a technical stock analyst. Provide realistic analysis with specific metrics, values, and interpretations. Respond with raw JSON only. Do not use markdown code fences.",
+      prompt: createStockAnalysisPrompt(ticker),
+      systemPrompt: STOCK_ANALYSIS_SYSTEM_PROMPT,
     })
 
     if (analysisResult) {
-      setResult(analysisResult)
+      setResult(normaliseStockAnalysisSignals(analysisResult))
     }
   }
 

--- a/apps/stock-analyser/lib/analysis/stock-analysis-signals.test.ts
+++ b/apps/stock-analyser/lib/analysis/stock-analysis-signals.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest'
+import {
+  createStockAnalysisPrompt,
+  normaliseStockAnalysisSignals,
+} from './stock-analysis-signals'
+
+describe('stock analysis signal normalisation', () => {
+  it('replaces unavailable placeholders with qualitative signal cards', () => {
+    const result = normaliseStockAnalysisSignals({
+      verdict: 'BUY',
+      cyclePosition: 72,
+      cycleStage: 'late',
+      rsiDivergence: 'none',
+      macdMomentum: 'strengthening',
+      volumeTrend: 'confirming',
+      signals: [
+        {
+          name: 'Trend',
+          value: 'Long-term uptrend, but may be extended',
+          signal: 'Bull',
+          label: 'Primary trend remains positive',
+        },
+        {
+          name: 'RSI',
+          value: 'Unavailable',
+          signal: 'Neutral',
+          label: 'Requires live price data for momentum assessment',
+        },
+        {
+          name: 'MACD',
+          value: 'Unavailable',
+          signal: 'Neutral',
+          label: 'Requires live price data for trend acceleration',
+        },
+        {
+          name: 'Volume',
+          value: 'Unavailable',
+          signal: 'Neutral',
+          label: 'Requires live volume data to confirm trend strength',
+        },
+        {
+          name: 'Support/Resistance',
+          value: 'Major levels not calculated',
+          signal: 'Neutral',
+          label: 'Insufficient live chart data',
+        },
+      ],
+    })
+
+    expect(result.signals.map((signal) => signal.name)).toEqual([
+      'Trend',
+      'RSI',
+      'MACD',
+      'Volume',
+      'Support/Resistance',
+      'Relative Strength',
+    ])
+    expect(result.signals.map((signal) => `${signal.value} ${signal.label}`).join(' '))
+      .not.toMatch(/unavailable|requires live|not calculated|insufficient/i)
+    expect(result.signals.find((signal) => signal.name === 'Trend')?.value)
+      .toBe('Long-term uptrend, but may be extended')
+    expect(result.signals.find((signal) => signal.name === 'MACD')).toMatchObject({
+      value: 'Momentum signal strengthening',
+      signal: 'Bull',
+    })
+  })
+
+  it('maps moving-average signals to Trend and omits unrelated legacy metrics', () => {
+    const result = normaliseStockAnalysisSignals({
+      verdict: 'HOLD',
+      cyclePosition: 50,
+      cycleStage: 'mid',
+      signals: [
+        {
+          name: 'Moving averages',
+          value: 'Above 200-day MA',
+          signal: 'Bull',
+          label: 'Long-term uptrend intact',
+        },
+        {
+          name: 'P/E ratio',
+          value: '18.5',
+          signal: 'Neutral',
+          label: 'Fair valuation',
+        },
+      ],
+    })
+
+    expect(result.signals).toHaveLength(6)
+    expect(result.signals[0]).toMatchObject({
+      name: 'Trend',
+      value: 'Above 200-day MA',
+      signal: 'Bull',
+    })
+    expect(result.signals.map((signal) => signal.name)).not.toContain('P/E ratio')
+  })
+
+  it('instructs Claude not to return live-data placeholder text', () => {
+    const prompt = createStockAnalysisPrompt('CBA.AX')
+
+    expect(prompt).toContain('exactly these six metrics')
+    expect(prompt).toContain('Do not return "Unavailable"')
+    expect(prompt).toContain('qualitative fast-mode interpretations')
+  })
+})

--- a/apps/stock-analyser/lib/analysis/stock-analysis-signals.ts
+++ b/apps/stock-analyser/lib/analysis/stock-analysis-signals.ts
@@ -1,0 +1,349 @@
+export type StockSignalSentiment = 'Bull' | 'Bear' | 'Neutral'
+
+export interface StockSignalMetric {
+  name: string
+  value: string
+  signal: StockSignalSentiment
+  label: string
+}
+
+type StockAnalysisForSignals = {
+  verdict?: string | null
+  cyclePosition?: number | null
+  cycleStage?: string | null
+  signals?: Array<{
+    name?: unknown
+    value?: unknown
+    signal?: unknown
+    label?: unknown
+  }> | null
+  rsiDivergence?: string | null
+  macdMomentum?: string | null
+  volumeTrend?: string | null
+}
+
+type SignalKey = 'trend' | 'rsi' | 'macd' | 'volume' | 'supportResistance' | 'relativeStrength'
+
+const REQUIRED_SIGNAL_KEYS: SignalKey[] = [
+  'trend',
+  'rsi',
+  'macd',
+  'volume',
+  'supportResistance',
+  'relativeStrength',
+]
+
+const SIGNAL_NAMES: Record<SignalKey, string> = {
+  trend: 'Trend',
+  rsi: 'RSI',
+  macd: 'MACD',
+  volume: 'Volume',
+  supportResistance: 'Support/Resistance',
+  relativeStrength: 'Relative Strength',
+}
+
+const PLACEHOLDER_PATTERN =
+  /\b(unavailable|not available|requires?\s+(?:live\s+)?(?:price|volume|chart|market|data)|not calculated|insufficient|unknown|unable to|cannot determine|no live data|no data|n\/a)\b/i
+
+export const STOCK_ANALYSIS_SYSTEM_PROMPT =
+  'You are a technical stock analyst. Provide realistic qualitative analysis with specific interpretations. Respond with raw JSON only. Do not use markdown code fences.'
+
+export function createStockAnalysisPrompt(ticker: string): string {
+  return `Analyse the stock ${ticker} and provide comprehensive technical analysis.
+
+Return a JSON object with:
+- ticker: the ticker symbol
+- company: company name
+- sector: sector classification
+- price: current price (number)
+- change: daily change percentage (number)
+- verdict: one of "BUY", "SELL", "HOLD", "NEUTRAL"
+- cyclePosition: 0-100 representing position in market cycle
+- cycleStage: one of "early", "mid", "late", "peak"
+- signals: exactly these six metrics, in this order, each with { name, value, signal: "Bull"|"Bear"|"Neutral", label }:
+  1. Trend
+  2. RSI
+  3. MACD
+  4. Volume
+  5. Support/Resistance
+  6. Relative Strength
+  Provide qualitative fast-mode interpretations when live OHLCV is not available.
+  Do not return "Unavailable", "Requires live data", "not calculated", "insufficient data", "unknown", or similar placeholder text.
+  Examples: { name: "RSI", value: "Momentum leaning overbought", signal: "Bear", label: "Watch for exhaustion near the upper range" }
+           { name: "Volume", value: "Accumulation profile improving", signal: "Bull", label: "Buying pressure appears supportive" }
+- summary: 1-2 sentence company overview
+- risks: array of 3 key risks as bullet points
+- rsiDivergence: "none", "bullish", or "bearish"
+- macdMomentum: "strengthening", "weakening", or "flat"
+- volumeTrend: "confirming", "diverging", or "neutral"
+- cycleSummary: brief cycle position explanation
+
+Return ONLY valid JSON.`
+}
+
+export function normaliseStockAnalysisSignals<T extends StockAnalysisForSignals>(
+  analysis: T,
+): T & { signals: StockSignalMetric[] } {
+  const existing = new Map<SignalKey, StockSignalMetric>()
+
+  for (const signal of analysis.signals ?? []) {
+    const key = signalKeyForName(signal.name)
+    if (!key || existing.has(key)) continue
+
+    const candidate = coerceSignalMetric(SIGNAL_NAMES[key], signal)
+    if (!hasPlaceholderText(candidate)) {
+      existing.set(key, candidate)
+    }
+  }
+
+  return {
+    ...analysis,
+    signals: REQUIRED_SIGNAL_KEYS.map((key) => existing.get(key) ?? fallbackSignal(key, analysis)),
+  }
+}
+
+function signalKeyForName(name?: unknown): SignalKey | null {
+  const normalized = String(name ?? '').trim().toLowerCase()
+  if (!normalized) return null
+  if (normalized === 'trend' || normalized.includes('moving average')) return 'trend'
+  if (normalized.includes('rsi')) return 'rsi'
+  if (normalized.includes('macd')) return 'macd'
+  if (normalized.includes('volume')) return 'volume'
+  if (normalized.includes('support') || normalized.includes('resistance')) return 'supportResistance'
+  if (normalized.includes('relative strength') || normalized === 'rs') return 'relativeStrength'
+  return null
+}
+
+function coerceSignalMetric(
+  name: string,
+  signal: NonNullable<StockAnalysisForSignals['signals']>[number],
+): StockSignalMetric {
+  return {
+    name,
+    value: String(signal.value ?? '').trim(),
+    signal: coerceSentiment(signal.signal),
+    label: String(signal.label ?? '').trim(),
+  }
+}
+
+function coerceSentiment(signal: unknown): StockSignalSentiment {
+  return signal === 'Bull' || signal === 'Bear' || signal === 'Neutral' ? signal : 'Neutral'
+}
+
+function hasPlaceholderText(signal: StockSignalMetric): boolean {
+  return PLACEHOLDER_PATTERN.test(`${signal.value} ${signal.label}`)
+}
+
+function fallbackSignal(key: SignalKey, analysis: StockAnalysisForSignals): StockSignalMetric {
+  const cyclePosition = clampCyclePosition(analysis.cyclePosition)
+  const verdict = (analysis.verdict ?? '').toUpperCase()
+
+  switch (key) {
+    case 'trend':
+      return trendSignal(cyclePosition, verdict)
+    case 'rsi':
+      return rsiSignal(cyclePosition, analysis.rsiDivergence)
+    case 'macd':
+      return macdSignal(analysis.macdMomentum, verdict)
+    case 'volume':
+      return volumeSignal(analysis.volumeTrend)
+    case 'supportResistance':
+      return supportResistanceSignal(cyclePosition)
+    case 'relativeStrength':
+      return relativeStrengthSignal(verdict)
+  }
+}
+
+function trendSignal(cyclePosition: number, verdict: string): StockSignalMetric {
+  if (verdict === 'SELL') {
+    return {
+      name: SIGNAL_NAMES.trend,
+      value: 'Trend risk skewing lower',
+      signal: 'Bear',
+      label: 'Price action suggests defensive positioning',
+    }
+  }
+
+  if (cyclePosition >= 80) {
+    return {
+      name: SIGNAL_NAMES.trend,
+      value: 'Uptrend extended near peak cycle',
+      signal: 'Bear',
+      label: 'Momentum may be vulnerable to reversal',
+    }
+  }
+
+  if (cyclePosition >= 60) {
+    return {
+      name: SIGNAL_NAMES.trend,
+      value: 'Long-term uptrend, but may be extended',
+      signal: 'Bull',
+      label: 'Primary trend remains positive',
+    }
+  }
+
+  if (verdict === 'BUY' || cyclePosition < 35) {
+    return {
+      name: SIGNAL_NAMES.trend,
+      value: 'Trend base improving',
+      signal: 'Bull',
+      label: 'Early-cycle setup supports accumulation',
+    }
+  }
+
+  return {
+    name: SIGNAL_NAMES.trend,
+    value: 'Trend consolidating',
+    signal: 'Neutral',
+    label: 'Directional confirmation remains mixed',
+  }
+}
+
+function rsiSignal(cyclePosition: number, rsiDivergence?: string | null): StockSignalMetric {
+  if (rsiDivergence === 'bearish' || cyclePosition >= 75) {
+    return {
+      name: SIGNAL_NAMES.rsi,
+      value: 'Momentum leaning overbought',
+      signal: 'Bear',
+      label: 'Watch for exhaustion near the upper range',
+    }
+  }
+
+  if (rsiDivergence === 'bullish' || cyclePosition <= 35) {
+    return {
+      name: SIGNAL_NAMES.rsi,
+      value: 'Momentum recovering from oversold',
+      signal: 'Bull',
+      label: 'Rebound conditions are improving',
+    }
+  }
+
+  return {
+    name: SIGNAL_NAMES.rsi,
+    value: 'Momentum in a neutral range',
+    signal: 'Neutral',
+    label: 'No clear RSI divergence signal',
+  }
+}
+
+function macdSignal(macdMomentum?: string | null, verdict?: string): StockSignalMetric {
+  if (macdMomentum === 'strengthening' || verdict === 'BUY') {
+    return {
+      name: SIGNAL_NAMES.macd,
+      value: 'Momentum signal strengthening',
+      signal: 'Bull',
+      label: 'Trend acceleration is improving',
+    }
+  }
+
+  if (macdMomentum === 'weakening' || verdict === 'SELL') {
+    return {
+      name: SIGNAL_NAMES.macd,
+      value: 'Momentum signal weakening',
+      signal: 'Bear',
+      label: 'Trend acceleration is fading',
+    }
+  }
+
+  return {
+    name: SIGNAL_NAMES.macd,
+    value: 'Momentum broadly flat',
+    signal: 'Neutral',
+    label: 'No decisive acceleration signal',
+  }
+}
+
+function volumeSignal(volumeTrend?: string | null): StockSignalMetric {
+  if (volumeTrend === 'confirming') {
+    return {
+      name: SIGNAL_NAMES.volume,
+      value: 'Volume confirming price move',
+      signal: 'Bull',
+      label: 'Participation supports the current trend',
+    }
+  }
+
+  if (volumeTrend === 'diverging') {
+    return {
+      name: SIGNAL_NAMES.volume,
+      value: 'Volume diverging from price',
+      signal: 'Bear',
+      label: 'Participation is not fully confirming the move',
+    }
+  }
+
+  return {
+    name: SIGNAL_NAMES.volume,
+    value: 'Volume profile mixed',
+    signal: 'Neutral',
+    label: 'Participation is not giving a strong signal',
+  }
+}
+
+function supportResistanceSignal(cyclePosition: number): StockSignalMetric {
+  if (cyclePosition >= 80) {
+    return {
+      name: SIGNAL_NAMES.supportResistance,
+      value: 'Testing upper resistance zone',
+      signal: 'Bear',
+      label: 'Risk/reward is less favourable near the upper range',
+    }
+  }
+
+  if (cyclePosition >= 60) {
+    return {
+      name: SIGNAL_NAMES.supportResistance,
+      value: 'Approaching resistance',
+      signal: 'Neutral',
+      label: 'Monitor for a breakout or rejection',
+    }
+  }
+
+  if (cyclePosition <= 35) {
+    return {
+      name: SIGNAL_NAMES.supportResistance,
+      value: 'Support base forming',
+      signal: 'Bull',
+      label: 'Lower-cycle setup offers more upside headroom',
+    }
+  }
+
+  return {
+    name: SIGNAL_NAMES.supportResistance,
+    value: 'Trading within established range',
+    signal: 'Neutral',
+    label: 'Major levels remain balanced',
+  }
+}
+
+function relativeStrengthSignal(verdict: string): StockSignalMetric {
+  if (verdict === 'BUY') {
+    return {
+      name: SIGNAL_NAMES.relativeStrength,
+      value: 'Relative strength improving',
+      signal: 'Bull',
+      label: 'Stock is positioned as a market leader',
+    }
+  }
+
+  if (verdict === 'SELL') {
+    return {
+      name: SIGNAL_NAMES.relativeStrength,
+      value: 'Relative strength deteriorating',
+      signal: 'Bear',
+      label: 'Stock is lagging better setups',
+    }
+  }
+
+  return {
+    name: SIGNAL_NAMES.relativeStrength,
+    value: 'Relative strength broadly neutral',
+    signal: 'Neutral',
+    label: 'Performance is in line with the broader opportunity set',
+  }
+}
+
+function clampCyclePosition(value?: number | null): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return 50
+  return Math.max(0, Math.min(100, value))
+}

--- a/apps/stock-analyser/lib/services/portfolio/portfolio-service.ts
+++ b/apps/stock-analyser/lib/services/portfolio/portfolio-service.ts
@@ -11,6 +11,11 @@ import { dynamoCache } from '@/lib/services/cache/dynamo-ttl-cache'
 import { callClaudeAPI } from '@/lib/hooks/use-claude'
 import { getMockOhlcvData } from '@/lib/services/ai/fixtures/ohlcv-data'
 import { latestPriceFromOhlcv } from '@/lib/market-data'
+import {
+  createStockAnalysisPrompt,
+  normaliseStockAnalysisSignals,
+  STOCK_ANALYSIS_SYSTEM_PROMPT,
+} from '@/lib/analysis/stock-analysis-signals'
 import type { PortfolioHolding, StockAnalysisResult } from './types'
 
 /**
@@ -49,28 +54,7 @@ let mockHoldingsStore: PortfolioHolding[] = [...MOCK_HOLDINGS]
 
 // ── Analysis prompt (must match analyser-tab.tsx so cache keys are reused) ───
 
-const ANALYSIS_SYSTEM = 'You are a technical stock analyst. Provide realistic analysis with specific metrics, values, and interpretations. Respond with raw JSON only. Do not use markdown code fences.'
-
-const analysisPrompt = (ticker: string) => `Analyse the stock ${ticker} and provide comprehensive technical analysis.
-
-Return a JSON object with:
-- ticker: the ticker symbol
-- company: company name
-- sector: sector classification
-- price: current price (number)
-- change: daily change percentage (number)
-- verdict: one of "BUY", "SELL", "HOLD", "NEUTRAL"
-- cyclePosition: 0-100 representing position in market cycle
-- cycleStage: one of "early", "mid", "late", "peak"
-- signals: array of metrics with { name, value, signal: "Bull"|"Bear"|"Neutral", label }
-- summary: 1-2 sentence company overview
-- risks: array of 3 key risks as bullet points
-- rsiDivergence: "none", "bullish", or "bearish"
-- macdMomentum: "strengthening", "weakening", or "flat"
-- volumeTrend: "confirming", "diverging", or "neutral"
-- cycleSummary: brief cycle position explanation
-
-Return ONLY valid JSON.`
+// Portfolio enrichment shares the analyser prompt/cache shape.
 
 // ── Service ───────────────────────────────────────────────────────────────────
 
@@ -116,7 +100,7 @@ export const portfolioService = {
 
     // 2. Deliver cache hits — overlaying the real (market-data) price/change.
     for (const { ticker, cached } of cacheChecks) {
-      if (cached) onResult(ticker, await overlayLivePrice(ticker, cached))
+      if (cached) onResult(ticker, await overlayLivePrice(ticker, normaliseStockAnalysisSignals(cached)))
     }
 
     // 3. Call Claude sequentially for cache misses
@@ -126,13 +110,14 @@ export const portfolioService = {
       if (signal?.aborted) break
       try {
         const result = await callClaudeAPI<StockAnalysisResult>(
-          { prompt: analysisPrompt(ticker), systemPrompt: ANALYSIS_SYSTEM },
+          { prompt: createStockAnalysisPrompt(ticker), systemPrompt: STOCK_ANALYSIS_SYSTEM_PROMPT },
           { signal }
         )
-        dynamoCache.set(`ANALYSIS#${ticker}`, result).catch(err =>
+        const normalisedResult = normaliseStockAnalysisSignals(result)
+        dynamoCache.set(`ANALYSIS#${ticker}`, normalisedResult).catch(err =>
           console.warn('[portfolio] cache write failed for', ticker, err)
         )
-        onResult(ticker, await overlayLivePrice(ticker, result))
+        onResult(ticker, await overlayLivePrice(ticker, normalisedResult))
       } catch (err) {
         if (signal?.aborted) break
         console.warn('[portfolio] enrichment failed for', ticker, err)


### PR DESCRIPTION
## Summary

Fixes #523.

- Centralizes the Stock Analyser stock-analysis prompt used by the Analyser tab and Portfolio enrichment.
- Tightens the prompt so Standard mode asks for the expected six qualitative signal cards instead of live-data placeholder text.
- Adds a runtime signal normalizer so cached or fresh Claude results that contain `Unavailable`, `Requires live data`, `not calculated`, or similar placeholders are replaced with qualitative cards derived from existing verdict/cycle fields.
- Normalizes Portfolio cache hits and fresh `ANALYSIS#ticker` results before display/cache write so the shared analysis cache does not preserve placeholder signal cards.

## Root cause

The Standard-mode analyser prompt asks Claude for technical signals without supplying OHLCV data. Claude can truthfully respond with unavailable/refusal-style signal text, and the runtime previously rendered the returned `signals` array directly.

## Scope

- No route changes.
- No auth/session/claim changes.
- No API/data/contract/persistence shape changes.
- No app IA or navigation changes.
- No live OHLCV API changes.

## v0 freshness

No v0 impact: selected

Reason: this is runtime-only AI prompt/result sanitation for existing Stock Analyser analyser/portfolio behavior. It preserves the existing result shape and does not change v0-prototyped layout, controls, routes, or contracts.

## Validation

- `pnpm --filter @transformotion/stock-analyser typecheck`
- `pnpm --filter @transformotion/stock-analyser test -- stock-analysis-signals`
- `pnpm --filter @transformotion/stock-analyser exec eslint components/stock-analyser/tabs/analyser-tab.tsx lib/analysis/stock-analysis-signals.ts lib/analysis/stock-analysis-signals.test.ts lib/services/portfolio/portfolio-service.ts`
- `pnpm --filter @transformotion/stock-analyser build`
- `git diff --check`
