### PR TITLE
feat(m11): pending-invitations data + enriched v0 rows on both surfaces (#555)

### DIFF
--- a/apps/launchpad/components/launchpad/admin/account-management-view.tsx
+++ b/apps/launchpad/components/launchpad/admin/account-management-view.tsx
@@ -61,20 +61,58 @@ function toMemberVM(row: AccountMemberRow): MemberVM {
 }
 
 /** v0 pending-invitation row shape — one row per account-invite grant. */
-type PendingInviteVM = { bundleId: string; grantId: string; email: string; status: string }
+type PendingInviteVM = {
+  bundleId: string
+  grantId: string
+  email: string
+  status: string
+  role: AccountRole
+  createdAt: string
+  expiresAt: number
+}
 
 /**
  * Flatten the contract's `pendingInvitations` (bundles, grants already scoped to
- * this account by the backend, #556) into v0's row shape — exactly what the v0
- * `listPendingInvitationsForAccount` mock returned (one row per account-invite
- * grant). Presentation is reproduced verbatim; only the data source is live.
+ * this account by the backend, #556) into v0's enriched row shape — exactly what
+ * the v0 `listPendingInvitationsForAccount` returns (one row per account-invite
+ * grant, carrying role + sent/expiry). Presentation is reproduced verbatim; only
+ * the data source is live.
  */
 function toPendingInviteVMs(bundles: InvitationBundle[]): PendingInviteVM[] {
   return bundles.flatMap((b) =>
     (b.grants ?? [])
       .filter((g) => g.kind === 'account-invite')
-      .map((g) => ({ bundleId: b.bundleId, grantId: g.grantId, email: b.email, status: b.status })),
+      .map((g) => ({
+        bundleId: b.bundleId,
+        grantId: g.grantId,
+        email: b.email,
+        status: b.status,
+        role: (g as { role: AccountRole }).role,
+        createdAt: b.createdAt,
+        expiresAt: b.expiresAt,
+      })),
   )
+}
+
+// Format helpers — ported verbatim from the v0 prototype
+// (`components/launchpad/admin/account-management-view.tsx`).
+/** Sent date — absolute date from an ISO timestamp. */
+function formatSentDate(iso: string): string {
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return '—'
+  return d.toLocaleDateString(undefined, { day: 'numeric', month: 'short', year: 'numeric' })
+}
+
+/** Expiry — absolute date from a Unix-seconds timestamp. */
+function formatExpiry(expiresAt: number): string {
+  const d = new Date(expiresAt * 1000)
+  if (Number.isNaN(d.getTime())) return '—'
+  return d.toLocaleDateString(undefined, { day: 'numeric', month: 'short', year: 'numeric' })
+}
+
+/** Past-expiry guard (Unix seconds vs now). */
+function isInvitationExpired(expiresAt: number): boolean {
+  return expiresAt * 1000 < Date.now()
 }
 
 /**
@@ -446,18 +484,43 @@ function AccountDetailPanel({
               <ul className="space-y-2">
                 {invitations.map((invite) => {
                   const cancel = canCancelInvitationGrant(viewerRole, viewerIsSiteAdmin)
+                  const expired = isInvitationExpired(invite.expiresAt)
                   return (
                     <li
                       key={invite.grantId}
-                      className="flex items-center gap-2 rounded-lg border border-border bg-surface/30 px-3 py-2"
+                      className="flex items-start gap-2 rounded-lg border border-border bg-surface/30 px-3 py-2"
                     >
-                      <Clock className="size-3.5 shrink-0 text-signal-gold" />
-                      <span className="min-w-0 flex-1 truncate text-xs text-foreground">
-                        {invite.email}
+                      <Clock className="mt-0.5 size-3.5 shrink-0 text-signal-gold" />
+                      <div className="min-w-0 flex-1">
+                        {/* Invited email + role/grant */}
+                        <div className="flex flex-wrap items-center gap-1.5">
+                          <span className="min-w-0 truncate text-xs font-medium text-foreground">
+                            {invite.email}
+                          </span>
+                          <RoleChip role={invite.role} />
+                        </div>
+                        {/* Sent date + expiry */}
+                        <p className="mt-0.5 text-[11px] text-muted-foreground">
+                          Sent {formatSentDate(invite.createdAt)}
+                          {' · '}
+                          <span className={cn(expired && 'text-signal-red')}>
+                            {expired ? 'Expired ' : 'Expires '}
+                            {formatExpiry(invite.expiresAt)}
+                          </span>
+                        </p>
+                      </div>
+                      <span
+                        className={cn(
+                          'shrink-0 rounded-full px-2 py-0.5 text-[9px] font-semibold uppercase tracking-wider',
+                          expired
+                            ? 'bg-signal-red/15 text-signal-red'
+                            : 'bg-signal-gold/15 text-signal-gold',
+                        )}
+                      >
+                        {expired ? 'expired' : invite.status}
                       </span>
-                      <span className="shrink-0 rounded-full bg-signal-gold/15 px-2 py-0.5 text-[9px] font-semibold uppercase tracking-wider text-signal-gold">
-                        {invite.status}
-                      </span>
+                      {/* Cancel control: v0 wires onClick→cpCancelGrant; runtime has no
+                          cancel-grant endpoint yet, so the X stays inert (separate item). */}
                       <button
                         disabled={!cancel.allowed}
                         title={cancel.reason}

--- a/apps/launchpad/components/launchpad/admin/account-management-view.tsx
+++ b/apps/launchpad/components/launchpad/admin/account-management-view.tsx
@@ -33,7 +33,7 @@ import {
 } from '@/lib/admin/account-policy'
 import { getControlPlaneClient } from '@/lib/services/control-plane-client'
 import { authService } from '@/lib/services/auth'
-import type { AccountMemberRow } from '@transformotion/contracts/launchpad/invitations'
+import type { AccountMemberRow, InvitationBundle } from '@transformotion/contracts/launchpad/invitations'
 import type { AccountRole, EntitledAppSlug } from '@transformotion/contracts/_shared/auth'
 
 /** Minimal account shape the view renders (accountId + appSlug + name). */
@@ -60,6 +60,23 @@ function toMemberVM(row: AccountMemberRow): MemberVM {
   }
 }
 
