### PR TITLE
Clean up Stock Analyser CTA hierarchy and BUY badges

### DIFF
--- a/apps/stock-analyser/components/stock-analyser/status-badge.test.ts
+++ b/apps/stock-analyser/components/stock-analyser/status-badge.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest"
+import { stockSignalBadgeClassName } from "./status-badge"
+
+describe("stockSignalBadgeClassName", () => {
+  it("renders BUY and ENTER as green positive badges", () => {
+    expect(stockSignalBadgeClassName("BUY")).toContain("bg-signal-green")
+    expect(stockSignalBadgeClassName("ENTER")).toContain("bg-signal-green")
+  })
+
+  it("preserves negative, hold, and neutral badge treatments", () => {
+    expect(stockSignalBadgeClassName("SELL")).toContain("bg-signal-red")
+    expect(stockSignalBadgeClassName("EXIT")).toContain("bg-signal-red")
+    expect(stockSignalBadgeClassName("HOLD")).toContain("bg-signal-amber")
+    expect(stockSignalBadgeClassName("NEUTRAL")).toContain("bg-muted")
+  })
+})

--- a/apps/stock-analyser/components/stock-analyser/status-badge.ts
+++ b/apps/stock-analyser/components/stock-analyser/status-badge.ts
@@ -1,0 +1,13 @@
+type StockSignal = "BUY" | "ENTER" | "HOLD" | "WATCH" | "SELL" | "EXIT" | "NEUTRAL" | string
+
+export function stockSignalBadgeClassName(signal: StockSignal): string {
+  const tone = signal === "BUY" || signal === "ENTER"
+    ? "bg-signal-green text-white"
+    : signal === "SELL" || signal === "EXIT"
+      ? "bg-signal-red text-white"
+      : signal === "HOLD" || signal === "WATCH"
+        ? "bg-signal-amber/80 text-background"
+        : "bg-muted/50 text-muted-foreground"
+
+  return `px-2 py-0.5 rounded text-[10px] font-semibold uppercase ${tone}`
+}

--- a/apps/stock-analyser/components/stock-analyser/tabs/etfs-tab.tsx
+++ b/apps/stock-analyser/components/stock-analyser/tabs/etfs-tab.tsx
@@ -10,10 +10,11 @@ import {
   PrimaryButton,
   TextToggle,
 } from "@transformotion/ui-primitives"
-import { ChevronRight, ChevronDown, AlertCircle } from "lucide-react"
+import { ChevronRight, ChevronDown, AlertCircle, RefreshCw } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { useClaude } from "@/lib/hooks"
 import { Spinner } from "@transformotion/ui-primitives"
+import { stockSignalBadgeClassName } from "../status-badge"
 
 type Market = "ASX" | "US" | "Global"
 type Category = "All" | "Index" | "Sector" | "Bond" | "Thematic" | "Property"
