### PR TITLE
feat(m11): wire Users & Access detail list to live pending-invitations (#555)

### DIFF
--- a/apps/launchpad/components/launchpad/admin/settings-permissions-view.tsx
+++ b/apps/launchpad/components/launchpad/admin/settings-permissions-view.tsx
@@ -179,7 +179,7 @@ function useSettingsDirectory(viewer: AdminUser) {
       setUsers(res.users.map(toViewUserAccessSummary))
     } catch {
       // Non-site-admin (or read failure): fall back to the viewer alone.
-      setUsers([{ user: viewer, appAccess: [], pendingInvites: 0 }])
+      setUsers([{ user: viewer, appAccess: [], pendingInvites: 0, pendingInvitations: [] }])
     }
   }, [viewer])
 

--- a/apps/launchpad/components/launchpad/admin/users-access-view.tsx
+++ b/apps/launchpad/components/launchpad/admin/users-access-view.tsx
@@ -97,6 +97,24 @@ function RoleChip({ role }: { role: AccountRole }) {
   )
 }
 
+// Pending-invitation date helpers — ported verbatim from the v0 prototype
+// (`components/launchpad/admin/users-access-view.tsx`).
+function formatInviteSent(iso: string): string {
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return '—'
+  return d.toLocaleDateString(undefined, { day: 'numeric', month: 'short', year: 'numeric' })
+}
+
+function formatInviteExpiry(expiresAt: number): { label: string; expired: boolean } {
+  const ms = expiresAt * 1000
+  const d = new Date(ms)
+  if (Number.isNaN(d.getTime())) return { label: '—', expired: false }
+  return {
+    label: d.toLocaleDateString(undefined, { day: 'numeric', month: 'short', year: 'numeric' }),
+    expired: ms < Date.now(),
+  }
+}
+
 function StatusChip({ status }: { status: AdminUser['status'] }) {
   return (
     <span
@@ -149,11 +167,10 @@ function UserDetailPanel({
   onSetStatus: (userId: string, status: 'active' | 'disabled') => void
 }) {
   const { user } = summary
-  // M11: the COUNT badge (`summary.pendingInvites`) is live, and the backend now
-  // also returns the per-user LIST (`summary.pendingInvitations`, since the v0
-  // contract field landed). Wiring THIS detail list to consume it is a separate
-  // prompt (v0's enriched users-access detail display); kept stubbed for now.
-  const pendingInvites: Array<{ invitationId: string; accountId: string; status: string }> = []
+  // M11: live per-user pending-invitation rows from the contract
+  // (`summary.pendingInvitations`, populated by access-summary). Count badge and
+  // this detail list now agree (one row per grant).
+  const pendingInvites = summary.pendingInvitations
 
   return (
     <div className="space-y-4" aria-label={`Access detail for ${resolveUserLabel(user)}`}>
@@ -231,18 +248,51 @@ function UserDetailPanel({
               <p className="text-sm text-muted-foreground">None.</p>
             ) : (
               <ul className="space-y-1.5">
-                {pendingInvites.map((invite) => (
-                  <li
-                    key={invite.invitationId}
-                    className="flex items-center gap-2 rounded-lg border border-border bg-surface/30 px-3 py-2"
-                  >
-                    <Clock className="size-3.5 shrink-0 text-signal-gold" />
-                    <span className="text-xs text-foreground">{invite.accountId}</span>
-                    <span className="ml-auto text-[10px] uppercase tracking-wider text-muted-foreground">
-                      {invite.status}
-                    </span>
-                  </li>
-                ))}
+                {pendingInvites.map((invite) => {
+                  const expiry = formatInviteExpiry(invite.expiresAt)
+                  return (
+                    <li
+                      key={invite.grantId}
+                      className="flex items-start gap-2 rounded-lg border border-border bg-surface/30 px-3 py-2"
+                    >
+                      <Clock className="mt-0.5 size-3.5 shrink-0 text-signal-gold" />
+                      <div className="min-w-0 flex-1">
+                        {/* Target account/app + role/grant */}
+                        <div className="flex flex-wrap items-center gap-1.5">
+                          <span className="min-w-0 truncate text-xs font-medium text-foreground">
+                            {invite.target}
+                          </span>
+                          {invite.role ? (
+                            <RoleChip role={invite.role} />
+                          ) : (
+                            <span className="inline-flex items-center rounded-full bg-surface2 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+                              App access
+                            </span>
+                          )}
+                        </div>
+                        {/* Sent + expires */}
+                        <p className="mt-0.5 text-[11px] text-muted-foreground">
+                          Sent {formatInviteSent(invite.createdAt)}
+                          {' · '}
+                          <span className={cn(expiry.expired && 'text-signal-red')}>
+                            {expiry.expired ? 'Expired ' : 'Expires '}
+                            {expiry.label}
+                          </span>
+                        </p>
+                      </div>
+                      <span
+                        className={cn(
+                          'shrink-0 rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider',
+                          expiry.expired
+                            ? 'bg-signal-red/15 text-signal-red'
+                            : 'bg-signal-gold/15 text-signal-gold',
+                        )}
+                      >
+                        {expiry.expired ? 'expired' : invite.status}
+                      </span>
+                    </li>
+                  )
+                })}
               </ul>
             )}
           </div>

--- a/apps/launchpad/lib/admin/view-model.ts
+++ b/apps/launchpad/lib/admin/view-model.ts
@@ -32,7 +32,7 @@ import {
   type EntitledAppSlug,
   type UserStatus,
 } from '@transformotion/contracts/_shared/auth'
-import type { UserAccessSummary as ContractUserAccessSummary } from '@transformotion/contracts/launchpad/invitations'
+import type { UserAccessSummary as ContractUserAccessSummary, UserPendingInvitation } from '@transformotion/contracts/launchpad/invitations'
 
 // ---------------------------------------------------------------------------
 // View-model types (mirror the v0 prototype names the ported views import)
@@ -74,6 +74,9 @@ export interface UserAccessSummary {
   user: AdminUser
   appAccess: AppAccountAccess[]
   pendingInvites: number
+  /** Per-user pending-invitation rows (one per grant) for the detail list (M11).
+   *  v0 derives these client-side; runtime carries the live contract list here. */
+  pendingInvitations: UserPendingInvitation[]
 }
 
 // ---------------------------------------------------------------------------
@@ -146,6 +149,7 @@ export function toViewUserAccessSummary(s: ContractUserAccessSummary): UserAcces
       })),
     })),
     pendingInvites: s.pendingInvites,
