### PR TITLE
feat(m19-584): warm the market-wide cache (MARKET#{region}) in the daily job

### DIFF
--- a/apps/stock-analyser/AGENTS.md
+++ b/apps/stock-analyser/AGENTS.md
@@ -52,11 +52,11 @@ Current state after #366/#386: Stock Analyser owns its REST API Gateway, AI prox
 | `transformotion-analysis-cache-{stage}` | `apps/stock-analyser/functions/analysis-cache` | `GET/PUT/DELETE /analysis-cache/{key}` |
 | `stock-analyser-settings-{stage}` | `apps/stock-analyser/functions/settings` | `GET/PATCH /settings`, `GET /ai-config`, `PUT/DELETE /ai-config/override`, `GET/PUT /cache-freshness`, `GET/PUT /notification-config`, `GET/PUT /notification-consent`, `GET/PUT /notification-engine-config` (#571 kill-switch; PUT site/app-admin) |
 | `stock-analyser-ai-proxy-{stage}` | `apps/stock-analyser/functions/ai-proxy` | `POST /api/claude` |
-| `stock-analyser-notification-engine-{stage}` | `apps/stock-analyser/functions/notification-engine` | EventBridge scheduled (daily, no HTTP route) |
+| `stock-analyser-notification-engine-{stage}` | `apps/stock-analyser/functions/notification-engine` | EventBridge scheduled (daily, no HTTP route). Warms the market-wide cache `MARKET#{region}` (#584) AND runs notification transitions/sends — both gated by the #571 kill-switch |
 | `stock-analyser-notification-history-{stage}` | `apps/stock-analyser/functions/notification-history` | `GET /notification-history` (#573 run-history; server-scoped per viewer) |
 | `transformotion-cycle-check-{stage}` | `apps/stock-analyser/functions/cycle-check` | EventBridge scheduled (no HTTP route) |
 | `transformotion-cycle-data-{stage}` | `apps/stock-analyser/functions/cycle-data` | `GET /cycle/ohlcv?ticker=` |
-| `transformotion-market-data-{stage}` | `apps/stock-analyser/functions/market-data` | `GET /price/ohlcv?ticker=&range=&interval=` |
+| `transformotion-market-data-{stage}` | `apps/stock-analyser/functions/market-data` | `GET /price/ohlcv?ticker=&range=&interval=`; plus a service-principal `get-ohlcv` invoke branch for the notification engine's #535 grounding (#584) |
 
 ## DynamoDB tables
 

--- a/apps/stock-analyser/CLAUDE.md
+++ b/apps/stock-analyser/CLAUDE.md
@@ -55,11 +55,11 @@ Current state after #366/#386: Stock Analyser owns its REST API Gateway, AI prox
 | `transformotion-analysis-cache-{stage}` | `apps/stock-analyser/functions/analysis-cache` | `GET/PUT/DELETE /analysis-cache/{key}` |
 | `stock-analyser-settings-{stage}` | `apps/stock-analyser/functions/settings` | `GET/PATCH /settings`, `GET /ai-config`, `PUT/DELETE /ai-config/override`, `GET/PUT /cache-freshness`, `GET/PUT /notification-config`, `GET/PUT /notification-consent`, `GET/PUT /notification-engine-config` (#571 kill-switch; PUT site/app-admin) |
 | `stock-analyser-ai-proxy-{stage}` | `apps/stock-analyser/functions/ai-proxy` | `POST /api/claude` |
-| `stock-analyser-notification-engine-{stage}` | `apps/stock-analyser/functions/notification-engine` | EventBridge scheduled (daily, no HTTP route) |
+| `stock-analyser-notification-engine-{stage}` | `apps/stock-analyser/functions/notification-engine` | EventBridge scheduled (daily, no HTTP route). Warms the market-wide cache `MARKET#{region}` (#584) AND runs notification transitions/sends — both gated by the #571 kill-switch |
 | `stock-analyser-notification-history-{stage}` | `apps/stock-analyser/functions/notification-history` | `GET /notification-history` (#573 run-history; server-scoped per viewer) |
 | `transformotion-cycle-check-{stage}` | `apps/stock-analyser/functions/cycle-check` | EventBridge scheduled (no HTTP route) |
 | `transformotion-cycle-data-{stage}` | `apps/stock-analyser/functions/cycle-data` | `GET /cycle/ohlcv?ticker=` |
-| `transformotion-market-data-{stage}` | `apps/stock-analyser/functions/market-data` | `GET /price/ohlcv?ticker=&range=&interval=` |
+| `transformotion-market-data-{stage}` | `apps/stock-analyser/functions/market-data` | `GET /price/ohlcv?ticker=&range=&interval=`; plus a service-principal `get-ohlcv` invoke branch for the notification engine's #535 grounding (#584) |
 
 ## DynamoDB tables
 

--- a/apps/stock-analyser/components/stock-analyser/markets.ts
+++ b/apps/stock-analyser/components/stock-analyser/markets.ts
@@ -5,20 +5,18 @@ import {
   type AnalysisRegion,
   type RecommendationUniverse,
 } from "@transformotion/contracts/stock-analyser/types"
+// REGION_LABELS is owned by the shared market-analysis-signals module (the single
+// source the prompt + the cache-warming job also use); re-exported here for the UI.
+// Relative (not `@/`) so the vitest graph — which has no `@/` alias — resolves it.
+import { REGION_LABELS } from "../../lib/analysis/market-analysis-signals"
 
 export {
   ANALYSIS_REGIONS,
   RECOMMENDATION_UNIVERSES,
   REGION_TO_RECOMMENDATION_UNIVERSES,
+  REGION_LABELS,
   type AnalysisRegion,
   type RecommendationUniverse,
-}
-
-export const REGION_LABELS: Record<AnalysisRegion, string> = {
-  global: "Global",
-  australia: "Australia",
-  us: "US",
-  uk: "UK",
 }
 
 const REGION_LABEL_TO_REGION = Object.fromEntries(

--- a/apps/stock-analyser/components/stock-analyser/tabs/market-analysis-tab.tsx
+++ b/apps/stock-analyser/components/stock-analyser/tabs/market-analysis-tab.tsx
@@ -24,7 +24,7 @@ import {
 } from "lucide-react"
 import { useCacheStatus, useClaude } from "@/lib/hooks"
 import { cn } from "@/lib/utils"
-import type { AnalysisRegion } from "@transformotion/contracts/stock-analyser/types"
+import type { AnalysisRegion, PriceRange, PriceInterval } from "@transformotion/contracts/stock-analyser/types"
 // #535: the Market Analysis result model is now canonical (promoted out of this
 // tab into the contract). Per-card `source` attribution lives on MacroIndicator
 // and SectorSignal; `opportunity` was reconciled away in the promotion.
@@ -36,14 +36,35 @@ import type {
 import {
   ANALYSIS_REGIONS,
   REGION_LABELS,
-  REGION_TO_RECOMMENDATION_UNIVERSES,
   regionFromLabel,
   resolveSectorUniverse,
 } from "../markets"
 import { createMarketSectorNavigationPayload } from "../recommendations-flow"
 import { stockSignalBadgeClassName } from "../status-badge"
 import { buildSectorSuppliedData } from "@/lib/analysis/market-analysis-grounding"
+import { createMarketAnalysisPrompt, MARKET_ANALYSIS_SYSTEM_PROMPT } from "@/lib/analysis/market-analysis-signals"
 import { dynamoCache } from "@/lib/services/cache/dynamo-ttl-cache"
+import { getConfig } from "@/lib/config"
+import { getStockAnalyserClient } from "@/lib/api"
+import { getMockOhlcvData } from "@/lib/services/ai/fixtures/ohlcv-data"
+
+/**
+ * Client OHLCV source for the #535 Bucket-1 grounding — preserves the prior
+ * mock-vs-live split that used to live inside the grounding module. The grounding
+ * builder now takes this as an INJECTED fetcher so the SAME builder is reusable
+ * server-side by the daily cache-warming job (#584).
+ */
+async function fetchClientSectorOhlcv(
+  ticker: string,
+  range: PriceRange,
+  interval: PriceInterval,
+): Promise<readonly number[] | null> {
+  const ohlcv =
+    getConfig().ai.provider === "mock"
+      ? getMockOhlcvData(ticker, range, interval)
+      : await getStockAnalyserClient().getOhlcvData(ticker, range, interval)
+  return ohlcv?.closes ?? null
+}
 
 const IMPACT_STYLES: Record<MacroIndicatorImpact, { bg: string; text: string }> = {
   Supportive: { bg: "bg-signal-green/15", text: "text-signal-green" },
@@ -166,67 +187,23 @@ export function MarketAnalysisTab() {
   }, [defaultSearchMode])
 
   const runAnalysis = async (forceRefresh = false) => {
-    const supportedUniverses = REGION_TO_RECOMMENDATION_UNIVERSES[region]
     // #535 Bucket-1 grounding: only when we will actually call the model (cache
     // miss or forced refresh) fetch real sector OHLCV and feed it in as supplied
     // data, so sector levels/returns are grounded in prices rather than searched.
     // Skipped on a cache hit (the prompt is unused then).
     const willCallModel = forceRefresh || (await dynamoCache.get<MarketAnalysisResult>(cacheKey)) === null
     // Grounding is best-effort: a fetch/format failure must never block analysis.
-    const suppliedSectorData = willCallModel ? await buildSectorSuppliedData(region).catch(() => "") : ""
+    // The OHLCV source is injected so the SAME builder runs server-side (#584).
+    const suppliedSectorData = willCallModel ? await buildSectorSuppliedData(region, fetchClientSectorOhlcv).catch(() => "") : ""
     const data = await callClaude({
       cacheKey,
       forceRefresh,
       onCacheMetadata: cacheStatus.markWritten,
       webSearch: isLive,
-      prompt: `Provide comprehensive market analysis for the ${REGION_LABELS[region]} region.
-
-SOURCE ATTRIBUTION (required, per card): For EACH macro indicator and EACH sector, name the authoritative source you based that card's read on and return it as "source": { "name": string } (e.g. "RBA", "ASX", "EIA"). Prefer authoritative / primary sources — exchanges, central banks, regulators, and established financial press. DO NOT base figures on social media, forums, or unattributed aggregators. Source attribution applies ONLY to the macro indicators and sector cards — NOT to "briefing" or "actionSummary".${suppliedSectorData}
-
-Return a JSON object with the following fields:
-
-"macro" — 4 market condition cards, each with label, title, description, impact ("Supportive" / "Neutral" / "Headwind"), and source ({ name: string }):
-  - cycleStage — where the market is in the economic cycle
-  - rateDirection — current interest rate trend
-  - keyRisk — primary macro risk to watch
-  - currency — USD/currency effect on the market
-
-"briefing" — a 2-3 sentence narrative paragraph summarising the macro outlook (synthesis — no source field)
-
-"sectors" — array of 8 sectors, each with:
-
-  - sector: sector name — one of: Financials, Materials, Energy, Healthcare, Technology, Industrials, Consumer Discretionary, Real Estate & REITs
-
-  - signal: "BUY" / "HOLD" / "EXIT"
-    The overall recommendation, synthesising cycle position, valuation, and momentum.
-
-  - cyclePosition: integer 0–100
-    Where the sector sits in its economic cycle.
-    0 = early cycle (just beginning to recover/accelerate)
-    50 = mid cycle (established trend, neither early nor late)
-    100 = late cycle (extended, peak territory, vulnerable to rotation out)
-    This is a POSITIONAL metric only — it does not imply good or bad.
-
-  - valuation: one of "Cheap" / "Attractive" / "Fair" / "Expensive" / "Overvalued" / "Extended"
-    How the sector is priced relative to its own fundamentals and history.
-    INDEPENDENT of cyclePosition. A sector can be late-cycle but cheap (if beaten down), or early-cycle but expensive (if priced on expectations).
-
-  - change: weekly % change (number, e.g. 2.1 or -0.8)
-    Where SUPPLIED SECTOR DATA is given for a sector, base its level/return read on those figures, not on searched or recalled numbers.
-
-  - reason: 1-2 sentence explanation tying the dimensions together.
-    Example: "Late-cycle but still cheap on forward earnings; defensive qualities attractive as growth slows."
-
-  - bestExchange: the best listing universe for this sector. MUST be one of: ${supportedUniverses.join(", ")}
-
-  - source: { name: string } — the authoritative source this sector's read is based on (use the supplied proxy where given for that sector)
-
-"actionSummary" — top-3 trades (conclusions — no source field):
-  - enter: array of top 3 { sector, reason } to buy/overweight
-  - exit: array of top 3 { sector, reason } to sell/reduce
-
-IMPORTANT: Your entire response must be a single valid JSON object. Begin your response with { and end with }. Do not include any text, preamble, explanation, or markdown outside the JSON.`,
-      systemPrompt: "You are a senior market strategist. Provide institutional-quality sector rotation analysis grounded in authoritative, attributable sources. For every macro indicator and sector card, name the authoritative source you relied on (exchanges, central banks, regulators, established financial press) and never base figures on social media, forums, or unattributed aggregators. Respond with raw JSON only. Do not use markdown code fences.",
+      // #584: prompt + system come from the shared market-analysis-signals module
+      // (the SINGLE source) so the daily warm-write === a live run by construction.
+      prompt: createMarketAnalysisPrompt(region, suppliedSectorData),
+      systemPrompt: MARKET_ANALYSIS_SYSTEM_PROMPT,
     })
 
     if (data) {

--- a/apps/stock-analyser/functions/market-data/src/index.ts
+++ b/apps/stock-analyser/functions/market-data/src/index.ts
@@ -1,5 +1,6 @@
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { DynamoDBDocumentClient, GetCommand, PutCommand } from '@aws-sdk/lib-dynamodb';
+import type { APIGatewayProxyEvent, Context } from 'aws-lambda';
 import {
   withAuth,
   ok,
@@ -20,11 +21,13 @@ const TTL_SECS = 28800; // 8 hours
 const VALID_RANGES    = new Set(['1mo', '3mo', '6mo', '1y', '5y', 'max']);
 const VALID_INTERVALS = new Set(['1d', '1wk', '1mo']);
 
-export const handler = withAuth(async ({ auth, account, event }) => {
-  saData.read(auth, account.accountId);
-
-  const { ticker, range = '1y', interval = '1d' } = event.queryStringParameters ?? {};
-  if (!ticker) throw badRequest('ticker is required');
+/**
+ * Core OHLCV read: SHARED cache-first, then Yahoo via the shared fetcher, then
+ * cache-write. Shared by the authenticated API path AND the service-principal
+ * path (#584), so both return byte-identical OHLCV from the SAME source — the
+ * property the cache-warming job's grounding depends on (warm === live).
+ */
+async function getOhlcv(ticker: string, range: string, interval: string) {
   if (!VALID_RANGES.has(range)) throw badRequest(`range must be one of: ${[...VALID_RANGES].join(', ')}`);
   if (!VALID_INTERVALS.has(interval)) throw badRequest(`interval must be one of: ${[...VALID_INTERVALS].join(', ')}`);
 
@@ -39,7 +42,7 @@ export const handler = withAuth(async ({ auth, account, event }) => {
     const data = typeof cached.Item.data === 'string'
       ? JSON.parse(cached.Item.data)
       : cached.Item.data;
-    return ok({ ...data, source: 'cache' as const });
+    return { ...data, source: 'cache' as const };
   }
 
   let ohlcv: Awaited<ReturnType<typeof fetchOhlcv>>;
@@ -78,5 +81,49 @@ export const handler = withAuth(async ({ auth, account, event }) => {
 
   console.log(`[market-data] Fetched and cached: ${cacheKey}`);
 
-  return ok({ ...payload, source: 'live' as const });
+  return { ...payload, source: 'live' as const };
+}
+
+const apiHandler = withAuth(async ({ auth, account, event }) => {
+  saData.read(auth, account.accountId);
+
+  const { ticker, range = '1y', interval = '1d' } = event.queryStringParameters ?? {};
+  if (!ticker) throw badRequest('ticker is required');
+
+  return ok(await getOhlcv(ticker, range, interval));
 });
+
+// ── #584 service-principal OHLCV read (no JWT/account) ───────────────────────
+// The daily cache-warming job fetches sector-proxy OHLCV for #535 grounding
+// through this branch — the SAME shared market-data source the frontend
+// ultimately hits, so warmed sector data === live. Authorization is the
+// dedicated least-privilege IAM caller (a read of SHARED market data); the
+// invoke is restricted to the notification-engine role.
+interface ServicePrincipalOhlcvEvent {
+  servicePrincipal: 'stock-analyser-notification-engine';
+  operation: 'get-ohlcv';
+  ticker: string;
+  range?: string;
+  interval?: string;
+}
+
+function isServicePrincipalOhlcvEvent(event: unknown): event is ServicePrincipalOhlcvEvent {
+  const candidate = event as Partial<ServicePrincipalOhlcvEvent> | null;
+  return (
+    !!candidate &&
+    candidate.servicePrincipal === 'stock-analyser-notification-engine' &&
+    candidate.operation === 'get-ohlcv' &&
+    typeof candidate.ticker === 'string'
+  );
+}
+
+async function getOhlcvForServicePrincipal(event: ServicePrincipalOhlcvEvent) {
+  return getOhlcv(event.ticker, event.range ?? '3mo', event.interval ?? '1d');
+}
+
+export async function handler(event: APIGatewayProxyEvent | ServicePrincipalOhlcvEvent, _context?: Context) {
+  if (isServicePrincipalOhlcvEvent(event)) {
+    return getOhlcvForServicePrincipal(event);
+  }
+  return apiHandler(event as APIGatewayProxyEvent);
+}

--- a/apps/stock-analyser/functions/notification-engine/src/engine.test.ts
+++ b/apps/stock-analyser/functions/notification-engine/src/engine.test.ts
@@ -83,6 +83,7 @@ function deps(overrides: Partial<NotificationEngineDeps> = {}): NotificationEngi
     readAccountName: vi.fn(async (accountId) => `Acct ${accountId}`),
     recordSendLog: vi.fn(async () => undefined),
     readEngineEnabled: vi.fn(async () => true),
+    warmMarketCache: vi.fn(async () => undefined),
   };
   return { ...base, ...overrides };
 }
@@ -433,6 +434,35 @@ describe('notification send-log (#572)', () => {
     expect(run.sendLog).toMatchObject({ status: 'success', note: 'engine-disabled', accountsEvaluated: 0, emailsSent: 0 });
     expect(run.sendLog.accounts).toEqual([]);
     expect(recordSendLog).toHaveBeenCalledOnce(); // audit record still written via finally
+  });
+
+  it('warms the market cache ONCE per run — not per account, AFTER the kill-switch gate (#584)', async () => {
+    const warmMarketCache = vi.fn(async () => undefined);
+    await runNotificationEngine(deps({
+      listStockAnalyserMembers: vi.fn(async () => [
+        { ...activeMember, accountId: 'acct-a', userId: 'user-a' },
+        { ...activeMember, accountId: 'acct-b', userId: 'user-b' },
+      ]),
+      warmMarketCache,
+    }));
+    expect(warmMarketCache).toHaveBeenCalledTimes(1); // once per run, regardless of 2 accounts
+  });
+
+  it('does NOT warm the market cache when the kill-switch is OFF (#584 inside the #571 gate)', async () => {
+    const warmMarketCache = vi.fn(async () => undefined);
+    const run = await runNotificationEngine(deps({
+      readEngineEnabled: vi.fn(async () => false),
+      warmMarketCache,
+    }));
+    expect(warmMarketCache).not.toHaveBeenCalled(); // whole batch no-ops when OFF
+    expect(run.sendLog.note).toBe('engine-disabled');
+  });
+
+  it('a market-warming failure is best-effort — it does not abort the notification run (#584)', async () => {
+    const warmMarketCache = vi.fn(async () => { throw new Error('all regions failed'); });
+    const run = await runNotificationEngine(deps({ warmMarketCache }));
+    expect(warmMarketCache).toHaveBeenCalledOnce();
+    expect(run.sendLog.accounts.length).toBeGreaterThan(0); // accounts still processed
   });
 
   it('cross-account tripwire: flags a member outcome that is not a member of the account', async () => {

--- a/apps/stock-analyser/functions/notification-engine/src/engine.ts
+++ b/apps/stock-analyser/functions/notification-engine/src/engine.ts
@@ -68,6 +68,12 @@ export interface NotificationEngineDeps {
   recordSendLog: (run: SendLogRun) => Promise<void>;
   /** #571 kill-switch: app-wide `notificationsEnabled` (default ON). */
   readEngineEnabled: () => Promise<boolean>;
+  /**
+   * #584: warm the market-wide analysis cache (`MARKET#{region}` for each
+   * region). Runs ONCE per job execution, AFTER the kill-switch gate, so an
+   * engine-OFF run does NO market warming. Optional so unit tests can omit it.
+   */
+  warmMarketCache?: () => Promise<void>;
 }
 
 export interface NotificationEngineResult {
@@ -505,6 +511,16 @@ export async function runNotificationEngine(deps: NotificationEngineDeps): Promi
       sendLog.note = 'engine-disabled';
       deps.log?.('notification-engine-disabled-skip', { runId: sendLog.runId });
       return result;
+    }
+
+    // #584: warm the market-wide analysis cache ONCE per run, AFTER the
+    // kill-switch gate (engine OFF → no warming AND no sends — the switch pauses
+    // the WHOLE batch, the bigger AI-credit consumer). Best-effort: a warming
+    // failure must never abort the notification run.
+    try {
+      await deps.warmMarketCache?.();
+    } catch (err) {
+      deps.log?.('notification-market-warm-error', { err: String(err) });
     }
 
     const today = deps.today();

--- a/apps/stock-analyser/functions/notification-engine/src/index.ts
+++ b/apps/stock-analyser/functions/notification-engine/src/index.ts
@@ -40,6 +40,9 @@ import {
   type SendLogRun,
 } from './engine';
 import { SEND_LOG_TTL_SECONDS, writeSendLog } from './send-log';
+import { buildSectorSuppliedData, type SectorOhlcvFetcher } from '../../../lib/analysis/market-analysis-grounding';
+import { createMarketAnalysisPrompt, MARKET_ANALYSIS_SYSTEM_PROMPT } from '../../../lib/analysis/market-analysis-signals';
+import { ANALYSIS_REGIONS, type AnalysisRegion } from '@transformotion/contracts/stock-analyser/types';
 
 // removeUndefinedValues (#578): the safety net so a stray `undefined` (e.g. a
 // member with no email) can never throw mid-write and drop subsequent records.
@@ -52,6 +55,8 @@ const ses = new SESv2Client({});
 
 const APP_SLUG = 'stock-analyser';
 const ANALYSIS_TTL_SECONDS = 24 * 60 * 60;
+// #584: MARKET#{region} warm-write TTL — matches the live Market tab's cache TTL.
+const MARKET_TTL_SECONDS = 24 * 60 * 60;
 
 interface RuntimeEnv {
   stage: string;
@@ -64,6 +69,7 @@ interface RuntimeEnv {
   sendLogTable: string;
   accountsTable: string;
   analysisCacheFunctionName: string;
+  marketDataFunctionName: string;
   anthropicSecretName: string;
   openaiSecretName?: string;
   aiConfigTableName?: string;
@@ -93,6 +99,7 @@ function env(): RuntimeEnv {
     sendLogTable: requireEnv('SEND_LOG_TABLE'),
     accountsTable: requireEnv('ACCOUNTS_TABLE'),
     analysisCacheFunctionName: requireEnv('ANALYSIS_CACHE_FUNCTION_NAME'),
+    marketDataFunctionName: requireEnv('MARKET_DATA_FUNCTION_NAME'),
     anthropicSecretName: requireEnv('ANTHROPIC_SECRET_NAME'),
     openaiSecretName: process.env.OPENAI_SECRET_NAME,
     aiConfigTableName: process.env.AI_CONFIG_TABLE,
@@ -404,12 +411,91 @@ async function readEngineEnabled(runtime: RuntimeEnv): Promise<boolean> {
   return typeof enabled === 'boolean' ? enabled : true;
 }
 
+// ── #584 market-wide cache warming ───────────────────────────────────────────
+// Server-side OHLCV for the #535 Bucket-1 grounding: invoke the market-data
+// Lambda's service-principal branch — the SAME shared source the frontend
+// ultimately hits, so warmed sector data === live. Best-effort: any failure
+// yields null and the grounding omits that sector (never blocks the warm).
+function makeServerOhlcvFetcher(runtime: RuntimeEnv): SectorOhlcvFetcher {
+  return async (ticker, range, interval) => {
+    try {
+      const res = await lambda.send(new InvokeCommand({
+        FunctionName: runtime.marketDataFunctionName,
+        InvocationType: 'RequestResponse',
+        Payload: Buffer.from(JSON.stringify({
+          servicePrincipal: 'stock-analyser-notification-engine',
+          operation: 'get-ohlcv',
+          ticker, range, interval,
+        })),
+      }));
+      if (res.FunctionError) return null;
+      const payload = res.Payload ? JSON.parse(Buffer.from(res.Payload).toString('utf8')) : null;
+      const closes = (payload as { closes?: unknown } | null)?.closes;
+      return Array.isArray(closes) ? (closes as number[]) : null;
+    } catch {
+      return null;
+    }
+  };
+}
+
+// SHARED-write the warmed MARKET#{region} entry via the analysis-cache
+// service-principal path (#537 SHARED-prefix; reuses the engine's existing
+// analysis-cache invoke). 24h TTL — matches the live Market tab.
+async function writeSharedMarketCache(runtime: RuntimeEnv, region: AnalysisRegion, data: unknown): Promise<void> {
+  const response = await lambda.send(new InvokeCommand({
+    FunctionName: runtime.analysisCacheFunctionName,
+    InvocationType: 'RequestResponse',
+    Payload: Buffer.from(JSON.stringify({
+      servicePrincipal: 'stock-analyser-notification-engine',
+      operation: 'put-shared-cache',
+      cacheKey: `MARKET#${region}`,
+      data,
+      ttlSeconds: MARKET_TTL_SECONDS,
+      mode: 'live',
+      type: 'market',
+    })),
+  }));
+  if (response.FunctionError) {
+    const payload = response.Payload ? Buffer.from(response.Payload).toString('utf8') : '';
+    throw new Error(`market cache service-principal write failed: ${response.FunctionError} ${payload}`);
+  }
+}
+
+// Warm MARKET#{region} for EVERY region, ONCE per job run. Each region is the
+// SAME grounded computation the live Market tab runs (shared prompt + system +
+// grounding) → the warm-write is identical-to-live by construction. Per-region
+// isolation: one region's model/cache failure never drops the others.
+function makeWarmMarketCache(runtime: RuntimeEnv): () => Promise<void> {
+  const providerFactory = makeAiProviderFactory(runtime);
+  const fetchOhlcv = makeServerOhlcvFetcher(runtime);
+  return async () => {
+    const { provider, config } = await providerFactory();
+    for (const region of ANALYSIS_REGIONS) {
+      try {
+        const suppliedSectorData = await buildSectorSuppliedData(region, fetchOhlcv).catch(() => '');
+        const result = await provider.generate({
+          prompt: createMarketAnalysisPrompt(region, suppliedSectorData),
+          system: MARKET_ANALYSIS_SYSTEM_PROMPT,
+          model: config.model,
+          webSearch: true,
+        });
+        const data = JSON.parse(stripCodeFences(result.content));
+        await writeSharedMarketCache(runtime, region, data);
+        console.log(JSON.stringify({ message: 'notification-market-warm-ok', region }));
+      } catch (err) {
+        console.log(JSON.stringify({ message: 'notification-market-warm-region-error', region, err: String(err) }));
+      }
+    }
+  };
+}
+
 export function createDependencies(runtime: RuntimeEnv = env()): NotificationEngineDeps {
   return {
     today: todayUtc,
     nowEpochSeconds: () => Math.floor(Date.now() / 1000),
     newRunId: () => randomUUID(),
     readEngineEnabled: () => readEngineEnabled(runtime),
+    warmMarketCache: makeWarmMarketCache(runtime),
     readAccountName: (accountId) => readAccountName(runtime, accountId),
     recordSendLog: (run) => recordSendLog(runtime, run),
     listStockAnalyserMembers: () => listStockAnalyserMembers(runtime),

--- a/apps/stock-analyser/infrastructure/stock-analyser-api-stack.ts
+++ b/apps/stock-analyser/infrastructure/stock-analyser-api-stack.ts
@@ -243,6 +243,9 @@ export class StockAnalyserApiStack extends cdk.Stack {
         ANALYSIS_CACHE_TABLE: analysisCacheTable.tableName,
         ACCOUNT_MEMBERS_TABLE: accountMembersTable.tableName,
         ANALYSIS_CACHE_FUNCTION_NAME: cacheFn.functionName,
+        // #584: invoke market-data's service-principal branch for #535 sector
+        // OHLCV grounding when warming MARKET#{region}.
+        MARKET_DATA_FUNCTION_NAME: marketDataFn.functionName,
         ANTHROPIC_SECRET_NAME: anthropicSecret.secretName,
         OPENAI_SECRET_NAME: openaiSecret.secretName,
         AI_CONFIG_TABLE: aiRuntimeConfigTable.tableName,
@@ -279,6 +282,9 @@ export class StockAnalyserApiStack extends cdk.Stack {
     openaiSecret.grantRead(notificationEngineFn);
     aiRuntimeConfigTable.grantReadData(notificationEngineFn);
     cacheFn.grantInvoke(notificationEngineFn);
+    // #584: warm MARKET#{region} — invoke market-data (service-principal OHLCV
+    // grounding) and write the warmed entry via the analysis-cache invoke above.
+    marketDataFn.grantInvoke(notificationEngineFn);
     notificationEngineFn.addToRolePolicy(new iam.PolicyStatement({
       actions: ['ses:SendEmail', 'sesv2:SendEmail'],
       resources: ['*'],

--- a/apps/stock-analyser/lib/analysis/market-analysis-grounding.test.ts
+++ b/apps/stock-analyser/lib/analysis/market-analysis-grounding.test.ts
@@ -1,51 +1,44 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
+import { buildSectorSuppliedData, type SectorOhlcvFetcher } from './market-analysis-grounding'
 
-// Force the live OHLCV branch and control what getOhlcvData returns, so we can
-// feed the null-laden `closes` arrays real feeds produce (Yahoo gaps).
-vi.mock('@/lib/config', () => ({ getConfig: () => ({ ai: { provider: 'live' } }) }))
-const getOhlcvData = vi.fn()
-vi.mock('@/lib/api', () => ({ getStockAnalyserClient: () => ({ getOhlcvData }) }))
-// Unused on the live branch, but mocked so vitest need not resolve the fixture module.
-vi.mock('@/lib/services/ai/fixtures/ohlcv-data', () => ({ getMockOhlcvData: vi.fn() }))
-
-import { buildSectorSuppliedData } from './market-analysis-grounding'
+// The OHLCV source is now INJECTED (#584), so we feed the null-laden `closes`
+// arrays real feeds produce (Yahoo gaps) directly — no module mocks needed.
+const closes = (arr: readonly (number | null)[]): SectorOhlcvFetcher =>
+  vi.fn(async () => arr as unknown as readonly number[])
 
 describe('market-analysis grounding — null-safety (#535 US-market crash regression)', () => {
-  beforeEach(() => getOhlcvData.mockReset())
-
   it('does NOT throw when closes end in null (the crash) — omits the bad sector', async () => {
     // Pre-fix: `closes[len-1]` was null, the `=== undefined`-only guard let it
     // through, and `last.toFixed(2)` threw "Cannot read properties of null".
-    getOhlcvData.mockResolvedValue({ closes: [10, 11, null] })
-    const block = await buildSectorSuppliedData('us')
+    const block = await buildSectorSuppliedData('us', closes([10, 11, null]))
     expect(typeof block).toBe('string')
     expect(block).not.toMatch(/last (null|NaN|undefined)/)
   })
 
   it('keeps a sector when only an INTERIOR close is null (last is finite)', async () => {
-    getOhlcvData.mockResolvedValue({ closes: [10, null, 12] })
-    const block = await buildSectorSuppliedData('us')
+    const block = await buildSectorSuppliedData('us', closes([10, null, 12]))
     expect(block).toContain('SUPPLIED SECTOR DATA')
     expect(block).toMatch(/last 12\.00/)
   })
 
   it('formats finite closes into a supplied-data block', async () => {
-    getOhlcvData.mockResolvedValue({ closes: [100, 102, 105] })
-    const block = await buildSectorSuppliedData('us')
+    const block = await buildSectorSuppliedData('us', closes([100, 102, 105]))
     expect(block).toContain('SUPPLIED SECTOR DATA')
     expect(block).toMatch(/last 105\.00/)
   })
 
   it('returns "" for an unmapped region and never fetches (global / uk)', async () => {
-    expect(await buildSectorSuppliedData('global')).toBe('')
-    expect(await buildSectorSuppliedData('uk')).toBe('')
-    expect(getOhlcvData).not.toHaveBeenCalled()
+    const fetch = vi.fn(async () => [100, 102, 105] as readonly number[])
+    expect(await buildSectorSuppliedData('global', fetch)).toBe('')
+    expect(await buildSectorSuppliedData('uk', fetch)).toBe('')
+    expect(fetch).not.toHaveBeenCalled()
   })
 
-  it('is best-effort: a rejected fetch is omitted, not propagated', async () => {
-    getOhlcvData.mockResolvedValueOnce({ closes: [100, 102, 105] })
-    getOhlcvData.mockResolvedValue({ closes: [50, null, null] }) // others degrade to omitted
-    const block = await buildSectorSuppliedData('us')
+  it('is best-effort: a thrown fetch is omitted, not propagated', async () => {
+    const fetch: SectorOhlcvFetcher = vi.fn(async () => {
+      throw new Error('feed down')
+    })
+    const block = await buildSectorSuppliedData('us', fetch)
     expect(typeof block).toBe('string') // resolved, never threw
   })
 })

--- a/apps/stock-analyser/lib/analysis/market-analysis-grounding.ts
+++ b/apps/stock-analyser/lib/analysis/market-analysis-grounding.ts
@@ -26,10 +26,24 @@
  *   - uk: FULLY UNMAPPED pending owner-supplied FTSE sector proxies.
  */
 
-import { getStockAnalyserClient } from '@/lib/api'
-import { getConfig } from '@/lib/config'
-import { getMockOhlcvData } from '@/lib/services/ai/fixtures/ohlcv-data'
-import type { AnalysisRegion } from '@transformotion/contracts/stock-analyser/types'
+import type {
+  AnalysisRegion,
+  PriceRange,
+  PriceInterval,
+} from '@transformotion/contracts/stock-analyser/types'
+
+/**
+ * OHLCV source, INJECTED by the caller (#584). The frontend passes a client/mock
+ * fetcher; the daily cache-warming job passes a server-side fetcher (market-data
+ * Lambda). Keeping this module free of frontend seams lets the Lambda import it
+ * and produce the SAME supplied-data block the live tab does. Returns `closes`
+ * (most-recent last) or `null` when unavailable.
+ */
+export type SectorOhlcvFetcher = (
+  ticker: string,
+  range: PriceRange,
+  interval: PriceInterval,
+) => Promise<readonly number[] | null>;
 
 /** The eight sectors the Market Analysis prompt enumerates (must match the prompt). */
 export const MARKET_ANALYSIS_SECTORS = [
@@ -110,13 +124,10 @@ function pctChange(closes: readonly number[], lookback: number): number | null {
 async function fetchSectorLevel(
   sector: MarketAnalysisSector,
   ticker: string,
+  fetchOhlcv: SectorOhlcvFetcher,
 ): Promise<SectorLevel | null> {
   try {
-    const ohlcv =
-      getConfig().ai.provider === 'mock'
-        ? getMockOhlcvData(ticker, '3mo', '1d')
-        : await getStockAnalyserClient().getOhlcvData(ticker, '3mo', '1d')
-    const closes = ohlcv?.closes ?? []
+    const closes = (await fetchOhlcv(ticker, '3mo', '1d')) ?? []
     const last = finite(closes[closes.length - 1])
     if (last === null) return null // non-finite/absent last close → omit this sector
     return {
@@ -137,7 +148,10 @@ async function fetchSectorLevel(
  * the model reasons over fed sector levels rather than searching for them.
  * Returns `''` when nothing could be fetched (caller injects nothing).
  */
-export async function buildSectorSuppliedData(region: AnalysisRegion): Promise<string> {
+export async function buildSectorSuppliedData(
+  region: AnalysisRegion,
+  fetchOhlcv: SectorOhlcvFetcher,
+): Promise<string> {
   // Top-level guard: grounding is best-effort and must NEVER reject — a failure
   // here can never be allowed to block the analysis call.
   try {
@@ -146,7 +160,7 @@ export async function buildSectorSuppliedData(region: AnalysisRegion): Promise<s
     if (entries.length === 0) return ''
 
     const levels = (
-      await Promise.all(entries.map(([sector, ticker]) => fetchSectorLevel(sector, ticker)))
+      await Promise.all(entries.map(([sector, ticker]) => fetchSectorLevel(sector, ticker, fetchOhlcv)))
     ).filter((l): l is SectorLevel => l !== null)
 
     if (levels.length === 0) return ''

--- a/apps/stock-analyser/lib/analysis/market-analysis-signals.test.ts
+++ b/apps/stock-analyser/lib/analysis/market-analysis-signals.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest'
+import {
+  REGION_LABELS,
+  MARKET_ANALYSIS_SYSTEM_PROMPT,
+  createMarketAnalysisPrompt,
+} from './market-analysis-signals'
+import { REGION_TO_RECOMMENDATION_UNIVERSES } from '@transformotion/contracts/stock-analyser/types'
+
+// #584: this module is the SINGLE source of the market-analysis prompt, imported
+// by BOTH the live Market tab and the daily cache-warming job. These tests pin
+// the prompt so the warm-write stays identical-to-live by construction.
+
+describe('shared market-analysis prompt (#584)', () => {
+  it('embeds the region label and the region-correct bestExchange universes', () => {
+    const us = createMarketAnalysisPrompt('us', '')
+    expect(us).toContain(`for the ${REGION_LABELS.us} region`)
+    expect(us).toContain(`MUST be one of: ${REGION_TO_RECOMMENDATION_UNIVERSES.us.join(', ')}`)
+
+    const au = createMarketAnalysisPrompt('australia', '')
+    expect(au).toContain('for the Australia region')
+    expect(au).toContain(`MUST be one of: ${REGION_TO_RECOMMENDATION_UNIVERSES.australia.join(', ')}`)
+  })
+
+  it('carries the #535 source-attribution + the full 8-sector contract', () => {
+    const p = createMarketAnalysisPrompt('global', '')
+    expect(p).toContain('SOURCE ATTRIBUTION (required, per card)')
+    for (const sector of [
+      'Financials', 'Materials', 'Energy', 'Healthcare',
+      'Technology', 'Industrials', 'Consumer Discretionary', 'Real Estate & REITs',
+    ]) {
+      expect(p).toContain(sector)
+    }
+  })
+
+  it('splices the supplied-sector-data block immediately after the attribution sentence', () => {
+    const supplied = '\n\nSUPPLIED SECTOR DATA (real market prices ...):\n- Financials (proxy XLF): last 1.00, 1m +1.0%, 3m +1.0%'
+    const grounded = createMarketAnalysisPrompt('us', supplied)
+    const ungrounded = createMarketAnalysisPrompt('us', '')
+    expect(grounded).toContain(supplied)
+    // The grounded prompt is exactly the ungrounded one with the block spliced in
+    // (only difference) — proves grounding is additive, nothing else shifts.
+    expect(grounded).toBe(ungrounded.replace('.\n\nReturn a JSON object', `.${supplied}\n\nReturn a JSON object`))
+    expect(grounded.length).toBe(ungrounded.length + supplied.length)
+  })
+
+  it('exposes the system prompt as a stable constant', () => {
+    expect(MARKET_ANALYSIS_SYSTEM_PROMPT).toMatch(/senior market strategist/)
+    expect(MARKET_ANALYSIS_SYSTEM_PROMPT).toMatch(/raw JSON only/)
+  })
+})

--- a/apps/stock-analyser/lib/analysis/market-analysis-signals.ts
+++ b/apps/stock-analyser/lib/analysis/market-analysis-signals.ts
@@ -1,0 +1,91 @@
+/**
+ * Market Analysis — shared prompt + system message (M19 #584).
+ *
+ * The SINGLE source of the Market Analysis computation, used by BOTH:
+ *   - the live Market tab (components/.../market-analysis-tab.tsx), and
+ *   - the daily cache-warming job (functions/notification-engine).
+ *
+ * This is the same pattern as the per-ticker `stock-analysis-signals.ts`: by
+ * importing ONE prompt definition, the warmed `MARKET#{region}` cache entry is
+ * identical-by-construction to what a live Market-tab run produces. There must
+ * be exactly one copy of this prompt — do NOT inline it in either caller.
+ *
+ * NOTE: the live path writes the RAW model output to the `MARKET#{region}`
+ * cache; the per-card universe enrichment (`recommendationUniverse`,
+ * `sourceRegion`) is applied CLIENT-SIDE on read (see the tab). So warm === live
+ * at the cache requires only the same prompt/system/grounding — which this
+ * module provides. The enrichment intentionally stays in the tab.
+ */
+
+import {
+  REGION_TO_RECOMMENDATION_UNIVERSES,
+  type AnalysisRegion,
+} from '@transformotion/contracts/stock-analyser/types';
+
+/** Human label per region — single source (re-exported by components/markets.ts). */
+export const REGION_LABELS: Record<AnalysisRegion, string> = {
+  global: 'Global',
+  australia: 'Australia',
+  us: 'US',
+  uk: 'UK',
+};
+
+export const MARKET_ANALYSIS_SYSTEM_PROMPT =
+  "You are a senior market strategist. Provide institutional-quality sector rotation analysis grounded in authoritative, attributable sources. For every macro indicator and sector card, name the authoritative source you relied on (exchanges, central banks, regulators, established financial press) and never base figures on social media, forums, or unattributed aggregators. Respond with raw JSON only. Do not use markdown code fences.";
+
+/**
+ * Build the Market Analysis prompt for a region. `suppliedSectorData` is the
+ * #535 Bucket-1 grounding block (real sector OHLCV summary), or `''` when a
+ * region has no proxies — both callers MUST pass the same grounding so the
+ * resulting prompt (and therefore the model output) is identical.
+ */
+export function createMarketAnalysisPrompt(region: AnalysisRegion, suppliedSectorData: string): string {
+  const supportedUniverses = REGION_TO_RECOMMENDATION_UNIVERSES[region];
+  return `Provide comprehensive market analysis for the ${REGION_LABELS[region]} region.
+
+SOURCE ATTRIBUTION (required, per card): For EACH macro indicator and EACH sector, name the authoritative source you based that card's read on and return it as "source": { "name": string } (e.g. "RBA", "ASX", "EIA"). Prefer authoritative / primary sources — exchanges, central banks, regulators, and established financial press. DO NOT base figures on social media, forums, or unattributed aggregators. Source attribution applies ONLY to the macro indicators and sector cards — NOT to "briefing" or "actionSummary".${suppliedSectorData}
+
+Return a JSON object with the following fields:
+
+"macro" — 4 market condition cards, each with label, title, description, impact ("Supportive" / "Neutral" / "Headwind"), and source ({ name: string }):
+  - cycleStage — where the market is in the economic cycle
+  - rateDirection — current interest rate trend
+  - keyRisk — primary macro risk to watch
+  - currency — USD/currency effect on the market
+
+"briefing" — a 2-3 sentence narrative paragraph summarising the macro outlook (synthesis — no source field)
+
+"sectors" — array of 8 sectors, each with:
+
+  - sector: sector name — one of: Financials, Materials, Energy, Healthcare, Technology, Industrials, Consumer Discretionary, Real Estate & REITs
+
+  - signal: "BUY" / "HOLD" / "EXIT"
+    The overall recommendation, synthesising cycle position, valuation, and momentum.
+
+  - cyclePosition: integer 0–100
+    Where the sector sits in its economic cycle.
+    0 = early cycle (just beginning to recover/accelerate)
+    50 = mid cycle (established trend, neither early nor late)
+    100 = late cycle (extended, peak territory, vulnerable to rotation out)
+    This is a POSITIONAL metric only — it does not imply good or bad.
+
+  - valuation: one of "Cheap" / "Attractive" / "Fair" / "Expensive" / "Overvalued" / "Extended"
+    How the sector is priced relative to its own fundamentals and history.
+    INDEPENDENT of cyclePosition. A sector can be late-cycle but cheap (if beaten down), or early-cycle but expensive (if priced on expectations).
+
+  - change: weekly % change (number, e.g. 2.1 or -0.8)
+    Where SUPPLIED SECTOR DATA is given for a sector, base its level/return read on those figures, not on searched or recalled numbers.
+
+  - reason: 1-2 sentence explanation tying the dimensions together.
+    Example: "Late-cycle but still cheap on forward earnings; defensive qualities attractive as growth slows."
+
+  - bestExchange: the best listing universe for this sector. MUST be one of: ${supportedUniverses.join(", ")}
+
+  - source: { name: string } — the authoritative source this sector's read is based on (use the supplied proxy where given for that sector)
+
+"actionSummary" — top-3 trades (conclusions — no source field):
+  - enter: array of top 3 { sector, reason } to buy/overweight
+  - exit: array of top 3 { sector, reason } to sell/reduce
+
+IMPORTANT: Your entire response must be a single valid JSON object. Begin your response with { and end with }. Do not include any text, preamble, explanation, or markdown outside the JSON.`;
+}

--- a/docs/architecture/cdk.md
+++ b/docs/architecture/cdk.md
@@ -210,6 +210,20 @@ delivery. The exemption is backed by tests for SHARED-only cache writes,
 cross-account isolation, and fail-closed delivery; the check is waived, not the
 auth requirement.
 
+#584 (market-wide cache warming): the same engine run, AFTER the #571
+kill-switch gate, warms `MARKET#{region}` for every region by running the SAME
+grounded market-analysis computation the live Market tab runs (shared
+`lib/analysis/market-analysis-signals` prompt + `market-analysis-grounding`),
+then SHARED-writes each result through the existing analysis-cache
+service-principal invoke (`MARKET` is a `SHARED_PREFIXES` key). For the #535
+Bucket-1 grounding it invokes the **market-data** Lambda's service-principal
+`get-ohlcv` branch (the same shared OHLCV source the frontend hits), so the
+engine role gains `lambda:InvokeFunction` on `transformotion-market-data-{stage}`
+and the `MARKET_DATA_FUNCTION_NAME` env var. `market-data`'s service-principal
+branch is JWT-less but reachable only by the granted engine role; the
+authenticated API path keeps its `requireAccountData` gate (so the handler-authz
+check still passes via `saData.read`).
+
 ## Adding a new app's CDK stacks
 
 1. Create `apps/{app-name}/infrastructure/{app-name}-tables-stack.ts` for app-owned tables where needed.

--- a/docs/architecture/data.md
+++ b/docs/architecture/data.md
@@ -225,7 +225,11 @@ Managed by `TransformotionDev-StockAnalyserTables` /
 
 ### `stock-analyser.analysis-cache-{stage}`
 
-Cache of AI analysis results and shared market data.
+Cache of AI analysis results and shared market data. The market-wide entries
+`MARKET#{region}` (`SHARED` partition, 24h TTL) are **warmed daily** by the
+notification engine (#584) so the Market tab reads hit cache instead of running
+a live model call; the warm-write runs the SAME grounded computation as a live
+Market-tab run (identical-by-construction) and is gated by the #571 kill-switch.
 
 | Attribute | Type | Notes |
 |---|---|---|


### PR DESCRIPTION
## What & why
Fixes #584 — the dropped M19 core deliverable. The daily job warmed only per-ticker `ANALYSIS#{ticker}`; it never warmed the `MARKET#{region}` entries the Market tab reads, so opening the Market tab recomputed the full grounded analysis LIVE every time (slow). This warms `MARKET#{global,australia,us,uk}` once per daily run, **identical-to-live by construction**.

## Point 1 (server-callability) — resolved by extraction, not a divergent in-job prompt
The grounded market computation was split between the frontend component (prompt/system inline) and a grounding helper wired to frontend seams — NOT cleanly callable from the job. Per approved Option 1, the build makes the computation a single shared source both callers use:
- **New `lib/analysis/market-analysis-signals.ts`** is the SINGLE source of the market prompt + system message. The live Market tab now **imports** it (inline copy removed) and the job imports the same — exactly one prompt definition, verified **byte-identical** (3110-char prompt + system diffed equal) before removing the inline copy.
- **`buildSectorSuppliedData` (#535 grounding)** refactored to take an **injected OHLCV fetcher**, free of frontend seams. The tab injects its client/mock fetcher (behaviour preserved); the job injects a server fetcher invoking **market-data's new service-principal `get-ohlcv` branch** — the same shared OHLCV source the frontend hits.

## Job wiring (notification-engine)
- `warmMarketCache` runs **ONCE per run, AFTER the #571 kill-switch gate** — engine OFF ⇒ no warming AND no sends. Per-region isolation; best-effort (never aborts notifications).
- SHARED-writes `MARKET#{region}` (24h TTL, `type:'market'`) via the existing analysis-cache service-principal invoke (`MARKET` is a `SHARED_PREFIXES` key).
- Warms the **raw** model output (the live path writes raw; per-card enrichment stays client-side on read) ⇒ warm === live at the cache.

## IAM / env
Engine role gains `lambda:InvokeFunction` on `transformotion-market-data-{stage}` + `MARKET_DATA_FUNCTION_NAME`. market-data's authenticated path keeps its `requireAccountData` gate.

## Tests (120 SA tests pass; SA + CDK typecheck clean; authz guard OK)
Shared prompt parity/content; grounding via injected fetcher; warm ONCE per run (not per account); NO warm when kill-switch OFF; warm failure best-effort. The market-data SP branch reuses the API-exercised `getOhlcv` core and is integration-verified by the dev warmed===live check.

## §2.1 docs
`cdk.md` (engine #584 warming, market-data SP branch, IAM/env), `data.md` (`MARKET#{region}` warmed daily, kill-switch-gated), SA `CLAUDE.md`/`AGENTS.md` (lambda rows).

## v0 freshness
- [x] No v0 impact:

Reason: The `market-analysis-tab.tsx` + `markets.ts` edits are a non-presentational extraction of runtime AI logic (prompt/system + grounding source) into a shared lib. No JSX/markup/layout/className/copy change, no contract or mock-shape change, and the extracted prompt is provably byte-identical (3110-char prompt + system diffed equal) to the prior inline one. The UI renders exactly as before; only the computation source moved so the daily warming job can reuse it.

## After merge + deploy
`apps/stock-analyser/**` triggers the SA deploy. Dev verification post-deploy: a job run (engine ON) writes `MARKET#{global,australia,us,uk}` @24h TTL full grounded shape; Market tab gets cache hits; **warmed === live on a grounded region (us/australia)** vs a `forceRefresh` live run; engine OFF writes none.

## Status
**Held for owner merge.**