@@ -112,33 +113,37 @@ Provide 6 ETFs. Return ONLY valid JSON.`,
         }
       />
 
-      {/* Market selector + controls */}
-      <div className="flex items-center gap-2 flex-wrap">
-        <SegmentedControl
-          options={["ASX", "US", "Global"] as Market[]}
-          value={market}
-          onChange={setMarket}
-        />
-        <PrimaryButton
-          onClick={() => runAnalysis(etfResults.length > 0)}
-          disabled={isAnalyzing}
-        >
-          {isAnalyzing ? (
-            <>
-              <Spinner className="size-4" />
-              Loading...
-            </>
-          ) : (
-            "Refresh"
-          )}
-        </PrimaryButton>
-        <ModeToggle 
-          isLive={isLive} 
-          onToggle={() => setIsLive(!isLive)} 
-          cacheAge="3m ago"
-          freshness="recent"
-        />
-      </div>
+      {/* Market selector (secondary filter) */}
+      <SegmentedControl
+        options={["ASX", "US", "Global"] as Market[]}
+        value={market}
+        onChange={setMarket}
+      />
+
+      {/* Compact cached/live status */}
+      <ModeToggle
+        isLive={isLive}
+        onToggle={() => setIsLive(!isLive)}
+        cacheAge="3m ago"
+        freshness="recent"
+      />
+
+      {/* Primary CTA */}
+      <PrimaryButton
+        onClick={() => runAnalysis(etfResults.length > 0)}
+        disabled={isAnalyzing}
+        icon={isAnalyzing ? undefined : RefreshCw}
+        className="w-full"
+      >
+        {isAnalyzing ? (
+          <>
+            <Spinner className="size-4" />
+            Refreshing ETF signals...
+          </>
+        ) : (
+          "Refresh ETF signals"
+        )}
+      </PrimaryButton>
 
       {/* Date indicator */}
       <p className="text-xs text-muted-foreground">{market} ETFs · {new Date().toLocaleDateString('en-AU', { month: 'long', year: 'numeric' })}</p>
@@ -168,13 +173,7 @@ Provide 6 ETFs. Return ONLY valid JSON.`,
                     <p className="mt-0.5 font-display text-xs font-medium leading-tight tracking-wide text-muted-foreground">{etf.name}</p>
                     <p className="text-[11px] text-muted-foreground mt-1">{etf.category}</p>
                   </div>
-                  <span className={cn(
-                    "px-2 py-0.5 rounded text-[10px] font-semibold uppercase shrink-0 ml-2",
-                    etf.signal === "BUY" ? "bg-signal-green text-white" :
-                    etf.signal === "HOLD" ? "bg-signal-amber/80 text-background" :
-                    etf.signal === "SELL" ? "bg-signal-red text-white" :
-                    "bg-muted/50 text-muted-foreground"
-                  )}>
+                  <span className={cn(stockSignalBadgeClassName(etf.signal), "shrink-0 ml-2")}>
                     {etf.signal}
                   </span>
                 </div>

--- a/apps/stock-analyser/components/stock-analyser/tabs/market-analysis-tab.tsx
+++ b/apps/stock-analyser/components/stock-analyser/tabs/market-analysis-tab.tsx
@@ -36,6 +36,7 @@ import {
   resolveSectorUniverse,
 } from "../markets"
 import { createMarketSectorNavigationPayload } from "../recommendations-flow"
+import { stockSignalBadgeClassName } from "../status-badge"
 
 type Impact = "Supportive" | "Neutral" | "Headwind"
 type Valuation = "Cheap" | "Fair" | "Expensive" | "Extended"
@@ -423,12 +424,7 @@ IMPORTANT: Your entire response must be a single valid JSON object. Begin your r
                       {/* Header: Sector name + Signal badge */}
                       <div className="flex items-center justify-between">
                         <h4 className="font-display text-sm font-semibold tracking-wide text-foreground">{sector.sector}</h4>
-                        <span className={cn(
-                          "px-2 py-0.5 rounded text-[10px] font-semibold uppercase",
-                          sector.signal === "ENTER" ? "bg-signal-green text-white" :
-                          sector.signal === "EXIT" ? "bg-signal-red text-white" :
-                          "bg-signal-amber/80 text-background"
-                        )}>
+                        <span className={stockSignalBadgeClassName(sector.signal)}>
                           {sector.signal}
                         </span>
                       </div>