+/** v0 pending-invitation row shape — one row per account-invite grant. */
+type PendingInviteVM = { bundleId: string; grantId: string; email: string; status: string }
+
+/**
+ * Flatten the contract's `pendingInvitations` (bundles, grants already scoped to
+ * this account by the backend, #556) into v0's row shape — exactly what the v0
+ * `listPendingInvitationsForAccount` mock returned (one row per account-invite
+ * grant). Presentation is reproduced verbatim; only the data source is live.
+ */
+function toPendingInviteVMs(bundles: InvitationBundle[]): PendingInviteVM[] {
+  return bundles.flatMap((b) =>
+    (b.grants ?? [])
+      .filter((g) => g.kind === 'account-invite')
+      .map((g) => ({ bundleId: b.bundleId, grantId: g.grantId, email: b.email, status: b.status })),
+  )
+}
+
 /**
  * Live Account directory. v0 read the mock store via `useM11Store()`; the live
  * sources are CONTRACTED endpoints (no GET /accounts needed):
@@ -71,6 +88,7 @@ function toMemberVM(row: AccountMemberRow): MemberVM {
 function useAccountDirectory(viewer: AdminUser) {
   const [accounts, setAccounts] = useState<ManagedAccount[] | null>(null)
   const [membersByAccount, setMembersByAccount] = useState<Map<string, MemberVM[]>>(new Map())
+  const [pendingByAccount, setPendingByAccount] = useState<Map<string, PendingInviteVM[]>>(new Map())
   const [viewerRoleByAccount, setViewerRoleByAccount] = useState<Map<string, AccountRole>>(new Map())
 
   const isSiteAdmin = userIsSiteAdmin(viewer)
@@ -78,17 +96,20 @@ function useAccountDirectory(viewer: AdminUser) {
   const loadMembers = useCallback(async (accts: ManagedAccount[]) => {
     const client = getControlPlaneClient()
     const map = new Map<string, MemberVM[]>()
+    const pending = new Map<string, PendingInviteVM[]>()
     await Promise.all(
       accts.map(async (a) => {
         try {
           const res = await client.getMembersDetail(a.accountId)
           map.set(a.accountId, res.members.map(toMemberVM))
+          pending.set(a.accountId, toPendingInviteVMs(res.pendingInvitations))
         } catch (err) {
           console.warn('[admin] members read failed:', a.accountId, err)
         }
       }),
     )
     setMembersByAccount(map)
+    setPendingByAccount(pending)
   }, [])
 
   const load = useCallback(async () => {
@@ -147,26 +168,23 @@ function useAccountDirectory(viewer: AdminUser) {
     })
   }, [load])
 
+  const applyDetail = useCallback((accountId: string, res: { members: AccountMemberRow[]; pendingInvitations: InvitationBundle[] }) => {
+    setMembersByAccount((prev) => new Map(prev).set(accountId, res.members.map(toMemberVM)))
+    setPendingByAccount((prev) => new Map(prev).set(accountId, toPendingInviteVMs(res.pendingInvitations)))
+  }, [])
+
   const updateRole = useCallback(async (accountId: string, userId: string, role: AccountRole) => {
     const res = await getControlPlaneClient().updateMemberRole(accountId, userId, role)
-    setMembersByAccount((prev) => {
-      const next = new Map(prev)
-      next.set(accountId, res.members.map(toMemberVM))
-      return next
-    })
-  }, [])
+    applyDetail(accountId, res)
+  }, [applyDetail])
 
   const removeMember = useCallback(async (accountId: string, userId: string) => {
     await getControlPlaneClient().removeMember(accountId, userId)
     const res = await getControlPlaneClient().getMembersDetail(accountId)
-    setMembersByAccount((prev) => {
-      const next = new Map(prev)
-      next.set(accountId, res.members.map(toMemberVM))
-      return next
-    })
-  }, [])
+    applyDetail(accountId, res)
+  }, [applyDetail])
 
-  return { accounts, membersByAccount, viewerRoleByAccount, updateRole, removeMember }
+  return { accounts, membersByAccount, pendingByAccount, viewerRoleByAccount, updateRole, removeMember }
 }
 
 const ROLE_STYLES: Record<AccountRole, string> = {
@@ -321,6 +339,7 @@ function AccountDetailPanel({
   viewerIsSiteAdmin,
   account,
   members,
+  invitations,
   onUpdateRole,
   onRemoveMember,
 }: {
@@ -328,12 +347,13 @@ function AccountDetailPanel({
   viewerIsSiteAdmin: boolean
   account: ManagedAccount
   members: MemberVM[]
+  invitations: PendingInviteVM[]
   onUpdateRole: (accountId: string, userId: string, role: AccountRole) => Promise<void>
   onRemoveMember: (accountId: string, userId: string) => Promise<void>
 }) {
   const router = useRouter()
-  // pendingInvitations is shape-present but EMPTY until Phase 8 (bundles).
-  const invitations: Array<{ bundleId: string; grantId: string; email: string; status: string }> = []
+  // M11: real account-scoped pending invitations from GET …/members/detail
+  // (#556). The cancel-X has no server endpoint yet → stays inert (separate item).
   const manages = canManageAccountMembers(viewerRole)
   const supervisory = !manages && viewerIsSiteAdmin
 
@@ -470,7 +490,7 @@ function AccountDetailPanel({
 // ---------------------------------------------------------------------------
 
 export function AccountManagementView({ viewer }: { viewer: AdminUser }) {
-  const { accounts, membersByAccount, viewerRoleByAccount, updateRole, removeMember } =
+  const { accounts, membersByAccount, pendingByAccount, viewerRoleByAccount, updateRole, removeMember } =
     useAccountDirectory(viewer)
   const viewerIsSiteAdmin = userIsSiteAdmin(viewer)
   // Multiple accounts can stay expanded at once; "Collapse all" clears them.
@@ -531,6 +551,7 @@ export function AccountManagementView({ viewer }: { viewer: AdminUser }) {
           <div className="space-y-2">
             {list.map((account) => {
               const members = membersByAccount.get(account.accountId) ?? []
+              const invitations = pendingByAccount.get(account.accountId) ?? []
               const memberCount = members.length
               const role = viewerRoleByAccount.get(account.accountId) ?? null
               const expanded = expandedIds.has(account.accountId)
@@ -576,6 +597,7 @@ export function AccountManagementView({ viewer }: { viewer: AdminUser }) {
                         viewerIsSiteAdmin={viewerIsSiteAdmin}
                         account={account}
                         members={members}
+                        invitations={invitations}
                         onUpdateRole={updateRole}
                         onRemoveMember={removeMember}
                       />

--- a/apps/launchpad/components/launchpad/admin/users-access-view.tsx
+++ b/apps/launchpad/components/launchpad/admin/users-access-view.tsx
@@ -149,8 +149,10 @@ function UserDetailPanel({
   onSetStatus: (userId: string, status: 'active' | 'disabled') => void
 }) {
   const { user } = summary
-  // Pending-invitation detail has no live source yet (access-summary reports a
-  // count of 0; the by-account list is Phase 8). Shape present, no data.
+  // M11: the per-user pending-invitation COUNT is now live (see the table badge,
+  // `summary.pendingInvites`). This DETAIL LIST stays empty: `UserAccessSummary`
+  // carries only the count, not a per-user pending LIST — wiring it needs a new
+  // list field on the contract (v0-owned). Held until that v0 contract lands.
   const pendingInvites: Array<{ invitationId: string; accountId: string; status: string }> = []
 
   return (

--- a/apps/launchpad/components/launchpad/admin/users-access-view.tsx
+++ b/apps/launchpad/components/launchpad/admin/users-access-view.tsx
@@ -149,10 +149,10 @@ function UserDetailPanel({
   onSetStatus: (userId: string, status: 'active' | 'disabled') => void
 }) {
   const { user } = summary
-  // M11: the per-user pending-invitation COUNT is now live (see the table badge,
-  // `summary.pendingInvites`). This DETAIL LIST stays empty: `UserAccessSummary`
-  // carries only the count, not a per-user pending LIST — wiring it needs a new
-  // list field on the contract (v0-owned). Held until that v0 contract lands.
+  // M11: the COUNT badge (`summary.pendingInvites`) is live, and the backend now
+  // also returns the per-user LIST (`summary.pendingInvitations`, since the v0
+  // contract field landed). Wiring THIS detail list to consume it is a separate
+  // prompt (v0's enriched users-access detail display); kept stubbed for now.
   const pendingInvites: Array<{ invitationId: string; accountId: string; status: string }> = []
 
   return (

--- a/apps/launchpad/functions/access-summary/src/index.test.ts
+++ b/apps/launchpad/functions/access-summary/src/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { buildAccessSummaries } from './index';
+import { buildAccessSummaries, countPendingInvitesByEmail } from './index';
 
 // ---------------------------------------------------------------------------
 // Test area 4: Access summary against legacy membership rows missing appSlug
@@ -12,13 +12,14 @@ type U = { userId: string; email: string; displayName?: string; status?: 'active
 describe('buildAccessSummaries', () => {
   const noGrants = new Map<string, G[]>();
   const noSiteAdmins = new Set<string>();
+  const noPending = new Map<string, number>();
 
   it('includes membership when appSlug is denormalized on the row', () => {
     const user: U = { userId: 'u1', email: 'u1@example.com' };
     const members = new Map([['u1', [{ accountId: 'acc-1', userId: 'u1', appSlug: 'stock-analyser', role: 'owner' }] as M[]]]);
     const accountNames = new Map([['acc-1', 'My Portfolio']]);
 
-    const result = buildAccessSummaries([user], members, noGrants, new Map(), accountNames, noSiteAdmins);
+    const result = buildAccessSummaries([user], members, noGrants, new Map(), accountNames, noSiteAdmins, noPending);
 
     expect(result).toHaveLength(1);
     expect(result[0]!.appAccess).toHaveLength(1);
@@ -38,7 +39,7 @@ describe('buildAccessSummaries', () => {
     const appSlugByAccount = new Map([['acc-legacy', 'budget-tracker']]);
     const accountNames = new Map([['acc-legacy', 'Family Budget']]);
 
-    const result = buildAccessSummaries([user], members, noGrants, appSlugByAccount, accountNames, noSiteAdmins);
+    const result = buildAccessSummaries([user], members, noGrants, appSlugByAccount, accountNames, noSiteAdmins, noPending);
 
     expect(result[0]!.appAccess).toHaveLength(1);
     expect(result[0]!.appAccess[0]).toMatchObject({
@@ -53,7 +54,7 @@ describe('buildAccessSummaries', () => {
       ['u1', [{ accountId: 'acc-orphan', userId: 'u1', role: 'owner' }] as M[]], // no appSlug
     ]);
     // appSlugByAccount is empty — BatchGetItem returned nothing for this accountId
-    const result = buildAccessSummaries([user], members, noGrants, new Map(), new Map(), noSiteAdmins);
+    const result = buildAccessSummaries([user], members, noGrants, new Map(), new Map(), noSiteAdmins, noPending);
 
     expect(result[0]!.appAccess).toHaveLength(0);
   });
@@ -64,7 +65,7 @@ describe('buildAccessSummaries', () => {
       ['u1', [{ accountId: 'acc-x', userId: 'u1', appSlug: 'unknown-app' as 'stock-analyser', role: 'owner' }] as M[]],
     ]);
 
-    const result = buildAccessSummaries([user], members, noGrants, new Map(), new Map(), noSiteAdmins);
+    const result = buildAccessSummaries([user], members, noGrants, new Map(), new Map(), noSiteAdmins, noPending);
 
     expect(result[0]!.appAccess).toHaveLength(0);
   });
@@ -79,7 +80,7 @@ describe('buildAccessSummaries', () => {
     ]);
     const appSlugByAccount = new Map([['acc-bt', 'budget-tracker']]);
 
-    const result = buildAccessSummaries([user], members, noGrants, appSlugByAccount, new Map(), noSiteAdmins);
+    const result = buildAccessSummaries([user], members, noGrants, appSlugByAccount, new Map(), noSiteAdmins, noPending);
 
     const appSlugs = result[0]!.appAccess.map(a => a.appSlug).sort();
     expect(appSlugs).toEqual(['budget-tracker', 'stock-analyser']);
@@ -92,7 +93,7 @@ describe('buildAccessSummaries', () => {
     ];
     const siteAdminIds = new Set(['admin']);
 
-    const result = buildAccessSummaries(users, new Map(), noGrants, new Map(), new Map(), siteAdminIds);
+    const result = buildAccessSummaries(users, new Map(), noGrants, new Map(), new Map(), siteAdminIds, noPending);
 
     expect(result.find(u => u.userId === 'admin')!.siteAdmin).toBe(true);
     expect(result.find(u => u.userId === 'regular')!.siteAdmin).toBe(false);
@@ -104,7 +105,7 @@ describe('buildAccessSummaries', () => {
       { userId: 'u2', email: 'bob@example.com' },
     ];
 
-    const result = buildAccessSummaries(users, new Map(), noGrants, new Map(), new Map(), noSiteAdmins);
+    const result = buildAccessSummaries(users, new Map(), noGrants, new Map(), new Map(), noSiteAdmins, noPending);
 
     expect(result.find(u => u.userId === 'u1')!.displayName).toBe('Alice');
     expect(result.find(u => u.userId === 'u2')!.displayName).toBe('bob');
@@ -114,7 +115,7 @@ describe('buildAccessSummaries', () => {
     const user: U = { userId: 'u1', email: 'u1@example.com' };
     const grants = new Map([['u1', [{ appSlug: 'stock-analyser' as const, userId: 'u1' }] as G[]]]);
 
-    const result = buildAccessSummaries([user], new Map(), grants, new Map(), new Map(), noSiteAdmins);
+    const result = buildAccessSummaries([user], new Map(), grants, new Map(), new Map(), noSiteAdmins, noPending);
 
     expect(result[0]!.appAccess).toHaveLength(1);
     expect(result[0]!.appAccess[0]).toMatchObject({
@@ -124,9 +125,36 @@ describe('buildAccessSummaries', () => {
     });
   });
 
-  it('returns pending invites as 0 (Phase 8 placeholder)', () => {
-    const user: U = { userId: 'u1', email: 'u1@example.com' };
-    const result = buildAccessSummaries([user], new Map(), noGrants, new Map(), new Map(), noSiteAdmins);
-    expect(result[0]!.pendingInvites).toBe(0);
+  it('sets pendingInvites from the per-email count map (case-insensitive), 0 when absent (M11)', () => {
+    const users: U[] = [
+      { userId: 'u1', email: 'Alice@Example.com' }, // mixed case → matched lowercased
+      { userId: 'u2', email: 'bob@example.com' },   // no pending invites
+    ];
+    const pending = new Map<string, number>([['alice@example.com', 2]]);
+
+    const result = buildAccessSummaries(users, new Map(), noGrants, new Map(), new Map(), noSiteAdmins, pending);
+
+    expect(result.find(u => u.userId === 'u1')!.pendingInvites).toBe(2);
+    expect(result.find(u => u.userId === 'u2')!.pendingInvites).toBe(0);
+  });
+});
+
+describe('countPendingInvitesByEmail (M11)', () => {
+  it('counts pending bundles per lowercased email; ignores non-pending and missing email', () => {
+    const counts = countPendingInvitesByEmail([
+      { email: 'Alice@Example.com', status: 'pending' },
+      { email: 'alice@example.com', status: 'pending' }, // same user, 2nd pending bundle
+      { email: 'bob@example.com', status: 'accepted' },  // not pending → ignored
+      { email: 'carol@example.com', status: 'expired' }, // not pending → ignored
+      { status: 'pending' },                              // no email → ignored
+    ]);
+
+    expect(counts.get('alice@example.com')).toBe(2);
+    expect(counts.has('bob@example.com')).toBe(false);
+    expect(counts.has('carol@example.com')).toBe(false);
+  });
+
+  it('returns an empty map for no bundles', () => {
+    expect(countPendingInvitesByEmail([]).size).toBe(0);
   });
 });

--- a/apps/launchpad/functions/access-summary/src/index.test.ts
+++ b/apps/launchpad/functions/access-summary/src/index.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { buildAccessSummaries, countPendingInvitesByEmail } from './index';
+import { buildAccessSummaries, buildPendingByEmail, pendingTargetAccountIds } from './index';
+import type { UserPendingInvitation } from '@transformotion/contracts/launchpad/invitations';
 
 // ---------------------------------------------------------------------------
 // Test area 4: Access summary against legacy membership rows missing appSlug
@@ -12,7 +13,7 @@ type U = { userId: string; email: string; displayName?: string; status?: 'active
 describe('buildAccessSummaries', () => {
   const noGrants = new Map<string, G[]>();
   const noSiteAdmins = new Set<string>();
-  const noPending = new Map<string, number>();
+  const noPending = new Map<string, UserPendingInvitation[]>();
 
   it('includes membership when appSlug is denormalized on the row', () => {
     const user: U = { userId: 'u1', email: 'u1@example.com' };
@@ -125,36 +126,81 @@ describe('buildAccessSummaries', () => {
     });
   });
 
-  it('sets pendingInvites from the per-email count map (case-insensitive), 0 when absent (M11)', () => {
+  it('sets pendingInvitations from the per-email list (case-insensitive); count = length; [] when absent (M11)', () => {
     const users: U[] = [
       { userId: 'u1', email: 'Alice@Example.com' }, // mixed case → matched lowercased
       { userId: 'u2', email: 'bob@example.com' },   // no pending invites
     ];
-    const pending = new Map<string, number>([['alice@example.com', 2]]);
+    const invite: UserPendingInvitation = {
+      bundleId: 'b1', grantId: 'g1', kind: 'account-invite', appSlug: 'stock-analyser',
+      target: 'Alice Portfolio', role: 'member', status: 'pending',
+      createdAt: '2026-06-01T00:00:00.000Z', expiresAt: 1798761600,
+    };
+    const pending = new Map<string, UserPendingInvitation[]>([['alice@example.com', [invite, { ...invite, grantId: 'g2' }]]]);
 
     const result = buildAccessSummaries(users, new Map(), noGrants, new Map(), new Map(), noSiteAdmins, pending);
 
-    expect(result.find(u => u.userId === 'u1')!.pendingInvites).toBe(2);
-    expect(result.find(u => u.userId === 'u2')!.pendingInvites).toBe(0);
+    const u1 = result.find(u => u.userId === 'u1')!;
+    expect(u1.pendingInvitations).toHaveLength(2);
+    expect(u1.pendingInvites).toBe(2); // invariant: count === list length
+    const u2 = result.find(u => u.userId === 'u2')!;
+    expect(u2.pendingInvitations).toEqual([]);
+    expect(u2.pendingInvites).toBe(0);
   });
 });
 
-describe('countPendingInvitesByEmail (M11)', () => {
-  it('counts pending bundles per lowercased email; ignores non-pending and missing email', () => {
-    const counts = countPendingInvitesByEmail([
-      { email: 'Alice@Example.com', status: 'pending' },
-      { email: 'alice@example.com', status: 'pending' }, // same user, 2nd pending bundle
-      { email: 'bob@example.com', status: 'accepted' },  // not pending → ignored
-      { email: 'carol@example.com', status: 'expired' }, // not pending → ignored
-      { status: 'pending' },                              // no email → ignored
-    ]);
+describe('buildPendingByEmail (M11)', () => {
+  const names = new Map<string, string>([['acc-1', "Steve's Portfolio"]]);
 
-    expect(counts.get('alice@example.com')).toBe(2);
-    expect(counts.has('bob@example.com')).toBe(false);
-    expect(counts.has('carol@example.com')).toBe(false);
+  it('builds one row per grant; resolves account-invite target name + role; lowercased email key', () => {
+    const map = buildPendingByEmail(
+      [
+        {
+          bundleId: 'b1', email: 'Alice@Example.com', status: 'pending',
+          createdAt: '2026-06-01T00:00:00.000Z', expiresAt: 1798761600,
+          grants: [{ grantId: 'g1', kind: 'account-invite', appSlug: 'stock-analyser', accountId: 'acc-1', role: 'member' }],
+        },
+      ],
+      names,
+    );
+    const rows = map.get('alice@example.com')!;
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      bundleId: 'b1', grantId: 'g1', kind: 'account-invite', appSlug: 'stock-analyser',
+      target: "Steve's Portfolio", role: 'member', status: 'pending',
+    });
   });
 
-  it('returns an empty map for no bundles', () => {
-    expect(countPendingInvitesByEmail([]).size).toBe(0);
+  it('falls back to accountId when the target account name is unresolved', () => {
+    const rows = buildPendingByEmail(
+      [{ email: 'x@y.com', status: 'pending', grants: [{ grantId: 'g', kind: 'account-invite', appSlug: 'budget-tracker', accountId: 'acc-unknown', role: 'viewer' }] }],
+      new Map(),
+    ).get('x@y.com')!;
+    expect(rows[0]!.target).toBe('acc-unknown');
+  });
+
+  it('app-grant rows use the app label and carry no role', () => {
+    const rows = buildPendingByEmail(
+      [{ email: 'x@y.com', status: 'pending', grants: [{ grantId: 'g', kind: 'app-grant', appSlug: 'stock-analyser' }] }],
+      new Map(),
+    ).get('x@y.com')!;
+    expect(rows[0]!.target).toBe('Stock Analyser');
+    expect(rows[0]!.role).toBeUndefined();
+  });
+
+  it('ignores non-pending bundles and missing email', () => {
+    const map = buildPendingByEmail([
+      { email: 'a@b.com', status: 'accepted', grants: [{ grantId: 'g', kind: 'account-invite', appSlug: 'stock-analyser', accountId: 'acc-1' }] },
+      { status: 'pending', grants: [{ grantId: 'g', kind: 'account-invite', appSlug: 'stock-analyser', accountId: 'acc-1' }] },
+    ], names);
+    expect(map.size).toBe(0);
+  });
+
+  it('pendingTargetAccountIds collects account-invite target ids from pending bundles only', () => {
+    const ids = pendingTargetAccountIds([
+      { status: 'pending', grants: [{ grantId: 'g1', kind: 'account-invite', appSlug: 'stock-analyser', accountId: 'acc-1' }, { grantId: 'g2', kind: 'app-grant', appSlug: 'budget-tracker' }] },
+      { status: 'accepted', grants: [{ grantId: 'g3', kind: 'account-invite', appSlug: 'stock-analyser', accountId: 'acc-2' }] },
+    ]);
+    expect(ids).toEqual(['acc-1']);
   });
 });

--- a/apps/launchpad/functions/access-summary/src/index.ts
+++ b/apps/launchpad/functions/access-summary/src/index.ts
@@ -14,12 +14,15 @@ import {
   requireSiteAdmin,
   ok,
 } from '@transformotion/lambda-middleware';
-import type { EntitledAppSlug, UserStatus } from '@transformotion/contracts/_shared/auth';
+import type { AccountRole, EntitledAppSlug, UserStatus } from '@transformotion/contracts/_shared/auth';
 import type {
   UserAccessSummary,
   UserAppAccess,
   UserAccountAccess,
+  UserPendingInvitation,
+  InvitationGrantKind,
 } from '@transformotion/contracts/launchpad/invitations';
+import type { InvitationStatus } from '@transformotion/contracts/launchpad/types';
 
 const cognito = new CognitoIdentityProviderClient({});
 const ddb = DynamoDBDocumentClient.from(new DynamoDBClient({}));
@@ -31,26 +34,84 @@ const APP_ADMIN_GRANTS_TABLE = process.env.APP_ADMIN_GRANTS_TABLE!;
 const INVITATIONS_TABLE = process.env.INVITATIONS_TABLE!;
 const USER_POOL_ID = process.env.USER_POOL_ID!;
 
+interface StoredGrant {
+  grantId?: string;
+  kind?: string;
+  appSlug?: string;
+  accountId?: string;
+  role?: string;
+}
+
 interface StoredBundle {
+  bundleId?: string;
+  invitationId?: string;
   email?: string;
   status?: string;
+  createdAt?: string;
+  expiresAt?: number;
+  grants?: StoredGrant[];
+}
+
+const APP_LABELS: Record<string, string> = {
+  'stock-analyser': 'Stock Analyser',
+  'budget-tracker': 'Budget Tracker',
+};
+function appLabel(slug: string): string {
+  return APP_LABELS[slug] ?? slug;
 }
 
 /**
- * Pure: count pending invitation bundles per (normalized) email — the
- * `UserAccessSummary.pendingInvites` count badge (M11). Mirrors v0's derivation
- * exactly: bundles with `status === 'pending'`, grouped by lowercased email.
- * (Only EXISTING users surface a count — invitees who are not yet users do not
- * appear in the access directory.) Exported for unit tests.
+ * Pure: build the per-user pending-invitation LIST (one row per grant) keyed by
+ * lowercased email — `UserAccessSummary.pendingInvitations` (M11). Mirrors v0's
+ * `listPendingInvitationsForEmail`: pending bundles, per grant; target = account
+ * name (account-invite) or app label (app-grant); `role` only for account-invite.
+ * The count badge `pendingInvites` is then just the list length (the contract
+ * invariant `pendingInvites === pendingInvitations.length`). Only EXISTING users
+ * surface anything — invitees who are not yet users are absent from the directory.
+ * Exported for unit tests.
  */
