### PR TITLE
fix(stock-analyser): overlay real market-data price on Recs cards (was $0.00 for all)

### DIFF
--- a/apps/stock-analyser/components/stock-analyser/tabs/recommendations-tab.tsx
+++ b/apps/stock-analyser/components/stock-analyser/tabs/recommendations-tab.tsx
@@ -18,6 +18,10 @@ import {
 import { ChevronRight, ChevronDown, Search, Loader2, Stars, AlertCircle } from "lucide-react"
 import { useCacheStatus, useClaude } from "@/lib/hooks"
 import { cn } from "@/lib/utils"
+import { getStockAnalyserClient } from "@/lib/api"
+import { getConfig } from "@/lib/config"
+import { getMockOhlcvData } from "@/lib/services/ai/fixtures/ohlcv-data"
+import { latestPriceFromOhlcv } from "@/lib/market-data"
 import type { RecommendationUniverse } from "@transformotion/contracts/stock-analyser/types"
 import {
   RECOMMENDATION_UNIVERSES,
@@ -39,14 +43,37 @@ interface Stock {
   company: string
   sector: string
   subcategory: string
-  price: number
-  change: number
+  // Price/change are overlaid from REAL market data (OHLCV), not the AI — and are
+  // null when no live quote resolves (delisted/unknown ticker). The UI shows "—".
+  price: number | null
+  change: number | null
   verdict: Verdict
   cyclePosition: number
   cycleStage: CycleStage
   conviction: boolean
   analysis: string
   bestExchange: string
+}
+
+/**
+ * Overlay the REAL current price/change (market data / OHLCV) onto a recommended
+ * stock — the AI's own `price`/`change` are NOT trusted for display (#468: price
+ * from market data, not the AI). Best-effort: a ticker with no resolvable quote
+ * (e.g. a delisted symbol like OZL.AX) leaves both null, and the card shows "—".
+ * Mirrors `overlayLivePrice` in portfolio-service; keyed by the model's (already
+ * Yahoo-suffixed) ticker — NOT `normaliseTicker`, which would ASX-ify US codes.
+ */
+async function overlayStockPrice(stock: Stock): Promise<Stock> {
+  try {
+    const ticker = stock.ticker.trim()
+    const ohlcv = getConfig().ai.provider === 'mock'
+      ? getMockOhlcvData(ticker, '1mo', '1d')
+      : await getStockAnalyserClient().getOhlcvData(ticker, '1mo', '1d')
+    const { price, change } = latestPriceFromOhlcv(ohlcv)
+    return { ...stock, price, change }
+  } catch {
+    return { ...stock, price: null, change: null }
+  }
 }
 
 const TOP_PICKS: Stock[] = [
@@ -187,8 +214,10 @@ Return 6 stocks. Return ONLY valid JSON.`,
     })
 
     if (result?.stocks) {
-      setStockResults(result.stocks)
-      setTabCache("recs", { stocks: result.stocks })
+      // Overlay real market-data prices over the AI's numbers before display.
+      const overlaid = await Promise.all(result.stocks.map(overlayStockPrice))
+      setStockResults(overlaid)
+      setTabCache("recs", { stocks: overlaid })
       setHasRun(true)
     }
   }
@@ -384,12 +413,18 @@ Return 6 stocks. Return ONLY valid JSON.`,
                     </span>
                   </div>
 
-                  {/* Price section */}
+                  {/* Price section — real market-data overlay; "—" when no quote resolves */}
                   <div className="flex items-baseline gap-2">
-                    <span className="text-lg font-semibold text-foreground">${stock.price.toFixed(2)}</span>
-                    <span className={cn("text-xs font-semibold", stock.change >= 0 ? "text-signal-green" : "text-signal-red")}>
-                      {stock.change >= 0 ? "+" : ""}{stock.change.toFixed(1)}%
+                    <span className="text-lg font-semibold text-foreground">
+                      {stock.price !== null ? `$${stock.price.toFixed(2)}` : "—"}
                     </span>
+                    {stock.change !== null ? (
+                      <span className={cn("text-xs font-semibold", stock.change >= 0 ? "text-signal-green" : "text-signal-red")}>
+                        {stock.change >= 0 ? "+" : ""}{stock.change.toFixed(1)}%
+                      </span>
+                    ) : (
+                      <span className="text-xs font-semibold text-muted-foreground">—</span>
+                    )}
                   </div>
 
                   {/* Analysis text - conditionally visible or expandable */}


### PR DESCRIPTION
## What

Fixes the Recommendations tab showing **$0.00 / +0.0% for every stock** (both universes). Approved fix from the prior diagnosis.

## Root cause (recap)

Recs was the **only price-showing surface still trusting the AI's own `stock.price`/`change`** — it never overlaid live prices the way Analyser/Portfolio/Watchlist do (the ratified #468 principle: *price from market data, not the AI*). The model returns `0` for prices it won't fabricate, so every card rendered `$0.00`. Not a regression from #535/#542 (those touched only Market Analysis files; the recs tab and shared price helpers were untouched) — a pre-existing gap, surfaced now.

## Fix

- **Overlay** each recommended stock's `price`/`change` from market data — `getStockAnalyserClient().getOhlcvData → latestPriceFromOhlcv` — before display, **mirroring `portfolio-service`'s `overlayLivePrice`**. The AI's price is no longer trusted for display.
- **Keyed by the model's already-Yahoo-suffixed ticker** (trimmed), **not `normaliseTicker`** — `normaliseTicker` appends `.AX` to bare codes (`NVDA → NVDA.AX`), which would break US recs prices. (Noted in code.)
- **Honest degradation:** when no quote resolves (delisted/unknown ticker, e.g. **OZL.AX**), `price`/`change` are `null` and the card shows **"—"**, not `$0.00 / +0.0%`. `Stock.price`/`change` are now `number | null`.

## Out of scope

The model *recommending delisted tickers* (e.g. OZL.AX, acquired 2023) is a **separate backlog item** — this fix handles its symptom (shows "—"), not the cause.

## Verification

- **Static gates — GREEN:** typecheck, lint, build, test (70).
- **Dev re-test (owner):** confirm recs prices resolve to real market values across US Healthcare and ASX Materials, and that a delisted ticker (OZL.AX) shows **"—"**. The degradation path is `catch → null → render "—"` (mirrors the proven `overlayLivePrice`); the live-quote resolution needs a dev run (local is mock-only).

## v0 freshness

- [x] No v0 impact

Reason: runtime-only price-overlay parity fix (applies the existing market-data overlay pattern to the recs tab). No contract/mock/UI-shape change; no v0 surface authored here.