--- a/apps/stock-analyser/components/stock-analyser/tabs/metals-tab.tsx
+++ b/apps/stock-analyser/components/stock-analyser/tabs/metals-tab.tsx
@@ -168,31 +168,30 @@ Return ONLY valid JSON.`,
         }
       />
 
-      {/* Controls */}
-      <div className="flex items-center gap-2 flex-wrap">
-        <PrimaryButton
-          onClick={() => runAnalysis(metalResults.length > 0)}
-          disabled={isAnalyzing}
-        >
-          {isAnalyzing ? (
-            <>
-              <Spinner className="size-4" />
-              Loading...
-            </>
-          ) : (
-            <>
-              <RefreshCw className="size-4" />
-              Refresh
-            </>
-          )}
-        </PrimaryButton>
-        <ModeToggle 
-          isLive={isLive} 
-          onToggle={() => setIsLive(!isLive)} 
-          cacheAge="just now"
-          freshness="recent"
-        />
-      </div>
+      {/* Compact cached/live status */}
+      <ModeToggle
+        isLive={isLive}
+        onToggle={() => setIsLive(!isLive)}
+        cacheAge="just now"
+        freshness="recent"
+      />
+
+      {/* Primary CTA */}
+      <PrimaryButton
+        onClick={() => runAnalysis(metalResults.length > 0)}
+        disabled={isAnalyzing}
+        icon={isAnalyzing ? undefined : RefreshCw}
+        className="w-full"
+      >
+        {isAnalyzing ? (
+          <>
+            <Spinner className="size-4" />
+            Refreshing metals...
+          </>
+        ) : (
+          "Refresh metals"
+        )}
+      </PrimaryButton>
 
       {/* Date indicator */}
       <p className="text-xs text-muted-foreground">Spot prices · {new Date().toLocaleDateString('en-AU', { day: 'numeric', month: 'long', year: 'numeric' })}</p>

--- a/apps/stock-analyser/components/stock-analyser/tabs/portfolio-tab.tsx
+++ b/apps/stock-analyser/components/stock-analyser/tabs/portfolio-tab.tsx
@@ -56,7 +56,8 @@ export function PortfolioTab() {
   const toggleCardExpand = (ticker: string) => {
     setExpandedCards(prev => {
       const next = new Set(prev)
-      next.has(ticker) ? next.delete(ticker) : next.add(ticker)
+      if (next.has(ticker)) next.delete(ticker)
+      else next.add(ticker)
       return next
     })
   }
@@ -256,16 +257,30 @@ export function PortfolioTab() {
         action={<TextToggle visible={textVisible} onToggle={toggleText} isOverride={isTextOverride} />}
       />
 
-      {/* Actions */}
+      {/* Primary CTA */}
+      <PrimaryButton
+        icon={isAnalysing ? undefined : RefreshCw}
+        onClick={() => handleRefreshAll(true)}
+        disabled={isAnalysing}
+        className="w-full"
+      >
+        {isAnalysing ? (
+          <><Loader2 className="size-4 animate-spin" /> Refreshing portfolio signals{analysingLeft > 0 ? ` (${analysingLeft} left)` : ''}...</>
+        ) : (
+          'Refresh portfolio signals'
+        )}
+      </PrimaryButton>
+
+      {/* Utility actions */}
       <div className="flex items-center gap-2 flex-wrap">
-        <PrimaryButton icon={Upload} onClick={() => fileInputRef.current?.click()} className="h-9 px-3 text-sm">
+        <SecondaryButton icon={Upload} onClick={() => fileInputRef.current?.click()} className="h-9 px-3 text-sm">
           Import CSV
-        </PrimaryButton>
+        </SecondaryButton>
         <SecondaryButton
           icon={isAnalysing ? undefined : RefreshCw}
           onClick={() => handleRefreshAll(true)}
           disabled={isAnalysing}
-          className="h-9 px-3 text-sm"
+          className="hidden"
         >
           {isAnalysing ? (
             <><Loader2 className="size-3.5 animate-spin" /> Analysing{analysingLeft > 0 ? ` (${analysingLeft} left)` : ''}…</>

--- a/apps/stock-analyser/components/stock-analyser/tabs/recommendations-tab.tsx
+++ b/apps/stock-analyser/components/stock-analyser/tabs/recommendations-tab.tsx
@@ -30,6 +30,7 @@ import {
   isMarketOriginatedUniverseUnavailable,
   shouldDisableRecommendationsRun,
 } from "../recommendations-flow"
+import { stockSignalBadgeClassName } from "../status-badge"
 
 type Mode = "Top Picks" | "Bottom of Cycle"
 
@@ -375,13 +376,7 @@ Return 6 stocks. Return ONLY valid JSON.`,
                       <p className="text-xs text-muted-foreground leading-tight mt-0.5">{stock.company}</p>
                       <p className="text-[11px] text-muted-foreground mt-1">{stock.sector} · {stock.subcategory}</p>
                     </div>
