### PR TITLE
fix(m19-578): fault-tolerant send-log write (stop silent account drops)

### DIFF
--- a/apps/stock-analyser/functions/notification-engine/src/engine.test.ts
+++ b/apps/stock-analyser/functions/notification-engine/src/engine.test.ts
@@ -340,6 +340,23 @@ describe('notification send-log (#572)', () => {
     expect(outcome(run, 'boom')).toMatchObject({ outcome: 'skipped', reason: 'lookup-error' });
   });
 
+  it('omits email (never undefined) for members with no email — the clean record that broke the write (#578)', async () => {
+    // Mirrors run fd4461f3: seeded persona members with NO email. The leaf must be
+    // { userId, outcome, reason } — NOT { email: undefined, ... }, which the
+    // DynamoDB marshaller rejects (and previously dropped every later account).
+    const run = await runNotificationEngine(deps({
+      listStockAnalyserMembers: vi.fn(async () => [
+        { accountId: 'acct-a', userId: 'no-mail', appSlug: 'stock-analyser', role: 'member' }, // no email
+      ]),
+      readLiveMember: vi.fn(async (accountId, userId) => ({ accountId, userId, appSlug: 'stock-analyser', role: 'member', status: 'active' })), // live row also lacks email
+      readMemberConsent: vi.fn(async (accountId, userId) => ({ accountId, userId, receiveConsent: false, updatedAt: 'now' })), // consent off → gated path
+    }));
+
+    const o = outcome(run, 'no-mail')!;
+    expect(o).toMatchObject({ outcome: 'skipped', reason: 'consent-off' });
+    expect('email' in o).toBe(false); // key OMITTED, not present-as-undefined
+  });
+
   it('records no-actionable-transition for eligible members when no ticker fires', async () => {
     const run = await runNotificationEngine(deps({
       generateAnalysis: vi.fn(async (ticker) => analysis(ticker, 'HOLD')), // never actionable

--- a/apps/stock-analyser/functions/notification-engine/src/engine.ts
+++ b/apps/stock-analyser/functions/notification-engine/src/engine.ts
@@ -146,6 +146,30 @@ export function stateSk(type: NotificationSourceType, ticker: string): string {
   return `NOTIF#${type}#${ticker.toUpperCase()}`;
 }
 
+/**
+ * Build a member's leaf outcome with `email` OMITTED when the member has none
+ * (#578). A member with no email must yield `{ userId, outcome, reason }` — NOT
+ * `{ email: undefined, ... }`. The DynamoDB DocumentClient rejects `undefined`
+ * by default, and one such value previously threw mid-write and dropped every
+ * subsequent account from the send-log (run fd4461f3). Keep the record clean at
+ * the source; the marshaller's `removeUndefinedValues` is only the safety net.
+ */
+function memberOutcome(
+  userId: string,
+  email: string | undefined,
+  outcome: MemberOutcome['outcome'],
+  reason: SendLogReason,
+  tickers?: string[],
+): MemberOutcome {
+  return {
+    userId,
+    ...(email ? { email } : {}),
+    outcome,
+    reason,
+    ...(tickers && tickers.length > 0 ? { tickers } : {}),
+  };
+}
+
 function coerceVerdict(value: unknown): Verdict {
   const upper = String(value ?? '').toUpperCase();
   return upper === 'BUY' || upper === 'SELL' || upper === 'HOLD' || upper === 'NEUTRAL' ? upper : 'NEUTRAL';
@@ -361,7 +385,7 @@ async function processAccount(
   const eligible = decisions.filter((d) => d.eligible && d.recipient).map((d) => d.recipient!);
   const gatedOutcomes: MemberOutcome[] = decisions
     .filter((d) => !d.eligible)
-    .map((d) => ({ userId: d.candidate.userId, email: d.candidate.email, outcome: 'skipped', reason: d.skipReason! }));
+    .map((d) => memberOutcome(d.candidate.userId, d.candidate.email, 'skipped', d.skipReason!));
 
   // No eligible recipients → skip account (every member is gated).
   if (eligible.length === 0) {
@@ -384,7 +408,7 @@ async function processAccount(
     sendLog.accountsSkippedNotDue += 1;
     const memberOutcomes: MemberOutcome[] = [
       ...gatedOutcomes,
-      ...eligible.map((r): MemberOutcome => ({ userId: r.userId, email: r.email, outcome: 'skipped', reason: 'account-not-due' })),
+      ...eligible.map((r): MemberOutcome => memberOutcome(r.userId, r.email, 'skipped', 'account-not-due')),
     ];
     const account: SendLogAccount = { accountId, accountName, status: 'skipped-not-due', transitions: [], emailsSent: 0, memberOutcomes };
     assertNoCrossAccount(deps, accountId, candidateMembers, account);
@@ -441,8 +465,8 @@ async function processAccount(
     ...eligible.map((r): MemberOutcome => {
       const tickers = sentTickersByUser.get(r.userId);
       return tickers && tickers.length > 0
-        ? { userId: r.userId, email: r.email, outcome: 'sent', reason: 'delivered', tickers }
-        : { userId: r.userId, email: r.email, outcome: 'skipped', reason: 'no-actionable-transition' };
+        ? memberOutcome(r.userId, r.email, 'sent', 'delivered', tickers)
+        : memberOutcome(r.userId, r.email, 'skipped', 'no-actionable-transition');
     }),
   ];
 

--- a/apps/stock-analyser/functions/notification-engine/src/index.ts
+++ b/apps/stock-analyser/functions/notification-engine/src/index.ts
@@ -39,8 +39,14 @@ import {
   type NotificationTransition,
   type SendLogRun,
 } from './engine';
+import { SEND_LOG_TTL_SECONDS, writeSendLog } from './send-log';
 
-const ddb = DynamoDBDocumentClient.from(new DynamoDBClient({}));
+// removeUndefinedValues (#578): the safety net so a stray `undefined` (e.g. a
+// member with no email) can never throw mid-write and drop subsequent records.
+// Records are also kept clean at the source (see memberOutcome in engine.ts).
+const ddb = DynamoDBDocumentClient.from(new DynamoDBClient({}), {
+  marshallOptions: { removeUndefinedValues: true },
+});
 const lambda = new LambdaClient({});
 const ses = new SESv2Client({});
 
@@ -371,55 +377,21 @@ async function readAccountName(runtime: RuntimeEnv, accountId: string): Promise<
   }
 }
 
-// #572 send-log persistence — write the run summary + one item per account
-// (member outcomes embedded), with GSI keys for recency + per-account history
-// and a 90-day TTL (append-only audit that should age out).
-const SEND_LOG_TTL_SECONDS = 90 * 24 * 60 * 60;
-
+// #572 send-log persistence — run summary + one item per account (member
+// outcomes embedded), GSI keys for recency + per-account history, 90-day TTL.
+// #578: the write is fault-tolerant (per-account isolation, status escalation,
+// summary written last) — see writeSendLog in ./send-log.
 async function recordSendLog(runtime: RuntimeEnv, run: SendLogRun): Promise<void> {
-  const expiresAt = run.ranAt + SEND_LOG_TTL_SECONDS;
-  // 1. Run summary — GSI1 (RUNS → ranAt) drives the recency list.
-  await ddb.send(new PutCommand({
-    TableName: runtime.sendLogTable,
-    Item: {
-      pk: `RUN#${run.runId}`,
-      sk: 'SUMMARY',
-      gsi1pk: 'RUNS',
-      gsi1sk: run.ranAt,
-      runId: run.runId,
-      ranAt: run.ranAt,
-      status: run.status,
-      accountsEvaluated: run.accountsEvaluated,
-      accountsProcessed: run.accountsProcessed,
-      accountsSkippedNotDue: run.accountsSkippedNotDue,
-      accountsSkippedNoEligible: run.accountsSkippedNoEligible,
-      emailsSent: run.emailsSent,
-      ...(run.error ? { error: run.error } : {}),
-      expiresAt,
+  await writeSendLog(
+    async (item) => {
+      await ddb.send(new PutCommand({ TableName: runtime.sendLogTable, Item: item }));
     },
-  }));
-  // 2. Per-account items — GSI2 (ACCT#{id} → ranAt) drives per-account history.
-  for (const account of run.accounts) {
-    await ddb.send(new PutCommand({
-      TableName: runtime.sendLogTable,
-      Item: {
-        pk: `RUN#${run.runId}`,
-        sk: `ACCT#${account.accountId}`,
-        gsi2pk: `ACCT#${account.accountId}`,
-        gsi2sk: run.ranAt,
-        runId: run.runId,
-        ranAt: run.ranAt,
-        accountId: account.accountId,
-        ...(account.accountName ? { accountName: account.accountName } : {}),
-        status: account.status,
-        transitions: account.transitions,
-        emailsSent: account.emailsSent,
-        memberOutcomes: account.memberOutcomes,
-        ...(account.error ? { error: account.error } : {}),
-        expiresAt,
-      },
-    }));
-  }
+    run,
+    {
+      ttlSeconds: SEND_LOG_TTL_SECONDS,
+      log: (message, context) => console.log(JSON.stringify({ message, ...context })),
+    },
+  );
 }
 
 // #571 kill-switch: app-wide notificationsEnabled (default ON when absent/malformed).

--- a/apps/stock-analyser/functions/notification-engine/src/send-log.test.ts
+++ b/apps/stock-analyser/functions/notification-engine/src/send-log.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it, vi } from 'vitest';
+import { writeSendLog } from './send-log';
+import type { SendLogAccount, SendLogRun } from './engine';
+
+// #578 — the send-log WRITE must be fault-tolerant: one poison account is
+// recorded as errored and the loop CONTINUES (it never drops the accounts that
+// follow), the run status reflects the loss honestly, and the SUMMARY is
+// written last so its status is the real one.
+
+function account(id: string, over: Partial<SendLogAccount> = {}): SendLogAccount {
+  return {
+    accountId: id,
+    accountName: `Name ${id}`,
+    status: 'skipped-no-eligible',
+    transitions: [],
+    emailsSent: 0,
+    memberOutcomes: [{ userId: `u-${id}`, outcome: 'skipped', reason: 'consent-off' }],
+    ...over,
+  };
+}
+
+function run(accounts: SendLogAccount[], over: Partial<SendLogRun> = {}): SendLogRun {
+  return {
+    runId: 'run-1',
+    ranAt: 1_700_000_000,
+    status: 'success',
+    accountsEvaluated: accounts.length,
+    accountsProcessed: 0,
+    accountsSkippedNotDue: 0,
+    accountsSkippedNoEligible: accounts.length,
+    emailsSent: 0,
+    accounts,
+    ...over,
+  };
+}
+
+/** Index the persisted items by their store key (RUN#…/SUMMARY | ACCT#id). */
+function persisted(items: Record<string, unknown>[]) {
+  const summary = items.find((i) => i['sk'] === 'SUMMARY');
+  const accounts = new Map(items.filter((i) => String(i['sk']).startsWith('ACCT#')).map((i) => [i['accountId'] as string, i]));
+  return { summary, accounts };
+}
+
+describe('send-log fault-tolerant write (#578)', () => {
+  it('all accounts persist on a clean run; SUMMARY carries the unchanged status', async () => {
+    const items: Record<string, unknown>[] = [];
+    const r = run([account('a'), account('b'), account('c')]);
+
+    await writeSendLog(async (item) => { items.push(item); }, r);
+
+    const { summary, accounts } = persisted(items);
+    expect([...accounts.keys()].sort()).toEqual(['a', 'b', 'c']);
+    expect(summary).toMatchObject({ status: 'success' });
+    expect(r.status).toBe('success');
+  });
+
+  it('a poison account does NOT drop the accounts that follow it; the failing one is marked errored', async () => {
+    // 'b' fails its first (normal) write; the stripped marker write succeeds.
+    const items: Record<string, unknown>[] = [];
+    const putItem = vi.fn(async (item: Record<string, unknown>) => {
+      if (item['accountId'] === 'b' && item['status'] !== 'failed') {
+        throw new Error('marshalling blew up on b');
+      }
+      items.push(item);
+    });
+    const r = run([account('a'), account('b'), account('c')]); // 'c' comes AFTER the poison
+
+    await writeSendLog(putItem, r, { log: vi.fn() });
+
+    const { summary, accounts } = persisted(items);
+    // a, b, c ALL persisted — b survived as an errored marker, c was not dropped.
+    expect([...accounts.keys()].sort()).toEqual(['a', 'b', 'c']);
+    expect(accounts.get('a')).toMatchObject({ status: 'skipped-no-eligible' });
+    expect(accounts.get('c')).toMatchObject({ status: 'skipped-no-eligible' }); // the load-bearing assertion
+    expect(accounts.get('b')).toMatchObject({ status: 'failed' });
+    expect(String(accounts.get('b')!['error'])).toContain('send-log write failed');
+    // Honest status: escalated to partial on the wire AND in memory.
+    expect(summary).toMatchObject({ status: 'partial' });
+    expect(r.status).toBe('partial');
+  });
+
+  it('a run-level failure is never downgraded by a write loss (stays failed)', async () => {
+    const items: Record<string, unknown>[] = [];
+    const putItem = vi.fn(async (item: Record<string, unknown>) => {
+      if (item['accountId'] === 'a' && item['status'] !== 'failed') throw new Error('write blip');
+      items.push(item);
+    });
+    const r = run([account('a')], { status: 'failed', error: 'members scan failed' });
+
+    await writeSendLog(putItem, r, { log: vi.fn() });
+
+    expect(persisted(items).summary).toMatchObject({ status: 'failed' });
+    expect(r.status).toBe('failed');
+  });
+
+  it('SUMMARY is written LAST (after every account)', async () => {
+    const order: string[] = [];
+    const r = run([account('a'), account('b')]);
+
+    await writeSendLog(async (item) => { order.push(String(item['sk'])); }, r);
+
+    expect(order[order.length - 1]).toBe('SUMMARY');
+    expect(order.filter((sk) => sk.startsWith('ACCT#')).length).toBe(2);
+  });
+});

--- a/apps/stock-analyser/functions/notification-engine/src/send-log.ts
+++ b/apps/stock-analyser/functions/notification-engine/src/send-log.ts
@@ -1,0 +1,114 @@
+// #578 — fault-tolerant send-log writer (follow-up to #572).
+//
+// The send-log is the audit trail behind run-history (#573). Persisting it must
+// not be all-or-nothing: a single poison account (e.g. an item the marshaller
+// rejects, throttling, an oversized item) must NOT drop the accounts that come
+// after it, and the run's reported status must reflect any write loss instead
+// of silently under-persisting (run fd4461f3 lost accounts 4–9 this way).
+//
+// This module is pure (item shaping + an isolated write loop over an injected
+// `putItem`); the real DynamoDB `PutCommand` wrapping lives in index.ts, so the
+// fault-tolerance is unit-testable without the AWS SDK.
+
+import type { SendLogAccount, SendLogRun, SendLogStatus } from './engine';
+
+/** Append-only audit that should age out (90 days). */
+export const SEND_LOG_TTL_SECONDS = 90 * 24 * 60 * 60;
+
+/** Run SUMMARY item — GSI1 (RUNS → ranAt) drives the recency list. */
+export function summaryItem(run: SendLogRun, status: SendLogStatus, expiresAt: number): Record<string, unknown> {
+  return {
+    pk: `RUN#${run.runId}`,
+    sk: 'SUMMARY',
+    gsi1pk: 'RUNS',
+    gsi1sk: run.ranAt,
+    runId: run.runId,
+    ranAt: run.ranAt,
+    status,
+    accountsEvaluated: run.accountsEvaluated,
+    accountsProcessed: run.accountsProcessed,
+    accountsSkippedNotDue: run.accountsSkippedNotDue,
+    accountsSkippedNoEligible: run.accountsSkippedNoEligible,
+    emailsSent: run.emailsSent,
+    ...(run.error ? { error: run.error } : {}),
+    ...(run.note ? { note: run.note } : {}),
+    expiresAt,
+  };
+}
+
+/** Per-account item — GSI2 (ACCT#{id} → ranAt) drives per-account history. */
+export function accountItem(run: SendLogRun, account: SendLogAccount, expiresAt: number): Record<string, unknown> {
+  return {
+    pk: `RUN#${run.runId}`,
+    sk: `ACCT#${account.accountId}`,
+    gsi2pk: `ACCT#${account.accountId}`,
+    gsi2sk: run.ranAt,
+    runId: run.runId,
+    ranAt: run.ranAt,
+    accountId: account.accountId,
+    ...(account.accountName ? { accountName: account.accountName } : {}),
+    status: account.status,
+    transitions: account.transitions,
+    emailsSent: account.emailsSent,
+    memberOutcomes: account.memberOutcomes,
+    ...(account.error ? { error: account.error } : {}),
+    expiresAt,
+  };
+}
+
+/** The minimal honest marker for an account whose normal write failed (#578). */
+function erroredAccountMarker(account: SendLogAccount, err: unknown): SendLogAccount {
+  return {
+    accountId: account.accountId,
+    ...(account.accountName ? { accountName: account.accountName } : {}),
+    status: 'failed',
+    transitions: [],
+    emailsSent: 0,
+    memberOutcomes: [],
+    error: `send-log write failed: ${String((err as Error)?.message ?? err)}`,
+  };
+}
+
+export interface WriteSendLogOptions {
+  ttlSeconds?: number;
+  log?: (message: string, context?: Record<string, unknown>) => void;
+}
+
+/**
+ * Persist a run's audit record with PER-ACCOUNT ISOLATION (#578).
+ *
+ * Each account is written independently: if its write throws, that account is
+ * re-written as a minimal `failed` marker and the loop CONTINUES — a poison
+ * account never drops the rest of the run. Any write failure ESCALATES the run
+ * to `partial` (a `failed` run-level status is never downgraded), and the
+ * SUMMARY is written LAST so its status reflects the actual write outcome, not
+ * the pre-write optimistic value. `run.status` is mutated so the value the
+ * engine returns/logs is honest too.
+ */
+export async function writeSendLog(
+  putItem: (item: Record<string, unknown>) => Promise<void>,
+  run: SendLogRun,
+  options: WriteSendLogOptions = {},
+): Promise<void> {
+  const expiresAt = run.ranAt + (options.ttlSeconds ?? SEND_LOG_TTL_SECONDS);
+  let status: SendLogStatus = run.status;
+
+  for (const account of run.accounts) {
+    try {
+      await putItem(accountItem(run, account, expiresAt));
+    } catch (err) {
+      // A write loss is at least a partial run (never downgrade an outright failure).
+      if (status === 'success') status = 'partial';
+      options.log?.('notification-send-log-account-write-error', { accountId: account.accountId, err: String(err) });
+      // Record THIS account as errored and keep going — do not abort the loop.
+      try {
+        await putItem(accountItem(run, erroredAccountMarker(account, err), expiresAt));
+      } catch (markerErr) {
+        options.log?.('notification-send-log-account-marker-error', { accountId: account.accountId, err: String(markerErr) });
+      }
+    }
+  }
+
+  run.status = status; // honest run status reflects per-account write outcomes
+  await putItem(summaryItem(run, status, expiresAt));
+}

--- a/docs/architecture/data.md
+++ b/docs/architecture/data.md
@@ -309,6 +309,13 @@ notification-state's no-TTL store, which is why it is a separate table.
 - By-run reads (verification) use `Query` on `PK=RUN#{runId}` (summary + all accounts in one query).
 
 The engine holds **write-only** on this table (it appends run records); reads are #573's.
+The write is **fault-tolerant** (#578): per-account writes are isolated, so one
+account whose write fails is recorded as a `failed` marker (`error` set) and the
+loop continues rather than dropping the accounts that follow; any write loss
+escalates the run to `partial`, and the `SUMMARY` is written **last** so its
+`status` reflects the actual write outcome. Member leaves omit `email` when
+absent (never `undefined`), and the client uses `removeUndefinedValues` as a
+safety net.
 
 ## Budget Tracker tables
 


### PR DESCRIPTION
## What & why
Fixes #578. The notification send-log write was **all-or-nothing**: a single account whose `PutItem` threw aborted the sequential write loop and **silently dropped every account that followed**, while the run still reported `partial`.

Found during the M19 manual-invoke verification — dev run `fd4461f3`: 9 accounts evaluated, only **3** persisted, because account 4 (`acct-sa-research`) had members with no `email` → `email: undefined` → the DocumentClient rejected the undefined value → throw → loop abort. The dropped tail included the owner's own accounts.

## Changes (runtime-only — no contract change)
1. **Clean at the source** — `memberOutcome()` (engine.ts) omits `email` when the member has none (never `email: undefined`). Applied at all three outcome-construction sites.
2. **Safety net** — the DynamoDB DocumentClient is configured with `marshallOptions.removeUndefinedValues = true`, so any future stray `undefined` is dropped instead of throwing mid-write.
3. **Fault-tolerance (the load-bearing part)** — new `send-log.ts` `writeSendLog()` isolates each account write: a failure records THAT account as a minimal `failed` marker and the loop **continues** (subsequent accounts are never dropped). Any write loss **escalates** the run to `partial` (a `failed` run is never downgraded), and the `SUMMARY` is written **last** so its status reflects the actual outcome. `run.status` is mutated so the returned/logged result is honest — no more silent under-persisting.

Issue B (#579, surface engine errors in run-history) is **v0-first** and intentionally NOT in this PR — this stores only the minimal account-level error *marker*; the role-scoped error *display* conforms to a v0 contract later.

## Tests
`functions/notification-engine` — 21 pass (17 engine + 4 send-log):
- a member with no email persists with the `email` key **omitted** (the record that broke the write);
- a poison account does **not** drop the accounts that follow it (all persist; the failing one marked errored);
- a run-level failure is never downgraded by a write loss (stays `failed`);
- the `SUMMARY` is written **last**.

## §2.1 paired docs
- `docs/architecture/data.md` — send-log section notes the fault-tolerant write semantics (per-account isolation, `failed` marker, escalate-to-`partial`, summary-last, `email` omission + `removeUndefinedValues`). Table schema unchanged (`error?` / `partial` already documented).

## v0 freshness
No v0 impact: changes are backend Lambda (`functions/notification-engine`) + an architecture doc only — no `app/`, `components/`, UI `lib/`, `stores/`, `hooks/`, services, or `packages/contracts/` paths touched, and no contract shape changes.

## After merge + deploy
`apps/stock-analyser/**` matches the SA deploy filter → a deploy runs on merge. After it succeeds, re-invoke `stock-analyser-notification-engine-dev` and confirm a **complete** run persists (all 9 accounts incl. the owner's own + the credit-failed `a03f9cd4`), so the owner's Rule A persona-verification reads a complete run.

## Status
**Held for owner merge.**
