### PR TITLE
fix(m19-586): AI Engine override app-level (was per-account; broke batch)

### DIFF
--- a/apps/launchpad/functions/ai-runtime-config/src/index.test.ts
+++ b/apps/launchpad/functions/ai-runtime-config/src/index.test.ts
@@ -138,11 +138,8 @@ describe('ai-runtime-config handler', () => {
       [PLATFORM_DEFAULT_SK]: record(PLATFORM_DEFAULT_SK, 'claude', 'claude-sonnet-4-6'),
       [appOverrideSk('stock-analyser')]: record(appOverrideSk('stock-analyser'), 'claude', 'claude-haiku-4-5-20251001'),
       'budget-tracker.settings-dev|accountId=bt-account|settingKey=AI_CONFIG#APP#budget-tracker': record(appOverrideSk('budget-tracker'), 'openai', 'gpt-5.4-mini'),
-      'stock-analyser.settings-dev|pk=ACCOUNT#sa-account|sk=APP#AI_RUNTIME': {
-        pk: 'ACCOUNT#sa-account',
-        sk: 'APP#AI_RUNTIME',
-        config: record(appOverrideSk('stock-analyser'), 'openai', 'gpt-5.5'),
-      },
+      // #586: SA AI override is APP-LEVEL — top-level record at {AI_CONFIG, APP#stock-analyser}.
+      'stock-analyser.settings-dev|pk=AI_CONFIG|sk=APP#stock-analyser': record(appOverrideSk('stock-analyser'), 'openai', 'gpt-5.5'),
     });
     const handler = createHandler({
       client,

--- a/apps/launchpad/functions/ai-runtime-config/src/index.ts
+++ b/apps/launchpad/functions/ai-runtime-config/src/index.ts
@@ -36,7 +36,6 @@ const CONFIG_TABLE = process.env.AI_CONFIG_TABLE!;
 const BUDGET_TRACKER_SETTINGS_TABLE = process.env.BUDGET_TRACKER_SETTINGS_TABLE;
 const STOCK_ANALYSER_SETTINGS_TABLE = process.env.STOCK_ANALYSER_SETTINGS_TABLE;
 const BUDGET_TRACKER_SETTING_KEY = 'AI_CONFIG#APP#budget-tracker';
-const STOCK_ANALYSER_AI_RUNTIME_SK = 'APP#AI_RUNTIME';
 
 interface Dependencies {
   client: DynamoDBDocumentClient;
@@ -142,13 +141,14 @@ async function readBudgetTrackerAppOverride(
 
 async function readStockAnalyserAppOverride(
   deps: Dependencies,
-  auth: AuthClaims,
 ): Promise<AiRuntimeConfigRecord | null> {
-  const accountId = firstAccountId(auth, 'stock-analyser');
-  if (!deps.stockAnalyserSettingsTable || !accountId) return null;
+  // #586: the Stock Analyser AI override is APP-LEVEL — one record at
+  // {AI_CONFIG, APP#stock-analyser} in the SA settings table (was per-account
+  // {ACCOUNT#…, APP#AI_RUNTIME}). This admin view just reflects it.
+  if (!deps.stockAnalyserSettingsTable) return null;
   const res = await deps.client.send(new GetCommand({
     TableName: deps.stockAnalyserSettingsTable,
-    Key: { pk: `ACCOUNT#${accountId}`, sk: STOCK_ANALYSER_AI_RUNTIME_SK },
+    Key: { pk: AI_CONFIG_PK, sk: appOverrideSk('stock-analyser') },
   }));
   return parseRecord(res.Item, appOverrideSk('stock-analyser'));
 }
@@ -163,7 +163,7 @@ async function readAppOwnedOverride(
       return await readBudgetTrackerAppOverride(deps, auth);
     }
     if (appSlug === 'stock-analyser') {
-      return await readStockAnalyserAppOverride(deps, auth);
+      return await readStockAnalyserAppOverride(deps);
     }
   } catch (err) {
     console.warn(`[launchpad-ai-runtime-config] App-owned AI override read failed for ${appSlug}:`, err);

--- a/apps/stock-analyser/functions/ai-proxy/src/index.ts
+++ b/apps/stock-analyser/functions/ai-proxy/src/index.ts
@@ -1,4 +1,4 @@
-import { createAiProxyHandler } from '@transformotion/fn-ai-proxy-core';
+import { createAiProxyHandler, AI_CONFIG_PK, appOverrideSk } from '@transformotion/fn-ai-proxy-core';
 
 export const handler = createAiProxyHandler({
   appSlug: 'stock-analyser',
@@ -6,9 +6,12 @@ export const handler = createAiProxyHandler({
   openaiSecretName: process.env.OPENAI_SECRET_NAME,
   aiConfigTableName: process.env.AI_CONFIG_TABLE,
   appOverrideTableName: process.env.APP_AI_CONFIG_TABLE,
-  appOverrideKey: (accountId) => ({
-    pk: `ACCOUNT#${accountId}`,
-    sk: 'APP#AI_RUNTIME',
+  // #586: the AI Engine override is APP-LEVEL — read the same {AI_CONFIG,
+  // APP#stock-analyser} record the batch engine reads (was per-account
+  // {ACCOUNT#…, APP#AI_RUNTIME}, which only the live app honoured).
+  appOverrideKey: () => ({
+    pk: AI_CONFIG_PK,
+    sk: appOverrideSk('stock-analyser'),
   }),
   fallbackProvider: process.env.AI_FALLBACK_PROVIDER,
   fallbackModel: process.env.AI_FALLBACK_MODEL,

--- a/apps/stock-analyser/functions/settings/src/index.test.ts
+++ b/apps/stock-analyser/functions/settings/src/index.test.ts
@@ -91,6 +91,26 @@ describe('Stock Analyser settings handler', () => {
     });
   });
 
+  it('AI override save writes ONE app-level record (top-level shape), not a per-account row (#586)', async () => {
+    const { deps, getItem } = createFakeDeps();
+    const res = await createHandler(deps)(makeEvent(
+      'PUT',
+      { provider: 'openai', model: 'gpt-5.4-mini' },
+      { resource: '/ai-config/override', groups: 'site-admin' },
+    ));
+
+    expect(res.statusCode).toBe(200);
+    const written = getItem() as Record<string, unknown>;
+    // App-level key the engine + ai-proxy read — NOT {ACCOUNT#…, APP#AI_RUNTIME}.
+    expect(written.pk).toBe('AI_CONFIG');
+    expect(written.sk).toBe('APP#stock-analyser');
+    // Top-level provider/model (not nested under `config`) — the shape the resolver reads.
+    expect(written.provider).toBe('openai');
+    expect(written.model).toBe('gpt-5.4-mini');
+    expect(written).not.toHaveProperty('config');
+    expect(String(written.pk)).not.toMatch(/^ACCOUNT#/);
+  });
+
   it('patches defaultSearchMode without mutating explanatory text to an invalid value', async () => {
     const { deps, getItem } = createFakeDeps({
       pk: 'ACCOUNT#acct-1',

--- a/apps/stock-analyser/functions/settings/src/index.ts
+++ b/apps/stock-analyser/functions/settings/src/index.ts
@@ -87,7 +87,6 @@ function userPreferencesSk(userId: string) {
   return `USER#${userId}#PREFERENCES`;
 }
 
-const aiRuntimeSk = 'APP#AI_RUNTIME';
 const cacheFreshnessKey = {
   pk: 'SETTINGS',
   sk: 'CACHE_FRESHNESS#stock-analyser',
@@ -161,10 +160,14 @@ async function readPlatformDefault(deps: Dependencies): Promise<AiRuntimeConfigR
   return parseRecord(res.Item);
 }
 
-async function readAppOverride(deps: Dependencies, accountId: string): Promise<AiRuntimeConfigRecord | null> {
+// #586: the AI Engine override is APP-LEVEL — one record at {AI_CONFIG,
+// APP#stock-analyser} read by BOTH the live app (ai-proxy) and the batch job
+// (notification engine), in the top-level shape the resolver expects. (Was
+// per-account {ACCOUNT#…, APP#AI_RUNTIME}, which the batch never read.)
+async function readAppOverride(deps: Dependencies): Promise<AiRuntimeConfigRecord | null> {
   const res = await deps.client.send(new GetCommand({
     TableName: deps.settingsTable,
-    Key: { pk: accountPk(accountId), sk: aiRuntimeSk },
+    Key: { pk: AI_CONFIG_PK, sk: appOverrideSk(APP_SLUG) },
   }));
   return parseRecord(res.Item);
 }
@@ -265,10 +268,10 @@ async function patchSettings(deps: Dependencies, event: APIGatewayProxyEvent, ac
   return ok({ settings });
 }
 
-async function readAiConfig(deps: Dependencies, accountId: string) {
+async function readAiConfig(deps: Dependencies) {
   const [platformDefault, appOverride] = await Promise.all([
     readPlatformDefault(deps),
-    readAppOverride(deps, accountId),
+    readAppOverride(deps),
   ]);
   return ok(aiConfigResponse(platformDefault, appOverride));
 }
@@ -388,8 +391,10 @@ async function updateCacheFreshnessConfig(deps: Dependencies, event: APIGatewayP
   return ok({ config });
 }
 
-async function updateOverride(deps: Dependencies, event: APIGatewayProxyEvent, accountId: string) {
+async function updateOverride(deps: Dependencies, event: APIGatewayProxyEvent) {
   const { provider, model } = parseAiUpdateBody(event);
+  // #586: write ONE app-level record, TOP-LEVEL shape (provider/model on the
+  // item, not nested under `config`) so the engine's resolver reads it directly.
   const appOverride: AiRuntimeConfigRecord = {
     pk: AI_CONFIG_PK,
     sk: appOverrideSk(APP_SLUG),
@@ -399,21 +404,16 @@ async function updateOverride(deps: Dependencies, event: APIGatewayProxyEvent, a
   };
   await deps.client.send(new PutCommand({
     TableName: deps.settingsTable,
-    Item: {
-      pk: accountPk(accountId),
-      sk: aiRuntimeSk,
-      config: appOverride,
-      updatedAt: appOverride.updatedAt,
-    },
+    Item: appOverride,
   }));
   const platformDefault = await readPlatformDefault(deps);
   return ok(aiConfigResponse(platformDefault, appOverride));
 }
 
-async function resetOverride(deps: Dependencies, accountId: string) {
+async function resetOverride(deps: Dependencies) {
   await deps.client.send(new DeleteCommand({
     TableName: deps.settingsTable,
-    Key: { pk: accountPk(accountId), sk: aiRuntimeSk },
+    Key: { pk: AI_CONFIG_PK, sk: appOverrideSk(APP_SLUG) },
   }));
   return noContent();
 }
@@ -567,7 +567,7 @@ export function createHandler(deps: Dependencies = defaultDependencies) {
     }
     if (resource === '/ai-config' && event.httpMethod === 'GET') {
       saData.read(auth, account.accountId);
-      return readAiConfig(deps, account.accountId);
+      return readAiConfig(deps);
     }
     if (resource === '/cache-freshness' && event.httpMethod === 'GET') {
       saData.read(auth, account.accountId);
@@ -578,18 +578,19 @@ export function createHandler(deps: Dependencies = defaultDependencies) {
       requireCacheFreshnessAdmin(auth);
       return updateCacheFreshnessConfig(deps, event);
     }
-    // /ai-config/override is operational-config (D9) — site-admin write of an
-    // account-shared config row. Interim: preserve current behaviour (member +
-    // site-admin). PR-C rehomes this to app-level config gated by app-admin.
+    // /ai-config/override is APP-LEVEL operational config (#586): one record at
+    // {AI_CONFIG, APP#stock-analyser} governing the whole app (live + batch),
+    // site-admin write. (saData.read still establishes the account context for
+    // the D9 read gate; the override itself is no longer per-account.)
     if (resource === '/ai-config/override' && event.httpMethod === 'PUT') {
       saData.read(auth, account.accountId);
       requireSiteAdmin(auth);
-      return updateOverride(deps, event, account.accountId);
+      return updateOverride(deps, event);
     }
     if (resource === '/ai-config/override' && event.httpMethod === 'DELETE') {
       saData.read(auth, account.accountId);
       requireSiteAdmin(auth);
-      return resetOverride(deps, account.accountId);
+      return resetOverride(deps);
     }
 
     // ── Notification engine kill-switch (M19 #571, app-wide) ─────────────────

--- a/docs/architecture/data.md
+++ b/docs/architecture/data.md
@@ -260,8 +260,14 @@ preferences, and notification delivery consent.
 
 | Attribute | Type | Notes |
 |---|---|---|
-| `pk` (PK) | String | `SETTINGS`, `ACCOUNT#{accountId}`, or `NOTIFICATION_CONSENT#{accountId}` |
-| `sk` (SK) | String | `CACHE_FRESHNESS#stock-analyser`, `NOTIFICATION_ENGINE_CONFIG#stock-analyser` (#571 kill-switch), `NOTIFICATIONS#{accountId}`, `USER#{userId}#PREFERENCES`, `USER#{userId}`, or `APP#AI_RUNTIME` |
+| `pk` (PK) | String | `SETTINGS`, `ACCOUNT#{accountId}`, `NOTIFICATION_CONSENT#{accountId}`, or `AI_CONFIG` (#586 app-level AI override) |
+| `sk` (SK) | String | `CACHE_FRESHNESS#stock-analyser`, `NOTIFICATION_ENGINE_CONFIG#stock-analyser` (#571 kill-switch), `NOTIFICATIONS#{accountId}`, `USER#{userId}#PREFERENCES`, `USER#{userId}`, or `APP#stock-analyser` (#586 AI Engine override, under `pk=AI_CONFIG`) |
+
+The **AI Engine override** (#586) is **app-level**: ONE record at `AI_CONFIG` /
+`APP#stock-analyser` (`{ provider, model, updatedAt }`, top-level shape), read by
+BOTH the live app (ai-proxy) and the daily batch engine. It replaced a
+per-account `ACCOUNT#{accountId}` / `APP#AI_RUNTIME` row that the batch never
+read — see [auth/route classification](./route-classification-m16.md).
 
 The app-wide **engine kill-switch** (#571) lives at `SETTINGS` /
 `NOTIFICATION_ENGINE_CONFIG#stock-analyser` — `{ notificationsEnabled, updatedAt }`,

--- a/docs/architecture/route-classification-m16.md
+++ b/docs/architecture/route-classification-m16.md
@@ -38,7 +38,7 @@ This table is the **security-review artifact** for the site-admin-bypass removal
 | `GET /settings` | settings | …+ requireAccountAccess(member) | `requireAccountData.read` | **D12 user-scoped** `SK=USER#{userId}#PREFERENCES` | Confirmed | PR-B |
 | `PATCH /settings` | settings | …+ requireAccountAccess(member) | `requireAccountData.read` **+ handler SK-owner match** | **D12 user-scoped: viewer MAY write OWN prefs** — NOT `.write` (which rejects viewer) | Confirmed | PR-B |
 | `GET /ai-config` | settings | …+ requireAccountAccess(member) | `operational-config` (read) | effective AI config; retiring | Status-uncertain-resolved | PR-C |
-| `PUT/DELETE /ai-config/override` | settings | …+ **requireSiteAdmin** | `operational-config` → **app-admin** (D9) | per-account `APP#AI_RUNTIME`; **rehomed app-level** | Aspirational-never-built (site-admin write of account config) | PR-C |
+| `PUT/DELETE /ai-config/override` | settings | …+ **requireSiteAdmin** | `operational-config` → **app-admin** (D9) | **app-level** `AI_CONFIG` / `APP#stock-analyser` (top-level), read by live app + batch engine (#586; was per-account `APP#AI_RUNTIME`, which the batch never read) | **Implemented app-level (#586)** | #586 |
 
 ## 2. Budget Tracker — app-data routes (`requireAccountData('budget-tracker')`)
 


### PR DESCRIPTION
## What & why
Fixes #586. The AI Engine override is **app-level** (site-admin, governs the whole app) but was persisted **per-account** at `{ACCOUNT#{accountId}, APP#AI_RUNTIME}`. The live app (ai-proxy) read that per-account key so it honoured the OpenAI choice — but the **batch engine** reads the app-level key `{AI_CONFIG, APP#stock-analyser}`, which **nothing wrote**, so it fell to the platform default (Claude) and ignored the owner's choice. The "claude API error: credit too low" on every batch call was the symptom; this grain mismatch is the cause. It also broke #584 `warm===live` at the **provider** level (live = OpenAI, warm = Claude).

## Decision (owner, recorded)
The override is **app-level**: one record, one provider, read by both the live app and the batch. The per-account implementation was the defect.

## Step 0 — provenance (v0)
The AI Engine card already **presents** as app-level (site-admin-gated, "Stock Analyser uses…", no per-account framing anywhere in the surface). So this is a **storage/grain fix behind an unchanged surface** → runtime-only, no v0 change.

## Changes
- **settings `updateOverride`** writes ONE record at `{AI_CONFIG, APP#stock-analyser}` in the **top-level** shape the resolver reads (provider/model on the item, not nested under `config`, not per-account). `readAppOverride` + `resetOverride` repointed to that key.
- **ai-proxy `appOverrideKey`** repointed from per-account `{ACCOUNT#…, APP#AI_RUNTIME}` to the same app-level `{AI_CONFIG, APP#stock-analyser}`. The engine already reads it → live app + batch now resolve the **same** record.
- **launchpad `ai-runtime-config`** admin view (read-only display) repointed to the app-level key too — so **no path still reads the per-account key**. Removed the dead `APP#AI_RUNTIME` constant. `parseRecord` there already accepts the top-level shape.

## Tests (SA settings 22 · launchpad ai-runtime-config 7 · resolver 10 — all green; SA+launchpad typecheck/lint clean; authz guard OK)
- The card's save writes `{AI_CONFIG, APP#stock-analyser}` (top-level), **not** a per-account row.
- The launchpad admin view resolves the app-level override.
- The resolver already covers app-level top-level → `app_override`.

## Migration (post-merge, dev data — NOT in this PR)
After merge+deploy (so ai-proxy reads app-level before the per-account rows go): seed `{AI_CONFIG, APP#stock-analyser}` = `openai/gpt-5.5` (the chosen value), then delete the two stale per-account rows (`acct-sa-steve`, `a03f9cd4`).

## v0 freshness
- [x] No v0 impact:

Reason: Backend only (settings, ai-proxy, launchpad ai-runtime-config) + architecture docs. No `app/`, `components/`, UI `lib/`, `stores/`, `hooks/`, services, or `packages/contracts/` paths changed. The AI Engine card surface is unchanged — it already presented as app-level; this only moves where the value is stored/read.

## After merge + deploy
Both SA and launchpad deploy lanes trigger (settings/ai-proxy → SA; ai-runtime-config → launchpad). Then the migration makes the app's OpenAI choice govern the batch — which unblocks #584's verification for free: an engine invoke warms `MARKET#{region}` on **OpenAI** (sidestepping the exhausted Anthropic credit), and the warmed===live structural check on us/australia can finally run.

## Status
**Held for owner merge.**