-                    <span className={cn(
-                      "px-2 py-0.5 rounded text-[10px] font-semibold uppercase shrink-0 ml-2",
-                      stock.verdict === "BUY" ? "bg-signal-green text-white" :
-                      stock.verdict === "SELL" ? "bg-signal-red text-white" :
-                      stock.verdict === "HOLD" ? "bg-signal-amber/80 text-background" :
-                      "bg-muted/50 text-muted-foreground"
-                    )}>
+                    <span className={cn(stockSignalBadgeClassName(stock.verdict), "shrink-0 ml-2")}>
                       {stock.verdict}
                     </span>
                   </div>

--- a/apps/stock-analyser/components/stock-analyser/tabs/watchlist-tab.tsx
+++ b/apps/stock-analyser/components/stock-analyser/tabs/watchlist-tab.tsx
@@ -2,7 +2,6 @@
 
 import { useState, useEffect, useRef, useCallback } from "react"
 import { useNavigation } from "../app-shell"
-import { watchlistService, type WatchlistItem } from "@/lib/services/watchlist/watchlist-service"
 import { portfolioService, type StockAnalysisResult } from "@/lib/services/portfolio"
 import {
   PageHeader,
@@ -137,11 +136,11 @@ export function WatchlistTab() {
         onKeyDown={handleKeyDown}
         className="flex-[2] min-w-[160px] h-11 rounded-xl border border-border bg-surface2 px-4 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary"
       />
-      <PrimaryButton onClick={handleAdd} className="shrink-0">+ Add</PrimaryButton>
+      <SecondaryButton onClick={handleAdd} className="shrink-0">+ Add</SecondaryButton>
       <div onClick={e => e.stopPropagation()}>
         <SecondaryButton
           icon={RefreshCw}
-          className="shrink-0"
+          className="hidden"
           onClick={() => handleEnrich(watchlistEntries.map(e => e.ticker), true)}
           disabled={isAnalysing || watchlistEntries.length === 0}
         >
@@ -162,6 +161,14 @@ export function WatchlistTab() {
             <TextToggle visible={textVisible} onToggle={toggleTextVisibility} isOverride={isTextOverride} />
           }
         />
+        <PrimaryButton
+          icon={isAnalysing ? undefined : RefreshCw}
+          className="w-full"
+          onClick={() => handleEnrich(watchlistEntries.map(e => e.ticker), true)}
+          disabled={isAnalysing || watchlistEntries.length === 0}
+        >
+          {isAnalysing ? `Refreshing watchlist signals (${analysingLeft} left)` : "Refresh watchlist signals"}
+        </PrimaryButton>
         {addRow}
         <EmptyState
           icon={Eye}
@@ -183,6 +190,15 @@ export function WatchlistTab() {
           <TextToggle visible={textVisible} onToggle={toggleTextVisibility} isOverride={isTextOverride} />
         }
       />
+
+      <PrimaryButton
+        icon={isAnalysing ? undefined : RefreshCw}
+        className="w-full"
+        onClick={() => handleEnrich(watchlistEntries.map(e => e.ticker), true)}
+        disabled={isAnalysing}
+      >
+        {isAnalysing ? `Refreshing watchlist signals (${analysingLeft} left)` : "Refresh watchlist signals"}
+      </PrimaryButton>
 
       {addRow}
 


### PR DESCRIPTION
## Summary

Implements the owner-approved Stock Analyser CTA consistency cleanup from v0 commit `e3cc22b` and fixes the runtime BUY badge parity issue.

Scope classification:

- Existing Stock Analyser tabs/actions: [prototyped]
- CTA consistency cleanup: [net-new UI polish, owner-approved and v0-prototyped in `e3cc22b`]
- BUY tag green styling: [prototyped runtime parity bugfix]
- New workflows/actions/data changes: [net-new, out of scope]

No Launchpad or Budget Tracker files changed. No manual deployment performed.

## v0 freshness

This runtime change ports the approved Stock Analyser CTA cleanup from transformotion-apps-b8 commit:

- https://github.com/transformotion/transformotion-apps-b8/commit/e3cc22b

The commit is available in the v0 repo and is contained in `origin/main`.

## Files Changed

- `apps/stock-analyser/components/stock-analyser/tabs/etfs-tab.tsx`
- `apps/stock-analyser/components/stock-analyser/tabs/metals-tab.tsx`
- `apps/stock-analyser/components/stock-analyser/tabs/portfolio-tab.tsx`
- `apps/stock-analyser/components/stock-analyser/tabs/watchlist-tab.tsx`
- `apps/stock-analyser/components/stock-analyser/tabs/market-analysis-tab.tsx`
- `apps/stock-analyser/components/stock-analyser/tabs/recommendations-tab.tsx`
- `apps/stock-analyser/components/stock-analyser/status-badge.ts`
- `apps/stock-analyser/components/stock-analyser/status-badge.test.ts`

## CTA Before/After

- ETFs: replaced the small inline `Refresh` button with a full-width primary `Refresh ETF signals` CTA. Region selector and cached/live status remain secondary.
- Precious Metals: replaced the small inline `Refresh` button with a full-width primary `Refresh metals` CTA. Cached/live status remains compact metadata.
- Portfolio: added a full-width primary `Refresh portfolio signals` CTA using the existing `handleRefreshAll(true)` behaviour. `Import CSV` and `Clear all` remain secondary utilities.
- Watchlist: added a full-width primary `Refresh watchlist signals` CTA using the existing enrichment refresh behaviour. `+ Add` is now secondary data entry, and the old inline refresh control is no longer visible in empty or populated states.

## BUY Badge Root Cause And Fix

Runtime Market Analysis asked the model for `BUY` / `HOLD` / `EXIT`, but the card badge styling only treated `ENTER` as the positive green case. A returned `BUY` therefore fell through to the amber hold-style treatment.

Fix:

- Added a Stock Analyser-local `stockSignalBadgeClassName` helper.
- Mapped `BUY` and `ENTER` to green, `SELL` and `EXIT` to red, `HOLD` and `WATCH` to amber, and unknown/neutral values to muted.
- Reused the helper in Market Analysis, Recommendations, and ETFs where runtime previously duplicated manual badge classes.
- Added tests for the positive/negative/hold/neutral mappings.

## Behaviour Confirmations

- No contract changes.
- No data/API changes.
- No auth/session/account changes.
- No persistence changes.
- Existing refresh/import/add/clear handlers are preserved.
- Existing cards, analyse actions, Perth Mint links, holdings, calculations, import behaviour, clear behaviour, and watchlist data behaviour are preserved.
- No routes, app IA, M18 shell/sidebar/nav, logo, generated CSS, text/SVG logo, Launchpad, or Budget Tracker changes.

## Validation

- `pnpm sync:v0` - passed
- `pnpm check:v0-contracts` with explicit `V0_REPO_PATH=C:\Users\steve\OneDrive\Documents\Code Repo\transformotion-apps-b8` - passed
- `pnpm --filter @transformotion/stock-analyser typecheck` - passed
- `pnpm --filter @transformotion/stock-analyser build` - passed
- `pnpm --filter @transformotion/stock-analyser test` - passed, 7 files / 45 tests
- `pnpm --filter @transformotion/stock-analyser lint` - passed
- Targeted lint on changed TS/TSX files - passed
- `git diff --check` - passed

## Visual Verification

Local browser/CDP verification was not feasible in this workspace: no `chrome`, `msedge`, `chromium`, or `playwright` command is available in PATH.

Strongest feasible substitute:

- Source verified against v0 commit `e3cc22b`.
- Build verified the Stock Analyser static export compiles.
- Tests verify BUY/ENTER render through the green badge class and HOLD/SELL/EXIT/neutral mappings remain correct.
- Source-level handler check confirms the new full-width CTAs call the same existing refresh handlers as the old controls.

## Deployment

No manual deployment performed.