+    pendingInvitations: s.pendingInvitations,
   }
 }
 


### PR DESCRIPTION
## Summary
The last pending-invitations data-seam piece — wires the **Users & Access**
user-panel detail list to the live data, closing the "1 / None." inconsistency
flagged on #557.

> **Stacked on #557** (base = `claude-code/m11-pending-invites-data-wiring`).
> #557's access-summary backend populates `UserAccessSummary.pendingInvitations`;
> this PR consumes it. Retargets to `develop` once #557 merges.

After #557 the count badge was live but the expanded detail list still stubbed
`[]` ("None." under a count of 1). Now the detail list consumes
`summary.pendingInvitations` and **reproduces v0's enriched display verbatim**
(port of v0 `users-access-view`):
- **target** = account name (account-invite) or app label (app-grant),
- **role chip** for account-invites, or an **"App access"** pill for roleless
  app-grants,
- **"Sent {date} · Expires/Expired {date}"** with expired-state styling,
- status / `expired` chip.

Ported v0's `formatInviteSent` / `formatInviteExpiry` helpers verbatim.

`view-model`: carries `pendingInvitations` (`UserPendingInvitation[]`) through
`toViewUserAccessSummary` — v0 derives the list client-side from its mock store;
runtime carries the live contract list instead. `settings-permissions-view`'s
fallback summary literal updated for the new required field.

## Tests / gates
Typecheck (launchpad app) + ESLint clean. (No new unit tests — pure presentational
wiring of an existing contract field into a verbatim v0 port.)

## Functional verification (pending deploy — PR held)
On dev: expand the gmail/hotmail user (pending invite vs `a03f9cd4`) → the **count
badge AND the detail list both show the invitation row** (target, role, sent/
expires) — count and list consistent. Runs post-merge (after #557).

## v0 freshness
v0 PR: https://github.com/transformotion/transformotion-apps-b8/pull/73 — the
enriched users-access detail rows + `UserPendingInvitation` contract field.
Runtime reproduces the v0 presentation verbatim and consumes the synced contract;
no runtime-originated UI/contract change.

## Deploy
`apps/launchpad/**` only → `deploy-launchpad.yml` (frontend rebuild). No infra,
no `packages/*`.

Refs #555

🤖 Generated with [Claude Code](https://claude.com/claude-code)