### PR TITLE
fix(m19-581): run-history account name for errored accounts (no raw GUID)

### DIFF
--- a/apps/stock-analyser/functions/notification-engine/src/engine.test.ts
+++ b/apps/stock-analyser/functions/notification-engine/src/engine.test.ts
@@ -389,6 +389,24 @@ describe('notification send-log (#572)', () => {
     expect(recordSendLog).toHaveBeenCalledOnce(); // audit written despite the failure
   });
 
+  it('errored account still carries its accountName (#581) — name captured independently of processing', async () => {
+    // a03f9cd4-style: the account throws mid-processing (e.g. Claude credit), but
+    // its name must still be on the record — not lost, not a raw GUID fallback.
+    const run = await runNotificationEngine(deps({
+      listStockAnalyserMembers: vi.fn(async () => [
+        { accountId: 'acct-x', userId: 'u', email: 'u@x.com', appSlug: 'stock-analyser', role: 'member' },
+      ]),
+      readAccountName: vi.fn(async (id) => (id === 'acct-x' ? "Steve's Portfolio" : undefined)),
+      readPortfolio: vi.fn(async () => { throw new Error('claude API error: credit balance too low'); }),
+      readWatchlist: vi.fn(async () => []),
+    }));
+
+    const acct = run.sendLog.accounts.find((a) => a.accountId === 'acct-x')!;
+    expect(acct.status).toBe('failed');
+    expect(acct.error).toContain('credit balance');
+    expect(acct.accountName).toBe("Steve's Portfolio"); // NOT lost on error, NOT the GUID
+  });
+
   it('run-level failure: member listing throws → status failed, recorded, then rethrown', async () => {
     const recordSendLog = vi.fn(async (_run: SendLogRun) => undefined);
     await expect(runNotificationEngine(deps({

--- a/apps/stock-analyser/functions/notification-engine/src/engine.ts
+++ b/apps/stock-analyser/functions/notification-engine/src/engine.ts
@@ -372,14 +372,12 @@ async function processAccount(
   deps: NotificationEngineDeps,
   resolveAnalysis: (ticker: string) => Promise<StockAnalysisResult>,
   accountId: string,
+  accountName: string | undefined,
   candidateMembers: MemberRow[],
   today: string,
   result: NotificationEngineResult,
   sendLog: SendLogRun,
 ): Promise<SendLogAccount> {
-  const accountName = deps.readAccountName
-    ? await deps.readAccountName(accountId).catch(() => undefined)
-    : undefined;
 
   const decisions = await evaluateRecipients(deps, accountId, candidateMembers);
   const eligible = decisions.filter((d) => d.eligible && d.recipient).map((d) => d.recipient!);
@@ -516,13 +514,19 @@ export async function runNotificationEngine(deps: NotificationEngineDeps): Promi
     sendLog.accountsEvaluated = grouped.size;
 
     for (const [accountId, candidateMembers] of grouped) {
+      // Resolve the display name HERE (#581), independently of processing — it's a
+      // separate best-effort lookup, so an errored account still records its name
+      // rather than falling back to a raw GUID in run-history.
+      const accountName = deps.readAccountName
+        ? await deps.readAccountName(accountId).catch(() => undefined)
+        : undefined;
       // Per-account guard (#572): one account's failure is RECORDED and downgrades
       // the run to `partial` — it never loses the whole run's audit record.
       try {
-        sendLog.accounts.push(await processAccount(deps, resolveAnalysis, accountId, candidateMembers, today, result, sendLog));
+        sendLog.accounts.push(await processAccount(deps, resolveAnalysis, accountId, accountName, candidateMembers, today, result, sendLog));
       } catch (err) {
         deps.log?.('notification-account-error', { accountId, err: String(err) });
-        sendLog.accounts.push({ accountId, status: 'failed', transitions: [], emailsSent: 0, memberOutcomes: [], error: String((err as Error)?.message ?? err) });
+        sendLog.accounts.push({ accountId, ...(accountName ? { accountName } : {}), status: 'failed', transitions: [], emailsSent: 0, memberOutcomes: [], error: String((err as Error)?.message ?? err) });
         sendLog.status = 'partial';
       }
     }

--- a/apps/stock-analyser/functions/notification-history/src/index.test.ts
+++ b/apps/stock-analyser/functions/notification-history/src/index.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { APIGatewayProxyEvent } from 'aws-lambda';
-import { createHandler, type RunHistoryDeps } from './index';
+import { createHandler, mapAccount, type RunHistoryDeps } from './index';
 import type { NotificationRunSummary } from '@transformotion/contracts/stock-analyser/notification-run-history';
 
 // PIECE 1d — the REAL proof: per-viewer PAYLOAD SCOPING (not render). Per-member
@@ -62,6 +62,26 @@ async function run(groups: string, d: RunHistoryDeps, sub = 'viewer-1') {
 
 const acctOf = (view: { runs: Array<{ accounts: Array<{ accountId: string }> }> }, id: string) =>
   view.runs[0]?.accounts.find((a) => a.accountId === id);
+
+describe('notification run-history — account name fallback (#581)', () => {
+  const GUID = 'a03f9cd4-951f-463a-8b34-73c0f046e672';
+
+  it('a missing accountName never renders as a raw GUID — falls back to a readable label', () => {
+    const a = mapAccount({ accountId: GUID, status: 'failed', error: 'claude credit' });
+    expect(a.accountName).toBe('Unknown account');
+    expect(a.accountName).not.toContain(GUID);
+  });
+
+  it('a blank/whitespace accountName also falls back (never the GUID)', () => {
+    const a = mapAccount({ accountId: GUID, accountName: '   ', status: 'processed' });
+    expect(a.accountName).toBe('Unknown account');
+  });
+
+  it('a real accountName passes through unchanged', () => {
+    const a = mapAccount({ accountId: GUID, accountName: "Steve's Portfolio", status: 'failed' });
+    expect(a.accountName).toBe("Steve's Portfolio");
+  });
+});
 
 describe('notification run-history — payload scoping (#573)', () => {
   it('ADMIN-not-owner: SUMMARY-only for every account — member detail + transitions ABSENT from the payload', async () => {

--- a/apps/stock-analyser/functions/notification-history/src/index.ts
+++ b/apps/stock-analyser/functions/notification-history/src/index.ts
@@ -60,13 +60,19 @@ function mapMemberOutcome(o: Record<string, unknown>): NotificationMemberOutcome
   };
 }
 
-function mapAccount(item: Record<string, unknown>): NotificationRunAccount {
+// Defence-in-depth (#581): never render a raw accountId (GUID) as the name. The
+// engine now captures the name even for errored accounts, but a genuinely-absent
+// name falls back to a readable label rather than the GUID.
+const UNKNOWN_ACCOUNT_NAME = 'Unknown account';
+
+export function mapAccount(item: Record<string, unknown>): NotificationRunAccount {
   const accountId = String(item['accountId'] ?? '');
   const transitions = Array.isArray(item['transitions']) ? item['transitions'] : [];
   const memberOutcomes = Array.isArray(item['memberOutcomes']) ? item['memberOutcomes'] : [];
+  const rawName = typeof item['accountName'] === 'string' ? item['accountName'].trim() : '';
   return {
     accountId,
-    accountName: typeof item['accountName'] === 'string' && item['accountName'] ? item['accountName'] : accountId,
+    accountName: rawName || UNKNOWN_ACCOUNT_NAME,
     accountStatus: mapAccountStatus(item['status']),
     transitions: transitions.map((t) => mapTransition(t as Record<string, unknown>)),
     emailsSent: Number(item['emailsSent'] ?? 0),


### PR DESCRIPTION
## What & why
Fixes #581. In notification run-history, an account that **errored** during a run displayed its raw `accountId` (a GUID) instead of its name — seen for `a03f9cd4` ("Steve's Portfolio") on the Claude-credit failure. Two causes, both fixed.

## Changes (runtime; no contract/schema change)
1. **Engine — capture the name independently of processing.** `readAccountName` was a local inside `processAccount()` and was discarded when the account threw; the run-loop catch then rebuilt the failed record without a name. The lookup is hoisted into the run loop (a separate best-effort GetItem), so the errored/`failed` record carries `accountName` too. It no longer depends on processing succeeding.
2. **Display — graceful non-GUID fallback.** `notification-history` `mapAccount` fell back to the raw `accountId` when `accountName` was absent. It now falls back to `"Unknown account"` (trimming blanks) — defence-in-depth so a genuinely-absent name never renders as a GUID. `mapAccount` is exported for unit testing.

## Tests (30 notification tests pass)
- Engine: an account that throws mid-processing still records its `accountName` (not lost, not a GUID).
- `mapAccount`: a missing **and** a blank/whitespace name fall back to the readable label and never contain the GUID; a real name passes through unchanged.

## §2.1 docs
No normative-doc change: the send-log schema is unchanged (`accountName?` was already optional), and there is no route/IAM/auth/contract change. This corrects write/display behaviour only.

## v0 freshness
No v0 impact: backend Lambda (`functions/notification-engine`, `functions/notification-history`) only — no `app/`, `components/`, UI `lib/`, `stores/`, `hooks/`, services, or `packages/contracts/` paths, and no contract shape change. (The UI `RunAccountBlock` already renders `account.accountName`; this only changes the value it receives.)

## Related
- Defect 2 (owner-lock on the "Steve's" seed accounts): confirmed correct behaviour, no action.
- appSlug=null mis-scoping (#582): separate; dev-data/legacy artifact, handled as a dev-data backfill (not in this PR).

## After merge + deploy
`apps/stock-analyser/**` matches the SA deploy filter → a deploy runs on merge. Re-invoking the engine will then persist errored accounts WITH their names; existing pre-fix run records (e.g. b02faa56's `a03f9cd4`) stay nameless (audit history) but render as "Unknown account" rather than a GUID via the display fallback.

## Status
**Held for owner merge.**
