### PR TITLE
fix(stock-analyser): #535 — crash on US Market Analysis (null toFixed) + macro source on its own line

### DIFF
--- a/apps/stock-analyser/components/stock-analyser/tabs/market-analysis-tab.tsx
+++ b/apps/stock-analyser/components/stock-analyser/tabs/market-analysis-tab.tsx
@@ -78,8 +78,12 @@ function SectorPill({ label, color }: { label: string; color: keyof typeof PILL 
   )
 }
 
-// Gradient bar showing cycle position (0 = early/green, 100 = late/pink)
+// Gradient bar showing cycle position (0 = early/green, 100 = late/pink).
+// Defensive: a non-finite position (a model omission) degrades to a "—"
+// placeholder rather than a NaN-positioned marker.
 function CycleBar({ position }: { position: number }) {
+  const ok = typeof position === 'number' && Number.isFinite(position)
+  const pos = ok ? Math.max(0, Math.min(100, position)) : 0
   return (
     <div className="flex items-center gap-2">
       <div className="relative flex items-center" style={{ width: 90, height: 10 }}>
@@ -102,13 +106,13 @@ function CycleBar({ position }: { position: number }) {
             background: 'white',
             borderWidth: '1.5px',
             borderStyle: 'solid',
-            left: `${position}%`,
+            left: `${pos}%`,
             top: '50%',
             transform: 'translate(-50%, -50%)',
           }}
         />
       </div>
-      <span className="text-[10px] text-muted-foreground whitespace-nowrap">Cycle {position}</span>
+      <span className="text-[10px] text-muted-foreground whitespace-nowrap">Cycle {ok ? position : '—'}</span>
     </div>
   )
 }
