### PR TITLE
feat(m19): notification engine kill-switch — backend + write-authz (#571)

### DIFF
--- a/apps/stock-analyser/AGENTS.md
+++ b/apps/stock-analyser/AGENTS.md
@@ -50,7 +50,7 @@ Current state after #366/#386: Stock Analyser owns its REST API Gateway, AI prox
 | `transformotion-portfolio-{stage}` | `apps/stock-analyser/functions/portfolio` | `GET/PUT /portfolio` |
 | `transformotion-watchlist-{stage}` | `apps/stock-analyser/functions/watchlist` | `GET/PUT /watchlist` |
 | `transformotion-analysis-cache-{stage}` | `apps/stock-analyser/functions/analysis-cache` | `GET/PUT/DELETE /analysis-cache/{key}` |
-| `stock-analyser-settings-{stage}` | `apps/stock-analyser/functions/settings` | `GET/PATCH /settings`, `GET /ai-config`, `PUT/DELETE /ai-config/override`, `GET/PUT /cache-freshness`, `GET/PUT /notification-config`, `GET/PUT /notification-consent` |
+| `stock-analyser-settings-{stage}` | `apps/stock-analyser/functions/settings` | `GET/PATCH /settings`, `GET /ai-config`, `PUT/DELETE /ai-config/override`, `GET/PUT /cache-freshness`, `GET/PUT /notification-config`, `GET/PUT /notification-consent`, `GET/PUT /notification-engine-config` (#571 kill-switch; PUT site/app-admin) |
 | `stock-analyser-ai-proxy-{stage}` | `apps/stock-analyser/functions/ai-proxy` | `POST /api/claude` |
 | `stock-analyser-notification-engine-{stage}` | `apps/stock-analyser/functions/notification-engine` | EventBridge scheduled (daily, no HTTP route) |
 | `transformotion-cycle-check-{stage}` | `apps/stock-analyser/functions/cycle-check` | EventBridge scheduled (no HTTP route) |

--- a/apps/stock-analyser/CLAUDE.md
+++ b/apps/stock-analyser/CLAUDE.md
@@ -53,7 +53,7 @@ Current state after #366/#386: Stock Analyser owns its REST API Gateway, AI prox
 | `transformotion-portfolio-{stage}` | `apps/stock-analyser/functions/portfolio` | `GET/PUT /portfolio` |
 | `transformotion-watchlist-{stage}` | `apps/stock-analyser/functions/watchlist` | `GET/PUT /watchlist` |
 | `transformotion-analysis-cache-{stage}` | `apps/stock-analyser/functions/analysis-cache` | `GET/PUT/DELETE /analysis-cache/{key}` |
-| `stock-analyser-settings-{stage}` | `apps/stock-analyser/functions/settings` | `GET/PATCH /settings`, `GET /ai-config`, `PUT/DELETE /ai-config/override`, `GET/PUT /cache-freshness`, `GET/PUT /notification-config`, `GET/PUT /notification-consent` |
+| `stock-analyser-settings-{stage}` | `apps/stock-analyser/functions/settings` | `GET/PATCH /settings`, `GET /ai-config`, `PUT/DELETE /ai-config/override`, `GET/PUT /cache-freshness`, `GET/PUT /notification-config`, `GET/PUT /notification-consent`, `GET/PUT /notification-engine-config` (#571 kill-switch; PUT site/app-admin) |
 | `stock-analyser-ai-proxy-{stage}` | `apps/stock-analyser/functions/ai-proxy` | `POST /api/claude` |
 | `stock-analyser-notification-engine-{stage}` | `apps/stock-analyser/functions/notification-engine` | EventBridge scheduled (daily, no HTTP route) |
 | `transformotion-cycle-check-{stage}` | `apps/stock-analyser/functions/cycle-check` | EventBridge scheduled (no HTTP route) |

--- a/apps/stock-analyser/functions/notification-engine/src/engine.test.ts
+++ b/apps/stock-analyser/functions/notification-engine/src/engine.test.ts
@@ -82,6 +82,7 @@ function deps(overrides: Partial<NotificationEngineDeps> = {}): NotificationEngi
     newRunId: () => 'run-test',
     readAccountName: vi.fn(async (accountId) => `Acct ${accountId}`),
     recordSendLog: vi.fn(async () => undefined),
+    readEngineEnabled: vi.fn(async () => true),
   };
   return { ...base, ...overrides };
 }
@@ -379,6 +380,24 @@ describe('notification send-log (#572)', () => {
     }))).rejects.toThrow('members scan failed');
     expect(recordSendLog).toHaveBeenCalledOnce();
     expect(recordSendLog.mock.calls[0][0]).toMatchObject({ status: 'failed' });
