### PR TITLE
Apply Oswald typography coverage

### DIFF
--- a/apps/budget-tracker/components/budget-tracker/tabs/budget-tab.tsx
+++ b/apps/budget-tracker/components/budget-tracker/tabs/budget-tab.tsx
@@ -595,7 +595,7 @@ export function BudgetTab() {
         budgetSummary.isSurplus ? "bg-signal-green/10 border-signal-green/25" : "bg-signal-red/10 border-signal-red/25"
       )}>
         <div className="min-w-0">
-          <p className={cn("text-sm font-bold", budgetSummary.isSurplus ? "text-signal-green" : "text-signal-red")}>
+          <p className={cn("font-display text-sm font-bold tracking-wide", budgetSummary.isSurplus ? "text-signal-green" : "text-signal-red")}>
             {budgetSummary.isSurplus ? "Budget in surplus" : "Budget in deficit"}
           </p>
           <p className="text-xs text-muted-foreground mt-0.5">

--- a/apps/budget-tracker/components/budget-tracker/tabs/cashflow-tab.tsx
+++ b/apps/budget-tracker/components/budget-tracker/tabs/cashflow-tab.tsx
@@ -337,22 +337,22 @@ export function CashflowTab() {
           {stats && (
             <div className="grid grid-cols-2 gap-3">
               <Card>
-                <p className="text-[10px] uppercase tracking-wider text-muted-foreground mb-1">Avg Monthly Income</p>
+                <p className="font-display text-[10px] uppercase tracking-wider text-muted-foreground mb-1">Avg Monthly Income</p>
                 <p className="text-lg font-bold text-signal-green">{formatCurrencyFull(stats.avgIncome)}</p>
               </Card>
               <Card>
-                <p className="text-[10px] uppercase tracking-wider text-muted-foreground mb-1">Avg Monthly Expenses</p>
+                <p className="font-display text-[10px] uppercase tracking-wider text-muted-foreground mb-1">Avg Monthly Expenses</p>
                 <p className="text-lg font-bold text-signal-red">{formatCurrencyFull(stats.avgExpenses)}</p>
               </Card>
               <Card>
-                <p className="text-[10px] uppercase tracking-wider text-muted-foreground mb-1">Best Savings</p>
+                <p className="font-display text-[10px] uppercase tracking-wider text-muted-foreground mb-1">Best Savings</p>
                 <p className="text-sm font-medium text-foreground">{formatMonthFull(stats.bestMonth)}</p>
                 <p className={cn("text-xs", stats.bestNet >= 0 ? "text-signal-green" : "text-signal-red")}>
                   {stats.bestNet >= 0 ? "+" : ""}{formatCurrencyFull(stats.bestNet)}
                 </p>
               </Card>
               <Card>
-                <p className="text-[10px] uppercase tracking-wider text-muted-foreground mb-1">Lowest Savings</p>
+                <p className="font-display text-[10px] uppercase tracking-wider text-muted-foreground mb-1">Lowest Savings</p>
                 <p className="text-sm font-medium text-foreground">{formatMonthFull(stats.worstMonth)}</p>
                 <p className={cn("text-xs", stats.worstNet >= 0 ? "text-signal-green" : "text-signal-red")}>
                   {stats.worstNet >= 0 ? "+" : ""}{formatCurrencyFull(stats.worstNet)}
@@ -363,7 +363,7 @@ export function CashflowTab() {
 
           {sankeyData.hasData && (
             <Card>
-              <h3 className="text-sm font-semibold text-foreground mb-4">Money Flow</h3>
+              <h3 className="font-display text-sm font-semibold tracking-wide text-foreground mb-4">Money Flow</h3>
               <p className="text-xs text-muted-foreground mb-4">
                 How your income flows through expense categories
               </p>
@@ -412,7 +412,7 @@ export function CashflowTab() {
           )}
 
           <Card>
-            <h3 className="text-sm font-semibold text-foreground mb-4">Income vs Expenses Trend</h3>
+            <h3 className="font-display text-sm font-semibold tracking-wide text-foreground mb-4">Income vs Expenses Trend</h3>
             <div className="h-56">
               <ResponsiveContainer width="100%" height="100%">
                 <ComposedChart data={trendData} margin={{ top: 5, right: 5, left: -20, bottom: 5 }}>
@@ -464,7 +464,7 @@ export function CashflowTab() {
 
           {activeCategories.length > 0 && (
             <Card>
-              <h3 className="text-sm font-semibold text-foreground mb-4">Monthly Expenses by Category</h3>
+              <h3 className="font-display text-sm font-semibold tracking-wide text-foreground mb-4">Monthly Expenses by Category</h3>
               <div className="h-56">
                 <ResponsiveContainer width="100%" height="100%">
                   <BarChart data={categoryData} margin={{ top: 5, right: 5, left: -20, bottom: 5 }}>
@@ -570,7 +570,7 @@ export function CashflowTab() {
           )}
 
           <Card>
-            <h3 className="text-sm font-semibold text-foreground mb-4">Savings Rate Trend</h3>
+            <h3 className="font-display text-sm font-semibold tracking-wide text-foreground mb-4">Savings Rate Trend</h3>
             <div className="h-40">
               <ResponsiveContainer width="100%" height="100%">
                 <LineChart

--- a/apps/budget-tracker/components/budget-tracker/tabs/review-tab.tsx
+++ b/apps/budget-tracker/components/budget-tracker/tabs/review-tab.tsx
@@ -218,7 +218,7 @@ export function ReviewTab() {
       <Card>
         <div className="flex items-center justify-between mb-3">
           <div>
-            <p className="text-sm font-medium text-foreground">Uncategorised transactions</p>
+            <p className="font-display text-sm font-medium tracking-wide text-foreground">Uncategorised transactions</p>
             <p className="text-2xl font-bold text-signal-amber">{uncategorizedCount}</p>
           </div>
           <div className="size-12 rounded-full bg-signal-amber/15 flex items-center justify-center">

--- a/apps/budget-tracker/components/budget-tracker/tabs/rules-tab.tsx
+++ b/apps/budget-tracker/components/budget-tracker/tabs/rules-tab.tsx
@@ -250,7 +250,7 @@ export function RulesTab() {
 
       {/* Rule Tester */}
       <Card>
-        <h3 className="text-sm font-semibold text-foreground mb-3">Test a transaction</h3>
+        <h3 className="font-display text-sm font-semibold tracking-wide text-foreground mb-3">Test a transaction</h3>
         <div className="relative mb-3">
           <Search className="absolute left-3 top-1/2 -translate-y-1/2 size-4 text-muted-foreground" />
           <input
@@ -472,7 +472,7 @@ export function RulesTab() {
           className="w-full flex items-center justify-between"
         >
           <div className="flex items-center gap-2">
-            <h3 className="text-sm font-semibold text-foreground">Matching Rules</h3>
+            <h3 className="font-display text-sm font-semibold tracking-wide text-foreground">Matching Rules</h3>
             <span className="px-1.5 py-0.5 rounded bg-primary/15 text-[10px] font-medium text-primary">
               {matchingRules.length}
             </span>

--- a/apps/budget-tracker/components/budget-tracker/tabs/settings-tab.tsx
+++ b/apps/budget-tracker/components/budget-tracker/tabs/settings-tab.tsx
@@ -109,7 +109,7 @@ function AiEngineCard() {
           <Cpu className="size-4 text-primary" />
         </div>
         <div>
-          <h3 className="text-sm font-semibold text-foreground">AI Engine</h3>
+          <h3 className="font-display text-sm font-semibold tracking-wide text-foreground">AI Engine</h3>
           <p className="text-xs text-muted-foreground">
             Choose the provider and model Budget Tracker uses for AI features.
           </p>
@@ -279,7 +279,7 @@ export function SettingsTab() {
           <div className="size-8 rounded-lg bg-primary/15 flex items-center justify-center">
             <Settings className="size-4 text-primary" />
           </div>
-          <h3 className="text-sm font-semibold text-foreground">AI Review Configuration</h3>
+          <h3 className="font-display text-sm font-semibold tracking-wide text-foreground">AI Review Configuration</h3>
         </div>
 
         <div className="space-y-5">

--- a/apps/budget-tracker/components/budget-tracker/tabs/summary-tab.tsx
+++ b/apps/budget-tracker/components/budget-tracker/tabs/summary-tab.tsx
@@ -244,7 +244,7 @@ export function SummaryTab() {
           {/* P&L Overview */}
           <Card className="space-y-4">
             <div className="flex items-center justify-between">
-              <h3 className="text-sm font-medium text-muted-foreground">Personal Budget</h3>
+              <h3 className="font-display text-sm font-medium tracking-wide text-muted-foreground">Personal Budget</h3>
               <span className="text-[10px] text-muted-foreground">(excludes business &amp; capital)</span>
             </div>
 
@@ -283,7 +283,7 @@ export function SummaryTab() {
 
           {/* Category Breakdown */}
           <div className="space-y-2">
-            <h3 className="text-sm font-medium text-muted-foreground">By Category</h3>
+            <h3 className="font-display text-sm font-medium tracking-wide text-muted-foreground">By Category</h3>
 
             {getActiveCategories(categories).filter(c => c.type !== 'capital').map(cat => {
               const data = summary.byCategory[cat.name]
@@ -403,7 +403,7 @@ export function SummaryTab() {
           {(capitalSummary.totalCapitalSpend > 0) && (
             <div className="space-y-2">
               <div className="flex items-center gap-2">
-                <h3 className="text-sm font-medium text-signal-amber">Capital Expenditure</h3>
+                <h3 className="font-display text-sm font-medium tracking-wide text-signal-amber">Capital Expenditure</h3>
                 <span className="text-[10px] px-2 py-0.5 rounded-full bg-signal-amber/20 text-signal-amber">Not in budget</span>
               </div>
 

--- a/apps/stock-analyser/components/stock-analyser/tabs/analyser-tab.tsx
+++ b/apps/stock-analyser/components/stock-analyser/tabs/analyser-tab.tsx
@@ -253,7 +253,7 @@ export function AnalyserTab({
             </div>
             <div className="flex items-start justify-between">
               <div>
-                <h2 className="text-2xl font-bold text-foreground">{result.company}</h2>
+                <h2 className="font-display text-2xl font-bold tracking-wide text-foreground">{result.company}</h2>
                 <div className="flex items-baseline gap-3 mt-2">
                   <span className="text-3xl font-bold text-foreground">
                     {livePrice.price !== null ? `A$${livePrice.price.toFixed(3)}` : "—"}


### PR DESCRIPTION
## Summary

- Applies Oswald (`font-display`) to the remaining named runtime headings/labels from the owner-provided typography sweep.
- Covers Stock Analyser returned company name and Budget Tracker section/stat labels that still used Inter.
- Keeps existing copy, routes, auth/session/data/contracts, app behavior, navigation, and persistence unchanged.

## Scope notes

- Stock Analyser: analyser returned company name now uses `font-display`.
- Budget Tracker: surplus/deficit banner, Summary headings, Cashflow stat labels/chart headings, Rules section headings, Review heading, and Settings headings now use `font-display`.
- Launchpad/Auth surfaces already had the requested Oswald usage in the current runtime, so no Launchpad files changed.
- Budget Rules currently renders a `Matching Rules` section rather than the older `Custom Rules` / `Built-in Rules` / `AI Suggested Rules` copy; this PR applies Oswald to the current runtime heading without changing copy or IA.

## v0 freshness

Approved v0 design-of-record: https://github.com/transformotion/transformotion-apps-b8/commit/6a2a339

This is UI-affecting typography alignment only and follows the approved M18 brand-system foundation record plus the owner-provided Oswald usage list. No contract/data/API shape changes.

## Validation

- `pnpm --filter @transformotion/stock-analyser typecheck`
- `pnpm --filter @transformotion/budget typecheck`
- `pnpm --filter @transformotion/stock-analyser exec eslint components/stock-analyser/tabs/analyser-tab.tsx`
- `pnpm --filter @transformotion/budget exec eslint components/budget-tracker/tabs/budget-tab.tsx components/budget-tracker/tabs/cashflow-tab.tsx components/budget-tracker/tabs/review-tab.tsx components/budget-tracker/tabs/rules-tab.tsx components/budget-tracker/tabs/settings-tab.tsx components/budget-tracker/tabs/summary-tab.tsx`
- `pnpm --filter @transformotion/stock-analyser build`
- `pnpm --filter @transformotion/budget build`
- `git diff --check origin/develop...HEAD`