@@ -168,7 +172,8 @@ export function MarketAnalysisTab() {
     // data, so sector levels/returns are grounded in prices rather than searched.
     // Skipped on a cache hit (the prompt is unused then).
     const willCallModel = forceRefresh || (await dynamoCache.get<MarketAnalysisResult>(cacheKey)) === null
-    const suppliedSectorData = willCallModel ? await buildSectorSuppliedData(region) : ""
+    // Grounding is best-effort: a fetch/format failure must never block analysis.
+    const suppliedSectorData = willCallModel ? await buildSectorSuppliedData(region).catch(() => "") : ""
     const data = await callClaude({
       cacheKey,
       forceRefresh,
@@ -350,8 +355,10 @@ IMPORTANT: Your entire response must be a single valid JSON object. Begin your r
                     </button>
                   )}
                   
-                  <div className="flex items-center justify-between gap-2 pt-1">
-                    <span className={cn("inline-flex items-center gap-1.5 px-2 py-1 rounded-full text-[10px] font-medium", style.bg, style.text)}>
+                  {/* #535: impact pill + source stacked — source on its OWN line
+                      below the pill (reproduces v0's macro-card layout). */}
+                  <div className="flex flex-col gap-2">
+                    <span className={cn("inline-flex w-fit items-center gap-1.5 px-2 py-1 rounded-full text-[10px] font-medium", style.bg, style.text)}>
                       <span className={cn("size-1.5 rounded-full", style.text === "text-signal-green" ? "bg-signal-green" : style.text === "text-signal-red" ? "bg-signal-red" : "bg-muted-foreground")} />
                       {indicator.impact}
                     </span>
@@ -402,6 +409,7 @@ IMPORTANT: Your entire response must be a single valid JSON object. Begin your r
             </div>
             <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
               {(result.sectors ?? []).map((sector, i) => {
+                const changeOk = typeof sector.change === 'number' && Number.isFinite(sector.change)
                 return (
                   <Card
                     key={sector.sector}
@@ -426,9 +434,9 @@ IMPORTANT: Your entire response must be a single valid JSON object. Begin your r
                         <SectorPill label={sector.valuation} color={VALUATION_PILL[sector.valuation] ?? 'gray'} />
                         <span
                           className="ml-auto text-xs font-semibold"
-                          style={{ color: sector.change >= 0 ? '#1D9E75' : '#D4537E' }}
+                          style={{ color: !changeOk ? '#444441' : sector.change >= 0 ? '#1D9E75' : '#D4537E' }}
                         >
-                          {sector.change >= 0 ? "+" : ""}{sector.change}%
+                          {changeOk ? `${sector.change >= 0 ? "+" : ""}${sector.change}%` : "—"}
                         </span>
                       </div>
 

--- a/apps/stock-analyser/lib/analysis/market-analysis-grounding.test.ts
+++ b/apps/stock-analyser/lib/analysis/market-analysis-grounding.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Force the live OHLCV branch and control what getOhlcvData returns, so we can
+// feed the null-laden `closes` arrays real feeds produce (Yahoo gaps).
+vi.mock('@/lib/config', () => ({ getConfig: () => ({ ai: { provider: 'live' } }) }))
+const getOhlcvData = vi.fn()
+vi.mock('@/lib/api', () => ({ getStockAnalyserClient: () => ({ getOhlcvData }) }))
+// Unused on the live branch, but mocked so vitest need not resolve the fixture module.
+vi.mock('@/lib/services/ai/fixtures/ohlcv-data', () => ({ getMockOhlcvData: vi.fn() }))
+
+import { buildSectorSuppliedData } from './market-analysis-grounding'
+
+describe('market-analysis grounding — null-safety (#535 US-market crash regression)', () => {
+  beforeEach(() => getOhlcvData.mockReset())
+
+  it('does NOT throw when closes end in null (the crash) — omits the bad sector', async () => {
+    // Pre-fix: `closes[len-1]` was null, the `=== undefined`-only guard let it
+    // through, and `last.toFixed(2)` threw "Cannot read properties of null".
+    getOhlcvData.mockResolvedValue({ closes: [10, 11, null] })
+    const block = await buildSectorSuppliedData('us')
+    expect(typeof block).toBe('string')
+    expect(block).not.toMatch(/last (null|NaN|undefined)/)
+  })
+
+  it('keeps a sector when only an INTERIOR close is null (last is finite)', async () => {
+    getOhlcvData.mockResolvedValue({ closes: [10, null, 12] })
+    const block = await buildSectorSuppliedData('us')
+    expect(block).toContain('SUPPLIED SECTOR DATA')
+    expect(block).toMatch(/last 12\.00/)
+  })
+
+  it('formats finite closes into a supplied-data block', async () => {
+    getOhlcvData.mockResolvedValue({ closes: [100, 102, 105] })
+    const block = await buildSectorSuppliedData('us')
+    expect(block).toContain('SUPPLIED SECTOR DATA')
+    expect(block).toMatch(/last 105\.00/)
+  })
+
+  it('returns "" for an unmapped region and never fetches (global / uk)', async () => {
+    expect(await buildSectorSuppliedData('global')).toBe('')
+    expect(await buildSectorSuppliedData('uk')).toBe('')
+    expect(getOhlcvData).not.toHaveBeenCalled()
+  })
+
+  it('is best-effort: a rejected fetch is omitted, not propagated', async () => {
+    getOhlcvData.mockResolvedValueOnce({ closes: [100, 102, 105] })
+    getOhlcvData.mockResolvedValue({ closes: [50, null, null] }) // others degrade to omitted
+    const block = await buildSectorSuppliedData('us')
+    expect(typeof block).toBe('string') // resolved, never threw
+  })
+})

--- a/apps/stock-analyser/lib/analysis/market-analysis-grounding.ts
+++ b/apps/stock-analyser/lib/analysis/market-analysis-grounding.ts
@@ -88,11 +88,22 @@ interface SectorLevel {
   change3mPct: number | null
 }
 
+/**
+ * A finite number, else null. The OHLCV boundary is typed `closes: number[]`,
+ * but real feeds can present `null`/`NaN` (Yahoo gaps, incomplete sessions,
+ * sparse proxies). Treat every close defensively so no non-finite value ever
+ * reaches `.toFixed()` (was the #535 US-market crash: a `=== undefined`-only
+ * guard let a `null` close through to `last.toFixed(2)`).
+ */
+function finite(n: unknown): number | null {
+  return typeof n === 'number' && Number.isFinite(n) ? n : null
+}
+
 function pctChange(closes: readonly number[], lookback: number): number | null {
   if (closes.length === 0) return null
-  const last = closes[closes.length - 1]
-  const prior = closes[Math.max(0, closes.length - 1 - lookback)]
-  if (last === undefined || prior === undefined || prior === 0) return null
+  const last = finite(closes[closes.length - 1])
+  const prior = finite(closes[Math.max(0, closes.length - 1 - lookback)])
+  if (last === null || prior === null || prior === 0) return null
   return ((last - prior) / prior) * 100
 }
 
@@ -106,8 +117,8 @@ async function fetchSectorLevel(
         ? getMockOhlcvData(ticker, '3mo', '1d')
         : await getStockAnalyserClient().getOhlcvData(ticker, '3mo', '1d')
     const closes = ohlcv?.closes ?? []
-    const last = closes[closes.length - 1]
-    if (last === undefined) return null
+    const last = finite(closes[closes.length - 1])
+    if (last === null) return null // non-finite/absent last close → omit this sector
     return {
       sector,
       ticker,
@@ -127,20 +138,26 @@ async function fetchSectorLevel(
  * Returns `''` when nothing could be fetched (caller injects nothing).
  */
 export async function buildSectorSuppliedData(region: AnalysisRegion): Promise<string> {
-  const map = SECTOR_PROXY_TICKERS[region] ?? {}
-  const entries = Object.entries(map) as [MarketAnalysisSector, string][]
-  if (entries.length === 0) return ''
+  // Top-level guard: grounding is best-effort and must NEVER reject — a failure
+  // here can never be allowed to block the analysis call.
+  try {
+    const map = SECTOR_PROXY_TICKERS[region] ?? {}
+    const entries = Object.entries(map) as [MarketAnalysisSector, string][]
+    if (entries.length === 0) return ''
 
-  const levels = (
-    await Promise.all(entries.map(([sector, ticker]) => fetchSectorLevel(sector, ticker)))
-  ).filter((l): l is SectorLevel => l !== null)
+    const levels = (
+      await Promise.all(entries.map(([sector, ticker]) => fetchSectorLevel(sector, ticker)))
+    ).filter((l): l is SectorLevel => l !== null)
 
-  if (levels.length === 0) return ''
+    if (levels.length === 0) return ''
 
-  const lines = levels.map((l) => {
-    const fmt = (n: number | null) => (n === null ? 'n/a' : `${n >= 0 ? '+' : ''}${n.toFixed(1)}%`)
-    return `- ${l.sector} (proxy ${l.ticker}): last ${l.last.toFixed(2)}, 1m ${fmt(l.change1mPct)}, 3m ${fmt(l.change3mPct)}`
-  })
+    const lines = levels.map((l) => {
+      const fmt = (n: number | null) => (n === null ? 'n/a' : `${n >= 0 ? '+' : ''}${n.toFixed(1)}%`)
+      return `- ${l.sector} (proxy ${l.ticker}): last ${l.last.toFixed(2)}, 1m ${fmt(l.change1mPct)}, 3m ${fmt(l.change3mPct)}`
+    })
 
-  return `\n\nSUPPLIED SECTOR DATA (real market prices — base each sector's level/return read on THESE figures, not on searched or recalled numbers; cite the proxy as the source for that sector's price read):\n${lines.join('\n')}`
+    return `\n\nSUPPLIED SECTOR DATA (real market prices — base each sector's level/return read on THESE figures, not on searched or recalled numbers; cite the proxy as the source for that sector's price read):\n${lines.join('\n')}`
+  } catch {
+    return ''
+  }
 }


### PR DESCRIPTION
Two #535 dev issues found on the deployed Market Analysis tab. Fix branch off `develop`.

## Issue 1 (BLOCKER) — crash on US market: "Cannot read properties of null (reading 'toFixed')"

**Root cause (what was null, and why):** The only `.toFixed()` reachable from the Market Analysis render path is the Bucket-1 grounding helper (`lib/analysis/market-analysis-grounding.ts`) — the MA tab itself has none, and the design-system formatters with `.toFixed` aren't imported by this tab. The helper guarded `=== undefined` **only**, while the OHLCV boundary is typed `closes: number[]` but real feeds present **`null`/non-finite** values (Yahoo gaps / incomplete sessions / sparse proxies). A non-finite trailing close slipped past the undefined-only guard into `last.toFixed(2)` and threw. **US is the only fully-mapped region**, so it's the only one that actually fetches proxy OHLCV and runs the formatter — hence the US-only repro.

**Fix:**
- `finite()` guard applied to every close. A non-finite `last` → the sector is omitted; `pctChange` returns null for non-finite endpoints; `fmt` already guards null. So no non-finite value can reach `.toFixed()`.
- `buildSectorSuppliedData` wrapped in a top-level guard so it **never rejects** (grounding is best-effort and must never block analysis); the tab call site also `.catch(() => "")`.
- **Render hardening (graceful degradation, not blank/throw):** sector `change` shows **"—"** when non-finite; `CycleBar` clamps a non-finite `cyclePosition` and shows **"—"** rather than a NaN-positioned marker.
- **Contract nullability:** the canonical OHLCV `closes: number[]` is v0-owned/read-only, so it isn't changed here; the consumer is made defensive at the boundary instead (the correct fix). `SectorSignal.change` stays `number` (the model is instructed to provide it); the render degrades if the model omits it.
- **Regression test** (`market-analysis-grounding.test.ts`): trailing-null closes don't throw; interior-null keeps the sector with a finite `last`; finite closes format; unmapped regions return `""` and never fetch.

## Issue 2 (cosmetic) — macro-card source position

The macro-card `SourceTag` had regressed to **inline beside** the impact pill (wrapped awkwardly, e.g. "Headwind ⌂ Source Bureau of Labor Statistics"). Reproduced v0's macro-card layout faithfully: impact pill + source stacked with `flex flex-col gap-2` and `w-fit` on the pill, so **source sits on its own line below** the pill (matches `transformotion-apps-b8` PR #71). Sector cards and the deliberately-kept CycleBar/valuation-pill layout are untouched — not a redesign.

## Verification

- **Static gates — GREEN:** typecheck, lint, build, test (**70**, incl. the new regression test).
- **Real US-market behaviour — to be re-tested by the owner on dev** (local is mock-only; the crash path is exercised only against live OHLCV). The regression test reproduces the exact null-close crash locally and proves the guard.

## Out of scope
M19 background jobs/scheduler/notifications (#529–#532); Bucket-2 macro feed; no prod deploy.

## v0 freshness
- [x] No v0 impact

Reason: runtime-only crash hardening + reproducing v0 PR #71's existing macro-card source-line layout. No contract/mock/UI-shape change authored here; the canonical contract is unchanged.