+  });
+
+  it('kill-switch OFF (#571): no processing, no sends, minimal engine-disabled record still written', async () => {
+    const sendEmail = vi.fn(async () => undefined);
+    const listStockAnalyserMembers = vi.fn(async () => [activeMember]);
+    const recordSendLog = vi.fn(async (_run: SendLogRun) => undefined);
+    const run = await runNotificationEngine(deps({
+      readEngineEnabled: vi.fn(async () => false),
+      sendEmail,
+      listStockAnalyserMembers,
+      recordSendLog,
+    }));
+
+    expect(sendEmail).not.toHaveBeenCalled();
+    expect(listStockAnalyserMembers).not.toHaveBeenCalled(); // early-return before any account work
+    expect(run.sendLog).toMatchObject({ status: 'success', note: 'engine-disabled', accountsEvaluated: 0, emailsSent: 0 });
+    expect(run.sendLog.accounts).toEqual([]);
+    expect(recordSendLog).toHaveBeenCalledOnce(); // audit record still written via finally
   });
 
   it('cross-account tripwire: flags a member outcome that is not a member of the account', async () => {

--- a/apps/stock-analyser/functions/notification-engine/src/engine.ts
+++ b/apps/stock-analyser/functions/notification-engine/src/engine.ts
@@ -66,6 +66,8 @@ export interface NotificationEngineDeps {
   readAccountName?: (accountId: string) => Promise<string | undefined>;
   /** Persist the run's audit record (run summary + per-account + member outcomes). */
   recordSendLog: (run: SendLogRun) => Promise<void>;
+  /** #571 kill-switch: app-wide `notificationsEnabled` (default ON). */
+  readEngineEnabled: () => Promise<boolean>;
 }
 
 export interface NotificationEngineResult {
@@ -136,6 +138,8 @@ export interface SendLogRun {
   emailsSent: number;
   accounts: SendLogAccount[];
   error?: string;
+  /** #571: set to `engine-disabled` when the run no-op'd because the kill-switch was OFF. */
+  note?: string;
 }
 
 export function stateSk(type: NotificationSourceType, ticker: string): string {
@@ -471,6 +475,16 @@ export async function runNotificationEngine(deps: NotificationEngineDeps): Promi
 
   let runError: unknown;
   try {
+    // #571 kill-switch (OPTION A): flag-checked early-return at the TOP of the run.
+    // EventBridge still fires daily and is UNCHANGED; the job simply no-ops when
+    // OFF. A minimal `engine-disabled` audit record is written (via the finally)
+    // so the history shows the engine fired-but-skipped. Re-enable = flag flip.
+    if (!(await deps.readEngineEnabled())) {
+      sendLog.note = 'engine-disabled';
+      deps.log?.('notification-engine-disabled-skip', { runId: sendLog.runId });
+      return result;
+    }
+
     const today = deps.today();
     const grouped = groupMembersByAccount(await deps.listStockAnalyserMembers());
     const resolveAnalysis = createAnalysisResolver(deps);

--- a/apps/stock-analyser/functions/notification-engine/src/index.ts
+++ b/apps/stock-analyser/functions/notification-engine/src/index.ts
@@ -422,11 +422,22 @@ async function recordSendLog(runtime: RuntimeEnv, run: SendLogRun): Promise<void
   }
 }
 
+// #571 kill-switch: app-wide notificationsEnabled (default ON when absent/malformed).
+async function readEngineEnabled(runtime: RuntimeEnv): Promise<boolean> {
+  const res = await ddb.send(new GetCommand({
+    TableName: runtime.settingsTable,
+    Key: { pk: 'SETTINGS', sk: 'NOTIFICATION_ENGINE_CONFIG#stock-analyser' },
+  }));
+  const enabled = res.Item?.['notificationsEnabled'];
+  return typeof enabled === 'boolean' ? enabled : true;
+}
+
 export function createDependencies(runtime: RuntimeEnv = env()): NotificationEngineDeps {
   return {
     today: todayUtc,
     nowEpochSeconds: () => Math.floor(Date.now() / 1000),
     newRunId: () => randomUUID(),
+    readEngineEnabled: () => readEngineEnabled(runtime),
     readAccountName: (accountId) => readAccountName(runtime, accountId),
     recordSendLog: (run) => recordSendLog(runtime, run),
     listStockAnalyserMembers: () => listStockAnalyserMembers(runtime),

--- a/apps/stock-analyser/functions/settings/src/index.test.ts
+++ b/apps/stock-analyser/functions/settings/src/index.test.ts
@@ -353,4 +353,44 @@ describe('Notification preferences authorization', () => {
     ));
     expect(res.statusCode).toBe(503);
   });
+
+  // ── #571 PIECE 3 — engine kill-switch write authz (SITE/APP-ADMIN only) ────
+  // The write gate is GROUPS-authoritative (token cognito:groups) — no membership
+  // lookup — so it fails closed by construction (absent admin group → 403). An
+  // owner/manager/member/viewer all lack the admin group → all rejected, even a
+  // request crafted directly past the read-only/hidden UI. (The membership-lookup
+  // fail-closed case lives in the run-history scoping, #573, not this gate.)
+  it('GET engine-config: any member reads it (default ON when unset)', async () => {
+    const { deps } = createFakeDeps();
+    const res = await createHandler(deps)(makeEvent('GET', undefined, { resource: '/notification-engine-config' }));
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body).config).toMatchObject({ notificationsEnabled: true });
+  });
+
+  it('PUT engine-config: site-admin and stock-app-admin may toggle', async () => {
+    for (const groups of ['stock-app-access,site-admin', 'stock-app-access,stock-app-admin']) {
+      const { deps, getItem } = createFakeDeps();
+      const res = await createHandler(deps)(makeEvent('PUT', { notificationsEnabled: false }, { resource: '/notification-engine-config', groups }));
+      expect(res.statusCode).toBe(200);
+      expect(JSON.parse(res.body).config.notificationsEnabled).toBe(false);
+      expect((getItem() as { notificationsEnabled: boolean }).notificationsEnabled).toBe(false); // persisted
+    }
+  });
+
+  it('PUT engine-config: REJECTS (403) a non-admin (owner/manager/member/viewer — no admin group), nothing persisted', async () => {
+    // owner role in the token, but NO site/app-admin group → still rejected.
+    const { deps, getItem } = createFakeDeps();
+    const res = await createHandler(deps)(makeEvent(
+      'PUT', { notificationsEnabled: false },
+      { resource: '/notification-engine-config', groups: 'stock-app-access', accounts: { 'stock-analyser': [{ accountId: 'acct-1', role: 'owner' }] } },
+    ));
+    expect(res.statusCode).toBe(403);
+    expect(getItem()).toBeUndefined(); // fail-closed: no write
+  });
+
+  it('PUT engine-config: rejects (400) a missing/invalid notificationsEnabled', async () => {
+    const { deps } = createFakeDeps();
+    const res = await createHandler(deps)(makeEvent('PUT', { enabled: false }, { resource: '/notification-engine-config', groups: 'stock-app-access,site-admin' }));
+    expect(res.statusCode).toBe(400);
+  });
 });

