### PR TITLE
feat(m19): notifications UI — run-history (#573) + kill-switch toggle (#571)

### DIFF
--- a/apps/stock-analyser/components/stock-analyser/tabs/settings-tab.tsx
+++ b/apps/stock-analyser/components/stock-analyser/tabs/settings-tab.tsx
@@ -4,7 +4,7 @@ import { useEffect, useMemo, useState } from "react"
 import { useNavigation } from "../app-shell"
 import { selectUser, useAuthStore } from "@/stores/auth/use-auth-store"
 import { PageHeader, Card, PrimaryButton, SecondaryButton, SegmentedControl, Slider, TextToggle } from "@transformotion/ui-primitives"
-import { AlertCircle, Bell, Briefcase, Check, Clock, Cpu, Eye, FileText, Gauge, Lock, Minus, Plus, RotateCcw, Save, Trash2, Zap } from "lucide-react"
+import { AlertCircle, AlertTriangle, ArrowRight, Bell, Briefcase, Check, ChevronDown, Clock, Cpu, Eye, FileText, Gauge, History, Lock, Mail, Minus, MinusCircle, Plus, Power, RotateCcw, Save, Trash2, Zap } from "lucide-react"
 import type { SearchMode } from "../app-shell"
 import { useNotificationPreferences } from "@/lib/hooks/use-notification-preferences"
 import {
@@ -12,6 +12,13 @@ import {
   NOTIFICATION_TYPES,
   type NotificationType,
 } from "@transformotion/contracts/stock-analyser/notification-preferences"
+import type {
+  NotificationOutcomeReason,
+  NotificationRunStatus,
+  NotificationRunAccountView,
+  NotificationRunView,
+  NotificationRunHistoryView,
+} from "@transformotion/contracts/stock-analyser/notification-run-history"
 import { notifyCacheFreshnessPolicyUpdated } from "@/lib/hooks"
 import type { User } from "@transformotion/auth-client"
 import { cn } from "@/lib/utils"
@@ -752,6 +759,246 @@ function TypePill({
   )
 }
 
+/** Human label for each leaf member-outcome reason (#573). */
+const RUN_REASON_LABEL: Record<NotificationOutcomeReason, string> = {
+  delivered: "Delivered",
+  "consent-off": "Opted out",
+  disabled: "Engine disabled",
+  viewer: "Read-only viewer",
+  "not-a-member": "Not a member",
+  "lookup-error": "Lookup error",
+  "no-actionable-transition": "No actionable change",
+}
+
+/** Overall-run status chip styling (#573). */
+const RUN_STATUS_STYLE: Record<NotificationRunStatus, { label: string; cls: string }> = {
+  success: { label: "Success", cls: "bg-signal-green/15 text-signal-green" },
+  partial: { label: "Partial", cls: "bg-signal-gold/15 text-signal-gold" },
+  failed: { label: "Failed", cls: "bg-signal-red/15 text-signal-red" },
+}
+
+/** Short run date, e.g. "Jun 27". */
+function formatRunDate(iso: string): string {
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return "—"
+  return d.toLocaleDateString(undefined, { month: "short", day: "numeric" })
+}
+
+/**
+ * One account's record in the expanded run-history. Renders per the account's
+ * OWN visibility (#573 corrected): `detail` accounts show ticker transitions +
+ * per-member outcome rows; `summary` accounts (admin-without-ownership) show
+ * only the account line, status, and emails-sent count — member identities and
+ * transitions are never present in the payload, so there is nothing to hide.
+ */
+function RunAccountBlock({ account }: { account: NotificationRunAccountView }) {
+  const statusCls =
+    account.accountStatus === "processed"
+      ? "text-signal-green"
+      : account.accountStatus === "error"
+        ? "text-signal-red"
+        : "text-muted-foreground"
+  const isSummaryOnly = account.visibility === "summary"
+  return (
+    <div className="rounded-lg border border-border bg-surface/40 p-3">
+      <div className="flex items-center justify-between gap-2">
+        <p className="min-w-0 truncate text-sm font-medium text-foreground">{account.accountName}</p>
+        <span className={cn("shrink-0 text-[10px] font-semibold uppercase tracking-wider", statusCls)}>
+          {account.accountStatus}
+        </span>
+      </div>
+
+      {isSummaryOnly ? (
+        // Admin-without-ownership: count only, no member detail in the payload.
+        <div className="mt-2 flex items-center gap-2 text-xs text-muted-foreground">
+          <Mail className="size-3.5 shrink-0" />
+          <span>
+            {account.emailsSent} {account.emailsSent === 1 ? "email" : "emails"} sent
+          </span>
+          <span className="ml-auto inline-flex items-center gap-1 text-[10px]">
+            <Lock className="size-3" />
+            Member detail visible to account owners
+          </span>
+        </div>
+      ) : (
+        <>
+          {account.transitions.length > 0 && (
+            <div className="mt-2 flex flex-wrap gap-1.5">
+              {account.transitions.map((t) => (
+                <span
+                  key={t.ticker}
+                  className="inline-flex items-center gap-1 rounded-md bg-surface2 px-2 py-0.5 text-[10px] font-medium text-foreground"
+                >
+                  {t.ticker}
+                  <span className="text-muted-foreground">{t.from}</span>
+                  <ArrowRight className="size-3 text-muted-foreground" />
+                  <span className="text-foreground">{t.to}</span>
+                </span>
+              ))}
+            </div>
+          )}
+
+          <ul className="mt-2 space-y-1">
+            {account.memberOutcomes.map((m) => {
+              const sent = m.outcome === "sent"
+              return (
+                <li key={m.userId} className="flex items-center gap-2 text-xs">
+                  {sent ? (
+                    <Mail className="size-3.5 shrink-0 text-signal-green" />
+                  ) : (
+                    <MinusCircle className="size-3.5 shrink-0 text-muted-foreground" />
+                  )}
+                  <span className="min-w-0 flex-1 truncate text-foreground">{m.email}</span>
+                  {sent && m.tickers?.length ? (
+                    <span className="shrink-0 text-[10px] tabular-nums text-muted-foreground">
+                      {m.tickers.join(", ")}
+                    </span>
+                  ) : null}
+                  <span
+                    className={cn(
+                      "shrink-0 rounded-full px-2 py-0.5 text-[10px] font-medium",
+                      sent ? "bg-signal-green/15 text-signal-green" : "bg-surface2 text-muted-foreground",
+                    )}
+                  >
+                    {RUN_REASON_LABEL[m.reason]}
+                  </span>
+                </li>
+              )
+            })}
+          </ul>
+        </>
+      )}
+    </div>
+  )
+}
+
+/** The "N emails [across M accounts]" tail of a run's one-line summary. */
+function runEmailsLabel(run: NotificationRunView): string {
+  const emails = `${run.emailsSent} ${run.emailsSent === 1 ? "email" : "emails"}`
+  return run.showCrossAccountHeader
+    ? `${emails} across ${run.accountsEvaluated} ${run.accountsEvaluated === 1 ? "account" : "accounts"}`
+    : emails
+}
+
+/**
+ * LEVEL 2 (#573 extend): one RUN in the history list, independently expandable
+ * into its per-account breakdown. The run is already scoped/projected by the
+ * hook (per the per-account MAX rule); this row only renders what it is given.
+ */
+function RunRow({ run }: { run: NotificationRunView }) {
+  const [open, setOpen] = useState(false)
+  const status = RUN_STATUS_STYLE[run.status]
+
+  return (
+    <div className="rounded-lg border border-border bg-surface/40">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        className="flex w-full items-center gap-3 px-3 py-2.5 text-left"
+      >
+        <span className="shrink-0 text-xs font-medium tabular-nums text-foreground">
+          {formatRunDate(run.ranAt)}
+        </span>
+        <span
+          className={cn(
+            "shrink-0 rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider",
+            status.cls,
+          )}
+        >
+          {status.label}
+        </span>
+        <span className="min-w-0 flex-1 truncate text-xs text-muted-foreground">
+          {runEmailsLabel(run)}
+        </span>
+        <ChevronDown
+          className={cn(
+            "size-4 shrink-0 text-muted-foreground transition-transform",
+            open && "rotate-180",
+          )}
+        />
+      </button>
+
+      {open && (
+        <div className="space-y-3 border-t border-border px-3 py-3">
+          {run.accounts.length === 0 ? (
+            <p className="text-xs text-muted-foreground">No account records in this run.</p>
+          ) : (
+            run.accounts.map((account) => (
+              <RunAccountBlock key={account.accountId} account={account} />
+            ))
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+/**
+ * LEVEL 1 (#573 extend): notification run-HISTORY. COLLAPSED by default: the
+ * latest run's one-line summary + status chip (cross-account for admins;
+ * account-scoped for owner/manager — no cross-account count). EXPANDED: the
+ * LIST of runs (most-recent-first), each a {@link RunRow} that itself expands
+ * into per-account → per-member detail. The `history` is already scoped/
+ * projected per run by the hook; this component only renders what it is given
+ * (the server is the real scoping boundary — see
+ * notification-run-history.behaviour.md).
+ */
+function NotificationRunHistory({ history }: { history: NotificationRunHistoryView }) {
+  const [expanded, setExpanded] = useState(false)
+  const runs = history.runs
+  const latest = runs[0]
+  const latestStatus = RUN_STATUS_STYLE[latest.status]
+
+  return (
+    <div className="rounded-xl border border-border bg-surface2/60">
+      <button
+        type="button"
+        onClick={() => setExpanded((v) => !v)}
+        aria-expanded={expanded}
+        className="flex w-full items-center gap-3 px-4 py-3 text-left"
+      >
+        <History className="size-4 shrink-0 text-muted-foreground" />
+        <div className="min-w-0 flex-1">
+          <p className="flex items-center gap-2 text-sm font-medium text-foreground">
+            Run history
+            <span
+              className={cn(
+                "rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider",
+                latestStatus.cls,
+              )}
+            >
+              {latestStatus.label}
+            </span>
+          </p>
+          <p className="truncate text-xs text-muted-foreground">
+            {`Last run ${formatRunDate(latest.ranAt)}, ${runEmailsLabel(latest)}`}
+          </p>
+        </div>
+        <ChevronDown
+          className={cn(
+            "size-4 shrink-0 text-muted-foreground transition-transform",
+            expanded && "rotate-180",
+          )}
+        />
+      </button>
+
+      {expanded && (
+        <div className="space-y-2 border-t border-border px-4 py-3">
+          {runs.map((run) => (
+            <RunRow key={run.runId} run={run} />
+          ))}
+          {history.nextCursor && (
+            <p className="px-1 pt-1 text-[11px] text-muted-foreground">
+              Showing the {runs.length} most recent runs.
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
 /**
  * Notification preferences (M19 #534) — role-conditional.
  *
@@ -769,9 +1016,12 @@ function NotificationsCard() {
     visibility,
     config,
     consent,
+    engine,
+    runHistory,
     setIntervalDays,
     setActiveTypes,
     setReceiveConsent,
+    setNotificationsEnabled,
   } = useNotificationPreferences(user.activeAccountId ?? null)
 
   // Not ready (SSR/first paint) or the entire feature is inapplicable (viewer):
@@ -782,6 +1032,12 @@ function NotificationsCard() {
   const accountReadOnly = visibility.intervalDays === "read-only"
   const showAccountConfig = visibility.intervalDays !== "hidden" && config
   const showConsent = visibility.receiveConsent !== "hidden"
+
+  // App-wide kill-switch (#571): editable for site/app-admin, read-only for
+  // owner/manager, hidden for member/viewer.
+  const showEngineToggle = visibility.engineToggle !== "hidden"
+  const engineEditable = visibility.engineToggle === "editable"
+  const notificationsEnabled = engine?.notificationsEnabled ?? true
 
   const activeTypes = config?.activeTypes ?? []
   const intervalDays = config?.intervalDays ?? MIN_NOTIFICATION_INTERVAL_DAYS
@@ -807,6 +1063,67 @@ function NotificationsCard() {
           </p>
         </div>
       </div>
+
+      {/* APP-WIDE engine kill-switch (#571) — platform control, admin-editable. */}
+      {showEngineToggle && (
+        <div
+          className={cn(
+            "rounded-xl border p-4",
+            notificationsEnabled
+              ? "border-border bg-surface2/60"
+              : "border-signal-red/40 bg-signal-red/10",
+          )}
+        >
+          <div className="flex items-start justify-between gap-3">
+            <div className="flex items-start gap-2.5">
+              <Power
+                className={cn(
+                  "mt-0.5 size-4 shrink-0",
+                  notificationsEnabled ? "text-signal-green" : "text-signal-red",
+                )}
+              />
+              <div>
+                <p className="text-sm font-medium text-foreground flex items-center gap-2">
+                  Notification engine
+                  <span
+                    className={cn(
+                      "rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider",
+                      notificationsEnabled
+                        ? "bg-signal-green/15 text-signal-green"
+                        : "bg-signal-red/15 text-signal-red",
+                    )}
+                  >
+                    {notificationsEnabled ? "Enabled" : "Disabled"}
+                  </span>
+                </p>
+                <p className="text-xs text-muted-foreground leading-relaxed">
+                  {notificationsEnabled
+                    ? "The daily notification job runs platform-wide. Disable to pause all sends (e.g. when AI credit is exhausted)."
+                    : "All notification sends are paused platform-wide. No one is delivered notifications until re-enabled."}
+                </p>
+                {!engineEditable && (
+                  <span className="mt-1.5 inline-flex items-center gap-1 text-[10px] text-muted-foreground">
+                    <Lock className="size-3" />
+                    Administrators only
+                  </span>
+                )}
+              </div>
+            </div>
+            <Switch
+              label="Notification engine enabled"
+              checked={notificationsEnabled}
+              disabled={!engineEditable}
+              onChange={(next) => setNotificationsEnabled(next)}
+            />
+          </div>
+          {!notificationsEnabled && (
+            <p className="mt-3 flex items-center gap-1.5 rounded-lg bg-signal-red/10 px-3 py-2 text-[11px] font-medium text-signal-red">
+              <AlertTriangle className="size-3.5 shrink-0" />
+              Account interval and per-member consent below have no effect while the engine is disabled.
+            </p>
+          )}
+        </div>
+      )}
 
       {/* ACCOUNT-level config (owner/manager-controlled). */}
       {showAccountConfig && (
@@ -901,6 +1218,11 @@ function NotificationsCard() {
           />
         </div>
       )}
+
+      {/* Run-history / send-log (#573) — a LIST of runs, each expandable into
+          its per-account detail. admin: full + cross-account counts;
+          owner/manager: own accounts only; member/viewer: not rendered. */}
+      {runHistory && <NotificationRunHistory history={runHistory} />}
     </Card>
   )
 }

--- a/apps/stock-analyser/lib/api/index.ts
+++ b/apps/stock-analyser/lib/api/index.ts
@@ -9,9 +9,11 @@ import type {
 } from '@transformotion/contracts/stock-analyser/api'
 import type {
   NotificationAccountConfig,
+  NotificationEngineConfig,
   NotificationMemberConsent,
   NotificationType,
 } from '@transformotion/contracts/stock-analyser/notification-preferences'
+import type { NotificationRunHistoryView } from '@transformotion/contracts/stock-analyser/notification-run-history'
 import { authService } from '../services/auth'
 import { getConfig } from '../config'
 import { getActiveAccountId } from '@/stores/active-account/use-active-account-store'
@@ -87,6 +89,20 @@ export const stockAnalyserClient = {
   },
   updateNotificationConsent(body: { receiveConsent: boolean }): Promise<{ consent: NotificationMemberConsent }> {
     return http().put('notification-consent', body)
+  },
+  // App-wide notification engine kill-switch (M19 #571). PUT is site/app-admin-gated
+  // server-side. Run-history (M19 #573) is ALREADY projected per-viewer by the
+  // server — the client consumes the response as the view (no client-side scoping).
+  getNotificationEngineConfig(): Promise<{ config: NotificationEngineConfig }> {
+    return http().get('notification-engine-config')
+  },
+  updateNotificationEngineConfig(
+    body: { notificationsEnabled: boolean },
+  ): Promise<{ config: NotificationEngineConfig }> {
+    return http().put('notification-engine-config', body)
+  },
+  getNotificationRunHistory(): Promise<NotificationRunHistoryView> {
+    return http().get('notification-history')
   },
   putCacheEntry(key: string, body: PutCacheRequest): Promise<void> {
     return http().put(`analysis-cache/${encodeURIComponent(key)}`, body)

--- a/apps/stock-analyser/lib/hooks/use-notification-preferences.ts
+++ b/apps/stock-analyser/lib/hooks/use-notification-preferences.ts
@@ -8,10 +8,12 @@ import {
   normalizeIntervalDays,
   resolveNotificationVisibility,
   type NotificationAccountConfig,
+  type NotificationEngineConfig,
   type NotificationMemberConsent,
   type NotificationViewerContext,
   type NotificationVisibility,
 } from "@transformotion/contracts/stock-analyser/notification-preferences"
+import type { NotificationRunHistoryView } from "@transformotion/contracts/stock-analyser/notification-run-history"
 import { stockAnalyserNotificationService } from "@/lib/services/notifications/notification-preferences-service"
 
 /**
@@ -34,9 +36,18 @@ export interface UseNotificationPreferencesResult {
   visibility: NotificationVisibility
   config: NotificationAccountConfig | null
   consent: NotificationMemberConsent | null
+  engine: NotificationEngineConfig | null
+  /**
+   * Run-history LIST (most-recent-first), ALREADY PROJECTED to what this viewer
+   * may see (#573). The server is the scoping boundary; the client consumes the
+   * response as the view (it does NOT call projectRunHistoryForViewer). `null`
+   * when there is nothing to show, so the card omits the section entirely.
+   */
+  runHistory: NotificationRunHistoryView | null
   setIntervalDays: (days: number) => void
   setActiveTypes: (types: NotificationAccountConfig["activeTypes"]) => void
   setReceiveConsent: (receive: boolean) => void
+  setNotificationsEnabled: (enabled: boolean) => void
 }
 
 const HIDDEN_VISIBILITY: NotificationVisibility = {
@@ -61,6 +72,8 @@ export function useNotificationPreferences(
   const [context, setContext] = useState<NotificationViewerContext>(EMPTY_CONTEXT)
   const [config, setConfig] = useState<NotificationAccountConfig | null>(null)
   const [consent, setConsent] = useState<NotificationMemberConsent | null>(null)
+  const [engine, setEngine] = useState<NotificationEngineConfig | null>(null)
+  const [runHistory, setRunHistory] = useState<NotificationRunHistoryView | null>(null)
 
   const isSiteAdmin = user?.metadata?.siteAdmin === true
   const isAppAdmin = ((user?.metadata?.appAdmin as string[] | undefined) ?? []).includes("stock-analyser")
@@ -80,16 +93,27 @@ export function useNotificationPreferences(
 
       let cfg: NotificationAccountConfig | null = null
       let cns: NotificationMemberConsent | null = null
+      let eng: NotificationEngineConfig | null = null
+      let rh: NotificationRunHistoryView | null = null
       if (activeAccountId && isNotificationFeatureApplicable(ctx)) {
-        ;[cfg, cns] = await Promise.all([
+        ;[cfg, cns, eng, rh] = await Promise.all([
           stockAnalyserNotificationService.getConfig(activeAccountId).catch(() => null),
           stockAnalyserNotificationService.getConsent(activeAccountId).catch(() => null),
+          stockAnalyserNotificationService.getEngineConfig().catch(() => null),
+          // The server already projects run-history per viewer — consume as-is.
+          // Empty-runs responses collapse to null so the card omits the section.
+          stockAnalyserNotificationService
+            .getRunHistory()
+            .then((view) => (view.runs.length > 0 ? view : null))
+            .catch(() => null),
         ])
       }
       if (cancelled) return
       setContext(ctx)
       setConfig(cfg)
       setConsent(cns)
+      setEngine(eng)
+      setRunHistory(rh)
       setReady(true)
     })()
     return () => {
@@ -109,6 +133,9 @@ export function useNotificationPreferences(
       stockAnalyserNotificationService.getConsent(activeAccountId).then(setConsent).catch(() => {})
     }
   }, [activeAccountId])
+  const refetchEngine = useCallback(() => {
+    stockAnalyserNotificationService.getEngineConfig().then(setEngine).catch(() => {})
+  }, [])
 
   const setIntervalDays = useCallback(
     (days: number) => {
@@ -147,5 +174,28 @@ export function useNotificationPreferences(
     [activeAccountId, refetchConsent],
   )
 
-  return { ready, context, visibility, config, consent, setIntervalDays, setActiveTypes, setReceiveConsent }
+  const setNotificationsEnabled = useCallback(
+    (enabled: boolean) => {
+      setEngine((e) => (e ? { ...e, notificationsEnabled: enabled } : e)) // optimistic
+      stockAnalyserNotificationService
+        .setEngineConfig(enabled)
+        .then(setEngine)
+        .catch(refetchEngine)
+    },
+    [refetchEngine],
+  )
+
+  return {
+    ready,
+    context,
+    visibility,
+    config,
+    consent,
+    engine,
+    runHistory,
+    setIntervalDays,
+    setActiveTypes,
+    setReceiveConsent,
+    setNotificationsEnabled,
+  }
 }

--- a/apps/stock-analyser/lib/services/notifications/notification-preferences-service.ts
+++ b/apps/stock-analyser/lib/services/notifications/notification-preferences-service.ts
@@ -11,12 +11,15 @@ import { stockAnalyserClient } from '@/lib/api'
 import {
   NOTIFICATION_TYPES,
   defaultNotificationAccountConfig,
+  defaultNotificationEngineConfig,
   defaultNotificationMemberConsent,
   normalizeIntervalDays,
   type NotificationAccountConfig,
+  type NotificationEngineConfig,
   type NotificationMemberConsent,
   type NotificationType,
 } from '@transformotion/contracts/stock-analyser/notification-preferences'
+import type { NotificationRunHistoryView } from '@transformotion/contracts/stock-analyser/notification-run-history'
 
 export interface NotificationPreferencesService {
   getConfig(accountId: string): Promise<NotificationAccountConfig>
@@ -26,12 +29,19 @@ export interface NotificationPreferencesService {
   ): Promise<NotificationAccountConfig>
   getConsent(accountId: string): Promise<NotificationMemberConsent>
   putConsent(accountId: string, receiveConsent: boolean): Promise<NotificationMemberConsent>
+  // App-wide engine kill-switch (M19 #571) — a single global record, account-independent.
+  getEngineConfig(): Promise<NotificationEngineConfig>
+  setEngineConfig(notificationsEnabled: boolean): Promise<NotificationEngineConfig>
+  // Run-history (M19 #573) — the response is ALREADY projected per viewer server-side.
+  getRunHistory(): Promise<NotificationRunHistoryView>
 }
 
 // ── Mock (local dev) — in-memory, single implicit user ──────────────────────────
 const mockConfigs = new Map<string, NotificationAccountConfig>()
 const mockConsents = new Map<string, NotificationMemberConsent>()
 const MOCK_USER = 'user-local'
+// App-wide kill-switch — single global record (default ON), account-independent.
+let mockEngine: NotificationEngineConfig = defaultNotificationEngineConfig()
 
 const mockService: NotificationPreferencesService = {
   async getConfig(accountId) {
@@ -63,6 +73,16 @@ const mockService: NotificationPreferencesService = {
     mockConsents.set(accountId, next)
     return next
   },
+  async getEngineConfig() {
+    return mockEngine
+  },
+  async setEngineConfig(notificationsEnabled) {
+    mockEngine = { notificationsEnabled, updatedAt: new Date().toISOString() }
+    return mockEngine
+  },
+  async getRunHistory() {
+    return { runs: [] }
+  },
 }
 
 // ── Live — settings Lambda (account derived from the X-Account-Id header) ───────
@@ -78,6 +98,16 @@ const realService: NotificationPreferencesService = {
   },
   async putConsent(_accountId, receiveConsent) {
     return (await stockAnalyserClient.updateNotificationConsent({ receiveConsent })).consent
+  },
+  async getEngineConfig() {
+    return (await stockAnalyserClient.getNotificationEngineConfig()).config
+  },
+  async setEngineConfig(notificationsEnabled) {
+    return (await stockAnalyserClient.updateNotificationEngineConfig({ notificationsEnabled })).config
+  },
+  // The server already projects run-history per viewer — consume the response as-is.
+  async getRunHistory() {
+    return stockAnalyserClient.getNotificationRunHistory()
   },
 }
 


### PR DESCRIPTION
## Summary
The **final UI ports**, v0-verbatim into the Settings → NotificationsCard. Both
backends are merged + deployed (#575 toggle config+authz; #576 run-history
read+scoping), so this completes #573 and #571 end-to-end.

### #573 Piece 1c — run-history section
`NotificationRunHistory` + per-account record + status/reason label maps, ported
**byte-identical** from v0's settings-tab (the component `diff`s clean vs v0).
Wired to `GET /notification-history`. **CRUCIAL:** the server already projects
per-viewer, so the client consumes the response **as the view** — it does **not**
call `projectRunHistoryForViewer`. Empty runs → `null` (v0's omit-the-section
contract) is normalised in the **hook's data layer**, keeping the component verbatim.

### #571 Piece 2c — kill-switch toggle
The engine-toggle block ported verbatim; visibility from `visibility.engineToggle`
(editable site/app-admin · read-only owner/manager · hidden otherwise — UX only;
the **server** is the boundary, proven in #575). Wired to
`GET/PUT /notification-engine-config`.

### Data layer (the only thing that differs from v0, §8.A)
`stockAnalyserClient` gains `get/updateNotificationEngineConfig` +
`getNotificationRunHistory`; the notification service + hook expose `engine` /
`runHistory` / `setNotificationsEnabled`.

## Gates
SA typecheck + eslint + **build (compiles, 5/5 static pages)** + the notification
suites (26 tests) pass. Verbatim verified: `NotificationRunHistory` is byte-identical
to v0; distinctive copy matches; no client-side projection.

## v0 freshness
v0 PR: https://github.com/transformotion/transformotion-apps-b8/pull/74 — the
NotificationsCard run-history + engine-toggle design. Runtime reproduces the
presentation **verbatim** (component diffs clean) and changes only the data layer
(real endpoints; server-projected run-history). No runtime-originated UI/contract change.

## Deploy
`apps/stock-analyser/**` → `deploy-stock-analyser.yml` (frontend rebuild; no infra).

## Owner dev verification (post-merge) — personas
admin-not-owner → summary-only run rows (no member identities); owner → own-account
detail; member/viewer → no run history; toggle OFF → next engine run no-ops; a
crafted unauthorised toggle write → 403 (already proven server-side in #575).

Closes #573 · Refs #571

🤖 Generated with [Claude Code](https://claude.com/claude-code)