### PR TITLE
[codex] Log non-JSON AI analysis responses

### DIFF
--- a/apps/stock-analyser/functions/notification-engine/src/engine.test.ts
+++ b/apps/stock-analyser/functions/notification-engine/src/engine.test.ts
@@ -130,6 +130,25 @@ describe('notification transition predicate', () => {
   });
 });
 
+describe('notification engine analysis error reporting', () => {
+  it('records a useful account error when ticker analysis returns non-JSON output', async () => {
+    const run = await runNotificationEngine(deps({
+      readPortfolio: vi.fn(async () => []),
+      readWatchlist: vi.fn(async () => [{ ticker: 'FMG.AX', name: 'Fortescue', addedAt: 1 }]),
+      generateAnalysis: vi.fn(async () => {
+        throw new Error('model output unparseable while analysing FMG.AX');
+      }),
+    }));
+
+    expect(run.sendLog.status).toBe('partial');
+    expect(run.sendLog.accounts[0]).toMatchObject({
+      accountId: 'acct-a',
+      status: 'failed',
+      error: 'model output unparseable while analysing FMG.AX',
+    });
+  });
+});
+
 describe('notification due check', () => {
   it('skips accounts whose interval has not elapsed and processes due accounts', () => {
     expect(accountIsDue([{ accountId: 'acct-a', sk: 'x', type: 'Portfolio', ticker: 'CBA.AX', lastProcessedDate: '2026-06-25' }], 7, '2026-06-26')).toBe(false);
@@ -209,7 +228,11 @@ describe('notification engine account processing', () => {
     await runNotificationEngine(engineDeps);
 
     expect(generateAnalysis).toHaveBeenCalledTimes(1);
-    expect(generateAnalysis).toHaveBeenCalledWith('CBA.AX');
+    expect(generateAnalysis).toHaveBeenCalledWith('CBA.AX', expect.objectContaining({
+      accountId: 'acct-a',
+      runId: 'run-test',
+      sourceType: 'Portfolio',
+    }));
     expect(writeSharedAnalysisCache).toHaveBeenCalledTimes(1);
     expect(writeSharedAnalysisCache).toHaveBeenCalledWith('CBA.AX', expect.objectContaining({ ticker: 'CBA.AX' }));
   });

--- a/apps/stock-analyser/functions/notification-engine/src/engine.ts
+++ b/apps/stock-analyser/functions/notification-engine/src/engine.ts
@@ -43,6 +43,12 @@ export interface NotificationTransition {
   analysis: StockAnalysisResult;
 }
 
+export interface AnalysisGenerationContext {
+  accountId: string;
+  runId: string;
+  sourceType: NotificationSourceType;
+}
+
 export interface NotificationEngineDeps {
   today: () => string;
   nowEpochSeconds: () => number;
@@ -55,7 +61,7 @@ export interface NotificationEngineDeps {
   readPortfolio: (accountId: string) => Promise<PortfolioHolding[]>;
   readWatchlist: (accountId: string) => Promise<WatchlistItem[]>;
   readSharedAnalysisCache: (ticker: string) => Promise<StockAnalysisResult | null>;
-  generateAnalysis: (ticker: string) => Promise<StockAnalysisResult>;
+  generateAnalysis: (ticker: string, context?: AnalysisGenerationContext) => Promise<StockAnalysisResult>;
   writeSharedAnalysisCache: (ticker: string, analysis: StockAnalysisResult) => Promise<void>;
   sendEmail: (recipient: MemberRow, transition: NotificationTransition) => Promise<void>;
   log?: (message: string, context?: Record<string, unknown>) => void;
@@ -296,7 +302,7 @@ function configEnablesType(config: NotificationAccountConfig, type: Notification
 
 function createAnalysisResolver(deps: NotificationEngineDeps) {
   const memo = new Map<string, Promise<StockAnalysisResult>>();
-  return (ticker: string): Promise<StockAnalysisResult> => {
+  return (ticker: string, context?: AnalysisGenerationContext): Promise<StockAnalysisResult> => {
     const normalisedTicker = ticker.toUpperCase();
     const existing = memo.get(normalisedTicker);
     if (existing) return existing;
@@ -305,7 +311,7 @@ function createAnalysisResolver(deps: NotificationEngineDeps) {
       const cached = await deps.readSharedAnalysisCache(normalisedTicker);
       if (cached) return cached;
 
-      const generated = await deps.generateAnalysis(normalisedTicker);
+      const generated = await deps.generateAnalysis(normalisedTicker, context);
       await deps.writeSharedAnalysisCache(normalisedTicker, generated);
       return generated;
     })();
@@ -316,8 +322,9 @@ function createAnalysisResolver(deps: NotificationEngineDeps) {
 
 async function processTicker(
   deps: NotificationEngineDeps,
-  resolveAnalysis: (ticker: string) => Promise<StockAnalysisResult>,
+  resolveAnalysis: (ticker: string, context?: AnalysisGenerationContext) => Promise<StockAnalysisResult>,
   accountId: string,
+  runId: string,
   type: NotificationSourceType,
   ticker: string,
   previous: NotificationStateRecord | undefined,
@@ -325,7 +332,7 @@ async function processTicker(
   today: string,
 ): Promise<{ transition: NotificationTransition; sentUserIds: string[]; sent: number }> {
   const normalisedTicker = ticker.toUpperCase();
-  const analysis = await resolveAnalysis(normalisedTicker);
+  const analysis = await resolveAnalysis(normalisedTicker, { accountId, runId, sourceType: type });
 
   const transition = evaluateTransition({ accountId, type, ticker: normalisedTicker, analysis, previous });
   const sentUserIds: string[] = [];
@@ -376,7 +383,7 @@ export function assertNoCrossAccount(
 
 async function processAccount(
   deps: NotificationEngineDeps,
-  resolveAnalysis: (ticker: string) => Promise<StockAnalysisResult>,
+  resolveAnalysis: (ticker: string, context?: AnalysisGenerationContext) => Promise<StockAnalysisResult>,
   accountId: string,
   accountName: string | undefined,
   candidateMembers: MemberRow[],
@@ -438,6 +445,7 @@ async function processAccount(
       deps,
       resolveAnalysis,
       accountId,
+      sendLog.runId,
       item.type,
       item.ticker,
       statesByKey.get(stateSk(item.type, item.ticker)),

--- a/apps/stock-analyser/functions/notification-engine/src/index.test.ts
+++ b/apps/stock-analyser/functions/notification-engine/src/index.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from 'vitest';
+import { parseStockAnalysisProviderResult } from './index';
+
+describe('notification-engine AI result parsing', () => {
+  it('logs model-output parse failures with provider, model, ticker, account, run, and output prefix', () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    try {
+      expect(() => parseStockAnalysisProviderResult({
+        content: '<!DOCTYPE html><title>not json</title>',
+        provider: 'openai',
+        model: 'gpt-5.5',
+        inputTokens: 10,
+        outputTokens: 20,
+      }, 'FMG.AX', {
+        accountId: 'a03f9cd4-951f-463a-8b34-73c0f046e672',
+        runId: 'run-1',
+        sourceType: 'Watchlist',
+      })).toThrow('model output unparseable while analysing FMG.AX');
+
+      const logged = JSON.parse(String(logSpy.mock.calls.at(-1)?.[0])) as Record<string, unknown>;
+      expect(logged).toMatchObject({
+        message: 'notification-analysis-model-output-unparseable',
+        phase: 'model_output_json_parse',
+        provider: 'openai',
+        model: 'gpt-5.5',
+        ticker: 'FMG.AX',
+        accountId: 'a03f9cd4-951f-463a-8b34-73c0f046e672',
+        runId: 'run-1',
+        sourceType: 'Watchlist',
+        modelOutputPrefix: '<!DOCTYPE html><title>not json</title>',
+      });
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
+});

--- a/apps/stock-analyser/functions/notification-engine/src/index.ts
+++ b/apps/stock-analyser/functions/notification-engine/src/index.ts
@@ -10,9 +10,11 @@ import { InvokeCommand, LambdaClient } from '@aws-sdk/client-lambda';
 import { SESv2Client, SendEmailCommand } from '@aws-sdk/client-sesv2';
 import type { ScheduledEvent } from 'aws-lambda';
 import {
+  AiProviderNonJsonError,
   createAiProvider,
   resolveAiRuntimeConfig,
   type AiProvider,
+  type AiProviderResult,
   type ResolvedAiRuntimeConfig,
 } from '@transformotion/fn-ai-proxy-core';
 import {
@@ -33,6 +35,7 @@ import { buildNotificationEmail } from './email';
 import { randomUUID } from 'crypto';
 import {
   runNotificationEngine,
+  type AnalysisGenerationContext,
   type MemberRow,
   type NotificationEngineDeps,
   type NotificationStateRecord,
@@ -57,6 +60,7 @@ const APP_SLUG = 'stock-analyser';
 const ANALYSIS_TTL_SECONDS = 24 * 60 * 60;
 // #584: MARKET#{region} warm-write TTL — matches the live Market tab's cache TTL.
 const MARKET_TTL_SECONDS = 24 * 60 * 60;
+const AI_RESPONSE_LOG_PREFIX_CHARS = 1000;
 
 interface RuntimeEnv {
   stage: string;
@@ -286,6 +290,58 @@ function stripCodeFences(text: string): string {
     .trim();
 }
 
+function textPrefix(value: string): string {
+  return value.slice(0, AI_RESPONSE_LOG_PREFIX_CHARS);
+}
+
+function logAnalysisGenerationError(
+  message: string,
+  context: {
+    ticker: string;
+    provider: string;
+    model: string;
+    generationContext?: AnalysisGenerationContext;
+    err?: unknown;
+    details?: Record<string, unknown>;
+  },
+) {
+  console.log(JSON.stringify({
+    message,
+    ticker: context.ticker,
+    provider: context.provider,
+    model: context.model,
+    accountId: context.generationContext?.accountId,
+    runId: context.generationContext?.runId,
+    sourceType: context.generationContext?.sourceType,
+    ...(context.details ?? {}),
+    ...(context.err ? { err: context.err instanceof Error ? context.err.message : String(context.err) } : {}),
+  }));
+}
+
+export function parseStockAnalysisProviderResult(
+  result: AiProviderResult,
+  ticker: string,
+  generationContext?: AnalysisGenerationContext,
+): StockAnalysisResult {
+  const rawOutput = stripCodeFences(result.content);
+  try {
+    return normaliseStockAnalysisSignals(JSON.parse(rawOutput) as StockAnalysisResult);
+  } catch (err) {
+    logAnalysisGenerationError('notification-analysis-model-output-unparseable', {
+      ticker,
+      provider: result.provider,
+      model: result.model,
+      generationContext,
+      err,
+      details: {
+        phase: 'model_output_json_parse',
+        modelOutputPrefix: textPrefix(rawOutput),
+      },
+    });
+    throw new Error(`model output unparseable while analysing ${ticker}`);
+  }
+}
+
 function makeAiProviderFactory(runtime: RuntimeEnv) {
   let cached: Promise<{ provider: AiProvider; config: ResolvedAiRuntimeConfig }> | null = null;
   return async () => {
@@ -315,15 +371,37 @@ function makeAiProviderFactory(runtime: RuntimeEnv) {
 
 function makeGenerateAnalysis(runtime: RuntimeEnv) {
   const providerFactory = makeAiProviderFactory(runtime);
-  return async (ticker: string): Promise<StockAnalysisResult> => {
+  return async (ticker: string, generationContext?: AnalysisGenerationContext): Promise<StockAnalysisResult> => {
     const { provider, config } = await providerFactory();
-    const result = await provider.generate({
-      prompt: createStockAnalysisPrompt(ticker),
-      system: STOCK_ANALYSIS_SYSTEM_PROMPT,
-      model: config.model,
-      webSearch: true,
-    });
-    return normaliseStockAnalysisSignals(JSON.parse(stripCodeFences(result.content)) as StockAnalysisResult);
+    let result: Awaited<ReturnType<AiProvider['generate']>>;
+    try {
+      result = await provider.generate({
+        prompt: createStockAnalysisPrompt(ticker),
+        system: STOCK_ANALYSIS_SYSTEM_PROMPT,
+        model: config.model,
+        webSearch: true,
+      });
+    } catch (err) {
+      if (err instanceof AiProviderNonJsonError) {
+        logAnalysisGenerationError('notification-analysis-provider-non-json', {
+          ticker,
+          provider: err.diagnostics.provider,
+          model: err.diagnostics.model,
+          generationContext,
+          err,
+          details: {
+            phase: err.diagnostics.phase,
+            httpStatus: err.diagnostics.httpStatus,
+            responseHeaders: err.diagnostics.responseHeaders,
+            responseBodyPrefix: err.diagnostics.responseBodyPrefix,
+          },
+        });
+        throw new Error(`provider returned non-JSON HTTP response while analysing ${ticker}`);
+      }
+      throw err;
+    }
+
+    return parseStockAnalysisProviderResult(result, ticker, generationContext);
   };
 }
 

--- a/packages/fn-ai-proxy-core/src/index.ts
+++ b/packages/fn-ai-proxy-core/src/index.ts
@@ -11,7 +11,7 @@ export {
   resolveAiRuntimeConfig,
   resolveEnvFallbackConfig,
 } from './config';
-export { AiProviderError } from './types';
+export { AiProviderError, AiProviderNonJsonError } from './types';
 export { callClaude, ClaudeProvider, stripAnthropicCitations } from './providers/claude';
 export { OpenAIProvider } from './providers/openai';
 export { executeAsyncJob } from './async-job';
@@ -25,6 +25,7 @@ export type {
   AiErrorClass,
   AiProvider,
   AiProviderId,
+  AiProviderResponseDiagnostics,
   AiProviderRequest,
   AiProviderResult,
   AiProxyAsyncResponse,

--- a/packages/fn-ai-proxy-core/src/providers.test.ts
+++ b/packages/fn-ai-proxy-core/src/providers.test.ts
@@ -130,6 +130,7 @@ describe('ClaudeProvider', () => {
 describe('OpenAIProvider', () => {
   beforeEach(() => {
     resetApiKeyCache();
+    warnSpy.mockClear();
   });
 
   it('maps OpenAI text and token usage into the provider contract', async () => {
@@ -192,6 +193,47 @@ describe('OpenAIProvider', () => {
       errorClass: 'authentication',
       statusCode: 502,
       retryable: false,
+    });
+  });
+
+  it('captures status, headers, and body prefix for non-JSON OpenAI HTTP responses', async () => {
+    const provider = new OpenAIProvider({
+      anthropicSecretName: 'unused',
+      openaiSecretName: 'openai-secret',
+      secretsManagerClient: secretClient('openai-key'),
+      fetchImpl: async () => new Response('<!DOCTYPE html><title>Gateway error</title>', {
+        status: 502,
+        headers: { 'Content-Type': 'text/html', 'x-request-id': 'req-1' },
+      }),
+    });
+
+    await expect(provider.generate({
+      prompt: 'Say hi',
+      model: 'gpt-5.5',
+      maxTokens: 100,
+    })).rejects.toMatchObject({
+      name: 'AiProviderNonJsonError',
+      diagnostics: {
+        provider: 'openai',
+        model: 'gpt-5.5',
+        phase: 'provider_http_json_parse',
+        httpStatus: 502,
+        responseBodyPrefix: '<!DOCTYPE html><title>Gateway error</title>',
+      },
+    });
+
+    const logged = JSON.parse(String(warnSpy.mock.calls.at(-1)?.[0])) as Record<string, unknown>;
+    expect(logged).toMatchObject({
+      eventName: 'ai_provider_non_json_response',
+      provider: 'openai',
+      model: 'gpt-5.5',
+      phase: 'provider_http_json_parse',
+      httpStatus: 502,
+      responseBodyPrefix: '<!DOCTYPE html><title>Gateway error</title>',
+    });
+    expect(logged.responseHeaders).toMatchObject({
+      'content-type': 'text/html',
+      'x-request-id': 'req-1',
     });
   });
 

--- a/packages/fn-ai-proxy-core/src/providers/openai.ts
+++ b/packages/fn-ai-proxy-core/src/providers/openai.ts
@@ -1,6 +1,16 @@
 import { getOpenAIApiKey } from '../secrets';
 import { normaliseProviderError } from '../provider';
-import { AiProviderError, type AiProvider, type AiProviderRequest, type AiProviderResult, type AiProxyOptions, type OpenAIResponse } from '../types';
+import {
+  AiProviderError,
+  AiProviderNonJsonError,
+  type AiProvider,
+  type AiProviderRequest,
+  type AiProviderResult,
+  type AiProxyOptions,
+  type OpenAIResponse,
+} from '../types';
+
+const RESPONSE_BODY_LOG_PREFIX_CHARS = 1000;
 
 function extractOpenAIText(data: OpenAIResponse): string | undefined {
   if (data.output_text?.trim()) {
@@ -16,6 +26,14 @@ function extractOpenAIText(data: OpenAIResponse): string | undefined {
   }
 
   return undefined;
+}
+
+function responseHeaders(headers: Headers): Record<string, string> {
+  return Object.fromEntries(headers.entries());
+}
+
+function bodyPrefix(body: string): string {
+  return body.slice(0, RESPONSE_BODY_LOG_PREFIX_CHARS);
 }
 
 export class OpenAIProvider implements AiProvider {
@@ -56,7 +74,26 @@ export class OpenAIProvider implements AiProvider {
       }),
     });
 
-    const data = await res.json() as OpenAIResponse;
+    const rawBody = await res.text();
+    let data: OpenAIResponse;
+    try {
+      data = JSON.parse(rawBody) as OpenAIResponse;
+    } catch (err) {
+      const diagnostics = {
+        provider: 'openai' as const,
+        model,
+        phase: 'provider_http_json_parse' as const,
+        httpStatus: res.status,
+        responseHeaders: responseHeaders(res.headers),
+        responseBodyPrefix: bodyPrefix(rawBody),
+      };
+      console.warn(JSON.stringify({
+        eventName: 'ai_provider_non_json_response',
+        ...diagnostics,
+        err: err instanceof Error ? err.message : String(err),
+      }));
+      throw new AiProviderNonJsonError('OpenAI provider returned a non-JSON HTTP response', diagnostics);
+    }
 
     if (!res.ok) {
       throw normaliseProviderError('openai', res.status, data?.error?.message ?? String(res.status), data?.error?.code ?? data?.error?.type);

--- a/packages/fn-ai-proxy-core/src/types.ts
+++ b/packages/fn-ai-proxy-core/src/types.ts
@@ -32,6 +32,26 @@ export class AiProviderError extends HttpError {
   }
 }
 
+export interface AiProviderResponseDiagnostics {
+  provider: AiProviderId;
+  model: string;
+  phase: 'provider_http_json_parse' | 'model_output_json_parse';
+  httpStatus?: number;
+  responseHeaders?: Record<string, string>;
+  responseBodyPrefix?: string;
+  modelOutputPrefix?: string;
+}
+
+export class AiProviderNonJsonError extends AiProviderError {
+  constructor(
+    message: string,
+    public readonly diagnostics: AiProviderResponseDiagnostics,
+  ) {
+    super('provider_bad_response', 502, false, message);
+    this.name = 'AiProviderNonJsonError';
+  }
+}
+
 export interface AiProxyOptions {
   anthropicSecretName?: string;
   openaiSecretName?: string;


### PR DESCRIPTION
## Summary

Fixes #588.

This PR adds the missing observability for Stock Analyser notification-engine analysis generation failures where JSON parsing sees an HTML/non-JSON payload, such as the recent `Unexpected token '<', "<!DOCTYPE"...` failure.

The change distinguishes the two important failure modes:

- provider HTTP response was not JSON: logged from `OpenAIProvider.generate` with HTTP status, response headers, and the first 1000 characters of the raw response body.
- model output was not parseable JSON: logged from the notification-engine analysis parser with provider, model, ticker, accountId, runId, sourceType, and the first 1000 characters of model output.

## Behaviour

- The engine now passes analysis-generation context into generated ticker analysis calls: `accountId`, `runId`, and source type.
- Provider non-JSON HTTP responses throw `AiProviderNonJsonError` with structured diagnostics.
- Notification-engine logs `notification-analysis-provider-non-json` for provider HTTP parse failures.
- Notification-engine logs `notification-analysis-model-output-unparseable` for model-output parse failures.
- Failures still surface loudly and mark the account run as failed/partial with a specific reason such as `provider returned non-JSON HTTP response while analysing TICKER` or `model output unparseable while analysing TICKER`.
- The account failure path remains defensive and continues the job rather than crashing the full scheduled run.

## Root Cause Note

The prior production/dev logs do not contain the raw HTML body, HTTP status, response headers, provider, model, ticker, or account/run correlation, so the actual source of the `<!DOCTYPE` response cannot be proven retrospectively. This PR fixes that observability gap first, without assuming the failure was transient or provider-side.

I did not force a live `FMG.AX` reproduction before this lands because the currently deployed code would still lack the diagnostic logging and a live generation can consume provider quota and mutate cache/run state. Once deployed, the next recurrence or controlled reproduction under the same OpenAI `gpt-5.5` config should identify whether the body came from the HTTP provider layer or model output.

## Scope

- Runtime-only observability and defensive error handling.
- No UI changes.
- No contract changes.
- No v0 changes required.
- No deploy performed.

## Validation

- `pnpm --filter @transformotion/fn-ai-proxy-core typecheck`
- `pnpm --filter @transformotion/fn-ai-proxy-core lint`
- `pnpm --filter @transformotion/fn-ai-proxy-core build`
- `pnpm --filter @transformotion/fn-ai-proxy-core test`
- `pnpm --filter @transformotion/fn-stock-analyser-notification-engine typecheck`
- `pnpm --filter @transformotion/fn-stock-analyser-notification-engine lint`
- `pnpm --filter @transformotion/fn-stock-analyser-notification-engine build`
- `pnpm --filter @transformotion/fn-stock-analyser-notification-engine test`
- `pnpm sync:v0`
- `pnpm check:v0-contracts`
- `pnpm check:v0-freshness`
- `git diff --check`

## v0 Freshness

No v0 impact: this is runtime-only backend/provider observability and defensive failure handling. No UI-affecting or contract-affecting paths changed.