### PR TITLE
fix(stock-analyser): ground Portfolio + Watchlist enrichment in web search

### DIFF
--- a/apps/stock-analyser/lib/services/portfolio/portfolio-service.ts
+++ b/apps/stock-analyser/lib/services/portfolio/portfolio-service.ts
@@ -110,7 +110,12 @@ export const portfolioService = {
       if (signal?.aborted) break
       try {
         const result = await callClaudeAPI<StockAnalysisResult>(
-          { prompt: createStockAnalysisPrompt(ticker), systemPrompt: STOCK_ANALYSIS_SYSTEM_PROMPT },
+          // webSearch: always-on grounding — parity with the Analyser tab, which sends
+          // the same prompt with webSearch:isLive. Portfolio + Watchlist (both route
+          // through this enrichHoldings) have no Live/Fast toggle in v0 and are
+          // always-live by design, so this is hardcoded true — no ModeToggle, zero
+          // surface change. Only cache MISSES reach here, so cost stays bounded.
+          { prompt: createStockAnalysisPrompt(ticker), systemPrompt: STOCK_ANALYSIS_SYSTEM_PROMPT, webSearch: true },
           { signal }
         )
         const normalisedResult = normaliseStockAnalysisSignals(result)


### PR DESCRIPTION
Fixes the grounding gap confirmed in recon: `enrichHoldings` called `callClaudeAPI({ prompt, systemPrompt })` with **no `webSearch`**, so Portfolio + Watchlist analyses ran ungrounded — unlike the Analyser tab, which sends the *identical* prompt with `webSearch: isLive`.

## Change (one line, both tabs)
`lib/services/portfolio/portfolio-service.ts` enrichHoldings → add `webSearch: true` to the `callClaudeAPI` request. Always-on (no `ModeToggle`): v0 has no Live/Fast toggle on these surfaces and the design intent is always-live. **Zero surface change.** Both Portfolio (`portfolio-tab.tsx:96`) and Watchlist (`watchlist-tab.tsx:83`) route through this single `enrichHoldings`.

## Self-checks (verified, not assumed)
- **Server honors the flag.** `packages/fn-ai-proxy-core/src/providers/claude.ts:41-43`: `if (webSearch) { requestBody['tools'] = [{ type: 'web_search_20250305', name: 'web_search' }] }`; the handler forwards `webSearch` end-to-end. So on deployed dev (`ai.provider='claude'`, `RUNTIME_PROFILE=live`) a `webSearch:true` call adds Anthropic's web_search tool. The Analyser tab already exercises this exact path in prod.
- **Cache still bounds cost.** `enrichHoldings` is cache-first: it checks `ANALYSIS#{ticker}` for every ticker (8h TTL), delivers hits, and calls Claude **only for misses**. It takes no `forceRefresh`, so a refresh never re-grounds every ticker — only stale/missing ones reach the grounded call. Unchanged by this edit.
- **Both tabs inherit it.** Confirmed above.
- **Prompt + price — important nuance:** the shared `createStockAnalysisPrompt` asks for "comprehensive technical analysis" + "current price" with fast-mode fallback language; it does **not** explicitly say "search the web for latest data as of [today]" the way the Metals prompt does (`"latest data for ${today}"`). It is, however, the **same prompt the grounded Analyser uses**, so this brings Portfolio/Watchlist to Analyser **parity** (tool available; the model uses web_search agentically). Critically, the **displayed price reconciles via `overlayLivePrice` (market-data Lambda), not Claude** — the code explicitly discards Claude's price and overlays the real latest close — so "a known ticker shows its real current price" is already handled there, independent of web search. `webSearch:true` grounds the qualitative **analysis** (verdict/signals/summary/recency), not the price.

## Functional gate — deployed-dev confirmation
The end-to-end mechanism is verified server-side (proxy adds web_search for `webSearch:true`) and by Analyser-parity. The live "a Portfolio/Watchlist refresh fires a `webSearch:true` call" check requires the change **deployed** (deploys run on merge to `develop`), so I'll confirm it post-merge via deploy-watch: a refresh of a stale/new ticker issues the grounded job, and the row shows the market-data price. Flagging that this specific step is post-merge, not pre-merge, given the deploy model.

## v0 freshness

- [x] No v0 impact

Reason: Runtime-only one-line change (adds the `webSearch` flag to an existing AI request). No contract, data shape, UI, or layout change — Portfolio/Watchlist stay pixel-identical (no toggle added), matching v0 which has no Live/Fast control on these tabs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)