-export function countPendingInvitesByEmail(bundles: StoredBundle[]): Map<string, number> {
-  const counts = new Map<string, number>();
+export function buildPendingByEmail(
+  bundles: StoredBundle[],
+  accountNameByAccount: Map<string, string>,
+): Map<string, UserPendingInvitation[]> {
+  const out = new Map<string, UserPendingInvitation[]>();
   for (const b of bundles) {
     if (b.status !== 'pending' || !b.email) continue;
     const key = b.email.trim().toLowerCase();
-    counts.set(key, (counts.get(key) ?? 0) + 1);
+    const list = out.get(key) ?? [];
+    for (const g of b.grants ?? []) {
+      if (!g.grantId || !g.kind || !g.appSlug) continue;
+      const target =
+        g.kind === 'account-invite'
+          ? (g.accountId ? accountNameByAccount.get(g.accountId) ?? g.accountId : '')
+          : appLabel(g.appSlug);
+      list.push({
+        bundleId: (b.bundleId ?? b.invitationId ?? '') as string,
+        grantId: g.grantId,
+        kind: g.kind as InvitationGrantKind,
+        appSlug: g.appSlug as EntitledAppSlug,
+        target,
+        ...(g.kind === 'account-invite' && g.role ? { role: g.role as AccountRole } : {}),
+        status: b.status as InvitationStatus,
+        createdAt: (b.createdAt ?? '') as UserPendingInvitation['createdAt'],
+        expiresAt: (b.expiresAt ?? 0) as UserPendingInvitation['expiresAt'],
+      });
+    }
+    out.set(key, list);
   }
-  return counts;
+  return out;
+}
+
+/** Account-invite target accountIds across all pending bundles (for name resolution). */
+export function pendingTargetAccountIds(bundles: StoredBundle[]): string[] {
+  const ids = new Set<string>();
+  for (const b of bundles) {
+    if (b.status !== 'pending') continue;
+    for (const g of b.grants ?? []) {
+      if (g.kind === 'account-invite' && g.accountId) ids.add(g.accountId);
+    }
+  }
+  return [...ids];
 }
 
 interface UserRow {
@@ -100,11 +161,12 @@ export function buildAccessSummaries(
   appSlugByAccount: Map<string, string>,
   accountNameByAccount: Map<string, string>,
   siteAdminIds: Set<string>,
-  pendingCountByEmail: Map<string, number>,
+  pendingByEmail: Map<string, UserPendingInvitation[]>,
 ): UserAccessSummary[] {
   return users.map(user => {
     const memberships = membershipsByUser.get(user.userId) ?? [];
     const grants = appAdminGrantsByUser.get(user.userId) ?? [];
+    const pending = pendingByEmail.get(user.email.trim().toLowerCase()) ?? [];
 
     const byApp = new Map<string, UserAccountAccess[]>();
     for (const m of memberships) {
@@ -136,7 +198,9 @@ export function buildAccessSummaries(
       status: (user.status ?? 'active') as UserStatus,
       siteAdmin: siteAdminIds.has(user.userId),
       appAccess,
-      pendingInvites: pendingCountByEmail.get(user.email.trim().toLowerCase()) ?? 0,
+      // Contract invariant: pendingInvites === pendingInvitations.length.
+      pendingInvitations: pending,
+      pendingInvites: pending.length,
     };
   });
 }
@@ -163,7 +227,7 @@ export const handler = withAuthOnly(async ({ auth }) => {
   requireSiteAdmin(auth);
 
   // 1. Scan all users + the invitation store (D4 — scan is the documented
-  //    approach at this scale; pending-invite COUNT per user email, M11).
+  //    approach at this scale; per-user pending-invitation list + count, M11).
   const [usersRes, siteAdminIds, invitesRes] = await Promise.all([
     ddb.send(new ScanCommand({
       TableName: USERS_TABLE,
@@ -173,12 +237,12 @@ export const handler = withAuthOnly(async ({ auth }) => {
     fetchSiteAdminUserIds(),
     ddb.send(new ScanCommand({
       TableName: INVITATIONS_TABLE,
-      ProjectionExpression: 'email, #st',
+      ProjectionExpression: 'bundleId, invitationId, email, #st, createdAt, expiresAt, grants',
       ExpressionAttributeNames: { '#st': 'status' },
     })),
   ]);
   const users = (usersRes.Items ?? []) as UserRow[];
-  const pendingCountByEmail = countPendingInvitesByEmail((invitesRes.Items ?? []) as StoredBundle[]);
+  const pendingBundles = (invitesRes.Items ?? []) as StoredBundle[];
 
   if (users.length === 0) return ok({ users: [] });
 
@@ -233,13 +297,16 @@ export const handler = withAuthOnly(async ({ auth }) => {
     }
   }
 
-  // 4. Fetch account names for rows that have appSlug already set (for display in summary)
-  const accountIdsWithAppSlug = [...new Set(
-    allMembershipRows.filter(m => m.appSlug).map(m => m.accountId),
-  )].filter(id => !accountNameByAccount.has(id));
+  // 4. Fetch account names for display — membership accounts (with appSlug) AND
+  //    pending-invitation TARGET accounts (M11; the invitee is not a member of
+  //    these, so they would otherwise be unresolved → name falls back to id).
+  const accountIdsNeedingName = [...new Set([
+    ...allMembershipRows.filter(m => m.appSlug).map(m => m.accountId),
+    ...pendingTargetAccountIds(pendingBundles),
+  ])].filter(id => !accountNameByAccount.has(id));
 
-  for (let i = 0; i < accountIdsWithAppSlug.length; i += 25) {
-    const chunk = accountIdsWithAppSlug.slice(i, i + 25).map(id => ({ accountId: id }));
+  for (let i = 0; i < accountIdsNeedingName.length; i += 25) {
+    const chunk = accountIdsNeedingName.slice(i, i + 25).map(id => ({ accountId: id }));
     const res = await ddb.send(new BatchGetCommand({
       RequestItems: { [ACCOUNTS_TABLE]: { Keys: chunk, ProjectionExpression: 'accountId, #n', ExpressionAttributeNames: { '#n': 'name' } } },
     }));
@@ -248,7 +315,8 @@ export const handler = withAuthOnly(async ({ auth }) => {
     }
   }
 
-  // 5. Build access summaries
+  // 5. Build access summaries (pending list keyed by email; count = list length)
+  const pendingByEmail = buildPendingByEmail(pendingBundles, accountNameByAccount);
   const summaries = buildAccessSummaries(
     users,
     membershipsByUser,
@@ -256,7 +324,7 @@ export const handler = withAuthOnly(async ({ auth }) => {
     appSlugByAccount,
     accountNameByAccount,
     siteAdminIds,
-    pendingCountByEmail,
+    pendingByEmail,
   );
 
   return ok({ users: summaries });

--- a/apps/launchpad/functions/access-summary/src/index.ts
+++ b/apps/launchpad/functions/access-summary/src/index.ts
@@ -28,7 +28,30 @@ const USERS_TABLE = process.env.USERS_TABLE!;
 const ACCOUNTS_TABLE = process.env.ACCOUNTS_TABLE!;
 const ACCOUNT_MEMBERS_TABLE = process.env.ACCOUNT_MEMBERS_TABLE!;
 const APP_ADMIN_GRANTS_TABLE = process.env.APP_ADMIN_GRANTS_TABLE!;
+const INVITATIONS_TABLE = process.env.INVITATIONS_TABLE!;
 const USER_POOL_ID = process.env.USER_POOL_ID!;
+
+interface StoredBundle {
+  email?: string;
+  status?: string;
+}
+
+/**
+ * Pure: count pending invitation bundles per (normalized) email — the
+ * `UserAccessSummary.pendingInvites` count badge (M11). Mirrors v0's derivation
+ * exactly: bundles with `status === 'pending'`, grouped by lowercased email.
+ * (Only EXISTING users surface a count — invitees who are not yet users do not
+ * appear in the access directory.) Exported for unit tests.
+ */
+export function countPendingInvitesByEmail(bundles: StoredBundle[]): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const b of bundles) {
+    if (b.status !== 'pending' || !b.email) continue;
+    const key = b.email.trim().toLowerCase();
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+  }
+  return counts;
+}
 
 interface UserRow {
   userId: string;
@@ -77,6 +100,7 @@ export function buildAccessSummaries(
   appSlugByAccount: Map<string, string>,
   accountNameByAccount: Map<string, string>,
   siteAdminIds: Set<string>,
+  pendingCountByEmail: Map<string, number>,
 ): UserAccessSummary[] {
   return users.map(user => {
     const memberships = membershipsByUser.get(user.userId) ?? [];
@@ -112,7 +136,7 @@ export function buildAccessSummaries(
       status: (user.status ?? 'active') as UserStatus,
       siteAdmin: siteAdminIds.has(user.userId),
       appAccess,
-      pendingInvites: 0,
+      pendingInvites: pendingCountByEmail.get(user.email.trim().toLowerCase()) ?? 0,
     };
   });
 }
@@ -138,16 +162,23 @@ async function fetchSiteAdminUserIds(): Promise<Set<string>> {
 export const handler = withAuthOnly(async ({ auth }) => {
   requireSiteAdmin(auth);
 
-  // 1. Scan all users (D4 — scan is the documented approach at this scale)
-  const [usersRes, siteAdminIds] = await Promise.all([
+  // 1. Scan all users + the invitation store (D4 — scan is the documented
+  //    approach at this scale; pending-invite COUNT per user email, M11).
+  const [usersRes, siteAdminIds, invitesRes] = await Promise.all([
     ddb.send(new ScanCommand({
       TableName: USERS_TABLE,
       ProjectionExpression: 'userId, email, displayName, #s',
       ExpressionAttributeNames: { '#s': 'status' },
     })),
     fetchSiteAdminUserIds(),
+    ddb.send(new ScanCommand({
+      TableName: INVITATIONS_TABLE,
+      ProjectionExpression: 'email, #st',
+      ExpressionAttributeNames: { '#st': 'status' },
+    })),
   ]);
   const users = (usersRes.Items ?? []) as UserRow[];
+  const pendingCountByEmail = countPendingInvitesByEmail((invitesRes.Items ?? []) as StoredBundle[]);
 
   if (users.length === 0) return ok({ users: [] });
 
@@ -225,6 +256,7 @@ export const handler = withAuthOnly(async ({ auth }) => {
     appSlugByAccount,
     accountNameByAccount,
     siteAdminIds,
+    pendingCountByEmail,
   );
 
   return ok({ users: summaries });

--- a/apps/launchpad/functions/access-summary/vitest.config.ts
+++ b/apps/launchpad/functions/access-summary/vitest.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    // Without a local config this package inherits apps/launchpad/vitest.config.ts
+    // (`include: ['lib/**']`), which silently skips these co-located src tests
+    // (same class as the accounts/user/ai-config fn fixes). Pin to src.
+    include: ['src/**/*.test.ts'],
+    // Module-load env for the const X = process.env.X! reads at import time. The
+    // tests exercise the exported pure functions (no handler IO), so these only
+    // need to be present.
+    env: {
+      USERS_TABLE: 'users-test',
+      ACCOUNTS_TABLE: 'accounts-test',
+      ACCOUNT_MEMBERS_TABLE: 'members-test',
+      APP_ADMIN_GRANTS_TABLE: 'app-admin-grants-test',
+      INVITATIONS_TABLE: 'invitations-test',
+      USER_POOL_ID: 'pool-test',
+    },
+  },
+});

--- a/apps/launchpad/hooks/use-self-access.ts
+++ b/apps/launchpad/hooks/use-self-access.ts
@@ -88,6 +88,10 @@ export function useSelfAccess(user: User | null): SelfAccess {
         status: 'active' as UserStatus,
         siteAdmin,
         appAccess,
+        // Self-access is derived client-side from claims and has no invitation-store
+        // read — the viewer's own pending invitations are out of scope here; keep
+        // empty (invariant: pendingInvites === pendingInvitations.length).
+        pendingInvitations: [],
         pendingInvites: 0,
       }
 

--- a/apps/launchpad/infrastructure/launchpad-control-plane-stack.ts
+++ b/apps/launchpad/infrastructure/launchpad-control-plane-stack.ts
@@ -317,6 +317,9 @@ export class LaunchpadControlPlaneStack extends cdk.Stack {
         ACCOUNTS_TABLE: accountsTable.tableName,
         ACCOUNT_MEMBERS_TABLE: accountMembersTable.tableName,
         APP_ADMIN_GRANTS_TABLE: appAdminGrantsTable.tableName,
+        // M11: per-user pending-invitation COUNT badge — read-only Scan of the
+        // invitation store (was a hardcoded 0 placeholder).
+        INVITATIONS_TABLE: invitationsTableName,
         USER_POOL_ID: userPoolId,
       },
       bundling: {
@@ -330,6 +333,10 @@ export class LaunchpadControlPlaneStack extends cdk.Stack {
     accountsTable.grantReadData(accessSummaryFn);
     accountMembersTable.grantReadData(accessSummaryFn);
     appAdminGrantsTable.grantReadData(accessSummaryFn);
+    // M11: read-only grant so AccessSummaryFn can Scan the invitation store for
+    // the per-user pending-invitation count.
+    dynamodb.Table.fromTableName(this, 'AccessSummaryInvitationsTable', invitationsTableName)
+      .grantReadData(accessSummaryFn);
 
     accessSummaryFn.addToRolePolicy(new iam.PolicyStatement({
       actions: ['cognito-idp:ListUsersInGroup'],

--- a/docs/architecture/cdk.md
+++ b/docs/architecture/cdk.md
@@ -157,7 +157,7 @@ Launchpad control-plane and auth-domain variables:
 | `USERS_TABLE` | `launchpad-user-{stage}`, `launchpad-account-provisioning-{stage}`, `launchpad-invitation-redemption-{stage}`, `launchpad-pre-token-generation-{stage}` (#501, read-only) | `launchpad-users-{stage}` |
 | `ACCOUNTS_TABLE` | Launchpad account-provisioning, accounts, invitations, pre-token generation | `launchpad-accounts-{stage}` |
 | `ACCOUNT_MEMBERS_TABLE` | Launchpad account-provisioning, accounts, pre-token generation | `launchpad-account-members-{stage}` |
-| `INVITATIONS_TABLE` | `launchpad-invitations-{stage}`, `launchpad-accounts-{stage}` (#555, read-only — surfaces an account's pending invitations on `GET …/members/detail`), `launchpad-access-summary-{stage}` (read-only — per-user pending-invitation count badge) | `launchpad-invitations-{stage}` |
+| `INVITATIONS_TABLE` | `launchpad-invitations-{stage}`, `launchpad-accounts-{stage}` (#555, read-only — surfaces an account's pending invitations on `GET …/members/detail`), `launchpad-access-summary-{stage}` (read-only — per-user pending-invitation list + count, M11) | `launchpad-invitations-{stage}` |
 | `RATE_LIMIT_TABLE` | `launchpad-forgot-provider-{stage}` | `launchpad-rate-limits-{stage}` |
 | `USER_POOL_ID` | Launchpad control-plane/auth Lambdas | LaunchpadAuth User Pool ID |
 | `APP_CLIENT_STOCK_ANALYSER` / `APP_CLIENT_BUDGET_TRACKER` | `launchpad-account-provisioning-{stage}` | LaunchpadAuth app client IDs |

--- a/docs/architecture/cdk.md
+++ b/docs/architecture/cdk.md
@@ -157,7 +157,7 @@ Launchpad control-plane and auth-domain variables:
 | `USERS_TABLE` | `launchpad-user-{stage}`, `launchpad-account-provisioning-{stage}`, `launchpad-invitation-redemption-{stage}`, `launchpad-pre-token-generation-{stage}` (#501, read-only) | `launchpad-users-{stage}` |
 | `ACCOUNTS_TABLE` | Launchpad account-provisioning, accounts, invitations, pre-token generation | `launchpad-accounts-{stage}` |
 | `ACCOUNT_MEMBERS_TABLE` | Launchpad account-provisioning, accounts, pre-token generation | `launchpad-account-members-{stage}` |
-| `INVITATIONS_TABLE` | `launchpad-invitations-{stage}`, `launchpad-accounts-{stage}` (#555, read-only — surfaces an account's pending invitations on `GET …/members/detail`) | `launchpad-invitations-{stage}` |
+| `INVITATIONS_TABLE` | `launchpad-invitations-{stage}`, `launchpad-accounts-{stage}` (#555, read-only — surfaces an account's pending invitations on `GET …/members/detail`), `launchpad-access-summary-{stage}` (read-only — per-user pending-invitation count badge) | `launchpad-invitations-{stage}` |
 | `RATE_LIMIT_TABLE` | `launchpad-forgot-provider-{stage}` | `launchpad-rate-limits-{stage}` |
 | `USER_POOL_ID` | Launchpad control-plane/auth Lambdas | LaunchpadAuth User Pool ID |
 | `APP_CLIENT_STOCK_ANALYSER` / `APP_CLIENT_BUDGET_TRACKER` | `launchpad-account-provisioning-{stage}` | LaunchpadAuth app client IDs |

--- a/docs/architecture/data.md
+++ b/docs/architecture/data.md
@@ -138,11 +138,14 @@ denormalising the write path. The handler therefore uses a filtered Scan (the
 same pattern as invitation-bundles-list and invitee-search) against this small,
 low-volume control-plane table.
 
-**Pending-count-by-email (M11):** `launchpad-access-summary-{stage}` also reads
-this table (read-only Scan) to compute the per-user pending-invitation **count**
-(`UserAccessSummary.pendingInvites`), matched by lowercased `email`. The
-per-user pending **list** display is not yet wired — `UserAccessSummary` carries
-only the count, so the by-email list awaits a v0 contract field.
+**Pending-by-email list (M11):** `launchpad-access-summary-{stage}` also reads
+this table (read-only Scan) to build the per-user pending-invitation **list**
+(`UserAccessSummary.pendingInvitations`, one row per grant), matched by
+lowercased `email`; the count badge `pendingInvites` is the list length (the
+contract invariant `pendingInvites === pendingInvitations.length`). Account-invite
+targets are resolved to account names (BatchGet on the accounts table, fallback to
+id). Only EXISTING users surface anything — invitees who are not yet users are
+absent from the directory.
 
 ### `launchpad-app-admin-grants-{stage}` (M16 D5)
 

--- a/docs/architecture/data.md
+++ b/docs/architecture/data.md
@@ -138,6 +138,12 @@ denormalising the write path. The handler therefore uses a filtered Scan (the
 same pattern as invitation-bundles-list and invitee-search) against this small,
 low-volume control-plane table.
 
+**Pending-count-by-email (M11):** `launchpad-access-summary-{stage}` also reads
+this table (read-only Scan) to compute the per-user pending-invitation **count**
+(`UserAccessSummary.pendingInvites`), matched by lowercased `email`. The
+per-user pending **list** display is not yet wired — `UserAccessSummary` carries
+only the count, so the by-email list awaits a v0 contract field.
+
 ### `launchpad-app-admin-grants-{stage}` (M16 D5)
 
 App-admin grants: policy primitive for app-scoped administrative authority. Kept separate from the membership table so `isAppAdmin(userId, appSlug)` is unambiguous and cannot be confused with account membership.


### PR DESCRIPTION
## Summary
Runtime data-seam completion of M11 pending-invitations, **reproducing v0's
enriched display verbatim** (v0 enriched both surfaces and landed the contract
field in `transformotion-apps-b8` #73). #556 fixed the backend read; this wires
the live data into v0's surfaces and ports v0's enrichment.

### Surface 1 — account-management panel ✅ (enriched)
Was discarding `res.pendingInvitations` (hardcoded `invitations = []`). Now
captures it, flattens to v0's **enriched** row VM (`role`, `createdAt`,
`expiresAt` — all already on `InvitationBundle`), and renders v0's enriched rows
**verbatim**: role chip, `Sent {date} · Expires/Expired {date}`, expired-state
styling, status chip. Ported v0's three format helpers
(`formatSentDate`/`formatExpiry`/`isInvitationExpired`) verbatim. Cancel-**X**
stays **inert** (no cancel-grant endpoint — separate item).

### Surface 2 — Users & Access
The v0 contract (47c1082) added a **required** `UserAccessSummary.pendingInvitations`
(one row per grant) with the invariant `pendingInvites === pendingInvitations.length`.
Because CI typecheck syncs v0 main, **every `UserAccessSummary` builder must now
supply the list** — a real count is no longer possible without the real list.
- **Backend ✅:** replaced the count-only helper with `buildPendingByEmail`
  (mirrors v0's `listPendingInvitationsForEmail`: per-grant rows; target = account
  name / app label; `role` only for account-invite); `pendingInvites` = list
  length. Resolves pending-target account names (BatchGet, fallback to id).
  `use-self-access` sets `pendingInvitations: []` (client-side, no invitation
  read — unchanged behaviour, invariant holds).
- **Count badge ✅:** `summary.pendingInvites` now lights up.
- **Detail LIST ⏸ (separate prompt):** backend now provides the data; wiring the
  `users-access-view` detail display to v0's enriched per-user list is the
  separate v0-enriched-display prompt. Comment updated; stub left.

## Tests / gates
- `access-summary`: **14 pass** (new `buildPendingByEmail` / `pendingTargetAccountIds`
  + invariant `count === length`). (These src tests were silently skipped before
  the inherited `lib/**` include; pinned `vitest.config.ts` added so they run.)
- Typecheck: access-summary fn, launchpad app (incl. the `use-self-access`
  contract fixup), infra — all pass. ESLint clean. `pnpm sync:v0` +
  `check-v0-contracts-synced` clean.

## Functional verification (pending deploy — PR held)
Static gates pass. Dev preconditions (read-only recon): bundles `8a50e462`
(gmail) + `dc71d0d9` (hotmail) pending against `a03f9cd4` (Steve's Portfolio);
both invitee emails ARE existing users. Post-deploy: S1 lists both enriched
invites; S2 count badge shows 1 on each of those user rows. Final UI check on merge.

## v0 freshness
v0 PR: https://github.com/transformotion/transformotion-apps-b8/pull/73
(commits https://github.com/transformotion/transformotion-apps-b8/commit/101872d
+ https://github.com/transformotion/transformotion-apps-b8/commit/47c1082) —
enriched account-management rows + format helpers, and the new
`UserAccessSummary.pendingInvitations` contract field. Runtime ports the v0
presentation verbatim and consumes the synced contract; no runtime-originated
UI/contract change.

## Deploy
`apps/launchpad/**` + `infrastructure/**` (access-summary env/grant from the
earlier commit) → `deploy-launchpad.yml`. No `packages/*` → no cross-app fan-out.

Refs #555

🤖 Generated with [Claude Code](https://claude.com/claude-code)