### PR TITLE
Implement Stock Analyser region/universe recommendations

### DIFF
--- a/apps/stock-analyser/components/stock-analyser/app-shell.tsx
+++ b/apps/stock-analyser/components/stock-analyser/app-shell.tsx
@@ -30,6 +30,10 @@ import { ConfirmationModal } from "@transformotion/ui-primitives"
 import { userFirstName, userInitials } from "@transformotion/auth-client"
 import { useActiveAccountStore } from "@/stores/active-account/use-active-account-store"
 import { useAuthStore, selectUser } from "@/stores/auth/use-auth-store"
+import type {
+  RecommendationsNavigationPayload,
+  StockAnalyserSearchMode,
+} from "@transformotion/contracts/stock-analyser/types"
 
 // ============================================================================
 // TYPES
@@ -52,11 +56,17 @@ export interface User {
 }
 
 export type WatchlistEntry = WatchlistItem
+export type SearchMode = StockAnalyserSearchMode
+type RecommendationsNavigationContext = Omit<RecommendationsNavigationPayload, "recommendationUniverse"> & {
+  recommendationUniverse: RecommendationsNavigationPayload["recommendationUniverse"] | null
+}
 
 export interface NavigationState {
   activeTab: TabId
   // Cross-screen navigation context
   sectorFilter: string | null
+  recsUniverse: RecommendationsNavigationPayload["recommendationUniverse"] | null
+  recsSourceRegion: RecommendationsNavigationPayload["sourceRegion"] | null
   recsSource: TabId | null
   analyserTicker: string | null
   analyserSource: TabId | null
@@ -67,6 +77,7 @@ export interface NavigationState {
   // Explanatory text visibility settings
   showExplanatoryText: boolean // global user setting (default: true)
   tabTextOverrides: Partial<Record<TabId, boolean>> // per-tab manual overrides
+  defaultSearchMode: SearchMode
   // Cached API results per tab (persists between tab switches)
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   tabCache: Partial<Record<TabId, any>>
@@ -74,7 +85,7 @@ export interface NavigationState {
 
 export interface NavigationActions {
   navigateTo: (tab: TabId) => void
-  navigateToRecsWithSector: (sector: string) => void
+  navigateToRecsWithSector: (payload: RecommendationsNavigationContext) => void
   navigateToAnalyser: (ticker: string, source: TabId) => void
   clearSectorFilter: () => void
   clearAnalyserContext: () => void
@@ -90,6 +101,7 @@ export interface NavigationActions {
   setShowExplanatoryText: (show: boolean) => void
   setTabTextOverride: (tab: TabId, show: boolean) => void
   getTabTextVisibility: (tab: TabId) => boolean
+  setDefaultSearchMode: (mode: SearchMode) => void
   // Tab result cache
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   setTabCache: (tab: TabId, data: any) => void
@@ -156,6 +168,8 @@ export function NavigationProvider({
   const [state, setState] = useState<NavigationState>({
     activeTab: initialTab,
     sectorFilter: null,
+    recsUniverse: null,
+    recsSourceRegion: null,
     recsSource: null,
     analyserTicker: null,
     analyserSource: null,
@@ -164,6 +178,7 @@ export function NavigationProvider({
     user: DEFAULT_USER,
     showExplanatoryText: true,
     tabTextOverrides: {},
+    defaultSearchMode: "live",
     tabCache: {},
   })
 
@@ -181,11 +196,13 @@ export function NavigationProvider({
     setState(prev => ({ ...prev, activeTab: tab }))
   }, [])
 
-  const navigateToRecsWithSector = useCallback((sector: string) => {
+  const navigateToRecsWithSector = useCallback((payload: RecommendationsNavigationContext) => {
     setState(prev => ({
       ...prev,
       activeTab: "recs",
-      sectorFilter: sector,
+      sectorFilter: payload.sector,
+      recsUniverse: payload.recommendationUniverse,
+      recsSourceRegion: payload.sourceRegion,
       recsSource: prev.activeTab,
     }))
   }, [])
@@ -200,7 +217,7 @@ export function NavigationProvider({
   }, [])
 
   const clearSectorFilter = useCallback(() => {
-    setState(prev => ({ ...prev, sectorFilter: null, recsSource: null }))
+    setState(prev => ({ ...prev, sectorFilter: null, recsUniverse: null, recsSourceRegion: null, recsSource: null }))
   }, [])
 
   const clearAnalyserContext = useCallback(() => {
@@ -245,6 +262,7 @@ export function NavigationProvider({
       .then(settings => setState(prev => ({
         ...prev,
         showExplanatoryText: settings.explanatoryTextEnabled,
+        defaultSearchMode: settings.defaultSearchMode,
         tabTextOverrides: {},
       })))
       .catch(err => console.warn('[stock-analyser-settings] load failed', err))
@@ -286,6 +304,12 @@ export function NavigationProvider({
       tabTextOverrides: {}, // Clear all overrides when global setting changes
     }))
     stockAnalyserSettingsService.patchSettings({ explanatoryTextEnabled: show })
+      .catch(err => console.warn('[stock-analyser-settings] save failed', err))
+  }, [])
+
+  const setDefaultSearchMode = useCallback((mode: SearchMode) => {
+    setState(prev => ({ ...prev, defaultSearchMode: mode }))
+    stockAnalyserSettingsService.patchSettings({ defaultSearchMode: mode })
       .catch(err => console.warn('[stock-analyser-settings] save failed', err))
   }, [])
 
@@ -343,6 +367,7 @@ export function NavigationProvider({
     setShowExplanatoryText,
     setTabTextOverride,
     getTabTextVisibility,
+    setDefaultSearchMode,
     setTabCache,
     getTabCache,
   }

--- a/apps/stock-analyser/components/stock-analyser/app-shell.tsx
+++ b/apps/stock-analyser/components/stock-analyser/app-shell.tsx
@@ -31,9 +31,12 @@ import { userFirstName, userInitials } from "@transformotion/auth-client"
 import { useActiveAccountStore } from "@/stores/active-account/use-active-account-store"
 import { useAuthStore, selectUser } from "@/stores/auth/use-auth-store"
 import type {
-  RecommendationsNavigationPayload,
   StockAnalyserSearchMode,
 } from "@transformotion/contracts/stock-analyser/types"
+import {
+  createRecommendationsNavigationState,
+  type RecommendationsNavigationContext,
+} from "./recommendations-flow"
 
 // ============================================================================
 // TYPES
@@ -57,16 +60,13 @@ export interface User {
 
 export type WatchlistEntry = WatchlistItem
 export type SearchMode = StockAnalyserSearchMode
-type RecommendationsNavigationContext = Omit<RecommendationsNavigationPayload, "recommendationUniverse"> & {
-  recommendationUniverse: RecommendationsNavigationPayload["recommendationUniverse"] | null
-}
 
 export interface NavigationState {
   activeTab: TabId
   // Cross-screen navigation context
   sectorFilter: string | null
-  recsUniverse: RecommendationsNavigationPayload["recommendationUniverse"] | null
-  recsSourceRegion: RecommendationsNavigationPayload["sourceRegion"] | null
+  recsUniverse: RecommendationsNavigationContext["recommendationUniverse"]
+  recsSourceRegion: RecommendationsNavigationContext["sourceRegion"] | null
   recsSource: TabId | null
   analyserTicker: string | null
   analyserSource: TabId | null
@@ -199,11 +199,7 @@ export function NavigationProvider({
   const navigateToRecsWithSector = useCallback((payload: RecommendationsNavigationContext) => {
     setState(prev => ({
       ...prev,
-      activeTab: "recs",
-      sectorFilter: payload.sector,
-      recsUniverse: payload.recommendationUniverse,
-      recsSourceRegion: payload.sourceRegion,
-      recsSource: prev.activeTab,
+      ...createRecommendationsNavigationState(prev.activeTab, payload),
     }))
   }, [])
 

--- a/apps/stock-analyser/components/stock-analyser/markets.ts
+++ b/apps/stock-analyser/components/stock-analyser/markets.ts
@@ -1,0 +1,70 @@
+import {
+  ANALYSIS_REGIONS,
+  RECOMMENDATION_UNIVERSES,
+  REGION_TO_RECOMMENDATION_UNIVERSES,
+  type AnalysisRegion,
+  type RecommendationUniverse,
+} from "@transformotion/contracts/stock-analyser/types"
+
+export {
+  ANALYSIS_REGIONS,
+  RECOMMENDATION_UNIVERSES,
+  REGION_TO_RECOMMENDATION_UNIVERSES,
+  type AnalysisRegion,
+  type RecommendationUniverse,
+}
+
+export const REGION_LABELS: Record<AnalysisRegion, string> = {
+  global: "Global",
+  australia: "Australia",
+  us: "US",
+  uk: "UK",
+}
+
+const REGION_LABEL_TO_REGION = Object.fromEntries(
+  (Object.entries(REGION_LABELS) as [AnalysisRegion, string][]).map(([region, label]) => [label, region]),
+) as Record<string, AnalysisRegion>
+
+export function regionFromLabel(label: string): AnalysisRegion {
+  return REGION_LABEL_TO_REGION[label] ?? "global"
+}
+
+export function isRecommendationUniverse(value: unknown): value is RecommendationUniverse {
+  return typeof value === "string" && (RECOMMENDATION_UNIVERSES as readonly string[]).includes(value)
+}
+
+const UNIVERSE_ALIASES: Record<string, RecommendationUniverse> = {
+  ASX: "ASX",
+  NASDAQ: "NASDAQ",
+  DOW: "Dow",
+  "DOW JONES": "Dow",
+  DJIA: "Dow",
+  "S&P 500": "Dow",
+  SP500: "Dow",
+  NYSE: "Dow",
+  FTSE: "FTSE",
+  "FTSE 100": "FTSE",
+  LSE: "FTSE",
+}
+
+export function normaliseUniverse(
+  raw: string | null | undefined,
+  region: AnalysisRegion,
+): RecommendationUniverse | null {
+  if (!raw) return null
+  const candidates: readonly RecommendationUniverse[] = REGION_TO_RECOMMENDATION_UNIVERSES[region]
+  const direct = isRecommendationUniverse(raw) ? raw : null
+  const mapped = direct ?? UNIVERSE_ALIASES[raw.trim().toUpperCase()] ?? null
+  return mapped && candidates.includes(mapped) ? mapped : null
+}
+
+export function defaultUniverseForRegion(region: AnalysisRegion): RecommendationUniverse {
+  return REGION_TO_RECOMMENDATION_UNIVERSES[region][0]
+}
+
+export function resolveSectorUniverse(
+  rawExchange: string | null | undefined,
+  region: AnalysisRegion,
+): RecommendationUniverse {
+  return normaliseUniverse(rawExchange, region) ?? defaultUniverseForRegion(region)
+}

--- a/apps/stock-analyser/components/stock-analyser/recommendations-flow.test.ts
+++ b/apps/stock-analyser/components/stock-analyser/recommendations-flow.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest"
+import {
+  createMarketSectorNavigationPayload,
+  createRecommendationsNavigationState,
+  getIncomingRecommendationUniverse,
+  getInitialRecommendationUniverse,
+  isLiveSearchMode,
+  isMarketOriginatedUniverseUnavailable,
+  shouldDisableRecommendationsRun,
+} from "./recommendations-flow"
+
+describe("Stock Analyser Market to Recommendations flow", () => {
+  it("passes sector, NASDAQ universe, and Global provenance for Global Technology", () => {
+    const sector = {
+      sector: "Technology",
+      bestExchange: "NASDAQ",
+      recommendationUniverse: "NASDAQ" as const,
+      sourceRegion: "global" as const,
+    }
+
+    const payload = createMarketSectorNavigationPayload(sector, "global")
+    const navigationState = createRecommendationsNavigationState("market", payload)
+
+    expect(payload).toEqual({
+      sector: "Technology",
+      recommendationUniverse: "NASDAQ",
+      sourceRegion: "global",
+    })
+    expect(navigationState).toMatchObject({
+      activeTab: "recs",
+      sectorFilter: "Technology",
+      recsUniverse: "NASDAQ",
+      recsSourceRegion: "global",
+      recsSource: "market",
+    })
+  })
+
+  it("normalises a Global Technology NYSE response to Dow instead of treating NYSE as geography", () => {
+    const sector = {
+      sector: "Technology",
+      bestExchange: "NYSE",
+    }
+
+    expect(createMarketSectorNavigationPayload(sector, "global")).toMatchObject({
+      sector: "Technology",
+      recommendationUniverse: "Dow",
+      sourceRegion: "global",
+    })
+  })
+
+  it("initializes Recommendations from incoming NASDAQ for market-originated navigation", () => {
+    const incomingUniverse = getIncomingRecommendationUniverse("NASDAQ")
+
+    expect(incomingUniverse).toBe("NASDAQ")
+    expect(getInitialRecommendationUniverse(incomingUniverse)).toBe("NASDAQ")
+    expect(isMarketOriginatedUniverseUnavailable("Technology", incomingUniverse)).toBe(false)
+    expect(shouldDisableRecommendationsRun(false, false)).toBe(false)
+  })
+
+  it("does not silently run ASX when market-originated universe is missing", () => {
+    const incomingUniverse = getIncomingRecommendationUniverse(null)
+    const universeUnavailable = isMarketOriginatedUniverseUnavailable("Technology", incomingUniverse)
+
+    expect(getInitialRecommendationUniverse(incomingUniverse)).toBe("ASX")
+    expect(universeUnavailable).toBe(true)
+    expect(shouldDisableRecommendationsRun(universeUnavailable, false)).toBe(true)
+    expect(shouldDisableRecommendationsRun(universeUnavailable, true)).toBe(false)
+  })
+
+  it("keeps direct Recommendations entry on ASX", () => {
+    const incomingUniverse = getIncomingRecommendationUniverse(null)
+
+    expect(isMarketOriginatedUniverseUnavailable(null, incomingUniverse)).toBe(false)
+    expect(getInitialRecommendationUniverse(incomingUniverse)).toBe("ASX")
+    expect(shouldDisableRecommendationsRun(false, false)).toBe(false)
+  })
+
+  it("defaults new per-run searches from the app default without mutating it", () => {
+    const appDefault = "live"
+    let perRunIsLive = isLiveSearchMode(appDefault)
+
+    expect(perRunIsLive).toBe(true)
+
+    perRunIsLive = !perRunIsLive
+
+    expect(perRunIsLive).toBe(false)
+    expect(appDefault).toBe("live")
+    expect(isLiveSearchMode("fast")).toBe(false)
+  })
+})

--- a/apps/stock-analyser/components/stock-analyser/recommendations-flow.ts
+++ b/apps/stock-analyser/components/stock-analyser/recommendations-flow.ts
@@ -1,0 +1,77 @@
+import type {
+  AnalysisRegion,
+  RecommendationsNavigationPayload,
+  RecommendationUniverse,
+  StockAnalyserSearchMode,
+} from "@transformotion/contracts/stock-analyser/types"
+import { isRecommendationUniverse, resolveSectorUniverse } from "./markets"
+import type { TabId } from "./app-shell"
+
+export type RecommendationsNavigationContext = Omit<RecommendationsNavigationPayload, "recommendationUniverse"> & {
+  recommendationUniverse: RecommendationsNavigationPayload["recommendationUniverse"] | null
+}
+
+type MarketSectorNavigationInput = {
+  sector: string
+  bestExchange: string
+  recommendationUniverse?: RecommendationUniverse
+  sourceRegion?: AnalysisRegion
+}
+
+export function createMarketSectorNavigationPayload(
+  sector: MarketSectorNavigationInput,
+  currentRegion: AnalysisRegion,
+): RecommendationsNavigationContext {
+  const sourceRegion = sector.sourceRegion ?? currentRegion
+  const recommendationUniverse = sector.recommendationUniverse
+    ?? resolveSectorUniverse(sector.bestExchange, sourceRegion)
+
+  return {
+    sector: sector.sector,
+    recommendationUniverse,
+    sourceRegion,
+  }
+}
+
+export function createRecommendationsNavigationState(
+  activeTab: TabId,
+  payload: RecommendationsNavigationContext,
+) {
+  return {
+    activeTab: "recs" as const,
+    sectorFilter: payload.sector,
+    recsUniverse: payload.recommendationUniverse,
+    recsSourceRegion: payload.sourceRegion,
+    recsSource: activeTab,
+  }
+}
+
+export function getIncomingRecommendationUniverse(
+  value: RecommendationUniverse | null,
+): RecommendationUniverse | null {
+  return isRecommendationUniverse(value) ? value : null
+}
+
+export function getInitialRecommendationUniverse(
+  value: RecommendationUniverse | null,
+): RecommendationUniverse {
+  return getIncomingRecommendationUniverse(value) ?? "ASX"
+}
+
+export function isMarketOriginatedUniverseUnavailable(
+  sectorFilter: string | null,
+  incomingUniverse: RecommendationUniverse | null,
+): boolean {
+  return !!sectorFilter && !incomingUniverse
+}
+
+export function shouldDisableRecommendationsRun(
+  universeUnavailable: boolean,
+  universeTouched: boolean,
+): boolean {
+  return universeUnavailable && !universeTouched
+}
+
+export function isLiveSearchMode(mode: StockAnalyserSearchMode): boolean {
+  return mode === "live"
+}

--- a/apps/stock-analyser/components/stock-analyser/tabs/analyser-tab.tsx
+++ b/apps/stock-analyser/components/stock-analyser/tabs/analyser-tab.tsx
@@ -78,14 +78,18 @@ export function AnalyserTab({
   initialTicker?: string | null
   source?: TabId | null
 }) {
-  const { navigateTo, clearAnalyserContext, isOnWatchlist, addToWatchlist, removeFromWatchlist } = useNavigation()
-  const [isLive, setIsLive] = useState(false)
+  const { navigateTo, clearAnalyserContext, isOnWatchlist, addToWatchlist, removeFromWatchlist, defaultSearchMode } = useNavigation()
+  const [isLive, setIsLive] = useState(defaultSearchMode === "live")
   const [searchValue, setSearchValue] = useState("")
   const [result, setResult] = useState<AnalysisResult | null>(null)
 
   const [chartRange, setChartRange] = useState<OhlcvRange>('1y')
 
   const { callClaude, isLoading: isAnalyzing, error } = useClaude<AnalysisResult>()
+
+  useEffect(() => {
+    setIsLive(defaultSearchMode === "live")
+  }, [defaultSearchMode])
   const { data: liveData, isLoading: isLoadingLive, error: liveError, fetch: fetchLive } = useCycleData()
   const { data: ohlcvData, isLoading: isLoadingChart, fetch: fetchOhlcv } = useOhlcvData()
 
@@ -120,6 +124,7 @@ export function AnalyserTab({
     const analysisResult = await callClaude({
       cacheKey: `ANALYSIS#${ticker}`,
       forceRefresh,
+      webSearch: isLive,
       prompt: createStockAnalysisPrompt(ticker),
       systemPrompt: STOCK_ANALYSIS_SYSTEM_PROMPT,
     })

--- a/apps/stock-analyser/components/stock-analyser/tabs/etfs-tab.tsx
+++ b/apps/stock-analyser/components/stock-analyser/tabs/etfs-tab.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState } from "react"
+import { useEffect, useState } from "react"
 import { useNavigation } from "../app-shell"
 import {
   PageHeader,
@@ -9,7 +9,6 @@ import {
   ModeToggle,
   PrimaryButton,
   TextToggle,
-  type Signal,
 } from "@transformotion/ui-primitives"
 import { ChevronRight, ChevronDown, AlertCircle } from "lucide-react"
 import { cn } from "@/lib/utils"
@@ -40,8 +39,8 @@ const ETFS: ETF[] = [
 ]
 
 export function ETFsTab() {
-  const { navigateToAnalyser, getTabTextVisibility, setTabTextOverride, showExplanatoryText, setTabCache, getTabCache } = useNavigation()
-  const [isLive, setIsLive] = useState(false)
+  const { navigateToAnalyser, getTabTextVisibility, setTabTextOverride, showExplanatoryText, defaultSearchMode, setTabCache, getTabCache } = useNavigation()
+  const [isLive, setIsLive] = useState(defaultSearchMode === "live")
   const [market, setMarket] = useState<Market>("ASX")
   const cachedEtfs = getTabCache("etfs")?.etfs as ETF[] | null
   const [etfResults, setEtfResults] = useState<ETF[]>(cachedEtfs ?? [])
@@ -62,10 +61,15 @@ export function ETFsTab() {
 
   const { callClaude, isLoading: isAnalyzing, error } = useClaude<{ etfs: ETF[] }>()
 
+  useEffect(() => {
+    setIsLive(defaultSearchMode === "live")
+  }, [defaultSearchMode])
+
   const runAnalysis = async (forceRefresh = false) => {
     const result = await callClaude({
       cacheKey: `ETF#${market}`,
       forceRefresh,
+      webSearch: isLive,
       prompt: `Provide ETF recommendations for the ${market} market.
 
 Return a JSON object with "etfs" array, each containing:

--- a/apps/stock-analyser/components/stock-analyser/tabs/market-analysis-tab.tsx
+++ b/apps/stock-analyser/components/stock-analyser/tabs/market-analysis-tab.tsx
@@ -35,6 +35,7 @@ import {
   regionFromLabel,
   resolveSectorUniverse,
 } from "../markets"
+import { createMarketSectorNavigationPayload } from "../recommendations-flow"
 
 type Impact = "Supportive" | "Neutral" | "Headwind"
 type Valuation = "Cheap" | "Fair" | "Expensive" | "Extended"
@@ -414,14 +415,7 @@ IMPORTANT: Your entire response must be a single valid JSON object. Begin your r
                     key={sector.sector}
                     interactive
                     onClick={() => {
-                      const sourceRegion = sector.sourceRegion ?? region
-                      const recommendationUniverse = sector.recommendationUniverse
-                        ?? resolveSectorUniverse(sector.bestExchange, sourceRegion)
-                      navigateToRecsWithSector({
-                        sector: sector.sector,
-                        recommendationUniverse,
-                        sourceRegion,
-                      })
+                      navigateToRecsWithSector(createMarketSectorNavigationPayload(sector, region))
                     }}
                     animationDelay={i * 30}
                   >

--- a/apps/stock-analyser/components/stock-analyser/tabs/market-analysis-tab.tsx
+++ b/apps/stock-analyser/components/stock-analyser/tabs/market-analysis-tab.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import React, { useState } from "react"
+import React, { useEffect, useState } from "react"
 import { useNavigation } from "../app-shell"
 import {
   PageHeader,
@@ -24,8 +24,18 @@ import {
 } from "lucide-react"
 import { useClaude } from "@/lib/hooks"
 import { cn } from "@/lib/utils"
+import type {
+  AnalysisRegion,
+  MarketAnalysisSectorResult,
+} from "@transformotion/contracts/stock-analyser/types"
+import {
+  ANALYSIS_REGIONS,
+  REGION_LABELS,
+  REGION_TO_RECOMMENDATION_UNIVERSES,
+  regionFromLabel,
+  resolveSectorUniverse,
+} from "../markets"
 
-type Geography = "Global" | "ASX" | "US" | "UK"
 type Impact = "Supportive" | "Neutral" | "Headwind"
 type Valuation = "Cheap" | "Fair" | "Expensive" | "Extended"
 type Opportunity = "Attractive" | "Neutral" | "Unattractive"
@@ -46,6 +56,8 @@ interface SectorSignal {
   change: number
   reason: string
   bestExchange: string
+  recommendationUniverse?: MarketAnalysisSectorResult["recommendationUniverse"]
+  sourceRegion?: AnalysisRegion
 }
 
 interface ActionItem {
@@ -141,9 +153,9 @@ function CycleBar({ position }: { position: number }) {
 }
 
 export function MarketAnalysisTab() {
-  const { navigateToRecsWithSector, getTabTextVisibility, setTabTextOverride, showExplanatoryText, setTabCache, getTabCache } = useNavigation()
-  const [isLive, setIsLive] = useState(false)
-  const [geography, setGeography] = useState<Geography>("ASX")
+  const { navigateToRecsWithSector, getTabTextVisibility, setTabTextOverride, showExplanatoryText, defaultSearchMode, setTabCache, getTabCache } = useNavigation()
+  const [isLive, setIsLive] = useState(defaultSearchMode === "live")
+  const [region, setRegion] = useState<AnalysisRegion>("australia")
   const cachedResult = getTabCache("market") as MarketAnalysisResult | null
   const [hasResults, setHasResults] = useState(!!cachedResult)
   const [result, setResult] = useState<MarketAnalysisResult | null>(cachedResult)
@@ -164,12 +176,17 @@ export function MarketAnalysisTab() {
 
   const { callClaude, isLoading: isAnalyzing, error } = useClaude<MarketAnalysisResult>()
 
+  useEffect(() => {
+    setIsLive(defaultSearchMode === "live")
+  }, [defaultSearchMode])
+
   const runAnalysis = async (forceRefresh = false) => {
+    const supportedUniverses = REGION_TO_RECOMMENDATION_UNIVERSES[region]
     const data = await callClaude({
-      cacheKey: `MARKET#${geography}`,
+      cacheKey: `MARKET#${region}`,
       forceRefresh,
       webSearch: isLive,
-      prompt: `Provide comprehensive market analysis for the ${geography} market.
+      prompt: `Provide comprehensive market analysis for the ${REGION_LABELS[region]} region.
 
 Return a JSON object with the following fields:
 
@@ -207,7 +224,7 @@ Return a JSON object with the following fields:
   - reason: 1-2 sentence explanation tying the three dimensions together.
     Example: "Late-cycle but still cheap on forward earnings; defensive qualities attractive as growth slows."
 
-  - bestExchange: which exchange is strongest for that sector right now
+  - bestExchange: the best listing universe for this sector. MUST be one of: ${supportedUniverses.join(", ")}
 
 "actionSummary" — top-3 trades:
   - enter: array of top 3 { sector, reason } to buy/overweight
@@ -218,8 +235,16 @@ IMPORTANT: Your entire response must be a single valid JSON object. Begin your r
     })
 
     if (data) {
-      setResult(data)
-      setTabCache("market", data)
+      const enriched: MarketAnalysisResult = {
+        ...data,
+        sectors: (data.sectors ?? []).map((sector) => ({
+          ...sector,
+          recommendationUniverse: resolveSectorUniverse(sector.bestExchange, region),
+          sourceRegion: region,
+        })),
+      }
+      setResult(enriched)
+      setTabCache("market", enriched)
       setHasResults(true)
     }
   }
@@ -240,11 +265,11 @@ IMPORTANT: Your entire response must be a single valid JSON object. Begin your r
         }
       />
 
-      {/* Geography Selector */}
+      {/* Region Selector */}
       <SegmentedControl
-        options={["Global", "ASX", "US", "UK"] as Geography[]}
-        value={geography}
-        onChange={setGeography}
+        options={ANALYSIS_REGIONS.map((option) => REGION_LABELS[option])}
+        value={REGION_LABELS[region]}
+        onChange={(label) => setRegion(regionFromLabel(label))}
       />
 
       {/* Cache Status / Mode Toggle - right above the action button */}
@@ -296,7 +321,7 @@ IMPORTANT: Your entire response must be a single valid JSON object. Begin your r
       {hasResults && result ? (
         <div className="space-y-6">
           {/* Date indicator */}
-          <p className="text-xs text-muted-foreground">{geography} · {new Date().toLocaleDateString('en-AU', { month: 'long', year: 'numeric' })}</p>
+          <p className="text-xs text-muted-foreground">{REGION_LABELS[region]} · {new Date().toLocaleDateString('en-AU', { month: 'long', year: 'numeric' })}</p>
 
           {/* Macro Indicator Cards */}
           <div className="flex gap-3 overflow-x-auto pb-2 -mx-4 px-4 md:mx-0 md:px-0 md:grid md:grid-cols-2 lg:grid-cols-4 md:overflow-visible scrollbar-hide">
@@ -388,7 +413,16 @@ IMPORTANT: Your entire response must be a single valid JSON object. Begin your r
                   <Card
                     key={sector.sector}
                     interactive
-                    onClick={() => navigateToRecsWithSector(sector.sector)}
+                    onClick={() => {
+                      const sourceRegion = sector.sourceRegion ?? region
+                      const recommendationUniverse = sector.recommendationUniverse
+                        ?? resolveSectorUniverse(sector.bestExchange, sourceRegion)
+                      navigateToRecsWithSector({
+                        sector: sector.sector,
+                        recommendationUniverse,
+                        sourceRegion,
+                      })
+                    }}
                     animationDelay={i * 30}
                   >
                     <div className="space-y-3">
@@ -447,9 +481,14 @@ IMPORTANT: Your entire response must be a single valid JSON object. Begin your r
                         </button>
                       )}
 
-                      {/* Best exchange + View picks */}
+                      {/* Recommendation universe + View picks */}
                       <div className="flex items-center justify-between pt-2 border-t border-border">
-                        <span className="text-xs text-muted-foreground">Best: <span className="text-foreground font-medium">{sector.bestExchange}</span></span>
+                        <span className="text-xs text-muted-foreground">
+                          Universe:{" "}
+                          <span className="text-foreground font-medium">
+                            {sector.recommendationUniverse ?? resolveSectorUniverse(sector.bestExchange, sector.sourceRegion ?? region)}
+                          </span>
+                        </span>
                         <span className="text-xs text-primary flex items-center gap-1">
                           View picks <ChevronRight className="size-3" />
                         </span>
@@ -520,7 +559,7 @@ IMPORTANT: Your entire response must be a single valid JSON object. Begin your r
           icon={BarChart3}
           title="No analysis yet"
           titleClassName="font-display"
-          description="Select a geography and tap Run Analysis to see AI-powered sector rotation signals."
+          description="Select a region and tap Run Analysis to see AI-powered sector rotation signals."
         />
       )}
     </div>

--- a/apps/stock-analyser/components/stock-analyser/tabs/metals-tab.tsx
+++ b/apps/stock-analyser/components/stock-analyser/tabs/metals-tab.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState } from "react"
+import { useEffect, useState } from "react"
 import { useNavigation } from "../app-shell"
 import {
   PageHeader,
@@ -11,15 +11,7 @@ import {
   TextToggle,
   type TrendSignal,
 } from "@transformotion/ui-primitives"
-import { 
-  TrendingUp, 
-  TrendingDown, 
-  Minus,
-  ChevronDown,
-  Sparkles,
-  AlertCircle,
-  RefreshCw,
-} from "lucide-react"
+import { ChevronDown, AlertCircle, RefreshCw } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { useClaude } from "@/lib/hooks"
 import { Spinner } from "@transformotion/ui-primitives"
@@ -99,9 +91,9 @@ const METALS: Metal[] = [
 ]
 
 export function MetalsTab() {
-  const { navigateToAnalyser, getTabTextVisibility, setTabTextOverride, showExplanatoryText, setTabCache, getTabCache } = useNavigation()
-  const [isLive, setIsLive] = useState(false)
-  const [hasRun, setHasRun] = useState(false)
+  const { navigateToAnalyser, getTabTextVisibility, setTabTextOverride, showExplanatoryText, defaultSearchMode, setTabCache, getTabCache } = useNavigation()
+  const [isLive, setIsLive] = useState(defaultSearchMode === "live")
+  const [, setHasRun] = useState(false)
   const cachedMetals = getTabCache("metals")?.metals as Metal[] | null
   const [metalResults, setMetalResults] = useState<Metal[]>(cachedMetals ?? [])
   const [expandedCards, setExpandedCards] = useState<Set<string>>(new Set())
@@ -121,11 +113,16 @@ export function MetalsTab() {
 
   const { callClaude, isLoading: isAnalyzing, error } = useClaude<{ metals: Metal[] }>()
 
+  useEffect(() => {
+    setIsLive(defaultSearchMode === "live")
+  }, [defaultSearchMode])
+
   const runAnalysis = async (forceRefresh = false) => {
     const today = new Date().toLocaleDateString('en-AU', { day: 'numeric', month: 'long', year: 'numeric' })
     const result = await callClaude({
       cacheKey: 'METALS',
       forceRefresh,
+      webSearch: isLive,
       prompt: `Provide precious metals spot price analysis with latest data for ${today}.
 
 Return a JSON object with "metals" array for Gold, Silver, Platinum, and Palladium. Each should contain:

--- a/apps/stock-analyser/components/stock-analyser/tabs/recommendations-tab.tsx
+++ b/apps/stock-analyser/components/stock-analyser/tabs/recommendations-tab.tsx
@@ -22,8 +22,14 @@ import type { RecommendationUniverse } from "@transformotion/contracts/stock-ana
 import {
   RECOMMENDATION_UNIVERSES,
   REGION_LABELS,
-  isRecommendationUniverse,
 } from "../markets"
+import {
+  getIncomingRecommendationUniverse,
+  getInitialRecommendationUniverse,
+  isLiveSearchMode,
+  isMarketOriginatedUniverseUnavailable,
+  shouldDisableRecommendationsRun,
+} from "../recommendations-flow"
 
 type Mode = "Top Picks" | "Bottom of Cycle"
 
@@ -110,11 +116,10 @@ const BOTTOM_OF_CYCLE: Stock[] = [
 
 export function RecommendationsTab() {
   const { navigateToAnalyser, sectorFilter, recsUniverse, recsSourceRegion, recsSource, clearSectorFilter, navigateTo, getTabTextVisibility, setTabTextOverride, showExplanatoryText, defaultSearchMode, setTabCache, getTabCache } = useNavigation()
-  const [isLive, setIsLive] = useState(defaultSearchMode === "live")
-  const marketOriginated = !!sectorFilter
-  const incomingUniverse = isRecommendationUniverse(recsUniverse) ? recsUniverse : null
-  const universeUnavailable = marketOriginated && !incomingUniverse
-  const [universe, setUniverse] = useState<RecommendationUniverse>(() => incomingUniverse ?? "ASX")
+  const [isLive, setIsLive] = useState(isLiveSearchMode(defaultSearchMode))
+  const incomingUniverse = getIncomingRecommendationUniverse(recsUniverse)
+  const universeUnavailable = isMarketOriginatedUniverseUnavailable(sectorFilter, incomingUniverse)
+  const [universe, setUniverse] = useState<RecommendationUniverse>(() => getInitialRecommendationUniverse(recsUniverse))
   const [universeTouched, setUniverseTouched] = useState(false)
   const [mode, setMode] = useState<Mode>("Top Picks")
   const [hasRun, setHasRun] = useState(false)
@@ -139,7 +144,7 @@ export function RecommendationsTab() {
   const { callClaude, isLoading, error } = useClaude<{ stocks: Stock[] }>()
 
   useEffect(() => {
-    setIsLive(defaultSearchMode === "live")
+    setIsLive(isLiveSearchMode(defaultSearchMode))
   }, [defaultSearchMode])
 
   const runRecommendations = async (
@@ -319,7 +324,7 @@ Return 6 stocks. Return ONLY valid JSON.`,
       {/* Run Analysis Button */}
       <PrimaryButton
         onClick={() => handleRunAnalysis(hasRun)}
-        disabled={isLoading || (universeUnavailable && !universeTouched)}
+        disabled={isLoading || shouldDisableRecommendationsRun(universeUnavailable, universeTouched)}
         className="w-full"
       >
         {isLoading ? (

--- a/apps/stock-analyser/components/stock-analyser/tabs/recommendations-tab.tsx
+++ b/apps/stock-analyser/components/stock-analyser/tabs/recommendations-tab.tsx
@@ -7,9 +7,6 @@ import {
   SegmentedControl,
   PillSelector,
   Card,
-  StockIcon,
-  VerdictBadge,
-  CycleGauge,
   BackLink,
   PrimaryButton,
   CacheStatusBar,
@@ -18,11 +15,16 @@ import {
   type Verdict,
   type CycleStage,
 } from "@transformotion/ui-primitives"
-import { ChevronRight, ChevronDown, Sparkles, Search, Loader2, Stars, AlertCircle } from "lucide-react"
+import { ChevronRight, ChevronDown, Search, Loader2, Stars, AlertCircle } from "lucide-react"
 import { useClaude } from "@/lib/hooks"
 import { cn } from "@/lib/utils"
+import type { RecommendationUniverse } from "@transformotion/contracts/stock-analyser/types"
+import {
+  RECOMMENDATION_UNIVERSES,
+  REGION_LABELS,
+  isRecommendationUniverse,
+} from "../markets"
 
-type Market = "ASX" | "NASDAQ" | "Dow" | "FTSE"
 type Mode = "Top Picks" | "Bottom of Cycle"
 
 interface Stock {
@@ -107,9 +109,13 @@ const BOTTOM_OF_CYCLE: Stock[] = [
 ]
 
 export function RecommendationsTab() {
-  const { navigateToAnalyser, sectorFilter, recsSource, clearSectorFilter, navigateTo, getTabTextVisibility, setTabTextOverride, showExplanatoryText, setTabCache, getTabCache } = useNavigation()
-  const [isLive, setIsLive] = useState(false)
-  const [market, setMarket] = useState<Market>("ASX")
+  const { navigateToAnalyser, sectorFilter, recsUniverse, recsSourceRegion, recsSource, clearSectorFilter, navigateTo, getTabTextVisibility, setTabTextOverride, showExplanatoryText, defaultSearchMode, setTabCache, getTabCache } = useNavigation()
+  const [isLive, setIsLive] = useState(defaultSearchMode === "live")
+  const marketOriginated = !!sectorFilter
+  const incomingUniverse = isRecommendationUniverse(recsUniverse) ? recsUniverse : null
+  const universeUnavailable = marketOriginated && !incomingUniverse
+  const [universe, setUniverse] = useState<RecommendationUniverse>(() => incomingUniverse ?? "ASX")
+  const [universeTouched, setUniverseTouched] = useState(false)
   const [mode, setMode] = useState<Mode>("Top Picks")
   const [hasRun, setHasRun] = useState(false)
   const cachedStocks = getTabCache("recs")?.stocks as Stock[] | null
@@ -132,13 +138,23 @@ export function RecommendationsTab() {
 
   const { callClaude, isLoading, error } = useClaude<{ stocks: Stock[] }>()
 
-  const runRecommendations = async (sectorOverride?: string, forceRefresh = false) => {
+  useEffect(() => {
+    setIsLive(defaultSearchMode === "live")
+  }, [defaultSearchMode])
+
+  const runRecommendations = async (
+    sectorOverride?: string,
+    forceRefresh = false,
+    universeOverride?: RecommendationUniverse,
+  ) => {
     const sector = sectorOverride || sectorFilter
-    const cacheKey = `RECS#${market}#${mode}${sector ? `#${sector}` : ''}`
+    const activeUniverse = universeOverride ?? universe
+    const cacheKey = `RECS#${activeUniverse}#${mode}${sector ? `#${sector}` : ''}`
     const result = await callClaude({
       cacheKey,
       forceRefresh,
-      prompt: `Provide stock recommendations for ${market} market${sector ? ` in the ${sector} sector` : ''}.
+      webSearch: isLive,
+      prompt: `Provide stock recommendations for the ${activeUniverse} universe${sector ? ` in the ${sector} sector` : ''}.
 Mode: ${mode}
 
 Return a JSON object with "stocks" array, each containing:
@@ -172,14 +188,20 @@ Return 6 stocks. Return ONLY valid JSON.`,
   useEffect(() => {
     if (sectorFilter) {
       setMode("Top Picks")
-      // Auto-trigger the search when coming from Market Analysis (only once per sector)
-      if (autoRunTriggeredRef.current !== sectorFilter) {
-        autoRunTriggeredRef.current = sectorFilter
-        runRecommendations(sectorFilter)
+      if (incomingUniverse) {
+        setUniverseTouched(false)
+        setUniverse(incomingUniverse)
+        const autoRunKey = `${sectorFilter}:${incomingUniverse}`
+        if (autoRunTriggeredRef.current !== autoRunKey) {
+          autoRunTriggeredRef.current = autoRunKey
+          runRecommendations(sectorFilter, false, incomingUniverse)
+        }
+      } else {
+        setUniverseTouched(false)
       }
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [sectorFilter])
+  }, [sectorFilter, recsUniverse])
 
   // Use AI results if available, otherwise fall back to static mock data
   const stocks = stockResults.length > 0 ? stockResults : (mode === "Top Picks" ? TOP_PICKS : BOTTOM_OF_CYCLE)
@@ -217,7 +239,15 @@ Return 6 stocks. Return ONLY valid JSON.`,
         <div className="flex items-center justify-between p-3 bg-card border border-border rounded-lg">
           <div>
             <p className="text-xs text-muted-foreground">Picks for:</p>
-            <p className="text-sm font-semibold text-foreground">{sectorFilter} <span className="text-muted-foreground">· Recommended: {market === "ASX" ? "ASX" : market}</span></p>
+            <p className="text-sm font-semibold text-foreground">
+              {sectorFilter}
+              {!universeUnavailable && (
+                <span className="text-muted-foreground"> · Universe: {universe}</span>
+              )}
+              {recsSourceRegion && (
+                <span className="text-muted-foreground"> · from {REGION_LABELS[recsSourceRegion]}</span>
+              )}
+            </p>
           </div>
           <button onClick={() => { clearSectorFilter(); setHasRun(false); }} className="text-xs font-medium text-primary hover:text-primary/80">
             × Clear
@@ -238,11 +268,25 @@ Return 6 stocks. Return ONLY valid JSON.`,
         }
       />
 
-      {/* Market Selector */}
+      {universeUnavailable && !universeTouched && (
+        <div className="p-3 rounded-lg bg-signal-amber/10 border border-signal-amber/20 flex items-start gap-2">
+          <AlertCircle className="size-4 text-signal-amber mt-0.5 shrink-0" />
+          <div className="text-sm text-foreground">
+            We could not determine a recommendation universe for{" "}
+            <span className="font-medium">{sectorFilter}</span>
+            {recsSourceRegion ? ` in ${REGION_LABELS[recsSourceRegion]}` : ""}. Choose a universe below to continue.
+          </div>
+        </div>
+      )}
+
+      {/* Universe Selector */}
       <SegmentedControl
-        options={["ASX", "NASDAQ", "Dow", "FTSE"] as Market[]}
-        value={market}
-        onChange={setMarket}
+        options={[...RECOMMENDATION_UNIVERSES]}
+        value={universe}
+        onChange={(nextUniverse) => {
+          setUniverse(nextUniverse)
+          setUniverseTouched(true)
+        }}
       />
 
       {/* Mode Selector */}
@@ -275,7 +319,7 @@ Return 6 stocks. Return ONLY valid JSON.`,
       {/* Run Analysis Button */}
       <PrimaryButton
         onClick={() => handleRunAnalysis(hasRun)}
-        disabled={isLoading}
+        disabled={isLoading || (universeUnavailable && !universeTouched)}
         className="w-full"
       >
         {isLoading ? (
@@ -286,7 +330,7 @@ Return 6 stocks. Return ONLY valid JSON.`,
         ) : hasRun ? (
           <>
             <Search className="size-4" />
-            Re-analyse {sectorFilter ? sectorFilter : market}
+            Re-analyse {sectorFilter ? sectorFilter : universe}
           </>
         ) : (
           <>
@@ -307,11 +351,11 @@ Return 6 stocks. Return ONLY valid JSON.`,
       {/* Stock List - Grid layout */}
       <div className="space-y-3">
         <p className="text-xs text-muted-foreground">
-          {sectorFilter ? sectorFilter : market} — {mode} · {new Date().toLocaleDateString('en-AU', { month: 'long', year: 'numeric' })}
+          {sectorFilter ? sectorFilter : universe} — {mode} · {new Date().toLocaleDateString('en-AU', { month: 'long', year: 'numeric' })}
           {!hasRun && <span className="ml-1 opacity-60">(cached)</span>}
         </p>
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
-          {stocks.map((stock, i) => (
+          {filteredStocks.map((stock, i) => (
               <Card
                 key={stock.ticker}
                 interactive

--- a/apps/stock-analyser/components/stock-analyser/tabs/settings-tab.tsx
+++ b/apps/stock-analyser/components/stock-analyser/tabs/settings-tab.tsx
@@ -3,8 +3,9 @@
 import { useEffect, useState } from "react"
 import { useNavigation } from "../app-shell"
 import { selectUser, useAuthStore } from "@/stores/auth/use-auth-store"
-import { PageHeader, Card, PrimaryButton, SecondaryButton, TextToggle } from "@transformotion/ui-primitives"
-import { AlertCircle, Check, Cpu, FileText, Lock, RotateCcw, Save } from "lucide-react"
+import { PageHeader, Card, PrimaryButton, SecondaryButton, SegmentedControl, TextToggle } from "@transformotion/ui-primitives"
+import { AlertCircle, Check, Cpu, FileText, Lock, RotateCcw, Save, Zap } from "lucide-react"
+import type { SearchMode } from "../app-shell"
 import {
   stockAnalyserSettingsService,
   SUPPORTED_AI_MODELS,
@@ -85,6 +86,46 @@ function AnalysisTextCard() {
             visible={showExplanatoryText}
             onToggle={() => void updatePreference(!showExplanatoryText)}
             size="md"
+          />
+        </div>
+      </div>
+    </Card>
+  )
+}
+
+const SEARCH_MODE_LABELS: Record<SearchMode, string> = { fast: "Fast", live: "Live" }
+const SEARCH_MODE_FROM_LABEL: Record<string, SearchMode> = { Fast: "fast", Live: "live" }
+
+function DefaultSearchModeCard() {
+  const { defaultSearchMode, setDefaultSearchMode } = useNavigation()
+
+  return (
+    <Card className="space-y-4">
+      <div className="flex items-start gap-3">
+        <div className="size-9 rounded-lg bg-primary/15 flex items-center justify-center shrink-0">
+          <Zap className="size-5 text-primary" />
+        </div>
+        <div>
+          <h3 className="font-display text-sm font-semibold tracking-wide text-foreground">Default search mode</h3>
+          <p className="text-xs text-muted-foreground leading-relaxed">
+            The mode each analysis and recommendation view starts in. Live uses fresh AI analysis; Fast favours cached results.
+            Per-run mode changes do not alter this default.
+          </p>
+        </div>
+      </div>
+
+      <div className="flex items-center justify-between gap-3 rounded-xl border border-border bg-surface2/60 px-3 py-3">
+        <div>
+          <p className="text-sm font-medium text-foreground">Mode</p>
+          <p className="text-xs text-muted-foreground">
+            New searches start in {SEARCH_MODE_LABELS[defaultSearchMode]} mode
+          </p>
+        </div>
+        <div className="w-40">
+          <SegmentedControl
+            options={["Fast", "Live"]}
+            value={SEARCH_MODE_LABELS[defaultSearchMode]}
+            onChange={(label) => setDefaultSearchMode(SEARCH_MODE_FROM_LABEL[label])}
           />
         </div>
       </div>
@@ -269,6 +310,7 @@ export function SettingsTab() {
         titleClassName="font-display uppercase tracking-wide"
       />
       <AnalysisTextCard />
+      <DefaultSearchModeCard />
       <AiEngineCard />
     </div>
   )

--- a/apps/stock-analyser/functions/settings/src/index.test.ts
+++ b/apps/stock-analyser/functions/settings/src/index.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { APIGatewayProxyEvent } from '@transformotion/lambda-middleware';
+import { createHandler } from './index';
+
+type HandlerDependencies = NonNullable<Parameters<typeof createHandler>[0]>;
+
+vi.mock('@transformotion/fn-ai-proxy-core', () => ({
+  AI_CONFIG_PK: 'AI_CONFIG',
+  AI_MODEL_ALLOWLIST: { claude: ['claude-sonnet-4-6'], openai: ['gpt-5.4-mini'] },
+  PLATFORM_DEFAULT_SK: 'PLATFORM#default',
+  appOverrideSk: (appSlug: string) => `APP#${appSlug}`,
+  assertValidAiConfig: () => undefined,
+  isSupportedAiModel: () => true,
+  isSupportedAiProvider: () => true,
+  resolveEnvFallbackConfig: () => ({
+    provider: 'claude',
+    model: 'claude-sonnet-4-6',
+    source: 'environment_fallback',
+  }),
+}));
+
+function makeEvent(method: 'GET' | 'PATCH', body?: unknown): APIGatewayProxyEvent {
+  return {
+    httpMethod: method,
+    resource: '/settings',
+    headers: { 'X-Account-Id': 'acct-1' },
+    body: body === undefined ? null : JSON.stringify(body),
+    requestContext: {
+      authorizer: {
+        claims: {
+          sub: 'user-1',
+          email: 'user@example.com',
+          apps: JSON.stringify(['stock-analyser']),
+          accounts: JSON.stringify({
+            'stock-analyser': [{ accountId: 'acct-1', role: 'viewer' }],
+          }),
+        },
+      },
+    },
+  } as unknown as APIGatewayProxyEvent;
+}
+
+function createFakeDeps(initialItem?: Record<string, unknown>) {
+  let item = initialItem;
+  return {
+    deps: {
+      client: {
+        async send(command: { input?: { Item?: Record<string, unknown> } }) {
+          if (command.input?.Item) {
+            item = command.input.Item;
+            return {};
+          }
+          return item ? { Item: item } : {};
+        },
+      },
+      settingsTable: 'settings',
+      platformConfigTable: 'platform',
+      now: () => new Date('2026-06-24T00:00:00.000Z'),
+    } as unknown as HandlerDependencies,
+    getItem: () => item,
+  };
+}
+
+describe('Stock Analyser settings handler', () => {
+  it('defaults defaultSearchMode to live when no preference exists', async () => {
+    const { deps } = createFakeDeps();
+    const res = await createHandler(deps)(makeEvent('GET'));
+
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toEqual({
+      settings: {
+        pk: 'SETTINGS',
+        sk: 'APP#stock-analyser',
+        explanatoryTextEnabled: true,
+        defaultSearchMode: 'live',
+        updatedAt: '2026-06-24T00:00:00.000Z',
+      },
+    });
+  });
+
+  it('patches defaultSearchMode without mutating explanatory text to an invalid value', async () => {
+    const { deps, getItem } = createFakeDeps({
+      pk: 'ACCOUNT#acct-1',
+      sk: 'USER#user-1#PREFERENCES',
+      explanatoryTextEnabled: false,
+      defaultSearchMode: 'live',
+      updatedAt: '2026-06-23T00:00:00.000Z',
+    });
+
+    const res = await createHandler(deps)(makeEvent('PATCH', { defaultSearchMode: 'fast' }));
+
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body).settings).toMatchObject({
+      explanatoryTextEnabled: false,
+      defaultSearchMode: 'fast',
+    });
+    expect(getItem()).toMatchObject({
+      explanatoryTextEnabled: false,
+      defaultSearchMode: 'fast',
+    });
+  });
+
+  it('rejects unsupported settings fields', async () => {
+    const { deps } = createFakeDeps();
+    const res = await createHandler(deps)(makeEvent('PATCH', { market: 'ASX' }));
+
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).message).toContain('Unsupported settings fields: market');
+  });
+});

--- a/apps/stock-analyser/functions/settings/src/index.ts
+++ b/apps/stock-analyser/functions/settings/src/index.ts
@@ -23,6 +23,7 @@ import {
   type AppAiRuntimeConfigResponse,
 } from '@transformotion/fn-ai-proxy-core';
 import type { StockAnalyserSettings } from '@transformotion/contracts/stock-analyser/types';
+import type { PatchSettingsRequest } from '@transformotion/contracts/stock-analyser/api';
 
 const ddb = DynamoDBDocumentClient.from(new DynamoDBClient({}));
 const SETTINGS_TABLE = process.env.SETTINGS_TABLE!;
@@ -135,6 +136,9 @@ async function readSettings(deps: Dependencies, accountId: string, userId: strin
   const explanatoryTextEnabled = typeof res.Item?.['explanatoryTextEnabled'] === 'boolean'
     ? res.Item['explanatoryTextEnabled'] as boolean
     : true;
+  const defaultSearchMode = res.Item?.['defaultSearchMode'] === 'fast' || res.Item?.['defaultSearchMode'] === 'live'
+    ? res.Item['defaultSearchMode'] as StockAnalyserSettings['defaultSearchMode']
+    : 'live';
   const updatedAt = typeof res.Item?.['updatedAt'] === 'string'
     ? res.Item['updatedAt'] as string
     : deps.now().toISOString();
@@ -142,34 +146,62 @@ async function readSettings(deps: Dependencies, accountId: string, userId: strin
     pk: 'SETTINGS',
     sk: 'APP#stock-analyser',
     explanatoryTextEnabled,
+    defaultSearchMode,
     updatedAt,
   };
   return ok({ settings });
 }
 
 async function patchSettings(deps: Dependencies, event: APIGatewayProxyEvent, accountId: string, userId: string) {
-  const body = parseBody<{ explanatoryTextEnabled?: unknown } & Record<string, unknown>>(event);
-  const unexpected = Object.keys(body).filter(key => key !== 'explanatoryTextEnabled');
+  const body = parseBody<PatchSettingsRequest & Record<string, unknown>>(event);
+  const unexpected = Object.keys(body).filter(key => key !== 'explanatoryTextEnabled' && key !== 'defaultSearchMode');
   if (unexpected.length) {
     throw badRequest(`Unsupported settings fields: ${unexpected.join(', ')}`);
   }
-  if (typeof body.explanatoryTextEnabled !== 'boolean') {
+  if (body.explanatoryTextEnabled !== undefined && typeof body.explanatoryTextEnabled !== 'boolean') {
     throw badRequest('explanatoryTextEnabled must be a boolean');
   }
+  if (
+    body.defaultSearchMode !== undefined &&
+    body.defaultSearchMode !== 'fast' &&
+    body.defaultSearchMode !== 'live'
+  ) {
+    throw badRequest('defaultSearchMode must be "live" or "fast"');
+  }
+  if (body.explanatoryTextEnabled === undefined && body.defaultSearchMode === undefined) {
+    throw badRequest('At least one supported settings field is required');
+  }
+
+  const existing = await deps.client.send(new GetCommand({
+    TableName: deps.settingsTable,
+    Key: { pk: accountPk(accountId), sk: userPreferencesSk(userId) },
+  }));
+  const explanatoryTextEnabled = body.explanatoryTextEnabled ?? (
+    typeof existing.Item?.['explanatoryTextEnabled'] === 'boolean'
+      ? existing.Item['explanatoryTextEnabled'] as boolean
+      : true
+  );
+  const defaultSearchMode = body.defaultSearchMode ?? (
+    existing.Item?.['defaultSearchMode'] === 'fast' || existing.Item?.['defaultSearchMode'] === 'live'
+      ? existing.Item['defaultSearchMode'] as StockAnalyserSettings['defaultSearchMode']
+      : 'live'
+  );
   const updatedAt = deps.now().toISOString();
   await deps.client.send(new PutCommand({
     TableName: deps.settingsTable,
     Item: {
       pk: accountPk(accountId),
       sk: userPreferencesSk(userId),
-      explanatoryTextEnabled: body.explanatoryTextEnabled,
+      explanatoryTextEnabled,
+      defaultSearchMode,
       updatedAt,
     },
   }));
   const settings: StockAnalyserSettings = {
     pk: 'SETTINGS',
     sk: 'APP#stock-analyser',
-    explanatoryTextEnabled: body.explanatoryTextEnabled,
+    explanatoryTextEnabled,
+    defaultSearchMode,
     updatedAt,
   };
   return ok({ settings });

--- a/apps/stock-analyser/lib/api/index.ts
+++ b/apps/stock-analyser/lib/api/index.ts
@@ -2,6 +2,7 @@ import { ApiClient, HttpClient } from '@transformotion/api-client'
 import type { PutCacheRequest, ClaudeProxyRequest } from '@transformotion/api-client'
 import type { AiRuntimeConfigUpdate, AppAiRuntimeConfigResponse } from '@transformotion/contracts/_shared/ai-runtime'
 import type { StockAnalyserSettings } from '@transformotion/contracts/stock-analyser/types'
+import type { PatchSettingsRequest } from '@transformotion/contracts/stock-analyser/api'
 import { authService } from '../services/auth'
 import { getConfig } from '../config'
 import { getActiveAccountId } from '@/stores/active-account/use-active-account-store'
@@ -44,7 +45,7 @@ export const stockAnalyserClient = {
   getSettings(): Promise<{ settings: StockAnalyserSettings }> {
     return http().get('settings')
   },
-  patchSettings(body: Partial<Pick<StockAnalyserSettings, 'explanatoryTextEnabled'>>): Promise<{ settings: StockAnalyserSettings }> {
+  patchSettings(body: PatchSettingsRequest): Promise<{ settings: StockAnalyserSettings }> {
     return http().patch('settings', body)
   },
   getAiConfig(): Promise<AppAiRuntimeConfigResponse> {

--- a/apps/stock-analyser/lib/services/settings/settings-service.ts
+++ b/apps/stock-analyser/lib/services/settings/settings-service.ts
@@ -6,6 +6,7 @@ import {
   type AiRuntimeConfigUpdate,
   type AppAiRuntimeConfigResponse,
 } from '@transformotion/contracts/_shared/ai-runtime';
+import type { PatchSettingsRequest } from '@transformotion/contracts/stock-analyser/api';
 import type { StockAnalyserSettings } from '@transformotion/contracts/stock-analyser/types';
 
 export type {
@@ -26,6 +27,7 @@ const mockSettings: StockAnalyserSettings = {
   pk: 'SETTINGS',
   sk: 'APP#stock-analyser',
   explanatoryTextEnabled: true,
+  defaultSearchMode: 'live',
   updatedAt: new Date().toISOString(),
 };
 
@@ -58,8 +60,13 @@ const mockService = {
   async getSettings(): Promise<StockAnalyserSettings> {
     return { ...mockSettings };
   },
-  async patchSettings(updates: Pick<StockAnalyserSettings, 'explanatoryTextEnabled'>): Promise<StockAnalyserSettings> {
-    mockSettings.explanatoryTextEnabled = updates.explanatoryTextEnabled;
+  async patchSettings(updates: PatchSettingsRequest): Promise<StockAnalyserSettings> {
+    if (typeof updates.explanatoryTextEnabled === 'boolean') {
+      mockSettings.explanatoryTextEnabled = updates.explanatoryTextEnabled;
+    }
+    if (updates.defaultSearchMode === 'fast' || updates.defaultSearchMode === 'live') {
+      mockSettings.defaultSearchMode = updates.defaultSearchMode;
+    }
     mockSettings.updatedAt = new Date().toISOString();
     return { ...mockSettings };
   },
@@ -87,7 +94,7 @@ const realService = {
     const res = await stockAnalyserClient.getSettings();
     return res.settings;
   },
-  async patchSettings(updates: Pick<StockAnalyserSettings, 'explanatoryTextEnabled'>): Promise<StockAnalyserSettings> {
+  async patchSettings(updates: PatchSettingsRequest): Promise<StockAnalyserSettings> {
     const res = await stockAnalyserClient.patchSettings(updates);
     return res.settings;
   },

--- a/apps/stock-analyser/vitest.config.ts
+++ b/apps/stock-analyser/vitest.config.ts
@@ -3,6 +3,6 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     environment: 'node',
-    include: ['lib/**/*.test.ts', 'stores/**/*.test.ts'],
+    include: ['lib/**/*.test.ts', 'stores/**/*.test.ts', 'functions/**/*.test.ts'],
   },
 });

--- a/apps/stock-analyser/vitest.config.ts
+++ b/apps/stock-analyser/vitest.config.ts
@@ -3,6 +3,6 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     environment: 'node',
-    include: ['lib/**/*.test.ts', 'stores/**/*.test.ts', 'functions/**/*.test.ts'],
+    include: ['components/**/*.test.ts', 'lib/**/*.test.ts', 'stores/**/*.test.ts', 'functions/**/*.test.ts'],
   },
 });


### PR DESCRIPTION
## Summary

Implements the v0-approved Stock Analyser region/universe recommendation flow and contract-backed default search mode from v0 PR #68.

Scope classification:

- Market Analysis region -> Recommendations universe handoff: [prototyped bugfix]
- `AnalysisRegion` / `RecommendationUniverse` contracts and navigation payload: [contracted via v0 PR #68]
- `defaultSearchMode: "live" | "fast"` setting: [contracted via v0 PR #68]
- New universes beyond v0 support: [net-new, out of scope]

No Launchpad or Budget Tracker files changed. No deployment performed.

## v0 freshness

This runtime change implements the canonical v0 Stock Analyser region/universe and default-search-mode contract from transformotion-apps-b8 PR #68 / merge commit:

- https://github.com/transformotion/transformotion-apps-b8/pull/68
- https://github.com/transformotion/transformotion-apps-b8/commit/1f883bb

## What Changed

- Synced v0 contracts from v0 `main` at merge commit `1f883bb` and confirmed the generated Stock Analyser contract includes:
  - `AnalysisRegion`
  - `RecommendationUniverse`
  - `REGION_TO_RECOMMENDATION_UNIVERSES`
  - `MarketAnalysisSectorResult`
  - `RecommendationsNavigationPayload`
  - `StockAnalyserSearchMode`
  - `StockAnalyserSettings.defaultSearchMode`
  - `PatchSettingsRequest.defaultSearchMode`
  - navigation docs requiring region-vs-universe separation and no silent ASX fallback
- Added Stock Analyser app-local projection helper at `apps/stock-analyser/components/stock-analyser/markets.ts`, importing the canonical contract constants/types and adding labels/model-string normalisation.
- Updated Market Analysis to use `AnalysisRegion`, constrain model output to supported universes, enrich sector results with `recommendationUniverse`, and pass `RecommendationsNavigationPayload` on sector click.
- Updated Recommendations to use `RecommendationUniverse`, initialize from the incoming structured universe, keep ASX only as the direct-entry default, and show a recoverable choose-a-universe state for Market-originated missing/invalid universe.
- Added `defaultSearchMode` support through app shell state, Settings UI, settings service/client, and the settings Lambda.
- Seeded per-run Fast/Live toggles from `defaultSearchMode` and wired `webSearch` through Stock Analyser search calls.
- Added settings Lambda tests for Live default, patching Fast, and unsupported field rejection.
- Added targeted runtime behavioural tests for the Market -> Recommendations handoff, NASDAQ activation, no silent ASX fallback, direct-entry ASX default, and per-run search-mode initialization.

## Implementation Notes

- `AnalysisRegion` and `RecommendationUniverse` are consumed from `@transformotion/contracts/stock-analyser/types` via the SA helper module.
- Region -> universe mapping is imported from `REGION_TO_RECOMMENDATION_UNIVERSES` in `apps/stock-analyser/components/stock-analyser/markets.ts` and used by Market Analysis when resolving each sector's `recommendationUniverse`.
- Market sector click passes `sector`, `recommendationUniverse`, and `sourceRegion` through `apps/stock-analyser/components/stock-analyser/recommendations-flow.ts`, which is used by the runtime components and covered by tests.
- ASX fallback is limited to direct Recommendations entry in `apps/stock-analyser/components/stock-analyser/tabs/recommendations-tab.tsx`; Market-originated missing/invalid universe disables the run button until an explicit universe is selected.
- `defaultSearchMode` is persisted/patched through `PATCH /settings` in `apps/stock-analyser/functions/settings/src/index.ts` and frontend service/client updates.

## Runtime Behavioural Verification

Local route/basePath evidence:

- Dev server launched at `http://localhost:3402`.
- Correct Stock Analyser route confirmed as `http://localhost:3402/stock-analyser/` with HTTP 200.
- Root `/` returns 404 in this standalone app context because the app uses `basePath: '/stock-analyser'`.

Local browser/CDP click-through was not achieved in this workspace because Playwright is not installed and the repo does not include a browser automation harness for this app. I added targeted automated coverage instead.

Targeted test evidence in `apps/stock-analyser/components/stock-analyser/recommendations-flow.test.ts`:

- Global -> Technology with `recommendationUniverse: 'NASDAQ'` creates payload `{ sector: 'Technology', recommendationUniverse: 'NASDAQ', sourceRegion: 'global' }`.
- The navigation state opened from Market sets `activeTab: 'recs'`, `sectorFilter: 'Technology'`, `recsUniverse: 'NASDAQ'`, `recsSourceRegion: 'global'`, and `recsSource: 'market'`.
- A Global sector response with `bestExchange: 'NYSE'` normalises to the contracted `Dow` universe instead of treating NYSE as geography.
- Market-originated missing universe keeps the internal direct-entry default at ASX but disables the run path until the user explicitly selects a universe, so it does not silently run ASX.
- Direct Recommendations entry still defaults to ASX and remains runnable.
- Default search mode initializes per-run mode as Live; toggling per-run mode does not mutate the app default.

## Validation

- `pnpm sync:v0` - passed
- `pnpm check:v0-contracts` - passed with explicit `V0_REPO_PATH=C:\Users\steve\OneDrive\Documents\Code Repo\transformotion-apps-b8`
- `pnpm --filter @transformotion/stock-analyser typecheck` - passed
- `pnpm --filter @transformotion/stock-analyser build` - passed
- `pnpm --filter @transformotion/stock-analyser test` - passed, 6 files / 43 tests
- Settings Lambda tests included via `functions/**/*.test.ts` and passed
- Runtime flow tests included via `components/**/*.test.ts` and passed
- Full `pnpm --filter @transformotion/stock-analyser lint` - failed on pre-existing unrelated lint debt in untouched files:
  - `components/stock-analyser/tabs/portfolio-tab.tsx`
  - `components/stock-analyser/tabs/watchlist-tab.tsx`
- Targeted lint on all changed TS/TSX files - passed
- `git diff --check` - passed
- `pnpm check:v0-freshness` with this PR body's `## v0 freshness` section and changed-file list - passed

## Non-Scope Confirmation

- No Launchpad or Budget Tracker changes.
- No deployment performed.
- No GitHub issues/projects modified.
- No unrelated route/auth/session/account behavior changed.
- No Watchlist, Portfolio, chart rendering, tabs, M18 visual shell, or app IA changes intended beyond the explicit Stock Analyser contract/settings/navigation update.