### PR TITLE
feat(m11): cancel-invitation (revoke grant) — make the cancel-X work (#558)

### DIFF
--- a/apps/launchpad/components/launchpad/admin/account-management-view.tsx
+++ b/apps/launchpad/components/launchpad/admin/account-management-view.tsx
@@ -222,7 +222,15 @@ function useAccountDirectory(viewer: AdminUser) {
     applyDetail(accountId, res)
   }, [applyDetail])
 
-  return { accounts, membersByAccount, pendingByAccount, viewerRoleByAccount, updateRole, removeMember }
+  // M11 cancel-invitation (#558): revoke the grant, then refetch so the row
+  // leaves the pending list (the server has removed it from the bundle).
+  const cancelInvitation = useCallback(async (accountId: string, bundleId: string, grantId: string) => {
+    await getControlPlaneClient().cancelInvitationGrant(bundleId, grantId)
+    const res = await getControlPlaneClient().getMembersDetail(accountId)
+    applyDetail(accountId, res)
+  }, [applyDetail])
+
+  return { accounts, membersByAccount, pendingByAccount, viewerRoleByAccount, updateRole, removeMember, cancelInvitation }
 }
 
 const ROLE_STYLES: Record<AccountRole, string> = {
@@ -380,6 +388,7 @@ function AccountDetailPanel({
   invitations,
   onUpdateRole,
   onRemoveMember,
+  onCancelInvitation,
 }: {
   viewerRole: AccountRole | null
   viewerIsSiteAdmin: boolean
@@ -388,6 +397,7 @@ function AccountDetailPanel({
   invitations: PendingInviteVM[]
   onUpdateRole: (accountId: string, userId: string, role: AccountRole) => Promise<void>
   onRemoveMember: (accountId: string, userId: string) => Promise<void>
+  onCancelInvitation: (bundleId: string, grantId: string) => Promise<void>
 }) {
   const router = useRouter()
   // M11: real account-scoped pending invitations from GET …/members/detail
@@ -519,10 +529,14 @@ function AccountDetailPanel({
                       >
                         {expired ? 'expired' : invite.status}
                       </span>
-                      {/* Cancel control: v0 wires onClick→cpCancelGrant; runtime has no
-                          cancel-grant endpoint yet, so the X stays inert (separate item). */}
+                      {/* Cancel control (#558): revoke this grant → DELETE
+                          .../grants/{grantId}; the row leaves the pending list. */}
                       <button
                         disabled={!cancel.allowed}
+                        onClick={() => {
+                          if (!cancel.allowed) return
+                          void onCancelInvitation(invite.bundleId, invite.grantId)
+                        }}
                         title={cancel.reason}
                         className="flex size-7 shrink-0 items-center justify-center rounded-md bg-surface2 text-muted-foreground transition-colors hover:text-signal-red disabled:cursor-not-allowed disabled:opacity-40"
                         aria-label={`Cancel invitation for ${invite.email}`}
@@ -553,7 +567,7 @@ function AccountDetailPanel({
 // ---------------------------------------------------------------------------
 
 export function AccountManagementView({ viewer }: { viewer: AdminUser }) {
-  const { accounts, membersByAccount, pendingByAccount, viewerRoleByAccount, updateRole, removeMember } =
+  const { accounts, membersByAccount, pendingByAccount, viewerRoleByAccount, updateRole, removeMember, cancelInvitation } =
     useAccountDirectory(viewer)
   const viewerIsSiteAdmin = userIsSiteAdmin(viewer)
   // Multiple accounts can stay expanded at once; "Collapse all" clears them.
@@ -663,6 +677,13 @@ export function AccountManagementView({ viewer }: { viewer: AdminUser }) {
                         invitations={invitations}
                         onUpdateRole={updateRole}
                         onRemoveMember={removeMember}
+                        onCancelInvitation={async (bundleId, grantId) => {
+                          try {
+                            await cancelInvitation(account.accountId, bundleId, grantId)
+                          } catch (err) {
+                            alert(err instanceof Error ? err.message : 'Could not cancel the invitation.')
+                          }
+                        }}
                       />
                     </div>
                   )}

--- a/apps/launchpad/functions/invitation-bundles/src/index.test.ts
+++ b/apps/launchpad/functions/invitation-bundles/src/index.test.ts
@@ -2,21 +2,56 @@ import { describe, expect, it } from 'vitest';
 import type { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
 import { createHandler } from './index';
 
-interface Seed { accounts?: Record<string, Record<string, unknown>> }
+interface Seed {
+  accounts?: Record<string, Record<string, unknown>>;
+  bundles?: Record<string, Record<string, unknown>>;             // keyed by invitationId
+  members?: Record<string, { role: string; status?: string }>;   // keyed by `${accountId}#${userId}`
+}
 
 function makeHandler(seed: Seed = {}) {
   const puts: Array<Record<string, unknown>> = [];
+  const updates: Array<Record<string, unknown>> = [];
   const ddb = {
     send: async (cmd: { constructor: { name: string }; input: Record<string, unknown> }) => {
       const name = cmd.constructor.name;
       const input = cmd.input as { TableName?: string; Key?: Record<string, string>; Item?: Record<string, unknown> };
       if (name === 'GetCommand' && input.TableName === 'accounts') return { Item: seed.accounts?.[input.Key!.accountId] };
+      if (name === 'GetCommand' && input.TableName === 'invitations') return { Item: seed.bundles?.[input.Key!.invitationId] };
+      if (name === 'GetCommand' && input.TableName === 'members') return { Item: seed.members?.[`${input.Key!.accountId}#${input.Key!.userId}`] };
       if (name === 'PutCommand' && input.TableName === 'invitations') { puts.push(input.Item ?? {}); return {}; }
+      if (name === 'UpdateCommand' && input.TableName === 'invitations') { updates.push(input); return {}; }
       throw new Error(`unexpected ddb command ${name} on ${input.TableName}`);
     },
   } as unknown as DynamoDBDocumentClient;
-  const handler = createHandler({ ddb, invitationsTable: 'invitations', accountsTable: 'accounts' });
-  return { handler, puts };
+  const handler = createHandler({ ddb, invitationsTable: 'invitations', accountsTable: 'accounts', accountMembersTable: 'members' });
+  return { handler, puts, updates };
+}
+
+/** DELETE /api/invitations/bundles/{bundleId}/grants/{grantId} as `sub` with `groups`. */
+function cancelEvent(groups: string, bundleId: string, grantId: string, sub = 'caller-1') {
+  return {
+    resource: '/api/invitations/bundles/{bundleId}/grants/{grantId}',
+    httpMethod: 'DELETE',
+    pathParameters: { bundleId, grantId },
+    headers: {},
+    requestContext: { authorizer: { claims: { sub, email: 'caller@example.com', 'cognito:groups': groups, apps: '[]', accounts: '{}' } } },
+    body: null,
+    isBase64Encoded: false,
+  } as never;
+}
+
+/** A two-grant pending bundle targeting acct-1 (g1) and acct-2 (g2). */
+function twoGrantBundle() {
+  return {
+    'b1': {
+      invitationId: 'b1', bundleId: 'b1', email: 'inv@example.com', invitedBy: 'admin-9',
+      createdAt: '2026-06-01T00:00:00.000Z', expiresAt: 1798761600, status: 'pending',
+      grants: [
+        { grantId: 'g1', kind: 'account-invite', appSlug: 'stock-analyser', accountId: 'acct-1', role: 'member' },
+        { grantId: 'g2', kind: 'account-invite', appSlug: 'stock-analyser', accountId: 'acct-2', role: 'viewer' },
+      ],
+    },
+  };
 }
 
 function event(groups: string, body: unknown) {
@@ -123,5 +158,68 @@ describe('invitation-bundles — POST /api/invitations/bundles (M11 Chunk 3, Opt
     const { handler } = makeHandler();
     expect(((await handler(event('site-admin', { grants: [{ kind: 'app-grant', appSlug: 'stock-analyser' }] }))) as { statusCode: number }).statusCode).toBe(400);
     expect(((await handler(event('site-admin', { email: 'a@b.com', grants: [] }))) as { statusCode: number }).statusCode).toBe(400);
+  });
+});
+
+describe('invitation-bundles — DELETE …/grants/{grantId} cancel (M11, #558)', () => {
+  // Authorization: owner/manager of the grant's TARGET account (live row) OR
+  // app-admin-for-app OR site-admin. Target-resolved + fail-closed.
+
+  it('an OWNER of the grant\'s account cancels it — even one a DIFFERENT admin sent (it is their account)', async () => {
+    const { handler, updates } = makeHandler({
+      bundles: twoGrantBundle(),                                   // invitedBy: admin-9 (a different admin)
+      members: { 'acct-1#caller-1': { role: 'owner', status: 'active' } },
+    });
+    const res = (await handler(cancelEvent('', 'b1', 'g1'))) as { statusCode: number; body: string };
+    expect(res.statusCode).toBe(200);
+    // Grant removed; the OTHER grant survives → bundle stays pending.
+    expect(updates).toHaveLength(1);
+    const vals = (updates[0] as { ExpressionAttributeValues: Record<string, unknown> }).ExpressionAttributeValues;
+    expect((vals[':g'] as unknown[]).map((g) => (g as { grantId: string }).grantId)).toEqual(['g2']);
+    expect(vals[':s']).toBe('pending');
+    expect(JSON.parse(res.body).bundle.grants).toHaveLength(1);
+  });
+
+  it('a MANAGER may cancel; cancelling the LAST grant marks the bundle revoked', async () => {
+    const single = { 'b1': { ...twoGrantBundle()['b1'], grants: [twoGrantBundle()['b1'].grants[0]] } };
+    const { handler, updates } = makeHandler({
+      bundles: single,
+      members: { 'acct-1#caller-1': { role: 'manager', status: 'active' } },
+    });
+    const res = (await handler(cancelEvent('', 'b1', 'g1'))) as { statusCode: number };
+    expect(res.statusCode).toBe(200);
+    const vals = (updates[0] as { ExpressionAttributeValues: Record<string, unknown> }).ExpressionAttributeValues;
+    expect(vals[':g']).toEqual([]);
+    expect(vals[':s']).toBe('revoked');
+  });
+
+  it('site-admin (supervisory) and app-admin-for-app may cancel without account membership', async () => {
+    const siteAdmin = makeHandler({ bundles: twoGrantBundle() });        // no members seed
+    expect(((await siteAdmin.handler(cancelEvent('site-admin', 'b1', 'g1'))) as { statusCode: number }).statusCode).toBe(200);
+    const appAdmin = makeHandler({ bundles: twoGrantBundle() });
+    expect(((await appAdmin.handler(cancelEvent('stock-app-admin', 'b1', 'g1'))) as { statusCode: number }).statusCode).toBe(200);
+  });
+
+  it('REJECTS (403) an unauthorized caller — a plain VIEWER of the account, no admin authority', async () => {
+    const { handler, updates } = makeHandler({
+      bundles: twoGrantBundle(),
+      members: { 'acct-1#caller-1': { role: 'viewer', status: 'active' } }, // viewer ≠ owner/manager
+    });
+    const res = (await handler(cancelEvent('', 'b1', 'g1'))) as { statusCode: number };
+    expect(res.statusCode).toBe(403);
+    expect(updates).toHaveLength(0); // fail closed — nothing written
+  });
+
+  it('REJECTS (403) a caller with NO membership on the target account and no admin group', async () => {
+    const { handler, updates } = makeHandler({ bundles: twoGrantBundle() }); // no members seed → undefined row
+    expect(((await handler(cancelEvent('', 'b1', 'g1'))) as { statusCode: number }).statusCode).toBe(403);
+    expect(updates).toHaveLength(0);
+  });
+
+  it('404 when the bundle or the grant does not resolve (fail closed)', async () => {
+    const missingBundle = makeHandler({ members: { 'acct-1#caller-1': { role: 'owner' } } });
+    expect(((await missingBundle.handler(cancelEvent('', 'nope', 'g1'))) as { statusCode: number }).statusCode).toBe(404);
+    const missingGrant = makeHandler({ bundles: twoGrantBundle(), members: { 'acct-1#caller-1': { role: 'owner' } } });
+    expect(((await missingGrant.handler(cancelEvent('', 'b1', 'ghost'))) as { statusCode: number }).statusCode).toBe(404);
   });
 });

--- a/apps/launchpad/functions/invitation-bundles/src/index.ts
+++ b/apps/launchpad/functions/invitation-bundles/src/index.ts
@@ -1,14 +1,17 @@
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
-import { DynamoDBDocumentClient, GetCommand, PutCommand, ScanCommand } from '@aws-sdk/lib-dynamodb';
+import { DynamoDBDocumentClient, GetCommand, PutCommand, ScanCommand, UpdateCommand } from '@aws-sdk/lib-dynamodb';
 import {
   withAuthOnly,
   parseBody,
   getPathParam,
   ok,
   badRequest,
+  forbidden,
   notFound,
+  requireAccountOwnerOrManager,
   type APIGatewayProxyEvent,
   type AuthClaims,
+  type MembershipLoader,
 } from '@transformotion/lambda-middleware';
 import {
   appAdminGroup,
@@ -47,6 +50,8 @@ export interface BundleCreationDeps {
   ddb: DynamoDBDocumentClient;
   invitationsTable: string;
   accountsTable: string;
+  /** Account-members table — the LIVE owner/manager check for grant cancellation (D8). */
+  accountMembersTable: string;
   // ── Redemption-email send seam (4b / #471) — all OPTIONAL ────────────────
   // When configured, bundle creation also sends the invitee the redemption email
   // carrying the grants preview + bearer link. Absent (e.g. in unit tests) → the
@@ -66,6 +71,19 @@ export function createHandler(deps: BundleCreationDeps) {
     return auth.groups.includes('site-admin')
       || auth.groups.includes(appAdminGroup(appSlug as EntitledAppSlug));
   }
+
+  // LIVE owner/manager check for grant cancellation (D8 write tier — the row is
+  // the authority, not a possibly-stale claim).
+  const membershipLoader: MembershipLoader = async (accountId, userId) => {
+    const res = await deps.ddb.send(new GetCommand({
+      TableName: deps.accountMembersTable,
+      Key: { accountId, userId },
+      ProjectionExpression: '#r, #s',
+      ExpressionAttributeNames: { '#r': 'role', '#s': 'status' },
+    }));
+    if (!res.Item) return undefined;
+    return { role: res.Item['role'] as AccountRole, status: res.Item['status'] as string | undefined };
+  };
 
   async function createBundle(auth: AuthClaims, event: APIGatewayProxyEvent) {
     const { email, grants } = parseBody<{ email?: string; grants?: GrantInput[] }>(event);
@@ -254,6 +272,63 @@ export function createHandler(deps: BundleCreationDeps) {
     return ok({ bundle });
   }
 
+  // Target-resolved authorization for cancelling a grant (contract policy:
+  // `account-owner-or-manager` OR `app-admin-for-app`, plus site-admin
+  // supervisory). Resolve the grant to its target account/app FIRST, then decide.
+  // RULING: any owner/manager of the grant's target account may cancel it —
+  // including one a DIFFERENT admin sent — because it is THEIR account. Fail closed.
+  async function authorizeCancelGrant(auth: AuthClaims, grant: InvitationGrant) {
+    if (auth.groups.includes('site-admin')) return;                                  // supervisory
+    if (auth.groups.includes(appAdminGroup(grant.appSlug as EntitledAppSlug))) return; // app-admin-for-app
+    if (grant.kind === 'account-invite' && grant.accountId) {
+      // LIVE owner/manager of the grant's target account (throws 403 otherwise).
+      await requireAccountOwnerOrManager(membershipLoader, grant.accountId, auth.userId);
+      return;
+    }
+    // An app-grant the caller doesn't app-admin, or an unresolved target → deny.
+    throw forbidden('You are not authorized to cancel this invitation.');
+  }
+
+  // DELETE /api/invitations/bundles/{bundleId}/grants/{grantId} — revoke ONE
+  // pending grant. Removes it from the bundle's grants[]; when none remain the
+  // bundle is marked `revoked`. The cancelled grant then leaves BOTH pending
+  // surfaces (account panel + Users & Access), which read this same store.
+  async function cancelGrant(auth: AuthClaims, bundleId: string, grantId: string) {
+    const res = await deps.ddb.send(new GetCommand({
+      TableName: deps.invitationsTable,
+      Key: { invitationId: bundleId },
+    }));
+    const item = res.Item as (InvitationBundle & { invitationId?: string; invitedBy?: string }) | undefined;
+    if (!item || !Array.isArray(item.grants)) throw notFound('Invitation not found');
+
+    const grant = item.grants.find((g) => g.grantId === grantId);
+    if (!grant) throw notFound('Invitation grant not found'); // unresolved target → fail closed
+
+    await authorizeCancelGrant(auth, grant);
+
+    const remaining = item.grants.filter((g) => g.grantId !== grantId);
+    const status = remaining.length === 0 ? 'revoked' : item.status;
+
+    await deps.ddb.send(new UpdateCommand({
+      TableName: deps.invitationsTable,
+      Key: { invitationId: bundleId },
+      UpdateExpression: 'SET #g = :g, #s = :s',
+      ExpressionAttributeNames: { '#g': 'grants', '#s': 'status' },
+      ExpressionAttributeValues: { ':g': remaining, ':s': status },
+    }));
+
+    const bundle: InvitationBundle = {
+      bundleId: item.bundleId ?? item.invitationId ?? bundleId,
+      email: item.email,
+      invitedBy: item.invitedBy ?? '',
+      createdAt: item.createdAt,
+      expiresAt: item.expiresAt,
+      status,
+      grants: remaining,
+    };
+    return ok({ bundle });
+  }
+
   return withAuthOnly(async ({ auth, event }) => {
     const e = event as APIGatewayProxyEvent;
     const resource = e.resource ?? '';
@@ -266,6 +341,9 @@ export function createHandler(deps: BundleCreationDeps) {
     if (resource === '/api/invitations/bundles/{bundleId}' && event.httpMethod === 'GET') {
       return getBundle(getPathParam(e, 'bundleId'));
     }
+    if (resource === '/api/invitations/bundles/{bundleId}/grants/{grantId}' && event.httpMethod === 'DELETE') {
+      return cancelGrant(auth, getPathParam(e, 'bundleId'), getPathParam(e, 'grantId'));
+    }
     throw badRequest(`Unrecognised route: ${event.httpMethod} ${resource}`);
   });
 }
@@ -274,6 +352,7 @@ export const handler = createHandler({
   ddb: DynamoDBDocumentClient.from(new DynamoDBClient({})),
   invitationsTable: process.env.INVITATIONS_TABLE!,
   accountsTable: process.env.ACCOUNTS_TABLE!,
+  accountMembersTable: process.env.ACCOUNT_MEMBERS_TABLE!,
   // Redemption-email send seam (4b / #471). FROM_EMAIL is stage-derived in the
   // stack; APP_URL builds the /redeem?bundle=<id> bearer link.
   ses: new SESv2Client({}),

--- a/apps/launchpad/infrastructure/launchpad-control-plane-stack.ts
+++ b/apps/launchpad/infrastructure/launchpad-control-plane-stack.ts
@@ -458,6 +458,8 @@ export class LaunchpadControlPlaneStack extends cdk.Stack {
       environment: {
         INVITATIONS_TABLE: invitationsTable.tableName,
         ACCOUNTS_TABLE: accountsTable.tableName,
+        // M11 cancel-grant: LIVE owner/manager check against the members table.
+        ACCOUNT_MEMBERS_TABLE: accountMembersTable.tableName,
         // Redemption-email send seam (4b / #471): the invitee gets the grants
         // preview + /redeem?bundle=<id> bearer link on bundle creation.
         FROM_EMAIL: redemptionFromAddress,
@@ -470,8 +472,9 @@ export class LaunchpadControlPlaneStack extends cdk.Stack {
       },
     });
 
-    invitationsTable.grantReadWriteData(invitationBundlesFn); // write the bundle
+    invitationsTable.grantReadWriteData(invitationBundlesFn); // write the bundle (create + cancel-grant)
     accountsTable.grantReadData(invitationBundlesFn);          // account-invite: validate account/app
+    accountMembersTable.grantReadData(invitationBundlesFn);    // M11 cancel-grant: LIVE owner/manager check
     // Send the redemption email (4b / #471). SES SendEmail can't be ARN-scoped to
     // a from-identity without conditions; mirror forgot-provider's grant.
     invitationBundlesFn.addToRolePolicy(new iam.PolicyStatement({
@@ -547,6 +550,13 @@ export class LaunchpadControlPlaneStack extends cdk.Stack {
     // A1 — GET {bundleId}: redemption link resolve (link-as-bearer; any authed
     // holder of the unguessable id). Served by the bundles fn (read-only).
     bundleResource.addMethod('GET', invitationBundlesIntegration, authOptions);
+    // M11 cancel-grant — DELETE {bundleId}/grants/{grantId}: revoke one pending
+    // grant (target-resolved authz: owner/manager of the grant's account OR
+    // app-admin OR site-admin). #558.
+    bundleResource
+      .addResource('grants')
+      .addResource('{grantId}')
+      .addMethod('DELETE', invitationBundlesIntegration, authOptions);
     const redemptionIntegration = new apigateway.LambdaIntegration(invitationRedemptionFn, { proxy: true });
     // A5 — POST {bundleId}/redeem (auth-only; invitee-only enforced in-handler).
     bundleResource.addResource('redeem').addMethod('POST', redemptionIntegration, authOptions);

--- a/docs/architecture/cdk.md
+++ b/docs/architecture/cdk.md
@@ -62,7 +62,7 @@ read-only and keep provider execution in their app runtimes.
 | `launchpad-user-{stage}` | `apps/launchpad/functions/user` | `GET /api/user/profile`, `PUT /api/user/preferences` |
 | `launchpad-accounts-{stage}` | `apps/launchpad/functions/accounts` | `POST /accounts`, `GET/PUT/DELETE /accounts/{id}`, `GET /accounts/{id}/members`, `GET /accounts/{id}/members/detail` (incl. account-scoped pending invitations, #555), `DELETE /accounts/{id}/members/{userId}` |
 | `launchpad-invitations-{stage}` | `apps/launchpad/functions/invitations` | `POST /accounts/{id}/invitations` |
-| `launchpad-invitation-bundles-{stage}` | `apps/launchpad/functions/invitation-bundles` | `POST /api/invitations/bundles` (create) |
+| `launchpad-invitation-bundles-{stage}` | `apps/launchpad/functions/invitation-bundles` | `POST /api/invitations/bundles` (create), `GET …/bundles` (list), `GET …/bundles/{bundleId}` (resolve), `DELETE …/bundles/{bundleId}/grants/{grantId}` (cancel grant, #558) |
 | `launchpad-invitation-redemption-{stage}` | `apps/launchpad/functions/invitation-redemption` | `POST /api/invitations/bundles/{bundleId}/redeem` + `…/redeem-as` (dev-only bypass, STAGE-guarded) |
 | `launchpad-ai-runtime-config-{stage}` | `apps/launchpad/functions/ai-runtime-config` | `GET /api/admin/ai-runtime-config`, `PUT /api/admin/ai-runtime-config/platform-default`, `PUT/DELETE /api/admin/ai-runtime-config/apps/{appSlug}/override` |
 | `launchpad-pre-token-generation-{stage}` | `apps/launchpad/functions/pre-token-generation` | Cognito pre-token generation trigger |
@@ -156,7 +156,7 @@ Launchpad control-plane and auth-domain variables:
 |---|---|---|
 | `USERS_TABLE` | `launchpad-user-{stage}`, `launchpad-account-provisioning-{stage}`, `launchpad-invitation-redemption-{stage}`, `launchpad-pre-token-generation-{stage}` (#501, read-only) | `launchpad-users-{stage}` |
 | `ACCOUNTS_TABLE` | Launchpad account-provisioning, accounts, invitations, pre-token generation | `launchpad-accounts-{stage}` |
-| `ACCOUNT_MEMBERS_TABLE` | Launchpad account-provisioning, accounts, pre-token generation | `launchpad-account-members-{stage}` |
+| `ACCOUNT_MEMBERS_TABLE` | Launchpad account-provisioning, accounts, pre-token generation, invitee-search, invitation-bundles (#558, read-only — cancel-grant owner/manager check) | `launchpad-account-members-{stage}` |
 | `INVITATIONS_TABLE` | `launchpad-invitations-{stage}`, `launchpad-accounts-{stage}` (#555, read-only — surfaces an account's pending invitations on `GET …/members/detail`), `launchpad-access-summary-{stage}` (read-only — per-user pending-invitation list + count, M11) | `launchpad-invitations-{stage}` |
 | `RATE_LIMIT_TABLE` | `launchpad-forgot-provider-{stage}` | `launchpad-rate-limits-{stage}` |
 | `USER_POOL_ID` | Launchpad control-plane/auth Lambdas | LaunchpadAuth User Pool ID |

--- a/docs/architecture/inventory.md
+++ b/docs/architecture/inventory.md
@@ -109,6 +109,7 @@ API and Lambdas:
 | `DELETE /accounts/{accountId}/members/{userId}` | `launchpad-accounts-{stage}` |
 | `POST /accounts/{accountId}/invitations` | `launchpad-invitations-{stage}` |
 | `POST /api/invitations/bundles` | `launchpad-invitation-bundles-{stage}` |
+| `DELETE /api/invitations/bundles/{bundleId}/grants/{grantId}` (cancel grant, owner/manager-of-account OR app/site-admin, #558) | `launchpad-invitation-bundles-{stage}` |
 | `POST /api/invitations/bundles/{bundleId}/redeem` | `launchpad-invitation-redemption-{stage}` |
 | `POST /api/invitations/bundles/{bundleId}/redeem-as` (dev-only bypass) | `launchpad-invitation-redemption-{stage}` |
 | `GET /api/admin/ai-runtime-config` | `launchpad-ai-runtime-config-{stage}` |

--- a/packages/api-client/src/control-plane.ts
+++ b/packages/api-client/src/control-plane.ts
@@ -87,6 +87,20 @@ export class ControlPlaneClient {
   }
 
   /**
+   * DELETE /api/invitations/bundles/{bundleId}/grants/{grantId} — revoke ONE
+   * pending invitation grant (the cancel-X). Target-resolved authz: owner/manager
+   * of the grant's account, OR app-admin for its app, OR site-admin (#558). The
+   * grant then leaves both pending surfaces; the caller refetches (mirrors
+   * removeMember — the server returns the updated bundle but the UI re-reads).
+   */
+  cancelInvitationGrant(bundleId: string, grantId: string, signal?: AbortSignal): Promise<void> {
+    return this.http.delete(
+      `api/invitations/bundles/${encodeURIComponent(bundleId)}/grants/${encodeURIComponent(grantId)}`,
+      signal,
+    );
+  }
+
+  /**
    * POST /api/invitations/invitee-search — scoped invitee discovery for the
    * Invite Composer (CHECK 1 only: who may the sender see/search/select). Returns
    * the sender's search `scope` and `results` (each with display-safe `reasons`).


### PR DESCRIPTION
Supersedes #559 (auto-closed when its #557 base branch was deleted on merge; now retargeted to `develop`).

## Summary
Makes the pending-invitations **cancel-X** work (was rendered but inert).

### Backend (`invitation-bundles`)
`DELETE /api/invitations/bundles/{bundleId}/grants/{grantId}` (in the v0 contract). Removes the grant from `grants[]`; when none remain the bundle becomes `status='revoked'`. The grant leaves both pending surfaces.

### Authorization (target-resolved, fail-closed)
Resolve the grant → target account/app first, then allow if the caller is owner/manager of the grant's account (LIVE membership, D8 write) OR app-admin for its app OR site-admin. RULING: an owner/manager may cancel an invite a *different* admin sent — it's their account. Unresolved → 404; unauthorized → 403, nothing written.

### Client + UI
`cancelInvitationGrant(bundleId, grantId)`; account-panel cancel-X onClick (gated) → cancel then refetch.

## Tests
7 new cancel cases incl. authz REJECTION (viewer→403, no-membership→403), owner-cancels-another-admin's-invite, manager+last-grant→revoked, site/app-admin allow, 404 unresolved. 15 pass. Typecheck + ESLint clean.

## v0 freshness
v0 PR: https://github.com/transformotion/transformotion-apps-b8/pull/73 — cancel-X + `cancelInvitationGrant` are v0-prototyped; runtime reproduces behaviour against the existing contract endpoint. No runtime-originated UI/contract change.

## Deploy
`apps/launchpad/**` + `infrastructure/**` + `packages/api-client/**` → `deploy-launchpad.yml`.

Closes #558 · Refs #555

🤖 Generated with [Claude Code](https://claude.com/claude-code)