--- a/apps/stock-analyser/functions/settings/src/index.ts
+++ b/apps/stock-analyser/functions/settings/src/index.ts
@@ -41,10 +41,12 @@ import {
 import {
   NOTIFICATION_TYPES,
   defaultNotificationAccountConfig,
+  defaultNotificationEngineConfig,
   defaultNotificationMemberConsent,
   isValidNotificationAccountConfig,
   normalizeIntervalDays,
   type NotificationAccountConfig,
+  type NotificationEngineConfig,
   type NotificationMemberConsent,
   type NotificationType,
 } from '@transformotion/contracts/stock-analyser/notification-preferences';
@@ -285,6 +287,66 @@ function requireCacheFreshnessAdmin(auth: Parameters<typeof requireSiteAdmin>[0]
     return;
   }
   requireAppAdminForApp(auth, APP_SLUG);
+}
+
+// ── #571 notification engine kill-switch (app-wide) ──────────────────────────
+const notificationEngineConfigKey = {
+  pk: 'SETTINGS',
+  sk: 'NOTIFICATION_ENGINE_CONFIG#stock-analyser',
+} as const;
+
+function parseNotificationEngineConfig(
+  item: Record<string, unknown> | undefined,
+  now: Date,
+): NotificationEngineConfig {
+  if (!item) return defaultNotificationEngineConfig(now.toISOString());
+  const enabled = item['notificationsEnabled'];
+  const updatedAt = item['updatedAt'];
+  if (typeof enabled !== 'boolean' || typeof updatedAt !== 'string') {
+    return defaultNotificationEngineConfig(now.toISOString());
+  }
+  return { notificationsEnabled: enabled, updatedAt };
+}
+
+/**
+ * #571 PIECE 3 — WRITE authz for the engine kill-switch: SITE or SA APP-ADMIN
+ * only, server-enforced + fail-closed. The read-only/hidden UI is UX; this is
+ * the boundary — an owner/manager/member/viewer write is rejected even if the
+ * request is crafted directly past the UI. (Same site-OR-app-admin gate as the
+ * cache-freshness app-wide config.)
+ */
+function requireNotificationEngineAdmin(auth: Parameters<typeof requireSiteAdmin>[0]) {
+  if (auth.siteAdmin) {
+    requireSiteAdmin(auth);
+    return;
+  }
+  requireAppAdminForApp(auth, APP_SLUG);
+}
+
+async function readNotificationEngineConfig(deps: Dependencies) {
+  const res = await deps.client.send(new GetCommand({
+    TableName: deps.settingsTable,
+    Key: notificationEngineConfigKey,
+  }));
+  return ok({ config: parseNotificationEngineConfig(res.Item, deps.now()) });
+}
+
+async function updateNotificationEngineConfig(deps: Dependencies, event: APIGatewayProxyEvent) {
+  const body = parseBody<{ notificationsEnabled?: unknown } & Record<string, unknown>>(event);
+  const unexpected = Object.keys(body).filter(key => key !== 'notificationsEnabled');
+  if (unexpected.length) throw badRequest(`Unsupported engine config fields: ${unexpected.join(', ')}`);
+  if (typeof body.notificationsEnabled !== 'boolean') {
+    throw badRequest('notificationsEnabled (boolean) is required');
+  }
+  const config: NotificationEngineConfig = {
+    notificationsEnabled: body.notificationsEnabled,
+    updatedAt: deps.now().toISOString(),
+  };
+  await deps.client.send(new PutCommand({
+    TableName: deps.settingsTable,
+    Item: { ...notificationEngineConfigKey, ...config },
+  }));
+  return ok({ config });
 }
 
 async function updateCacheFreshnessConfig(deps: Dependencies, event: APIGatewayProxyEvent) {
@@ -528,6 +590,19 @@ export function createHandler(deps: Dependencies = defaultDependencies) {
       saData.read(auth, account.accountId);
       requireSiteAdmin(auth);
       return resetOverride(deps, account.accountId);
+    }
+
+    // ── Notification engine kill-switch (M19 #571, app-wide) ─────────────────
+    // GET: any member may read (the card resolves toggle visibility per role).
+    if (resource === '/notification-engine-config' && event.httpMethod === 'GET') {
+      saData.read(auth, account.accountId);
+      return readNotificationEngineConfig(deps);
+    }
+    // PUT: SITE or SA APP-ADMIN only (Piece 3) — fail-closed past the UI.
+    if (resource === '/notification-engine-config' && event.httpMethod === 'PUT') {
+      saData.read(auth, account.accountId);
+      requireNotificationEngineAdmin(auth);
+      return updateNotificationEngineConfig(deps, event);
     }
 
     // ── Notification preferences (M19 #534) ──────────────────────────────────

--- a/apps/stock-analyser/infrastructure/stock-analyser-api-stack.ts
+++ b/apps/stock-analyser/infrastructure/stock-analyser-api-stack.ts
@@ -372,6 +372,10 @@ export class StockAnalyserApiStack extends cdk.Stack {
     const notificationConsent = this.api.root.addResource('notification-consent');
     notificationConsent.addMethod('GET', settingsIntegration, auth);
     notificationConsent.addMethod('PUT', settingsIntegration, auth);
+    // M19 #571 engine kill-switch (app-wide): GET any member; PUT site/app-admin.
+    const notificationEngineConfig = this.api.root.addResource('notification-engine-config');
+    notificationEngineConfig.addMethod('GET', settingsIntegration, auth);
+    notificationEngineConfig.addMethod('PUT', settingsIntegration, auth);
 
     new cdk.CfnOutput(this, 'ApiUrl', {
       value: this.api.url,

--- a/apps/stock-analyser/lib/hooks/use-notification-preferences.ts
+++ b/apps/stock-analyser/lib/hooks/use-notification-preferences.ts
@@ -43,6 +43,7 @@ const HIDDEN_VISIBILITY: NotificationVisibility = {
   intervalDays: "hidden",
   typeSelection: "hidden",
   receiveConsent: "hidden",
+  engineToggle: "hidden",
   allHidden: true,
 }
 

--- a/docs/architecture/data.md
+++ b/docs/architecture/data.md
@@ -257,7 +257,14 @@ preferences, and notification delivery consent.
 | Attribute | Type | Notes |
 |---|---|---|
 | `pk` (PK) | String | `SETTINGS`, `ACCOUNT#{accountId}`, or `NOTIFICATION_CONSENT#{accountId}` |
-| `sk` (SK) | String | `CACHE_FRESHNESS#stock-analyser`, `NOTIFICATIONS#{accountId}`, `USER#{userId}#PREFERENCES`, `USER#{userId}`, or `APP#AI_RUNTIME` |
+| `sk` (SK) | String | `CACHE_FRESHNESS#stock-analyser`, `NOTIFICATION_ENGINE_CONFIG#stock-analyser` (#571 kill-switch), `NOTIFICATIONS#{accountId}`, `USER#{userId}#PREFERENCES`, `USER#{userId}`, or `APP#AI_RUNTIME` |
+
+The app-wide **engine kill-switch** (#571) lives at `SETTINGS` /
+`NOTIFICATION_ENGINE_CONFIG#stock-analyser` — `{ notificationsEnabled, updatedAt }`,
+default ON. The notification engine reads it at the top of each daily run and
+no-ops (a minimal `engine-disabled` send-log record) when OFF; the EventBridge
+rule is unchanged. Write is **site/app-admin only** (server-enforced, fail-closed
+via token groups); read is any member (the card resolves toggle visibility).
 | `activePolicy` | Map | Cache freshness policy row |
 | `intervalDays` | Number | Notification account cadence, minimum 1 |
 | `activeTypes` | List | Notification source types, e.g. `portfolio`, `watchlist` |


### PR DESCRIPTION
## Summary
The **load-bearing server pieces of #571** (kill-switch), test-proven. OPTION A —
flag-checked early-return; **EventBridge untouched**.

> Scope: this PR is #571's **backend**. The toggle **UI** (Piece 2c) and all of
> **#573** (run-history read endpoint + scoping + UI) are the next PR — recon done.

### Storage + endpoint (SA settings fn)
`GET/PUT /notification-engine-config` — one app-wide record
(`SETTINGS / NOTIFICATION_ENGINE_CONFIG#stock-analyser`),
`{ notificationsEnabled, updatedAt }`, default ON, per the synced engine-config
contract (b8 #74: `NotificationEngineConfig` / `defaultNotificationEngineConfig`).

### Piece 3 — WRITE AUTHZ (the bit the screenshot can't prove)
PUT is **SITE or SA APP-ADMIN only**, server-enforced + **fail-closed**, independent
of the UI. Groups-authoritative (token `cognito:groups`), so it fails closed by
construction — an owner/manager/member/viewer (no admin group) is **rejected even
when crafted directly past the read-only/hidden UI**. GET is any member.

### Piece 2b — engine early-return
At the TOP of the daily run the engine reads `notificationsEnabled`; **OFF → no
account processing, no sends**, a minimal `engine-disabled` send-log record (via
`finally`). The **EventBridge rule is UNCHANGED** (no `events:Enable/DisableRule`)
— re-enable is just the flag flip.

## Tests (load-bearing authz proven)
- **settings**: site-admin + stock-app-admin PUT → 200; **non-admin
  (owner/manager/member/viewer, no admin group) → 403, nothing persisted**; 400 on
  invalid body; GET any-member → 200. (21 pass)
- **engine**: kill-switch OFF → no `listMembers`, no sends, run `note:'engine-disabled'`,
  audit record still written. (16 pass)
- Typecheck (contracts / SA app / infra) + CDK Synth clean.

## v0 freshness
v0 PR: https://github.com/transformotion/transformotion-apps-b8/pull/74 — the
`NotificationEngineConfig` + `resolveEngineToggleVisibility` contracts. This PR
consumes them (backend) and adds `engineToggle` to the runtime hook's
`HIDDEN_VISIBILITY` to match the synced `NotificationVisibility` (no UI markup
change — that's Piece 2c, next).

## Deploy
`apps/stock-analyser/**` + `infrastructure` → `deploy-stock-analyser.yml`
(new `/notification-engine-config` route on the settings fn; engine reads the flag
from the settings table it already reads — no new grant).

Refs #571

🤖 Generated with [Claude Code](https://claude.com/claude-code)