### PR TITLE
feat(m11): show '· N pending' on the collapsed account-list row (#565)

### DIFF
--- a/apps/launchpad/components/launchpad/admin/account-management-view.tsx
+++ b/apps/launchpad/components/launchpad/admin/account-management-view.tsx
@@ -650,6 +650,7 @@ export function AccountManagementView({ viewer }: { viewer: AdminUser }) {
                         </p>
                         <p className="truncate text-xs text-muted-foreground">
                           {memberCount} member{memberCount === 1 ? '' : 's'}
+                          {invitations.length > 0 ? ` · ${invitations.length} pending` : ''}
                         </p>
                       </div>
                       {role ? (


### PR DESCRIPTION
## Summary
The last M11 pending-invitations parity item. v0's collapsed account-list row
shows the pending count — "N members · N pending" — but the live row showed only
"N members", so an account with pending invites (Steve's Portfolio: "1 member"
with 2 pending) gave no at-a-glance signal.

Reproduces v0's row subtitle **verbatim** (one line): appends
`` · ${invitations.length} pending`` when `> 0`. The pending data already loads
(`pendingByAccount`, #557) and drives the expanded list — this only surfaces the
count on the collapsed row.

```
{memberCount} member{memberCount === 1 ? '' : 's'}
{invitations.length > 0 ? ` · ${invitations.length} pending` : ''}
```

## Tests / gates
Typecheck (launchpad) + ESLint clean. One-line presentational change.

## Functional verification (pending deploy — PR held)
On dev: the **Steve's Portfolio** row shows "1 member · 2 pending" without
expanding (2 pending bundles vs a03f9cd4). Runs post-merge.

## v0 freshness
v0 PR: https://github.com/transformotion/transformotion-apps-b8/pull/73 — the
account-row pending count is v0-prototyped (`account-management-view.tsx`:
`memberCount … {pending > 0 ? \` · ${pending} pending\` : ''}`). Runtime
reproduces it verbatim; no runtime-originated UI/contract change.

## Deploy
`apps/launchpad/**` only → `deploy-launchpad.yml` (frontend rebuild).

Closes #565 · Refs #555

🤖 Generated with [Claude Code](https://claude.com/claude-code)